### PR TITLE
issue-5894, issue-5895: not touching TIndexTabletActor upon IFileSystemShard response in Adapter mode

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -74,7 +74,8 @@ TIndexTabletActor::TIndexTabletActor(
         ITxReschedulerPtr txRescheduler)
     : TActor(&TThis::StateBoot)
     , TTabletBase(owner, std::move(storage), std::move(txRescheduler))
-    , Metrics{std::move(metricsRegistry)}
+    , Metrics(MakeIntrusive<TTabletMetrics>(std::move(metricsRegistry)))
+    , CPUUsageTimer(Metrics->CPUUsageMicros)
     , ProfileLog(std::move(profileLog))
     , TraceSerializer(std::move(traceSerializer))
     , SystemCounters(std::move(systemCounters))
@@ -218,7 +219,7 @@ void TIndexTabletActor::ReassignDataChannelsIfNeeded(
             sb.c_str());
     }
 
-    Metrics.ReassignCount.fetch_add(
+    Metrics->ReassignCount.fetch_add(
         channels.size(),
         std::memory_order_relaxed);
 
@@ -677,7 +678,7 @@ bool TIndexTabletActor::IsTabletConsideredOverloaded() const
         return false;
     }
 
-    return IsTabletOverloaded(*Config, *SystemCounters, Metrics.CPUUsageRate);
+    return IsTabletOverloaded(*Config, *SystemCounters, Metrics->CPUUsageRate);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -873,7 +874,7 @@ bool TIndexTabletActor::ShouldThrottleCleanup(
 
     const auto now = ctx.Now();
     const double cleanupCpu =
-        Metrics.Cleanup.AverageSecondsPerSecond(now) * 100.0;
+        Metrics->Cleanup.AverageSecondsPerSecond(now) * 100.0;
     return cleanupCpu > Config->GetCleanupCpuThrottlingThresholdPercentage();
 }
 
@@ -1806,12 +1807,12 @@ bool TIndexTabletActor::HasBlocksLeft(ui64 blocksRequired) const
     } else {
         // A new way to count available space that always takes into account the
         // byte count aggregated by all shards.
-        TABLET_VERIFY(Metrics.AggregateUsedBytesCount >= 0);
-        TABLET_VERIFY(Metrics.TotalBytesCount >= 0);
+        TABLET_VERIFY(Metrics->AggregateUsedBytesCount >= 0);
+        TABLET_VERIFY(Metrics->TotalBytesCount >= 0);
         const ui64 aggregateBytes =
-            static_cast<ui64>(Max<i64>(0, Metrics.AggregateUsedBytesCount));
+            static_cast<ui64>(Max<i64>(0, Metrics->AggregateUsedBytesCount));
         const ui64 totalBytes =
-            static_cast<ui64>(Max<i64>(0, Metrics.TotalBytesCount));
+            static_cast<ui64>(Max<i64>(0, Metrics->TotalBytesCount));
         // It makes sense for shardless filesystems, as it eliminates 15s delay
         // in AggregateUsedBytesCount calculation.
         const ui64 usedBytes =
@@ -1845,7 +1846,7 @@ bool TIndexTabletActor::HasNodesLeft() const
     // A new way to count available nodes uses the count aggregated across all
     // shards.
 
-    if (Metrics.AggregateUsedNodesCount < 0) {
+    if (Metrics->AggregateUsedNodesCount < 0) {
         ReportCounterIsNegative(
             TStringBuilder() << "FileSystem: " << GetFileSystemId()
                              << ". TMetrics::AggregateUsedNodesCount should "
@@ -1856,7 +1857,7 @@ bool TIndexTabletActor::HasNodesLeft() const
     // It makes sense for shardless filesystems, as it eliminates 15s delay
     // in AggregateUsedNodesCount calculation.
     const ui64 usedNodes = Max<ui64>(
-        static_cast<ui64>(Metrics.AggregateUsedNodesCount.load()),
+        static_cast<ui64>(Metrics->AggregateUsedNodesCount.load()),
         GetUsedNodesCount());
 
     return usedNodes < GetNodesCount();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -119,6 +119,19 @@ MakeRenameNodeInDestinationRequest(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+template <typename TMethod>
+void CompleteResponse(
+    const TStorageConfig& config,
+    const ITraceSerializerPtr& traceSerializer,
+    TSystemCounters& systemCounters,
+    const TString& fileSystemId,
+    TTabletMetrics& metrics,
+    typename TMethod::TResponse::ProtoRecordType& response,
+    const TCallContextPtr& callContext,
+    bool* builtTraceInfo);
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TIndexTabletActor final
     : public NActors::TActor<TIndexTabletActor>
     , public TTabletBase<TIndexTabletActor>
@@ -144,8 +157,8 @@ class TIndexTabletActor final
     };
 
 private:
-    TTabletMetrics Metrics;
-    TCPUUsageTimer CPUUsageTimer{Metrics.CPUUsageMicros};
+    TTabletMetricsPtr Metrics;
+    TCPUUsageTimer CPUUsageTimer;
 
     NProtoPrivate::TStorageStats CachedAggregateStats;
     TInstant CachedStatsFetchingStartTs;
@@ -377,12 +390,12 @@ private:
         }
 
         if (indexState && TryExecuteTx(ctx, *indexState, tx)) {
-            Metrics.InMemoryIndexStateROCacheHitCount.fetch_add(
+            Metrics->InMemoryIndexStateROCacheHitCount.fetch_add(
                 1,
                 std::memory_order_relaxed);
             return;
         }
-        Metrics.InMemoryIndexStateROCacheMissCount.fetch_add(
+        Metrics->InMemoryIndexStateROCacheMissCount.fetch_add(
             1,
             std::memory_order_relaxed);
         TTabletBase<TIndexTabletActor>::ExecuteTx<TTx>(ctx, tx);
@@ -393,7 +406,7 @@ private:
         const NActors::TActorContext& ctx,
         TArgs&&... args)
     {
-        Metrics.InMemoryIndexStateRWCount.fetch_add(
+        Metrics->InMemoryIndexStateRWCount.fetch_add(
             1,
             std::memory_order_relaxed);
         TTabletBase<TIndexTabletActor>::ExecuteTx<TTx>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adapter.cpp
@@ -42,6 +42,58 @@ ADAPTER_METRICS_REQUESTS_PUBLIC(DECLARE_UPDATE_ADAPTER_METRICS, TEvService)
 
 #undef DECLARE_UPDATE_ADAPTER_METRICS
 
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TMethod>
+void OnResponse(
+    TActorSystem* ass,
+    const TStorageConfig& config,
+    const ITraceSerializerPtr& traceSerializer,
+    TSystemCounters& systemCounters,
+    TTabletMetrics& metrics,
+    const TString& fileSystemId,
+    const TString& logTag,
+    TCallContextPtr callContext,
+    TActorId sender,
+    ui64 cookie,
+    TInstant startedTs,
+    ui64 requestBytes,
+    typename TMethod::TResponse::ProtoRecordType responseProto)
+{
+    auto response =
+        std::make_unique<typename TMethod::TResponse>(std::move(responseProto));
+
+    bool builtTraceInfo = false;
+    NStorage::CompleteResponse<TMethod>(
+        config,
+        traceSerializer,
+        systemCounters,
+        fileSystemId,
+        metrics,
+        response->Record,
+        callContext,
+        &builtTraceInfo);
+
+    LOG_DEBUG(*ass, TFileStoreComponents::TABLET,
+        "%s %s: #%lu completed (%s), trace-info: %d",
+        logTag.c_str(),
+        TMethod::Name,
+        callContext->RequestId,
+        FormatError(response->Record.GetError()).c_str(),
+        builtTraceInfo);
+    LOG_TRACE(*ass, TFileStoreComponents::TABLET,
+        "%s " Y_STRINGIZE(name) " response %s",
+        logTag.c_str(),
+        response->Record.ShortUtf8DebugString().Quote().c_str());
+
+    ass->Send(sender, response.release(), 0 /* flags */, cookie);
+
+    UpdateAdapterMetrics<TMethod>(
+        metrics,
+        requestBytes,
+        ass->Timestamp() - startedTs);
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -67,42 +119,34 @@ void TIndexTabletActor::HandleAdapter##name(                                   \
         return;                                                                \
     }                                                                          \
                                                                                \
-    TInstant startedTs = ctx.Now();                                            \
-    const ui64 requestBytes = CalculateByteCount(msg->Record);                 \
+    auto* ass = ctx.ActorSystem();                                             \
+    auto config = Config;                                                      \
+    auto traceSerializer = TraceSerializer;                                    \
+    auto systemCounters = SystemCounters;                                      \
+    auto metrics = Metrics;                                                    \
+    auto fileSystemId = GetFileSystemId();                                     \
+    auto logTag = LogTag;                                                      \
+    auto callContext = msg->CallContext;                                       \
     auto sender = ev->Sender;                                                  \
     ui64 cookie = ev->Cookie;                                                  \
-    auto* ass = ctx.ActorSystem();                                             \
-    auto callContext = msg->CallContext;                                       \
+    TInstant startedTs = ctx.Now();                                            \
+    const ui64 requestBytes = CalculateByteCount(msg->Record);                 \
     FastShard->name(std::move(msg->Record)).Subscribe(                         \
         [=] (const auto& f) {                                                  \
-            /* TODO(#5894): ensure that tablet actor is still alive */         \
-            auto response = std::make_unique<ns::TEv##name##Response>(         \
-                UnsafeExtractValue(f));                                        \
-                                                                               \
-            bool builtTraceInfo = false;                                       \
-            CompleteResponse<TMethod>(                                         \
-                response->Record,                                              \
+            OnResponse<TMethod>(                                               \
+                ass,                                                           \
+                *config,                                                       \
+                traceSerializer,                                               \
+                *systemCounters,                                               \
+                *metrics,                                                      \
+                fileSystemId,                                                  \
+                logTag,                                                        \
                 callContext,                                                   \
-                &builtTraceInfo);                                              \
-                                                                               \
-            LOG_DEBUG(*ass, TFileStoreComponents::TABLET,                      \
-                "%s %s: #%lu completed (%s), trace-info: %d",                  \
-                LogTag.c_str(),                                                \
-                TMethod::Name,                                                 \
-                callContext->RequestId,                                        \
-                FormatError(response->Record.GetError()).c_str(),              \
-                builtTraceInfo);                                               \
-            LOG_TRACE(*ass, TFileStoreComponents::TABLET,                      \
-                "%s " Y_STRINGIZE(name) " response %s",                        \
-                LogTag.c_str(),                                                \
-                response->Record.ShortUtf8DebugString().Quote().c_str());      \
-                                                                               \
-            ass->Send(sender, response.release(), 0 /* flags */, cookie);      \
-                                                                               \
-            UpdateAdapterMetrics<TMethod>(                                     \
-                Metrics,                                                       \
+                sender,                                                        \
+                cookie,                                                        \
+                startedTs,                                                     \
                 requestBytes,                                                  \
-                ass->Timestamp() - startedTs);                                 \
+                UnsafeExtractValue(f));                                        \
         });                                                                    \
 }                                                                              \
 // FILESTORE_IMPLEMENT_ADAPTER_REQUEST_IN_ACTOR

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -275,7 +275,7 @@ void TIndexTabletActor::CompleteTx_AddData(
         *Config,
         *SystemCounters,
         GetFileSystemId(),
-        Metrics.CPUUsageRate,
+        Metrics->CPUUsageRate,
         &backendInfo);
 
     auto actor = std::make_unique<TAddDataActor>(
@@ -452,7 +452,7 @@ void TIndexTabletActor::HandleGenerateBlobIds(
             generateBlobIdsBytes += part.GetContent().size();
         }
     }
-    Metrics.GenerateBlobIds.Update(
+    Metrics->GenerateBlobIds.Update(
         1,
         generateBlobIdsBytes,
         ctx.Now() - startedTs);
@@ -687,9 +687,9 @@ void TIndexTabletActor::HandleAddDataCompleted(
             LogTag.c_str(),
             FormatError(msg->Error).Quote().c_str());
     } else {
-        Metrics.AddData.Update(msg->Count, msg->Size, msg->Time);
+        Metrics->AddData.Update(msg->Count, msg->Size, msg->Time);
         if (msg->IsOverloaded) {
-            Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+            Metrics->OverloadedCount.fetch_add(1, std::memory_order_relaxed);
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -97,7 +97,7 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
             ProfileLog);
 
         if (!HasError(args.Error)) {
-            Metrics.AddDataUnconfirmed.Update(
+            Metrics->AddDataUnconfirmed.Update(
                 1,
                 requestBytes,
                 ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -152,7 +152,7 @@ void TIndexTabletActor::CompleteTx_Cleanup(
     EnqueueBlobIndexOpIfNeeded(ctx);
     EnqueueCollectGarbageIfNeeded(ctx);
 
-    Metrics.Cleanup.Update(
+    Metrics->Cleanup.Update(
         1,
         args.ProcessedDeletionMarkerCount * GetBlockSize(),
         ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanupsessions.cpp
@@ -476,7 +476,7 @@ void TIndexTabletActor::HandleCleanupSessions(
 
     CleanupSessionsScheduled = false;
 
-    Metrics.SessionCleanupAttempts.fetch_add(
+    Metrics->SessionCleanupAttempts.fetch_add(
         1,
         std::memory_order_relaxed);
 
@@ -491,7 +491,7 @@ void TIndexTabletActor::HandleCleanupSessions(
         return;
     }
 
-    Metrics.SessionTimeouts.fetch_add(
+    Metrics->SessionTimeouts.fetch_add(
         sessions.size(),
         std::memory_order_relaxed);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
@@ -496,7 +496,7 @@ void TIndexTabletActor::HandleCollectGarbageCompleted(
     WorkerActors.erase(ev->Sender);
     EnqueueCollectGarbageIfNeeded(ctx);
 
-    Metrics.CollectGarbage.Update(msg->Count, msg->Size, msg->Time);
+    Metrics->CollectGarbage.Update(msg->Count, msg->Size, msg->Time);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -745,11 +745,11 @@ void TIndexTabletActor::CompleteTx_Compaction(
 
         CompleteBlobIndexOp();
         EnqueueBlobIndexOpIfNeeded(ctx);
-        Metrics.Compaction.Update(
+        Metrics->Compaction.Update(
             1,  // count
             0,  // requestBytes
             ctx.Now() - args.RequestInfo->StartedTs);
-        Metrics.CompactionExtra.DudCount.fetch_add(
+        Metrics->CompactionExtra.DudCount.fetch_add(
             1,
             std::memory_order_relaxed);
         return;
@@ -848,7 +848,7 @@ void TIndexTabletActor::HandleCompactionCompleted(
     EnqueueBlobIndexOpIfNeeded(ctx);
     EnqueueCollectGarbageIfNeeded(ctx);
 
-    Metrics.Compaction.Update(msg->Count, msg->Size, msg->Time);
+    Metrics->Compaction.Update(msg->Count, msg->Size, msg->Time);
 
     WorkerActors.erase(ev->Sender);
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -63,7 +63,7 @@ void TIndexTabletActor::SendPendingConfirmAddDataResponse(
 
     for (auto& pending: pendingRequests) {
         if (!HasError(error)) {
-            Metrics.ConfirmAddData.Update(1, 0, ctx.Now() - pending.DeferredTs);
+            Metrics->ConfirmAddData.Update(1, 0, ctx.Now() - pending.DeferredTs);
         }
 
         SendDeferredConfirmAddDataResponse(ctx, std::move(pending), error);
@@ -194,7 +194,7 @@ void TIndexTabletActor::HandleConfirmAddData(
         UnconfirmedDataInProgress.end())
     {
         deferReply();
-        Metrics.ConfirmAddDataExtra.DeferredCount.fetch_add(
+        Metrics->ConfirmAddDataExtra.DeferredCount.fetch_add(
             1,
             std::memory_order_relaxed);
         return;
@@ -241,7 +241,7 @@ void TIndexTabletActor::HandleCancelAddData(
 
         finalizeProfile(responseError);
 
-        Metrics.CancelAddData.Update(1, 0, ctx.Now() - startedTs);
+        Metrics->CancelAddData.Update(1, 0, ctx.Now() - startedTs);
     };
 
     auto validator = [&](const TEvIndexTablet::TCancelAddDataMethod::TRequest::
@@ -256,7 +256,7 @@ void TIndexTabletActor::HandleCancelAddData(
             validator))
     {
         finalizeProfile(MakeError(E_REJECTED, "not accepted"));
-        Metrics.CancelAddData.Update(1, 0, ctx.Now() - startedTs);
+        Metrics->CancelAddData.Update(1, 0, ctx.Now() - startedTs);
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -369,190 +369,198 @@ void TIndexTabletActor::UpdateMetrics(
 {
     const ui32 blockSize = fileSystem.GetBlockSize();
 
-    Store(Metrics.TotalBytesCount, fileSystem.GetBlocksCount() * blockSize);
-    Store(Metrics.UsedBytesCount, stats.GetUsedBlocksCount() * blockSize);
+    Store(Metrics->TotalBytesCount, fileSystem.GetBlocksCount() * blockSize);
+    Store(Metrics->UsedBytesCount, stats.GetUsedBlocksCount() * blockSize);
 
-    Store(Metrics.TotalNodesCount, fileSystem.GetNodesCount());
-    Store(Metrics.UsedNodesCount, stats.GetUsedNodesCount());
+    Store(Metrics->TotalNodesCount, fileSystem.GetNodesCount());
+    Store(Metrics->UsedNodesCount, stats.GetUsedNodesCount());
 
-    Store(Metrics.UsedSessionsCount, stats.GetUsedSessionsCount());
-    Store(Metrics.UsedHandlesCount, stats.GetUsedHandlesCount());
-    Store(Metrics.UsedDirectHandlesCount, handlesStats.UsedDirectHandlesCount);
-    Store(Metrics.SevenBytesHandlesCount, handlesStats.SevenBytesHandlesCount);
-    Store(Metrics.UsedLocksCount, stats.GetUsedLocksCount());
+    Store(Metrics->UsedSessionsCount, stats.GetUsedSessionsCount());
+    Store(Metrics->UsedHandlesCount, stats.GetUsedHandlesCount());
+    Store(Metrics->UsedDirectHandlesCount, handlesStats.UsedDirectHandlesCount);
+    Store(Metrics->SevenBytesHandlesCount, handlesStats.SevenBytesHandlesCount);
+    Store(Metrics->UsedLocksCount, stats.GetUsedLocksCount());
 
     Store(
-        Metrics.StrictFileSystemSizeEnforcementEnabled,
+        Metrics->StrictFileSystemSizeEnforcementEnabled,
         fileSystem.GetStrictFileSystemSizeEnforcementEnabled());
     Store(
-        Metrics.DirectoryCreationInShardsEnabled,
+        Metrics->DirectoryCreationInShardsEnabled,
         fileSystem.GetDirectoryCreationInShardsEnabled());
 
-    Store(Metrics.FreshBytesCount, stats.GetFreshBytesCount());
-    Store(Metrics.FreshBytesItemCount, stats.GetFreshBytesItemCount());
-    Store(Metrics.DeletedFreshBytesCount, stats.GetDeletedFreshBytesCount());
-    Store(Metrics.MixedBytesCount, stats.GetMixedBlocksCount() * blockSize);
-    Store(Metrics.MixedBlobsCount, stats.GetMixedBlobsCount());
-    Store(Metrics.DeletionMarkersCount, stats.GetDeletionMarkersCount());
+    Store(Metrics->FreshBytesCount, stats.GetFreshBytesCount());
+    Store(Metrics->FreshBytesItemCount, stats.GetFreshBytesItemCount());
+    Store(Metrics->DeletedFreshBytesCount, stats.GetDeletedFreshBytesCount());
+    Store(Metrics->MixedBytesCount, stats.GetMixedBlocksCount() * blockSize);
+    Store(Metrics->MixedBlobsCount, stats.GetMixedBlobsCount());
+    Store(Metrics->DeletionMarkersCount, stats.GetDeletionMarkersCount());
     Store(
-        Metrics.LargeDeletionMarkersCount,
+        Metrics->LargeDeletionMarkersCount,
         stats.GetLargeDeletionMarkersCount());
-    Store(Metrics.GarbageQueueSize, stats.GetGarbageQueueSize());
-    Store(Metrics.GarbageBytesCount, stats.GetGarbageBlocksCount() * blockSize);
-    Store(Metrics.FreshBlocksCount, stats.GetFreshBlocksCount());
-    Store(Metrics.CMMixedBlobsCount, compactionStats.TotalBlobsCount);
-    Store(Metrics.CMDeletionMarkersCount, compactionStats.TotalDeletionsCount);
+    Store(Metrics->GarbageQueueSize, stats.GetGarbageQueueSize());
     Store(
-        Metrics.CMGarbageBlocksCount,
+        Metrics->GarbageBytesCount,
+        stats.GetGarbageBlocksCount() * blockSize);
+    Store(Metrics->FreshBlocksCount, stats.GetFreshBlocksCount());
+    Store(Metrics->CMMixedBlobsCount, compactionStats.TotalBlobsCount);
+    Store(Metrics->CMDeletionMarkersCount, compactionStats.TotalDeletionsCount);
+    Store(
+        Metrics->CMGarbageBlocksCount,
         compactionStats.TotalGarbageBlocksCount);
-    Store(Metrics.CollectCommitId, GetCollectCommitId());
+    Store(Metrics->CollectCommitId, GetCollectCommitId());
 
     TString backpressureReason;
     Store(
-        Metrics.IsWriteAllowed,
+        Metrics->IsWriteAllowed,
         TIndexTabletActor::IsWriteAllowed(
             backpressureThresholds,
             backpressureValues,
             &backpressureReason));
 
-    Store(Metrics.FlushBackpressureValue, backpressureValues.Flush);
-    Store(Metrics.FlushBackpressureThreshold, backpressureThresholds.Flush);
-    Store(Metrics.FlushBytesBackpressureValue, backpressureValues.FlushBytes);
+    Store(Metrics->FlushBackpressureValue, backpressureValues.Flush);
+    Store(Metrics->FlushBackpressureThreshold, backpressureThresholds.Flush);
+    Store(Metrics->FlushBytesBackpressureValue, backpressureValues.FlushBytes);
     Store(
-        Metrics.FlushBytesBackpressureThreshold,
+        Metrics->FlushBytesBackpressureThreshold,
         backpressureThresholds.FlushBytes);
     Store(
-        Metrics.FlushBytesItemCountBackpressureValue,
+        Metrics->FlushBytesItemCountBackpressureValue,
         backpressureValues.FlushBytesItemCount);
     Store(
-        Metrics.FlushBytesItemCountBackpressureThreshold,
+        Metrics->FlushBytesItemCountBackpressureThreshold,
         backpressureThresholds.FlushBytesItemCount);
     Store(
-        Metrics.CompactionBackpressureValue,
+        Metrics->CompactionBackpressureValue,
         backpressureValues.CompactionScore);
     Store(
-        Metrics.CompactionBackpressureThreshold,
+        Metrics->CompactionBackpressureThreshold,
         backpressureThresholds.CompactionScore);
-    Store(Metrics.CleanupBackpressureValue, backpressureValues.CleanupScore);
+    Store(Metrics->CleanupBackpressureValue, backpressureValues.CleanupScore);
     Store(
-        Metrics.CleanupBackpressureThreshold,
+        Metrics->CleanupBackpressureThreshold,
         backpressureThresholds.CleanupScore);
     Store(
-        Metrics.CollectGarbageBackpressureValue,
+        Metrics->CollectGarbageBackpressureValue,
         backpressureValues.CollectGarbage);
     Store(
-        Metrics.CollectGarbageBackpressureThreshold,
+        Metrics->CollectGarbageBackpressureThreshold,
         backpressureThresholds.CollectGarbage);
 
-    Store(Metrics.MaxReadIops, performanceProfile.GetMaxReadIops());
-    Store(Metrics.MaxWriteIops, performanceProfile.GetMaxWriteIops());
-    Store(Metrics.MaxReadBandwidth, performanceProfile.GetMaxReadBandwidth());
-    Store(Metrics.MaxWriteBandwidth, performanceProfile.GetMaxWriteBandwidth());
+    Store(Metrics->MaxReadIops, performanceProfile.GetMaxReadIops());
+    Store(Metrics->MaxWriteIops, performanceProfile.GetMaxWriteIops());
+    Store(Metrics->MaxReadBandwidth, performanceProfile.GetMaxReadBandwidth());
+    Store(
+        Metrics->MaxWriteBandwidth,
+        performanceProfile.GetMaxWriteBandwidth());
 
     Store(
-        Metrics.AllocatedCompactionRangesCount,
+        Metrics->AllocatedCompactionRangesCount,
         compactionStats.AllocatedRangesCount);
-    Store(Metrics.UsedCompactionRangesCount, compactionStats.UsedRangesCount);
+    Store(Metrics->UsedCompactionRangesCount, compactionStats.UsedRangesCount);
 
     if (compactionStats.TopRangesByCompactionScore.empty()) {
-        Store(Metrics.MaxBlobsInRange, 0);
+        Store(Metrics->MaxBlobsInRange, 0);
     } else {
         Store(
-            Metrics.MaxBlobsInRange,
+            Metrics->MaxBlobsInRange,
             compactionStats.TopRangesByCompactionScore.front()
                 .Stats.BlobsCount);
     }
     if (compactionStats.TopRangesByCleanupScore.empty()) {
-        Store(Metrics.MaxDeletionsInRange, 0);
+        Store(Metrics->MaxDeletionsInRange, 0);
     } else {
         Store(
-            Metrics.MaxDeletionsInRange,
+            Metrics->MaxDeletionsInRange,
             compactionStats.TopRangesByCleanupScore.front()
                 .Stats.DeletionsCount);
     }
     if (compactionStats.TopRangesByGarbageScore.empty()) {
-        Store(Metrics.MaxGarbageBlocksInRange, 0);
+        Store(Metrics->MaxGarbageBlocksInRange, 0);
     } else {
         Store(
-            Metrics.MaxGarbageBlocksInRange,
+            Metrics->MaxGarbageBlocksInRange,
             compactionStats.TopRangesByGarbageScore.front()
                 .Stats.GarbageBlocksCount);
     }
 
-    Store(Metrics.StatefulSessionsCount, sessionsStats.StatefulSessionsCount);
-    Store(Metrics.StatelessSessionsCount, sessionsStats.StatelessSessionsCount);
-    Store(Metrics.ActiveSessionsCount, sessionsStats.ActiveSessionsCount);
-    Store(Metrics.OrphanSessionsCount, sessionsStats.OrphanSessionsCount);
+    Store(Metrics->StatefulSessionsCount, sessionsStats.StatefulSessionsCount);
     Store(
-        Metrics.HandleStatsByNodeMaxSize,
+        Metrics->StatelessSessionsCount,
+        sessionsStats.StatelessSessionsCount);
+    Store(Metrics->ActiveSessionsCount, sessionsStats.ActiveSessionsCount);
+    Store(Metrics->OrphanSessionsCount, sessionsStats.OrphanSessionsCount);
+    Store(
+        Metrics->HandleStatsByNodeMaxSize,
         sessionsStats.HandleStatsByNodeMaxSize);
     Store(
-        Metrics.HandleStatsByNodeSumSize,
+        Metrics->HandleStatsByNodeSumSize,
         sessionsStats.HandleStatsByNodeSumSize);
     Store(
-        Metrics.HandleStatsByNodeMaxTotalSize,
+        Metrics->HandleStatsByNodeMaxTotalSize,
         sessionsStats.HandleStatsByNodeMaxTotalSize);
     Store(
-        Metrics.HandleStatsByNodeSumTotalSize,
+        Metrics->HandleStatsByNodeSumTotalSize,
         sessionsStats.HandleStatsByNodeSumTotalSize);
-    Store(Metrics.WritableChannelCount, channelsStats.WritableChannelCount);
-    Store(Metrics.UnwritableChannelCount, channelsStats.UnwritableChannelCount);
-    Store(Metrics.ChannelsToMoveCount, channelsStats.ChannelsToMoveCount);
-    Store(Metrics.ReadAheadCacheNodeCount, readAheadStats.NodeCount);
-    Store(Metrics.ReadNodeCacheBypassCount, GetReadNodeCacheBypassCount());
-    Store(Metrics.ReadAheadCacheBypassCount, GetReadAheadCacheBypassCount());
+    Store(Metrics->WritableChannelCount, channelsStats.WritableChannelCount);
+    Store(
+        Metrics->UnwritableChannelCount,
+        channelsStats.UnwritableChannelCount);
+    Store(Metrics->ChannelsToMoveCount, channelsStats.ChannelsToMoveCount);
+    Store(Metrics->ReadAheadCacheNodeCount, readAheadStats.NodeCount);
+    Store(Metrics->ReadNodeCacheBypassCount, GetReadNodeCacheBypassCount());
+    Store(Metrics->ReadAheadCacheBypassCount, GetReadAheadCacheBypassCount());
 
     Store(
-        Metrics.InMemoryIndexStateNodesCount,
+        Metrics->InMemoryIndexStateNodesCount,
         inMemoryIndexStateStats.NodesCount);
     Store(
-        Metrics.InMemoryIndexStateNodesCapacity,
+        Metrics->InMemoryIndexStateNodesCapacity,
         inMemoryIndexStateStats.NodesCapacity);
     Store(
-        Metrics.InMemoryIndexStateNodeRefsCount,
+        Metrics->InMemoryIndexStateNodeRefsCount,
         inMemoryIndexStateStats.NodeRefsCount);
     Store(
-        Metrics.InMemoryIndexStateNodeRefsCapacity,
+        Metrics->InMemoryIndexStateNodeRefsCapacity,
         inMemoryIndexStateStats.NodeRefsCapacity);
     Store(
-        Metrics.InMemoryIndexStateNodeAttrsCount,
+        Metrics->InMemoryIndexStateNodeAttrsCount,
         inMemoryIndexStateStats.NodeAttrsCount);
     Store(
-        Metrics.InMemoryIndexStateNodeAttrsCapacity,
+        Metrics->InMemoryIndexStateNodeAttrsCapacity,
         inMemoryIndexStateStats.NodeAttrsCapacity);
     Store(
-        Metrics.InMemoryIndexStateNodeRefsExhaustivenessCount,
+        Metrics->InMemoryIndexStateNodeRefsExhaustivenessCount,
         inMemoryIndexStateStats.NodeRefsExhaustivenessCount);
     Store(
-        Metrics.InMemoryIndexStateNodeRefsExhaustivenessCapacity,
+        Metrics->InMemoryIndexStateNodeRefsExhaustivenessCapacity,
         inMemoryIndexStateStats.NodeRefsExhaustivenessCapacity);
     Store(
-        Metrics.InMemoryIndexStateIsExhaustive,
+        Metrics->InMemoryIndexStateIsExhaustive,
         inMemoryIndexStateStats.IsNodeRefsExhaustive);
 
-    Store(Metrics.MixedIndexLoadedRanges, blobMetaMapStats.LoadedRanges);
-    Store(Metrics.MixedIndexOffloadedRanges, blobMetaMapStats.OffloadedRanges);
+    Store(Metrics->MixedIndexLoadedRanges, blobMetaMapStats.LoadedRanges);
+    Store(Metrics->MixedIndexOffloadedRanges, blobMetaMapStats.OffloadedRanges);
 
     Store(
-        Metrics.NodesOpenForWritingBySingleSession,
+        Metrics->NodesOpenForWritingBySingleSession,
         nodeToSessionCounters.NodesOpenForWritingBySingleSession);
     Store(
-        Metrics.NodesOpenForWritingByMultipleSessions,
+        Metrics->NodesOpenForWritingByMultipleSessions,
         nodeToSessionCounters.NodesOpenForWritingByMultipleSessions);
     Store(
-        Metrics.NodesOpenForReadingBySingleSession,
+        Metrics->NodesOpenForReadingBySingleSession,
         nodeToSessionCounters.NodesOpenForReadingBySingleSession);
     Store(
-        Metrics.NodesOpenForReadingByMultipleSessions,
+        Metrics->NodesOpenForReadingByMultipleSessions,
         nodeToSessionCounters.NodesOpenForReadingByMultipleSessions);
 
-    Store(Metrics.OrphanNodesCount, miscNodeStats.OrphanNodesCount);
+    Store(Metrics->OrphanNodesCount, miscNodeStats.OrphanNodesCount);
 
-    Metrics.BusyIdleCalc.OnUpdateStats();
-    Metrics.UpdatePerformanceMetrics(now, diagConfig, fileSystem);
+    Metrics->BusyIdleCalc.OnUpdateStats();
+    Metrics->UpdatePerformanceMetrics(now, diagConfig, fileSystem);
 
 #define FILESTORE_TABLET_UPDATE_REQUEST_METRICS(name, ...)                     \
-    Metrics.name.UpdatePrev(now);                                              \
+    Metrics->name.UpdatePrev(now);                                             \
 // FILESTORE_TABLET_METRICS_REQUEST
 
     FILESTORE_TABLET_METRICS_REQUESTS(FILESTORE_TABLET_UPDATE_REQUEST_METRICS)
@@ -615,13 +623,17 @@ void TIndexTabletActor::RegisterStatCounters(TInstant now)
 
     // TabletStartTimestamp should be set only once
     i64 expected = 0;
-    Metrics.TabletStartTimestamp.compare_exchange_strong(
+    Metrics->TabletStartTimestamp.compare_exchange_strong(
         expected,
         now.MicroSeconds());
-    Metrics.TabletId.store(TabletID());
-    Metrics.TabletGeneration.store(GetGeneration());
+    Metrics->TabletId.store(TabletID());
+    Metrics->TabletGeneration.store(GetGeneration());
 
-    Metrics.Register(fsId, fs.GetCloudId(), fs.GetFolderId(), storageMediaKind);
+    Metrics->Register(
+        fsId,
+        fs.GetCloudId(),
+        fs.GetFolderId(),
+        storageMediaKind);
 }
 
 void TIndexTabletActor::ScheduleUpdateCounters(const TActorContext& ctx)
@@ -643,7 +655,7 @@ void TIndexTabletActor::SendMetricsToExecutor(const TActorContext& ctx)
 {
     auto* resourceMetrics = Executor()->GetResourceMetrics();
     resourceMetrics->Network.Increment(
-        Metrics.CalculateNetworkRequestBytes(
+        Metrics->CalculateNetworkRequestBytes(
             Config->GetNonNetworkMetricsBalancingFactor()),
         ctx.Now());
     resourceMetrics->TryUpdate(ctx);
@@ -652,21 +664,21 @@ void TIndexTabletActor::SendMetricsToExecutor(const TActorContext& ctx)
 void TIndexTabletActor::CalculateActorCPUUsage(const TActorContext& ctx)
 {
     const i64 curUsageMicros =
-        Metrics.CPUUsageMicros.load(std::memory_order_relaxed);
+        Metrics->CPUUsageMicros.load(std::memory_order_relaxed);
     const TInstant ts = ctx.Now();
-    if (Metrics.PrevCPUUsageMicrosTs) {
-        const auto timeDiff = ts - Metrics.PrevCPUUsageMicrosTs;
+    if (Metrics->PrevCPUUsageMicrosTs) {
+        const auto timeDiff = ts - Metrics->PrevCPUUsageMicrosTs;
         if (timeDiff) {
             const double usageDiff =
-                curUsageMicros - Metrics.PrevCPUUsageMicros;
-            Metrics.CPUUsageRate.store(
+                curUsageMicros - Metrics->PrevCPUUsageMicros;
+            Metrics->CPUUsageRate.store(
                 100 * (usageDiff / timeDiff.MicroSeconds()),
                 std::memory_order_relaxed);
         }
     }
 
-    Metrics.PrevCPUUsageMicrosTs = ts;
-    Metrics.PrevCPUUsageMicros = curUsageMicros;
+    Metrics->PrevCPUUsageMicrosTs = ts;
+    Metrics->PrevCPUUsageMicros = curUsageMicros;
 }
 
 void TIndexTabletActor::HandleUpdateCounters(
@@ -695,8 +707,8 @@ void TIndexTabletActor::HandleUpdateCounters(
     CalculateActorCPUUsage(ctx);
     SendMetricsToExecutor(ctx);
 
-    Store(Metrics.OpLogEntryCount, GetOpLogEntryCount());
-    Store(Metrics.ResponseLogEntryCount, GetResponseLogEntryCount());
+    Store(Metrics->OpLogEntryCount, GetOpLogEntryCount());
+    Store(Metrics->ResponseLogEntryCount, GetResponseLogEntryCount());
 
     UpdateCountersScheduled = false;
     ScheduleUpdateCounters(ctx);
@@ -728,10 +740,10 @@ void TIndexTabletActor::HandleUpdateCounters(
                 CachedAggregateStatsTs = ctx.Now();
             }
             Store(
-                Metrics.AggregateUsedBytesCount,
+                Metrics->AggregateUsedBytesCount,
                 CachedAggregateStats.GetUsedBlocksCount() * GetBlockSize());
             Store(
-                Metrics.AggregateUsedNodesCount,
+                Metrics->AggregateUsedNodesCount,
                 CachedAggregateStats.GetUsedNodesCount());
 
             return;
@@ -786,14 +798,14 @@ void TIndexTabletActor::FillSelfStorageStats(
     stats->SetCollectGarbageState(static_cast<ui32>(
         CollectGarbageState.GetOperationState()));
 
-    stats->SetCurrentLoad(Metrics.CurrentLoad.load(std::memory_order_relaxed));
-    stats->SetSuffer(Metrics.Suffer.load(std::memory_order_relaxed));
+    stats->SetCurrentLoad(Metrics->CurrentLoad.load(std::memory_order_relaxed));
+    stats->SetSuffer(Metrics->Suffer.load(std::memory_order_relaxed));
 
     stats->SetTotalBlocksCount(GetFileSystem().GetBlocksCount());
 
     stats->SetFreshBytesItemCount(GetFreshBytesItemCount());
 
-    stats->SetSevenBytesHandlesCount(Metrics.SevenBytesHandlesCount);
+    stats->SetSevenBytesHandlesCount(Metrics->SevenBytesHandlesCount);
 
     stats->SetUnconfirmedDataCount(
         UnconfirmedData.size() + UnconfirmedDataInProgress.size());
@@ -808,7 +820,7 @@ void TIndexTabletActor::HandleGetStorageStats(
         std::make_unique<TEvIndexTablet::TEvGetStorageStatsResponse>();
     response->Record.SetMediaKind(GetFileSystem().GetStorageMediaKind());
     const i64 tabletStartTimestamp =
-        Metrics.TabletStartTimestamp.load(std::memory_order_relaxed);
+        Metrics->TabletStartTimestamp.load(std::memory_order_relaxed);
     if (tabletStartTimestamp) {
         const auto now = ctx.Now();
         const auto tabletStartTs = TInstant::MicroSeconds(tabletStartTimestamp);
@@ -870,8 +882,8 @@ void TIndexTabletActor::HandleGetStorageStats(
     }
 
     if (allowCache || shardIds.empty()) {
-        Metrics.StatFileStore.Update(1, 0, TDuration::Zero());
-        Metrics.GetStorageStats.Update(1, 0, TDuration::Zero());
+        Metrics->StatFileStore.Update(1, 0, TDuration::Zero());
+        Metrics->GetStorageStats.Update(1, 0, TDuration::Zero());
         NCloud::Reply(ctx, *ev, std::move(response));
         return;
     }
@@ -930,10 +942,10 @@ void TIndexTabletActor::HandleAggregateStatsCompleted(
 
     if (!HasError(msg->Error)) {
         if (msg->IsBackgroundRequest) {
-            Metrics.GetStorageStats.Update(1, 0, backgroundRequestDuration);
+            Metrics->GetStorageStats.Update(1, 0, backgroundRequestDuration);
         } else {
-            Metrics.StatFileStore.Update(1, 0, ctx.Now() - msg->StartedTs);
-            Metrics.GetStorageStats.Update(1, 0, ctx.Now() - msg->StartedTs);
+            Metrics->StatFileStore.Update(1, 0, ctx.Now() - msg->StartedTs);
+            Metrics->GetStorageStats.Update(1, 0, ctx.Now() - msg->StartedTs);
         }
         CachedAggregateStats = std::move(msg->AggregateStats);
         // TIndexTabletActor can reply to a GetStorageStats request from cache
@@ -953,7 +965,7 @@ void TIndexTabletActor::HandleAggregateStatsCompleted(
                 LogTag.c_str(),
                 FormatError(error).Quote().c_str());
 
-            Metrics.ShardBalancerUpdateErrorCount.fetch_add(
+            Metrics->ShardBalancerUpdateErrorCount.fetch_add(
                 1,
                 std::memory_order_relaxed);
         } else {
@@ -966,10 +978,10 @@ void TIndexTabletActor::HandleAggregateStatsCompleted(
         }
 
         Store(
-            Metrics.AggregateUsedBytesCount,
+            Metrics->AggregateUsedBytesCount,
             CachedAggregateStats.GetUsedBlocksCount() * GetBlockSize());
         Store(
-            Metrics.AggregateUsedNodesCount,
+            Metrics->AggregateUsedNodesCount,
             CachedAggregateStats.GetUsedNodesCount());
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -471,7 +471,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
                     Config->GetGuestCachingType() == NProto::GCT_ANY_READ);
             args.Response.SetGuestKeepCache(keepCache);
 
-            Metrics.CreateHandleExtra.GuestKeepCacheSet.fetch_add(
+            Metrics->CreateHandleExtra.GuestKeepCacheSet.fetch_add(
                 keepCache,
                 std::memory_order_relaxed);
         }
@@ -600,7 +600,7 @@ void TIndexTabletActor::CompleteCreateHandle(
         response->Record = std::move(args.Response);
     }
     auto& requestMetrics = args.ProfileLogRequest.GetBehaveAsShard()
-        ? Metrics.CreateHandleInShard : Metrics.CreateHandle;
+        ? Metrics->CreateHandleInShard : Metrics->CreateHandle;
     requestMetrics.Update(1, 0, ctx.Now() - args.RequestInfo->StartedTs);
 
     CompleteResponse<TEvService::TCreateHandleMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -942,7 +942,7 @@ void TIndexTabletActor::CompleteTx_CreateNode(
         ctx);
 
     auto& requestMetrics = args.ProfileLogRequest.GetBehaveAsShard()
-        ? Metrics.CreateNodeInShard : Metrics.CreateNode;
+        ? Metrics->CreateNodeInShard : Metrics->CreateNode;
     requestMetrics.Update(
         1,
         0,
@@ -977,10 +977,10 @@ void TIndexTabletActor::HandleNodeCreatedInShard(
 
     UnlockNodeRef(msg->OriginalNodeRefKey);
 
-    Metrics.NodeExistsWhileCreatingInShardCount.fetch_add(
+    Metrics->NodeExistsWhileCreatingInShardCount.fetch_add(
         msg->NodeAlreadyExists,
         std::memory_order_relaxed);
-    Metrics.CreateNodeInShardRetryCount.fetch_add(
+    Metrics->CreateNodeInShardRetryCount.fetch_add(
         msg->CreateNodeRetryCount,
         std::memory_order_relaxed);
 
@@ -1003,7 +1003,7 @@ void TIndexTabletActor::HandleNodeCreatedInShard(
                 ctx);
 
             auto& requestMetrics = msg->ProfileLogRequest.GetBehaveAsShard()
-                ? Metrics.CreateNodeInShard : Metrics.CreateNode;
+                ? Metrics->CreateNodeInShard : Metrics->CreateNode;
             requestMetrics.Update(
                 1,
                 0,
@@ -1034,7 +1034,7 @@ void TIndexTabletActor::HandleNodeCreatedInShard(
                 ctx);
 
             auto& requestMetrics = msg->ProfileLogRequest.GetBehaveAsShard()
-                ? Metrics.CreateHandleInShard : Metrics.CreateHandle;
+                ? Metrics->CreateHandleInShard : Metrics->CreateHandle;
             requestMetrics.Update(
                 1,
                 0,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -161,7 +161,7 @@ void TIndexTabletActor::CompleteDestroyHandle(
     RemoveInFlightRequest(*args.RequestInfo);
 
     if (!HasError(args.Error)) {
-        Metrics.DestroyHandle.Update(
+        Metrics->DestroyHandle.Update(
             1,
             0,
             ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -402,7 +402,7 @@ void TIndexTabletActor::HandleFlushCompleted(
     EnqueueFlushIfNeeded(ctx);
     EnqueueBlobIndexOpIfNeeded(ctx);
 
-    Metrics.Flush.Update(msg->Count, msg->Size, msg->Time);
+    Metrics->Flush.Update(msg->Count, msg->Size, msg->Time);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -941,7 +941,7 @@ void TIndexTabletActor::HandleFlushBytesCompleted(
         LogTag.c_str(),
         FormatError(msg->GetError()).c_str());
 
-    Metrics.FlushBytes.Update(1, msg->Size, msg->Time);
+    Metrics->FlushBytes.Update(1, msg->Size, msg->Time);
 
     auto requestInfo = CreateRequestInfo(
         ev->Sender,
@@ -1007,7 +1007,7 @@ void TIndexTabletActor::CompleteTx_TrimBytes(
         args.RequestInfo->CallContext,
         "TrimBytes");
 
-    Metrics.TrimBytes.Update(
+    Metrics->TrimBytes.Update(
         1,
         args.TrimmedBytes,
         ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
@@ -79,7 +79,7 @@ void TIndexTabletActor::HandleGetNodeAttr(
     requestInfo->StartedTs = ctx.Now();
 
     auto& requestMetrics = behaveAsShard
-        ? Metrics.GetNodeAttrInShard : Metrics.GetNodeAttr;
+        ? Metrics->GetNodeAttrInShard : Metrics->GetNodeAttr;
 
     AddInFlightRequest<TMethod>(*requestInfo);
 
@@ -383,11 +383,11 @@ void TIndexTabletActor::CompleteTx_GetNodeAttrBatch(
     if (!HasError(args.Error)) {
         response->Record = std::move(args.Response);
 
-        Metrics.GetNodeAttrInShard.Update(
+        Metrics->GetNodeAttrInShard.Update(
             args.Request.NamesSize(),
             0,
             ctx.Now() - args.RequestInfo->StartedTs);
-        Metrics.GetNodeAttrBatch.Update(
+        Metrics->GetNodeAttrBatch.Update(
             1,
             0,
             ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodexattr.cpp
@@ -129,7 +129,7 @@ void TIndexTabletActor::CompleteTx_GetNodeXAttr(
         response->Record,
         args.RequestInfo->CallContext,
         ctx);
-    Metrics.GetNodeXAttr.Update(1, 0, ctx.Now() - args.RequestInfo->StartedTs);
+    Metrics->GetNodeXAttr.Update(1, 0, ctx.Now() - args.RequestInfo->StartedTs);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -286,17 +286,17 @@ void TIndexTabletActor::ReplyListNodes(
             record.SetCookie(args.Next);
         }
 
-        Metrics.ListNodes.Update(
+        Metrics->ListNodes.Update(
             1,
             requestBytes,
             ctx.Now() - args.RequestInfo->StartedTs);
-        Metrics.ListNodesExtra.RequestedBytesPrecharge.fetch_add(
+        Metrics->ListNodesExtra.RequestedBytesPrecharge.fetch_add(
             args.BytesToPrecharge,
             std::memory_order_relaxed);
-        Metrics.ListNodesExtra.PrepareAttempts.fetch_add(
+        Metrics->ListNodesExtra.PrepareAttempts.fetch_add(
             args.PrepareAttempts,
             std::memory_order_relaxed);
-        Metrics.ListNodesExtra.ResponseNodeRefs.fetch_add(
+        Metrics->ListNodesExtra.ResponseNodeRefs.fetch_add(
             args.ChildRefs.size(),
             std::memory_order_relaxed);
     }
@@ -392,17 +392,17 @@ void TIndexTabletActor::ReplyListNodesInternal(
             record.SetCookie(args.Next);
         }
 
-        Metrics.ListNodes.Update(
+        Metrics->ListNodes.Update(
             1,
             nameBufferSize,
             ctx.Now() - args.RequestInfo->StartedTs);
-        Metrics.ListNodesExtra.RequestedBytesPrecharge.fetch_add(
+        Metrics->ListNodesExtra.RequestedBytesPrecharge.fetch_add(
             args.BytesToPrecharge,
             std::memory_order_relaxed);
-        Metrics.ListNodesExtra.PrepareAttempts.fetch_add(
+        Metrics->ListNodesExtra.PrepareAttempts.fetch_add(
             args.PrepareAttempts,
             std::memory_order_relaxed);
-        Metrics.ListNodesExtra.ResponseNodeRefs.fetch_add(
+        Metrics->ListNodesExtra.ResponseNodeRefs.fetch_add(
             args.ChildRefs.size(),
             std::memory_order_relaxed);
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -289,8 +289,8 @@ void TIndexTabletActor::CompleteAdapterLoadState(
             fastShardConfig.GetMemConfig());
     }
 
-    NMetrics::Store(Metrics.OpLogEntryCount, GetOpLogEntryCount());
-    NMetrics::Store(Metrics.ResponseLogEntryCount, GetResponseLogEntryCount());
+    NMetrics::Store(Metrics->OpLogEntryCount, GetOpLogEntryCount());
+    NMetrics::Store(Metrics->ResponseLogEntryCount, GetResponseLogEntryCount());
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Loading tablet sessions");
@@ -413,8 +413,8 @@ void TIndexTabletActor::CompleteTx_LoadState(
         config);
     UpdateLogTag();
 
-    NMetrics::Store(Metrics.OpLogEntryCount, GetOpLogEntryCount());
-    NMetrics::Store(Metrics.ResponseLogEntryCount, GetResponseLogEntryCount());
+    NMetrics::Store(Metrics->OpLogEntryCount, GetOpLogEntryCount());
+    NMetrics::Store(Metrics->ResponseLogEntryCount, GetResponseLogEntryCount());
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Loading tablet sessions");

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -46,7 +46,7 @@ void TIndexTabletActor::ReplayOpLog(
                                      << request.ShortUtf8DebugString().Quote());
             }
 
-            Metrics.ReplayedCreateNodeInShardRequestsCount.fetch_add(
+            Metrics->ReplayedCreateNodeInShardRequestsCount.fetch_add(
                 1,
                 std::memory_order_relaxed);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readblob.cpp
@@ -466,7 +466,7 @@ void TIndexTabletActor::HandleReadBlobCompleted(
 
     WorkerActors.erase(ev->Sender);
 
-    Metrics.ReadBlob.Update(msg->Count, msg->Size, msg->Time);
+    Metrics->ReadBlob.Update(msg->Count, msg->Size, msg->Time);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -705,9 +705,9 @@ void TIndexTabletActor::HandleReadDataCompleted(
     TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
     WorkerActors.erase(ev->Sender);
 
-    Metrics.ReadData.Update(msg->Count, msg->Size, msg->Time);
+    Metrics->ReadData.Update(msg->Count, msg->Size, msg->Time);
     if (msg->IsOverloaded) {
-        Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+        Metrics->OverloadedCount.fetch_add(1, std::memory_order_relaxed);
     }
 }
 
@@ -801,8 +801,8 @@ void TIndexTabletActor::HandleDescribeData(
 
         NCloud::Reply(ctx, *requestInfo, std::move(response));
 
-        Metrics.ReadAheadCacheHitCount.fetch_add(1, std::memory_order_relaxed);
-        Metrics.DescribeData.Update(
+        Metrics->ReadAheadCacheHitCount.fetch_add(1, std::memory_order_relaxed);
+        Metrics->DescribeData.Update(
             1,
             byteRange.Length,
             ctx.Now() - requestInfo->StartedTs);
@@ -1055,7 +1055,7 @@ void TIndexTabletActor::CompleteTx_ReadData(
 
         NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 
-        Metrics.DescribeData.Update(
+        Metrics->DescribeData.Update(
             1,
             args.OriginByteRange.Length,
             ctx.Now() - args.RequestInfo->StartedTs);
@@ -1154,7 +1154,7 @@ void TIndexTabletActor::CompleteTx_ReadData(
         *Config,
         *SystemCounters,
         GetFileSystemId(),
-        Metrics.CPUUsageRate,
+        Metrics->CPUUsageRate,
         &backendInfo);
 
     auto actor = std::make_unique<TReadDataActor>(
@@ -1262,7 +1262,7 @@ void TIndexTabletActor::HandleFakeDescribeData(
 
     NCloud::Reply(ctx, *requestInfo, std::move(response));
 
-    Metrics.DescribeData.Update(
+    Metrics->DescribeData.Update(
         1,
         byteRange.Length,
         ctx.Now() - requestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -807,7 +807,7 @@ void TIndexTabletActor::CompleteTx_RenameNode(
 
     RemoveInFlightRequest(*args.RequestInfo);
 
-    Metrics.RenameNode.Update(
+    Metrics->RenameNode.Update(
         1,
         0,
         ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -558,7 +558,7 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
         }
 
         if (!args.NewChildRef->IsExternal()) {
-            Metrics.RenameNotSupportedErrorCount.fetch_add(
+            Metrics->RenameNotSupportedErrorCount.fetch_add(
                 1,
                 std::memory_order_relaxed);
 
@@ -840,7 +840,7 @@ void TIndexTabletActor::CompleteTx_RenameNodeInDestination(
 
     RemoveInFlightRequest(*args.RequestInfo);
 
-    Metrics.RenameNodeInDestination.Update(
+    Metrics->RenameNodeInDestination.Update(
         1,
         0,
         ctx.Now() - args.RequestInfo->StartedTs);
@@ -916,7 +916,7 @@ void TIndexTabletActor::HandleUnlinkDirectoryNodeAbortedInShard(
             renameNodeRequest.GetNodeId(),
             renameNodeRequest.GetName()});
 
-        Metrics.RenameNode.Update(
+        Metrics->RenameNode.Update(
             1,
             0,
             ctx.Now() - msg->RequestInfo->StartedTs);
@@ -929,7 +929,7 @@ void TIndexTabletActor::HandleUnlinkDirectoryNodeAbortedInShard(
             ctx);
         NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
     } else {
-        Metrics.RenameNodeInDestination.Update(
+        Metrics->RenameNodeInDestination.Update(
             1,
             0,
             ctx.Now() - msg->RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -460,7 +460,7 @@ bool TIndexTabletActor::PrepareTx_PrepareRenameNodeInSource(
     }
 
     if (!args.ChildRef->IsExternal()) {
-        Metrics.RenameNotSupportedErrorCount.fetch_add(
+        Metrics->RenameNotSupportedErrorCount.fetch_add(
             1,
             std::memory_order_relaxed);
 
@@ -594,7 +594,7 @@ void TIndexTabletActor::CompleteTx_PrepareRenameNodeInSource(
 
     UnlockNodeRef({args.ParentNodeId, args.Name});
 
-    Metrics.RenameNode.Update(
+    Metrics->RenameNode.Update(
         1,
         0,
         ctx.Now() - args.RequestInfo->StartedTs);
@@ -827,7 +827,7 @@ void TIndexTabletActor::CompleteTx_CommitRenameNodeInSource(
         return;
     }
 
-    Metrics.RenameNode.Update(
+    Metrics->RenameNode.Update(
         1,
         0,
         ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -63,7 +63,7 @@ bool TIndexTabletActor::AcceptRequestNoSession(
             msg->CallContext->LWOrbit);
     }
 
-    Metrics.BusyIdleCalc.OnRequestStarted();
+    Metrics->BusyIdleCalc.OnRequestStarted();
 
     FILESTORE_TRACK(
         RequestReceived_Tablet,
@@ -93,7 +93,12 @@ bool TIndexTabletActor::AcceptRequestNoSession(
 }
 
 template <typename TMethod>
-void TIndexTabletActor::CompleteResponse(
+void CompleteResponse(
+    const TStorageConfig& config,
+    const ITraceSerializerPtr& traceSerializer,
+    TSystemCounters& systemCounters,
+    const TString& fileSystemId,
+    TTabletMetrics& metrics,
     typename TMethod::TResponse::ProtoRecordType& response,
     const TCallContextPtr& callContext,
     bool* builtTraceInfo)
@@ -110,24 +115,41 @@ void TIndexTabletActor::CompleteResponse(
         TMethod::Name);
 
     *builtTraceInfo = BuildTraceInfo(
-        TraceSerializer,
+        traceSerializer,
         callContext,
         response);
     BuildThrottlerInfo(*callContext, response);
     BuildBackendInfo(
-        *Config,
-        *SystemCounters,
-        GetFileSystemId(),
-        Metrics.CPUUsageRate,
+        config,
+        systemCounters,
+        fileSystemId,
+        metrics.CPUUsageRate,
         response);
     if constexpr (HasResponseHeaders<decltype(response)>()) {
         const auto& responseHeaders = response.GetHeaders();
         if (responseHeaders.GetBackendInfo().GetIsOverloaded()) {
-            Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+            metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
         }
     }
 
-    Metrics.BusyIdleCalc.OnRequestCompleted();
+    metrics.BusyIdleCalc.OnRequestCompleted();
+}
+
+template <typename TMethod>
+void TIndexTabletActor::CompleteResponse(
+    typename TMethod::TResponse::ProtoRecordType& response,
+    const TCallContextPtr& callContext,
+    bool* builtTraceInfo)
+{
+    NStorage::CompleteResponse<TMethod>(
+        *Config,
+        TraceSerializer,
+        *SystemCounters,
+        GetFileSystemId(),
+        *Metrics,
+        response,
+        callContext,
+        builtTraceInfo);
 }
 
 template <typename TMethod>

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
@@ -86,8 +86,8 @@ void TIndexTabletActor::HandleUpdateLeakyBucketCounters(
     const ui64 currentRate = std::ceil(
         GetThrottlingPolicy().CalculateCurrentSpentBudgetShare(ctx.Now()) * 100);
 
-    Metrics.MaxUsedQuota.Record(currentRate);
-    NMetrics::Add(Metrics.UsedQuota, currentRate);
+    Metrics->MaxUsedQuota.Record(currentRate);
+    NMetrics::Add(Metrics->UsedQuota, currentRate);
 
     UpdateLeakyBucketCountersScheduled = false;
     ScheduleUpdateCounters(ctx);
@@ -99,11 +99,11 @@ void TIndexTabletActor::UpdateDelayCounter(
 {
     switch (opType) {
         case TThrottlingPolicy::EOpType::Read: {
-            Metrics.ReadDataPostponed.Record(time.MicroSeconds());
+            Metrics->ReadDataPostponed.Record(time.MicroSeconds());
             return;
         }
         case TThrottlingPolicy::EOpType::Write: {
-            Metrics.WriteDataPostponed.Record(time.MicroSeconds());
+            Metrics->WriteDataPostponed.Record(time.MicroSeconds());
             return;
         }
         default:
@@ -140,14 +140,14 @@ NProto::TError TIndexTabletActor::Throttle(
 
     switch (status) {
         case ETabletThrottlerStatus::POSTPONED: {
-            NMetrics::Inc(Metrics.PostponedRequests);
+            NMetrics::Inc(Metrics->PostponedRequests);
             break;
         }
         case ETabletThrottlerStatus::ADVANCED: {
             break;
         }
         case ETabletThrottlerStatus::REJECTED: {
-            NMetrics::Inc(Metrics.RejectedRequests);
+            NMetrics::Inc(Metrics->RejectedRequests);
             return err;
         }
         default:

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -637,7 +637,7 @@ void TIndexTabletActor::CompleteTx_UnlinkNode(
     EnqueueBlobIndexOpIfNeeded(ctx);
 
     auto& requestMetrics = args.ProfileLogRequest.GetBehaveAsShard()
-        ? Metrics.UnlinkNodeInShard : Metrics.UnlinkNode;
+        ? Metrics->UnlinkNodeInShard : Metrics->UnlinkNode;
     requestMetrics.Update(
         1,
         0,
@@ -820,7 +820,7 @@ void TIndexTabletActor::CompleteTx_CompleteUnlinkNode(
     }
 
     auto& requestMetrics = args.ProfileLogRequest.GetBehaveAsShard()
-        ? Metrics.UnlinkNodeInShard : Metrics.UnlinkNode;
+        ? Metrics->UnlinkNodeInShard : Metrics->UnlinkNode;
     requestMetrics.Update(1, 0, ctx.Now() - args.RequestInfo->StartedTs);
 
     auto response = std::make_unique<TEvService::TEvUnlinkNodeResponse>(
@@ -867,7 +867,7 @@ void TIndexTabletActor::HandleNodeUnlinkedInShard(
                 msg->RequestInfo->CallContext,
                 ctx);
 
-            Metrics.RenameNode.Update(
+            Metrics->RenameNode.Update(
                 1,
                 0,
                 ctx.Now() - msg->RequestInfo->StartedTs);
@@ -885,7 +885,7 @@ void TIndexTabletActor::HandleNodeUnlinkedInShard(
                 msg->RequestInfo->CallContext,
                 ctx);
 
-            Metrics.RenameNode.Update(
+            Metrics->RenameNode.Update(
                 1,
                 0,
                 ctx.Now() - msg->RequestInfo->StartedTs);
@@ -906,7 +906,7 @@ void TIndexTabletActor::HandleNodeUnlinkedInShard(
                     ctx);
 
                 auto& requestMetrics = msg->ProfileLogRequest.GetBehaveAsShard()
-                    ? Metrics.UnlinkNodeInShard : Metrics.UnlinkNode;
+                    ? Metrics->UnlinkNodeInShard : Metrics->UnlinkNode;
                 requestMetrics.Update(
                     1,
                     0,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_abort.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_abort.cpp
@@ -316,7 +316,7 @@ void TIndexTabletActor::CompleteTx_AbortUnlinkDirectoryNode(
     EnqueueBlobIndexOpIfNeeded(ctx);
 
     if (!HasError(args.Error)) {
-        Metrics.AbortUnlinkDirectoryNodeInShard.Update(
+        Metrics->AbortUnlinkDirectoryNodeInShard.Update(
             1,
             0,
             ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
@@ -144,7 +144,7 @@ void TIndexTabletActor::CompleteTx_PrepareUnlinkDirectoryNode(
     EnqueueBlobIndexOpIfNeeded(ctx);
 
     if (!HasError(args.Error)) {
-        Metrics.PrepareUnlinkDirectoryNodeInShard.Update(
+        Metrics->PrepareUnlinkDirectoryNodeInShard.Update(
             1,
             0,
             ctx.Now() - args.RequestInfo->StartedTs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
@@ -326,10 +326,10 @@ void TIndexTabletActor::HandleWriteBlob(
                     chunk.begin());
             }
 
-            Metrics.UncompressedBytesWritten.fetch_add(
+            Metrics->UncompressedBytesWritten.fetch_add(
                 data.size(),
                 std::memory_order_relaxed);
-            Metrics.CompressedBytesWritten.fetch_add(
+            Metrics->CompressedBytesWritten.fetch_add(
                 compressedSize,
                 std::memory_order_relaxed);
         }
@@ -435,7 +435,7 @@ void TIndexTabletActor::HandleWriteBlobCompleted(
 
     WorkerActors.erase(ev->Sender);
 
-    Metrics.WriteBlob.Update(msg->Count, msg->Size, msg->Time);
+    Metrics->WriteBlob.Update(msg->Count, msg->Size, msg->Time);
 
     for (const auto& result: msg->Results) {
         RegisterEvPutResult(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -214,9 +214,9 @@ void TIndexTabletActor::HandleWriteDataCompleted(
     WorkerActors.erase(ev->Sender);
     EnqueueBlobIndexOpIfNeeded(ctx);
 
-    Metrics.WriteData.Update(msg->Count, msg->Size, msg->Time);
+    Metrics->WriteData.Update(msg->Count, msg->Size, msg->Time);
     if (msg->IsOverloaded) {
-        Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+        Metrics->OverloadedCount.fetch_add(1, std::memory_order_relaxed);
     }
 }
 
@@ -447,7 +447,7 @@ void TIndexTabletActor::CompleteTx_WriteData(
         EnqueueFlushIfNeeded(ctx);
         EnqueueBlobIndexOpIfNeeded(ctx);
 
-        Metrics.WriteData.Update(
+        Metrics->WriteData.Update(
             1,
             args.ByteRange.Length,
             ctx.Now() - args.RequestInfo->StartedTs);
@@ -510,7 +510,7 @@ void TIndexTabletActor::CompleteTx_WriteData(
         *Config,
         *SystemCounters,
         GetFileSystemId(),
-        Metrics.CPUUsageRate,
+        Metrics->CPUUsageRate,
         &backendInfo);
 
     auto actor = std::make_unique<TWriteDataActor>(

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -122,7 +122,14 @@ TTabletCountersPtr CreateIndexTabletCounters();
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TTabletMetrics
+/**
+ * This data structure holds index tablet actor-level metrics. Tracking new
+ * requests is thread-safe. Initialization/registration and complex functions
+ * that iterate various metrics are supposed to be called only by the tablet
+ * actor and are not thread-safe. So it's ok to pass a smart pointer to this
+ * structure to some other thread/actor for request completion tracking.
+ */
+struct TTabletMetrics: TAtomicRefCount<TTabletMetrics>
 {
     bool Initialized{false};
 
@@ -339,5 +346,7 @@ struct TTabletMetrics
 
     i64 CalculateNetworkRequestBytes(ui32 nonNetworkMetricsBalancingFactor);
 };
+
+using TTabletMetricsPtr = TIntrusivePtr<TTabletMetrics>;
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
### Notes
When `IFileSystemShard` responds in tablet Adapter mode we need to:
* fill backend info, trace and other similar response fields
* generate an actor-system event with the response
* register request metrics

These things are done in a `TFuture` subscriber which is usually launched from one of the threads used by `IFileSystemShard` implementation but it touches `TIndexTabletActor` fields which leads to a race condition.

This PR moves this code into a standalone function which requires making some other changes like:
* capturing the relevant `TIndexTabletActor` parts explicitly by-value in the callback capture list
* changing `TTabletMetrics Metrics` field to `TTabletMetricsPtr Metrics` (intrusive ptr) to be able to share it without the risk of it getting destroyed while the request is in progress
* extracting some other code like `TIndexTabletActor::CompleteResponse()` into standalone functions

Most of this PR is just boilerplate - changing `Metrics.` to `Metrics->` in many places

**PS** There's still one issue remaining (not introduced by this PR - we've had this bug for years already): `TBusyIdleTimeCalculator` pretends to be thread-safe but actually it's not thread-safe - I will fix it in a separate PR to make reviewing easier. Example race:
1. T1 - `OnRequestStarted()`
2. T1 - starts `OnRequestCompleted()`, decrements `InflightCount`, sees a zero value, moves on to `FinishState()`, calls `MicroSeconds()`, gets preempted
3. T2 - `OnRequestStarted()` - sees a value of one, updates `State[state]` with a later value of `MicroSeconds()`
4. T1 - continues, swaps-out the new value and subtracts it from its (stale) `MicroSeconds()` result obtained at step 2 - gets a huge value because of unsigned integer overflow

We have seen this multiple times in our blockstore metrics but IIRC we have never found the bug. This seems to be the bug.

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895