### PR TITLE
making TBusyIdleTimeCalculator actually thread-safe

### DIFF
--- a/cloud/storage/core/libs/diagnostics/busy_idle_calculator.h
+++ b/cloud/storage/core/libs/diagnostics/busy_idle_calculator.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <cloud/storage/core/libs/common/timer.h>
+
 #include <library/cpp/deprecated/atomic/atomic.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
@@ -102,17 +104,29 @@ public:
 template <TBusyIdleTimeStorage T>
 class TBusyIdleTimeCalculator
 {
-    std::array<TAtomic, EState::MAX> State;
-    TAtomic InflightCount = 0;
+    struct TFields
+    {
+        ui32 Gen = 0;
+        ui32 Inflight = 0;
+        ui64 Started = 0;
+    };
+
+    static_assert(sizeof(TFields) == 16);
+    static_assert(std::is_trivially_copyable_v<TFields>);
+    static_assert(std::atomic<TFields>::is_always_lock_free);
+
+    std::atomic<TFields> Fields;
+
     T Storage;
+    ITimerPtr Timer;
 
 public:
-    TBusyIdleTimeCalculator()
+    explicit TBusyIdleTimeCalculator(ITimerPtr timer = CreateWallClockTimer())
+        : Timer(std::move(timer))
     {
-        for (auto& e : State) {
-            AtomicSet(e, 0);
-        }
-        StartState(IDLE);
+        auto fields = Fields.load();
+        fields.Started = Timer->Now().MicroSeconds();
+        Fields.store(fields);
     }
 
     template <typename... Args>
@@ -123,17 +137,61 @@ public:
 
     void OnRequestStarted()
     {
-        if (AtomicIncrement(InflightCount) == 1) {
-            FinishState(IDLE);
-            StartState(BUSY);
+        auto fields = Fields.load(std::memory_order_acquire);
+
+        for (;;) {
+            auto newFields = fields;
+            ++newFields.Inflight;
+            ++newFields.Gen;
+            ui64 val = 0;
+            if (fields.Inflight == 0) {
+                ui64 now = Timer->Now().MicroSeconds();
+                val = now - fields.Started;
+                newFields.Started = now;
+            }
+
+            const bool success = Fields.compare_exchange_weak(
+                fields,
+                newFields,
+                std::memory_order_release,
+                std::memory_order_acquire);
+            if (success) {
+                if (val) {
+                    Storage.IncrementState(val, EState::IDLE);
+                }
+
+                break;
+            }
         }
     }
 
     void OnRequestCompleted()
     {
-        if (AtomicDecrement(InflightCount) == 0) {
-            FinishState(BUSY);
-            StartState(IDLE);
+        auto fields = Fields.load(std::memory_order_acquire);
+
+        for (;;) {
+            auto newFields = fields;
+            --newFields.Inflight;
+            ++newFields.Gen;
+            ui64 val = 0;
+            if (newFields.Inflight == 0) {
+                ui64 now = Timer->Now().MicroSeconds();
+                val = now - fields.Started;
+                newFields.Started = now;
+            }
+
+            const bool success = Fields.compare_exchange_weak(
+                fields,
+                newFields,
+                std::memory_order_release,
+                std::memory_order_acquire);
+            if (success) {
+                if (val) {
+                    Storage.IncrementState(val, EState::BUSY);
+                }
+
+                break;
+            }
         }
     }
 
@@ -144,28 +202,44 @@ public:
     }
 
 private:
-    void FinishState(EState state)
-    {
-        ui64 val = MicroSeconds() - AtomicSwap(&State[state], 0);
-        Storage.IncrementState(val, state);
-    }
-
-    void StartState(EState state)
-    {
-        AtomicSet(State[state], MicroSeconds());
-    }
-
     void UpdateProgress(EState state)
     {
         for (;;) {
-            ui64 started = AtomicGet(State[state]);
-            if (!started) {
-                return;
+            auto fields = Fields.load(std::memory_order_acquire);
+            auto newFields = fields;
+            ui64 value = 0;
+            switch (state) {
+                case EState::BUSY: {
+                    if (fields.Inflight == 0) {
+                        return;
+                    }
+
+                    break;
+                }
+
+                case EState::IDLE: {
+                    if (fields.Inflight != 0) {
+                        return;
+                    }
+
+                    break;
+                }
+
+                case EState::MAX: {
+                    Y_DEBUG_ABORT_UNLESS(false);
+                    return;
+                }
             }
 
-            auto now = MicroSeconds();
-            if (AtomicCas(&State[state], now, started)) {
-                ui64 value = now - started;
+            newFields.Started = Timer->Now().MicroSeconds();
+            value = newFields.Started - fields.Started;
+
+            const bool success = Fields.compare_exchange_weak(
+                fields,
+                newFields,
+                std::memory_order_release,
+                std::memory_order_acquire);
+            if (success) {
                 Storage.IncrementState(value, state);
                 return;
             }

--- a/cloud/storage/core/libs/diagnostics/busy_idle_calculator.h
+++ b/cloud/storage/core/libs/diagnostics/busy_idle_calculator.h
@@ -204,8 +204,9 @@ public:
 private:
     void UpdateProgress(EState state)
     {
+        auto fields = Fields.load(std::memory_order_acquire);
+
         for (;;) {
-            auto fields = Fields.load(std::memory_order_acquire);
             auto newFields = fields;
             ui64 value = 0;
             switch (state) {

--- a/cloud/storage/core/libs/diagnostics/busy_idle_calculator_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/busy_idle_calculator_ut.cpp
@@ -1,0 +1,135 @@
+#include "busy_idle_calculator.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/system/event.h>
+#include <util/thread/factory.h>
+
+namespace NCloud {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestTimer: ITimer
+{
+    std::atomic<ui64> T;
+
+    TInstant Now() override
+    {
+        Cdbg << "T=" << T.load() << Endl;
+        return TInstant::MicroSeconds(1 + T.fetch_add(1));
+    }
+
+    void Sleep(TDuration duration) override
+    {
+        Y_UNUSED(duration);
+
+        UNIT_ASSERT(false);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture
+{
+    std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
+    TBusyIdleTimeCalculatorAtomics Calc{Timer};
+
+    std::atomic<i64> Busy;
+    std::atomic<i64> Idle;
+
+    TFixture()
+    {
+        Calc.Register(&Busy, &Idle);
+    }
+
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TBusyIdleTimeCalculatorTest)
+{
+    Y_UNIT_TEST(BasicOps)
+    {
+        TFixture fx;
+        fx.Calc.OnRequestStarted();
+        fx.Calc.OnRequestCompleted();
+
+        UNIT_ASSERT_VALUES_EQUAL(1, fx.Busy.load());
+        UNIT_ASSERT_VALUES_EQUAL(1, fx.Idle.load());
+
+        fx.Calc.OnRequestStarted();
+
+        UNIT_ASSERT_VALUES_EQUAL(1, fx.Busy.load());
+        UNIT_ASSERT_VALUES_EQUAL(2, fx.Idle.load());
+
+        fx.Calc.OnRequestStarted();
+        fx.Calc.OnRequestCompleted();
+
+        UNIT_ASSERT_VALUES_EQUAL(1, fx.Busy.load());
+        UNIT_ASSERT_VALUES_EQUAL(2, fx.Idle.load());
+
+        fx.Calc.OnRequestCompleted();
+
+        UNIT_ASSERT_VALUES_EQUAL(2, fx.Busy.load());
+        UNIT_ASSERT_VALUES_EQUAL(2, fx.Idle.load());
+
+        fx.Calc.OnUpdateStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(2, fx.Busy.load());
+        UNIT_ASSERT_VALUES_EQUAL(3, fx.Idle.load());
+
+        fx.Calc.OnRequestStarted();
+
+        UNIT_ASSERT_VALUES_EQUAL(2, fx.Busy.load());
+        UNIT_ASSERT_VALUES_EQUAL(4, fx.Idle.load());
+
+        fx.Calc.OnUpdateStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(3, fx.Busy.load());
+        UNIT_ASSERT_VALUES_EQUAL(4, fx.Idle.load());
+    }
+
+    Y_UNIT_TEST(ThreadSafety)
+    {
+        TFixture fx;
+
+        const ui32 iters = 10'000;
+        TManualEvent e1;
+        TManualEvent e2;
+
+        SystemThreadFactory()->Run([&] () {
+            for (ui32 i = 0; i < iters; ++i) {
+                fx.Calc.OnRequestStarted();
+                fx.Calc.OnRequestCompleted();
+            }
+
+            e1.Signal();
+        });
+
+        SystemThreadFactory()->Run([&] () {
+            for (ui32 i = 0; i < iters; ++i) {
+                fx.Calc.OnRequestStarted();
+                fx.Calc.OnRequestCompleted();
+            }
+
+            e2.Signal();
+        });
+
+        e1.WaitI();
+        e2.WaitI();
+
+        Cerr << "Busy=" << fx.Busy.load() << Endl;
+        Cerr << "Idle=" << fx.Idle.load() << Endl;
+        Cerr << "T=" << fx.Timer->T.load() << Endl;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            fx.Timer->T.load() - 1,
+            fx.Busy.load() + fx.Idle.load());
+    }
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/diagnostics/ut/ya.make
+++ b/cloud/storage/core/libs/diagnostics/ut/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
 )
 
 SRCS(
+    busy_idle_calculator_ut.cpp
     cgroup_stats_fetcher_ut.cpp
     histogram_types_ut.cpp
     logging_ut.cpp


### PR DESCRIPTION
### Notes
_It's a follow-up PR for https://github.com/ydb-platform/nbs/pull/6673_

`TBusyIdleTimeCalculator` pretends to be thread-safe but actually it's not thread-safe. Example race:
1. T1 - `OnRequestStarted()`
2. T1 - starts `OnRequestCompleted()`, decrements `InflightCount`, sees a zero value, moves on to `FinishState()`, calls `MicroSeconds()`, gets preempted
3. T2 - `OnRequestStarted()` - sees a value of one, updates `State[state]` with a later value of `MicroSeconds()`
4. T1 - continues, swaps-out the new value and subtracts it from its (stale) `MicroSeconds()` result obtained at step 2 - gets a huge value because of unsigned integer overflow

We have seen this multiple times in our blockstore metrics but IIRC we have never found the bug. This seems to be the bug.

Fixing it by reimplementing `TBusyIdleTimeCalculator` via double CAS. Also injected `ITimer` into it and used it to write unit tests (this component didn't have unit tests). 

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895