### PR TITLE
[NBS] Fix Describe Blocks for zero fresh blocks in channel

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
@@ -39,11 +39,11 @@ public:
 
     bool Visit(const TFreshBlock& block) override
     {
-        Args.MarkBlock(
+        Args.MarkWithFreshBlock(
             block.Meta.BlockIndex,
             block.Meta.CommitId,
-            block.Content,
-            block.BlobId);
+            block.BlobId,
+            block.Content);
         return true;
     }
 
@@ -53,7 +53,11 @@ public:
         const TPartialBlobId& blobId,
         ui16 blobOffset) override
     {
-        Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
+        Args.MarkWithBlob(
+            blockIndex,
+            commitId,
+            blobId,
+            blobOffset);
         return true;
     }
 
@@ -65,7 +69,11 @@ public:
         ui8 compactionRangeCount) override
     {
         Y_UNUSED(compactionRangeCount);
-        Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
+        Args.MarkWithBlob(
+            blockIndex,
+            commitId,
+            blobId,
+            blobOffset);
         return true;
     }
 };
@@ -325,33 +333,80 @@ void TPartitionActor::FillDescribeBlocksResponse(
     TTxPartition::TDescribeBlocks& args,
     TEvVolume::TEvDescribeBlocksResponse* response)
 {
+    using TBlockMark = TTxPartition::TDescribeBlocks::TBlockMark;
+    using TFreshMark = TTxPartition::TDescribeBlocks::TFreshMark;
+    using TBlobMark = TTxPartition::TDescribeBlocks::TBlobMark;
+    using TEmptyMark = TTxPartition::TDescribeBlocks::TEmptyMark;
+
     for (auto& mark: args.Marks) {
-        if (!mark.Content) {
+        if (!std::holds_alternative<TFreshMark>(
+                mark))
+        {
+            continue;
+        }
+        const auto& freshMark =
+            std::get<TFreshMark>(mark);
+
+        if (!freshMark.Content) {
             continue;
         }
 
         auto* range = response->Record.AddFreshBlockRanges();
-        range->SetStartIndex(mark.BlockIndex);
+        range->SetStartIndex(freshMark.BlockIndex);
         // TODO(svartmetal): should be optimized.
         range->SetBlocksCount(1);
         if (!args.IndexOnly) {
-            range->SetBlocksContent(std::move(mark.Content));
+            range->SetBlocksContent(std::move(freshMark.Content));
         }
-        if (mark.BlobId) {
+        if (freshMark.BlobId) {
             if (args.IndexOnly) {
                 LogoBlobIDFromLogoBlobID(
-                    MakeBlobId(TabletID(), mark.BlobId),
+                    MakeBlobId(TabletID(), freshMark.BlobId),
                     range->MutableBlobId());
             }
-            mark.BlobId = {};
         }
     }
 
-    EraseIf(args.Marks, [] (const auto& m) { return IsDeletionMarker(m.BlobId); });
-    Sort(args.Marks);
+    auto toDelete = [](const TBlockMark& mark)
+    {
+        if (std::holds_alternative<TFreshMark>(
+                mark) ||
+            std::holds_alternative<TEmptyMark>(
+                mark))
+        {
+            return true;
+        }
 
-    auto iter = args.Marks.begin();
-    while (iter != args.Marks.end()) {
+        const auto& blobMark =
+            std::get<TBlobMark>(mark);
+
+        return IsDeletionMarker(blobMark.BlobId);
+    };
+
+    EraseIf(args.Marks, toDelete);
+
+    auto cmp = [](const TBlockMark& a, const TBlockMark& b)
+    {
+        const auto& aBlobMark =
+            std::get<TBlobMark>(a);
+        const auto& bBlobMark =
+            std::get<TBlobMark>(b);
+        return aBlobMark.BlobId < bBlobMark.BlobId ||
+            (aBlobMark.BlobId == bBlobMark.BlobId &&
+                aBlobMark.BlobOffset < bBlobMark.BlobOffset);
+    };
+
+    Sort(args.Marks, cmp);
+
+    TVector<TBlobMark> blobMarks;
+    blobMarks.reserve(args.Marks.size());
+    for (const auto& mark: args.Marks) {
+        Y_ABORT_UNLESS(std::holds_alternative<TBlobMark>(mark));
+        blobMarks.push_back(std::get<TBlobMark>(mark));
+    }
+
+    auto iter = blobMarks.begin();
+    while (iter != blobMarks.end()) {
         const auto& blobId = iter->BlobId;
         auto* blobPiece = response->Record.AddBlobPieces();
 
@@ -373,7 +428,7 @@ void TPartitionActor::FillDescribeBlocksResponse(
 
             ++iter;
             while (
-                iter != args.Marks.end() &&
+                iter != blobMarks.end() &&
                 iter->BlobId == blobId &&
                 iter->BlobOffset == blobOffset + 1 &&
                 iter->BlockIndex == blockIndex + 1
@@ -384,7 +439,7 @@ void TPartitionActor::FillDescribeBlocksResponse(
                 ++iter;
             }
             range->SetBlocksCount(blocksCount);
-        } while (iter != args.Marks.end() && iter->BlobId == blobId);
+        } while (iter != blobMarks.end() && iter->BlobId == blobId);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
@@ -53,11 +53,7 @@ public:
         const TPartialBlobId& blobId,
         ui16 blobOffset) override
     {
-        Args.MarkWithBlob(
-            blockIndex,
-            commitId,
-            blobId,
-            blobOffset);
+        Args.MarkWithBlob(blockIndex, commitId, blobId, blobOffset);
         return true;
     }
 
@@ -69,11 +65,7 @@ public:
         ui8 compactionRangeCount) override
     {
         Y_UNUSED(compactionRangeCount);
-        Args.MarkWithBlob(
-            blockIndex,
-            commitId,
-            blobId,
-            blobOffset);
+        Args.MarkWithBlob(blockIndex, commitId, blobId, blobOffset);
         return true;
     }
 };
@@ -99,8 +91,8 @@ TMaybe<ui64> TPartitionActor::VerifyDescribeBlocksCheckpoint(
 
     ui32 flags = 0;
     SetProtoFlag(flags, NProto::EF_SILENT);
-    auto response = std::make_unique<TEvVolume::TEvDescribeBlocksResponse>(
-        MakeError(
+    auto response =
+        std::make_unique<TEvVolume::TEvDescribeBlocksResponse>(MakeError(
             E_NOT_FOUND,
             TStringBuilder()
                 << "checkpoint not found: " << checkpointId.Quote(),
@@ -137,7 +129,11 @@ void TPartitionActor::DescribeBlocks(
 
     ExecuteTx(
         ctx,
-        CreateTx<TDescribeBlocks>(requestInfo, commitId, describeRange, indexOnly));
+        CreateTx<TDescribeBlocks>(
+            requestInfo,
+            commitId,
+            describeRange,
+            indexOnly));
 }
 
 void TPartitionActor::HandleDescribeBlocks(
@@ -146,10 +142,8 @@ void TPartitionActor::HandleDescribeBlocks(
 {
     auto* msg = ev->Get();
 
-    auto requestInfo = CreateRequestInfo(
-        ev->Sender,
-        ev->Cookie,
-        msg->CallContext);
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
 
     TRequestScope timer(*requestInfo);
 
@@ -159,7 +153,8 @@ void TPartitionActor::HandleDescribeBlocks(
         "DescribeBlocks",
         requestInfo->CallContext->RequestId);
 
-    auto reply = [&](auto response) {
+    auto reply = [&](auto response)
+    {
         LWTRACK(
             ResponseSent_Partition,
             requestInfo->CallContext->LWOrbit,
@@ -170,32 +165,32 @@ void TPartitionActor::HandleDescribeBlocks(
     };
 
     if (State->GetBaseDiskId()) {
-        auto response = std::make_unique<TEvVolume::TEvDescribeBlocksResponse>(
-            MakeError(E_NOT_IMPLEMENTED, TStringBuilder()
-                << "DescribeBlocks is not implemented for overlay disks"));
+        auto response =
+            std::make_unique<TEvVolume::TEvDescribeBlocksResponse>(MakeError(
+                E_NOT_IMPLEMENTED,
+                TStringBuilder()
+                    << "DescribeBlocks is not implemented for overlay disks"));
         reply(std::move(response));
         return;
     }
 
     if (msg->Record.GetBlocksCount() == 0) {
-        auto response = std::make_unique<TEvVolume::TEvDescribeBlocksResponse>(
-            MakeError(E_ARGUMENT, TStringBuilder()
-                << "empty block range is forbidden for DescribeBlocks: ["
-                << "index: " << msg->Record.GetStartIndex()
-                << ", count: " << msg->Record.GetBlocksCount()
-                << "]"));
+        auto response =
+            std::make_unique<TEvVolume::TEvDescribeBlocksResponse>(MakeError(
+                E_ARGUMENT,
+                TStringBuilder()
+                    << "empty block range is forbidden for DescribeBlocks: ["
+                    << "index: " << msg->Record.GetStartIndex()
+                    << ", count: " << msg->Record.GetBlocksCount() << "]"));
         reply(std::move(response));
         return;
     }
 
     auto range = TBlockRange64::WithLength(
         msg->Record.GetStartIndex(),
-        msg->Record.GetBlocksCount()
-    );
-    auto bounds = TBlockRange64::WithLength(
-        0,
-        State->GetConfig().GetBlocksCount()
-    );
+        msg->Record.GetBlocksCount());
+    auto bounds =
+        TBlockRange64::WithLength(0, State->GetConfig().GetBlocksCount());
 
     if (!bounds.Overlaps(range)) {
         // describing out of bounds range should return empty response
@@ -206,14 +201,19 @@ void TPartitionActor::HandleDescribeBlocks(
     range = bounds.Intersect(range);
 
     const auto commitId = VerifyDescribeBlocksCheckpoint(
-        ctx, msg->Record.GetCheckpointId(), *requestInfo);
+        ctx,
+        msg->Record.GetCheckpointId(),
+        *requestInfo);
 
     if (!commitId.Defined()) {
         return;
     }
 
     DescribeBlocks(
-        ctx, requestInfo, *commitId, ConvertRangeSafe(range),
+        ctx,
+        requestInfo,
+        *commitId,
+        ConvertRangeSafe(range),
         msg->Record.GetIndexOnly());
 }
 
@@ -246,16 +246,14 @@ bool TPartitionActor::PrepareDescribeBlocks(
     auto ready = db.FindMixedBlocks(
         visitor,
         args.DescribeRange,
-        false,  // precharge
-        commitId
-    );
+        false,   // precharge
+        commitId);
     ready &= db.FindMergedBlocks(
         visitor,
         args.DescribeRange,
-        false,  // precharge
+        false,   // precharge
         State->GetMaxBlocksInBlob(),
-        commitId
-    );
+        commitId);
 
     return ready;
 }
@@ -295,9 +293,10 @@ void TPartitionActor::CompleteDescribeBlocks(
     State->GetCleanupQueue().ReleaseBarrier(commitId);
 
     if (args.Interrupted) {
-        auto response = std::make_unique<TEvVolume::TEvDescribeBlocksResponse>(
-            MakeError(E_REJECTED, "DescribeBlocks transaction was interrupted")
-        );
+        auto response =
+            std::make_unique<TEvVolume::TEvDescribeBlocksResponse>(MakeError(
+                E_REJECTED,
+                "DescribeBlocks transaction was interrupted"));
         NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
         return;
     }
@@ -312,9 +311,11 @@ void TPartitionActor::CompleteDescribeBlocks(
     UpdateNetworkStat(ctx.Now(), responseBytes);
     UpdateCPUUsageStat(ctx.Now(), args.RequestInfo->GetExecCycles());
 
-    const auto duration = CyclesToDurationSafe(args.RequestInfo->GetTotalCycles());
+    const auto duration =
+        CyclesToDurationSafe(args.RequestInfo->GetTotalCycles());
     const auto time = duration.MicroSeconds();
-    const ui64 requestBytes = static_cast<ui64>(State->GetBlockSize()) * args.DescribeRange.Size();
+    const ui64 requestBytes =
+        static_cast<ui64>(State->GetBlockSize()) * args.DescribeRange.Size();
 
     PartCounters->RequestCounters.DescribeBlocks.AddRequest(time, requestBytes);
 
@@ -339,13 +340,10 @@ void TPartitionActor::FillDescribeBlocksResponse(
     using TEmptyMark = TTxPartition::TDescribeBlocks::TEmptyMark;
 
     for (auto& mark: args.Marks) {
-        if (!std::holds_alternative<TFreshMark>(
-                mark))
-        {
+        if (!std::holds_alternative<TFreshMark>(mark)) {
             continue;
         }
-        const auto& freshMark =
-            std::get<TFreshMark>(mark);
+        const auto& freshMark = std::get<TFreshMark>(mark);
 
         if (!freshMark.Content) {
             continue;
@@ -369,16 +367,13 @@ void TPartitionActor::FillDescribeBlocksResponse(
 
     auto toDelete = [](const TBlockMark& mark)
     {
-        if (std::holds_alternative<TFreshMark>(
-                mark) ||
-            std::holds_alternative<TEmptyMark>(
-                mark))
+        if (std::holds_alternative<TFreshMark>(mark) ||
+            std::holds_alternative<TEmptyMark>(mark))
         {
             return true;
         }
 
-        const auto& blobMark =
-            std::get<TBlobMark>(mark);
+        const auto& blobMark = std::get<TBlobMark>(mark);
 
         return IsDeletionMarker(blobMark.BlobId);
     };
@@ -387,13 +382,11 @@ void TPartitionActor::FillDescribeBlocksResponse(
 
     auto cmp = [](const TBlockMark& a, const TBlockMark& b)
     {
-        const auto& aBlobMark =
-            std::get<TBlobMark>(a);
-        const auto& bBlobMark =
-            std::get<TBlobMark>(b);
-        return aBlobMark.BlobId < bBlobMark.BlobId ||
-            (aBlobMark.BlobId == bBlobMark.BlobId &&
-                aBlobMark.BlobOffset < bBlobMark.BlobOffset);
+        const auto& aBlobMark = std::get<TBlobMark>(a);
+        const auto& bBlobMark = std::get<TBlobMark>(b);
+
+        return std::tie(aBlobMark.BlobId, aBlobMark.BlobOffset) <
+               std::tie(bBlobMark.BlobId, bBlobMark.BlobOffset);
     };
 
     Sort(args.Marks, cmp);
@@ -427,12 +420,10 @@ void TPartitionActor::FillDescribeBlocksResponse(
             ui32 blocksCount = 1;
 
             ++iter;
-            while (
-                iter != blobMarks.end() &&
-                iter->BlobId == blobId &&
-                iter->BlobOffset == blobOffset + 1 &&
-                iter->BlockIndex == blockIndex + 1
-            ) {
+            while (iter != blobMarks.end() && iter->BlobId == blobId &&
+                   iter->BlobOffset == blobOffset + 1 &&
+                   iter->BlockIndex == blockIndex + 1)
+            {
                 ++blobOffset;
                 ++blockIndex;
                 ++blocksCount;

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -1053,63 +1053,47 @@ struct TTxPartition
         const TBlockRange32 DescribeRange;
         const bool IndexOnly;
 
-        struct TBlockMark
+        struct TEmptyMark
         {
-            TBlockMark() = default;
+            ui32 BlockIndex = 0;
+        };
 
-            TBlockMark(
-                    ui32 blockIndex,
-                    ui64 commitId,
-                    TString content,
-                    TPartialBlobId blobId)
-                : BlockIndex(blockIndex)
-                , CommitId(commitId)
-                , BlobId(blobId)
-                , Content(std::move(content))
-            {}
-
-            TBlockMark(
-                    ui32 blockIndex,
-                    ui64 commitId,
-                    const TPartialBlobId& blobId,
-                    ui16 blobOffset)
-                : BlockIndex(blockIndex)
-                , CommitId(commitId)
-                , BlobId(blobId)
-                , BlobOffset(blobOffset)
-            {}
-
-            bool operator <(const TBlockMark& other) const
-            {
-                return BlobId < other.BlobId ||
-                    (BlobId == other.BlobId && BlobOffset < other.BlobOffset);
-            }
-
+        struct TBlobMark
+        {
             ui32 BlockIndex = 0;
             ui64 CommitId = 0;
             TPartialBlobId BlobId;
             ui16 BlobOffset = 0;
+        };
+
+        struct TFreshMark
+        {
+            ui32 BlockIndex = 0;
+            ui64 CommitId = 0;
+            TPartialBlobId BlobId;
             TString Content;
         };
+
+        using TBlockMark = std::variant<TEmptyMark, TBlobMark, TFreshMark>;
 
         TVector<TBlockMark> Marks;
         bool Interrupted = false;
 
         TDescribeBlocks(
-                TRequestInfoPtr requestInfo,
-                ui64 commitId,
-                const TBlockRange32& describeRange,
-                bool indexOnly)
+            TRequestInfoPtr requestInfo,
+            ui64 commitId,
+            const TBlockRange32& describeRange,
+            bool indexOnly)
             : RequestInfo(std::move(requestInfo))
             , CommitId(commitId)
             , DescribeRange(describeRange)
             , IndexOnly(indexOnly)
-            , Marks(DescribeRange.Size())
+            , Marks(DescribeRange.Size(), TEmptyMark{})
         {}
 
         void Clear()
         {
-            std::fill(Marks.begin(), Marks.end(), TBlockMark());
+            std::fill(Marks.begin(), Marks.end(), TEmptyMark());
         }
 
         ui32 GetBlockMarkIndex(ui32 blockIndex)
@@ -1118,29 +1102,50 @@ struct TTxPartition
             return blockIndex - DescribeRange.Start;
         }
 
-        void MarkBlock(
+        static ui64 GetMarkCommitId(const TBlockMark& mark)
+        {
+            return std::visit(
+                [](const auto& m) -> ui64
+                {
+                    using T = std::decay_t<decltype(m)>;
+                    if constexpr (std::is_same_v<T, TEmptyMark>) {
+                        return 0;
+                    } else {
+                        return m.CommitId;
+                    }
+                },
+                mark);
+        }
+
+        void MarkWithFreshBlock(
             ui32 blockIndex,
             ui64 commitId,
-            TStringBuf content,
-            TPartialBlobId blobId)
+            TPartialBlobId blobId,
+            TStringBuf content)
         {
             auto& mark = Marks[GetBlockMarkIndex(blockIndex)];
-
-            if (mark.CommitId < commitId) {
-                mark = TBlockMark(blockIndex, commitId, TString{content}, blobId);
+            if (GetMarkCommitId(mark) < commitId) {
+                mark = TFreshMark{
+                    .BlockIndex = blockIndex,
+                    .CommitId = commitId,
+                    .BlobId = blobId,
+                    .Content = TString(content)};
             }
         }
 
-        void MarkBlock(
+        void MarkWithBlob(
             ui32 blockIndex,
             ui64 commitId,
-            const TPartialBlobId& blobId,
+            TPartialBlobId blobId,
             ui16 blobOffset)
         {
             auto& mark = Marks[GetBlockMarkIndex(blockIndex)];
-
-            if (mark.CommitId < commitId) {
-                mark = TBlockMark(blockIndex, commitId, blobId, blobOffset);
+            if (GetMarkCommitId(mark) < commitId) {
+                mark = TBlobMark{
+                    .BlockIndex = blockIndex,
+                    .CommitId = commitId,
+                    .BlobId = blobId,
+                    .BlobOffset = blobOffset};
             }
         }
     };

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -15380,6 +15380,15 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.WriteBlocks(writeRange, char(1));
         partition.ZeroBlocks(zeroRange);
 
+        runtime->SetEventFilter(
+            [](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                return event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvFlushRequest;
+            });
+        partition.RebootTablet();
+        partition.WaitReady();
+
         const auto response = partition.DescribeBlocks(writeRange);
         const auto& record = response->Record;
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -15365,6 +15365,42 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldNotDescribeZeroedBlocksFromFreshChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto writeRange = TBlockRange32::WithLength(1, 4);
+        const auto zeroRange = TBlockRange32::WithLength(2, 2);
+        partition.WriteBlocks(writeRange, char(1));
+        partition.ZeroBlocks(zeroRange);
+
+        const auto response = partition.DescribeBlocks(writeRange);
+        const auto& record = response->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(2, record.FreshBlockRangesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, record.BlobPiecesSize());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            writeRange.Start,
+            record.GetFreshBlockRanges(0).GetStartIndex());
+        UNIT_ASSERT_VALUES_EQUAL(
+            writeRange.End,
+            record.GetFreshBlockRanges(1).GetStartIndex());
+        for (const auto& range: record.GetFreshBlockRanges()) {
+            UNIT_ASSERT_VALUES_EQUAL(1, range.GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(char(1)),
+                range.GetBlocksContent());
+            UNIT_ASSERT(!zeroRange.Contains(range.GetStartIndex()));
+        }
+    }
+
     Y_UNIT_TEST(ShouldReturnBlobIdForFreshBlocksInDescribeWhenIndexOnlyIsTrue)
     {
         auto config = DefaultConfig();


### PR DESCRIPTION
### Notes
Before fix fresh zero blocks, blobs with blobId were treated like regular merged blobs. We attempted to read them from the blob storage, but this caused failed read blob requests and failed snapshot taking.
```
actor_read_blob.cpp:161: [72075186362975953] TEvBlobStorage::TEvGet failed: invalid response received TEvGetResult
```
### Issue
Put links to the related issues here
