### PR TITLE
availability_monitoring close fix

### DIFF
--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -251,6 +251,7 @@ func run(
 				availabilityMonitoringStorage,
 				availabilityMonitoringMetricsRegistry,
 			)
+			defer availabilityMonitoring.Close()
 
 			s3, err = persistence.NewS3ClientFromConfig(
 				s3Config,

--- a/cloud/tasks/persistence/availability_monitoring.go
+++ b/cloud/tasks/persistence/availability_monitoring.go
@@ -21,7 +21,17 @@ type AvailabilityMonitoring struct {
 	registry                     metrics.Registry
 	successRateReportingInterval time.Duration
 
-	mutex sync.Mutex
+	mutex     sync.Mutex
+	closeOnce sync.Once
+	cancel    context.CancelFunc
+	done      chan struct{}
+}
+
+func (m *AvailabilityMonitoring) Close() {
+	m.closeOnce.Do(func() {
+		m.cancel()
+		<-m.done
+	})
 }
 
 func (m *AvailabilityMonitoring) AccountQuery(err error) {
@@ -70,6 +80,8 @@ func NewAvailabilityMonitoring(
 	registry metrics.Registry,
 ) *AvailabilityMonitoring {
 
+	ctx, cancel := context.WithCancel(ctx)
+
 	subRegistry := registry.WithTags(map[string]string{
 		"component": component,
 		"host":      host,
@@ -82,9 +94,14 @@ func NewAvailabilityMonitoring(
 		storage:                      storage,
 		registry:                     subRegistry,
 		successRateReportingInterval: successRateReportingInterval,
+
+		cancel: cancel,
+		done:   make(chan struct{}),
 	}
 
 	go func() {
+		defer close(m.done)
+
 		ticker := time.NewTicker(m.successRateReportingInterval)
 		defer ticker.Stop()
 

--- a/cloud/tasks/persistence/availability_monitoring_storage.go
+++ b/cloud/tasks/persistence/availability_monitoring_storage.go
@@ -125,7 +125,6 @@ func (s *AvailabilityMonitoringStorageYDB) getAvailabilityMonitoringResultsTx(
 		pragma TablePathPrefix = "%v";
 		declare $component as Utf8;
 		declare $host as Utf8;
-		declare $created_at as Timestamp;
 
 		select *
 		from availability_monitoring
@@ -155,7 +154,6 @@ func (s *AvailabilityMonitoringStorageYDB) getAvailabilityMonitoringResults(
 		pragma TablePathPrefix = "%v";
 		declare $component as Utf8;
 		declare $host as Utf8;
-		declare $created_at as Timestamp;
 
 		select *
 		from availability_monitoring

--- a/cloud/tasks/persistence/availability_monitoring_storage.go
+++ b/cloud/tasks/persistence/availability_monitoring_storage.go
@@ -125,6 +125,7 @@ func (s *AvailabilityMonitoringStorageYDB) getAvailabilityMonitoringResultsTx(
 		pragma TablePathPrefix = "%v";
 		declare $component as Utf8;
 		declare $host as Utf8;
+		declare $created_at as Timestamp;
 
 		select *
 		from availability_monitoring
@@ -154,6 +155,7 @@ func (s *AvailabilityMonitoringStorageYDB) getAvailabilityMonitoringResults(
 		pragma TablePathPrefix = "%v";
 		declare $component as Utf8;
 		declare $host as Utf8;
+		declare $created_at as Timestamp;
 
 		select *
 		from availability_monitoring

--- a/cloud/tasks/persistence/availability_monitoring_test.go
+++ b/cloud/tasks/persistence/availability_monitoring_test.go
@@ -73,6 +73,7 @@ func TestAvailabilityMonitoringShouldSendMetric(t *testing.T) {
 		storage,
 		registry,
 	)
+	defer monitoring.Close()
 	gaugeSetWg.Wait()
 
 	monitoring.AccountQuery(nil)


### PR DESCRIPTION
The problem is a shutdown race in `TestAvailabilityMonitoringShouldSendMetric`.

Sequence:

1. [`reportSuccessRate()`](/home/proller/nbs/cloud/tasks/persistence/availability_monitoring.go:49) calls `Gauge.Set()`.
2. The mock callback releases `gaugeSetWg`.
3. The test returns after [`gaugeSetWg.Wait()`](/home/proller/nbs/cloud/tasks/persistence/availability_monitoring_test.go:95).
4. `db.Close()` runs.
5. Meanwhile, the monitoring goroutine continues into [`storage.UpdateSuccessRate()`](/home/proller/nbs/cloud/tasks/persistence/availability_monitoring.go:50), executing the shown query at [`availability_monitoring_storage.go:123`](/home/proller/nbs/cloud/tasks/persistence/availability_monitoring_storage.go:123).
6. The connection closes during that query, producing `Unavailable ... EOF`.

The remote run passed all 15 tests, but reproduced the race in its logs: mock expectations passed, the YDB driver closed, then the background availability update failed with a closed network connection.

Also, because of LIFO defer order, [`db.Close()`](/home/proller/nbs/cloud/tasks/persistence/availability_monitoring_test.go:48) runs before [`cancel()`](/home/proller/nbs/cloud/tasks/persistence/availability_monitoring_test.go:44).

The robust fix is to give `AvailabilityMonitoring` a stop-and-wait lifecycle and wait for its goroutine before closing YDB. Merely reversing the defers reduces the window but does not guarantee the active report has finished.

I recommend adding an explicit stop-and-join lifecycle. This fixes the test race and protects production shutdown without changing metric/write ordering.

Because these defers are registered after db.Close, Go executes availabilityMonitoring.Close() first. It stops future ticks and waits for an in-flight YDB update to finish before closing the database.
I would avoid merely moving Gauge.Set() after UpdateSuccessRate()—that hides the test race but leaves the goroutine lifecycle unsafe.