### PR TITLE
[Filestore] Treat memory sanitizer as slow in TIndexTabletTest_Data_Stress::ShouldTruncateAndAllocateFiles

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -364,7 +364,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
         const auto sanitizerType = GetEnv("SANITIZER_TYPE");
         // temporary logging
         Cerr << "sanitizer: " << sanitizerType << Endl;
-        const THashSet<TString> slowSanitizers({"thread", "undefined", "address"});
+        const THashSet<TString> slowSanitizers(
+            {"thread", "undefined", "address", "memory"});
         const ui32 d = slowSanitizers.contains(sanitizerType) ? 20 : 1;
 
         PERFORM_TEST(5'000 / d);


### PR DESCRIPTION
## Summary

Add `memory` to the slow sanitizer set in `TIndexTabletTest_Data_Stress::ShouldTruncateAndAllocateFiles`. MSan now runs the same reduced workload as ASan, TSan, and UBSan. Non-sanitized runs are unchanged.

## Issue

The test scales its randomized workload down by 20 for slow sanitizers, but MSan was missing from the set. As a result, MSan executed all 6,000 stress steps and could exceed the 600-second medium-test timeout.

```
Killed by timeout (600 s)
List of the tests involved in the launch:
TIndexTabletTest_Data_Stress::ShouldTruncateAndAllocateFiles (timeout) duration: 597.58s
TIndexTabletTest_Data_Stress::ShouldTruncateLargeFiles test was not launched inside chunk.
```
