### PR TITLE
issue-1541: fix scheduling of HandleOpsQueue processing after a vhost restart

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1238,6 +1238,7 @@ private:
                 SessionState,
                 this);
 
+            FileSystem->Init();
             FuseLoop->Start();
         } catch (const TServiceError& e) {
             error = MakeError(e.GetCode(), TString(e.GetMessage()));
@@ -1391,8 +1392,6 @@ private:
             conn->want |= FUSE_CAP_POSIX_ACL;
             conn->want |= FUSE_CAP_DONT_MASK;
         }
-
-        FileSystem->Init();
     }
 
     void StopAsyncOnCompletionQueueStopped(TPromise<void> stopCompleted)

--- a/cloud/filestore/tests/async_close_test/test.py
+++ b/cloud/filestore/tests/async_close_test/test.py
@@ -16,7 +16,7 @@ from cloud.storage.core.tools.testing.qemu.lib.common import (
 RETRY_COUNT = 3
 WAIT_TIMEOUT_MS = 1000  # 1sec
 OPEN_HANDLE_COUNT = 10000
-MAX_WAIT_SECONDS = 600
+MAX_WAIT_SECONDS = 900
 MAX_NO_PROGRESS_SECONDS = 30
 
 

--- a/cloud/filestore/tests/async_close_test/ya.make
+++ b/cloud/filestore/tests/async_close_test/ya.make
@@ -25,6 +25,7 @@ SET(QEMU_INSTANCE_COUNT 1)
 SET(FILESTORE_VHOST_ENDPOINT_COUNT 1)
 SET(VIRTIOFS_SERVER_COUNT 1)
 SET(QEMU_INVOKE_TEST NO)
+SET(VHOST_RESTART_INTERVAL 5)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)


### PR DESCRIPTION
### Notes

After a filestore-vhost restart, the restored session does not receive a new FUSE_INIT. The session is marked as initialized https://github.com/ydb-platform/nbs/blob/ea1a784f0aeef1b96981c7df14e86af2ed142b3d/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c#L376-L387

HandleOpsQueue processing was started only from the FUSE_INIT callback, so it stopped working after a restart. Start HandleOpsQueue processing when the filesystem loop starts instead.

MAX_WAIT_SECONDS was increased to 900 because frequent filestore-vhost restarts slow down queue processing.

### Issue
#1541 