### PR TITLE
issue-5894: 1. TCPSideChannel should reset endpoint host/port upon E_UNAVAILABLE 2. E_UNAVAILABLE should be retriable

### DIFF
--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -139,7 +139,8 @@ using TEndpointPoolPtr = TIntrusivePtr<TEndpointPool>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TFileSystemTCPSideChannel: public TThrRefBase
+class TFileSystemTCPSideChannel final
+    : public std::enable_shared_from_this<TFileSystemTCPSideChannel>
 {
 private:
     TAdaptiveLock Lock;
@@ -169,20 +170,8 @@ public:
         const ui32 port = backendInfo.GetFastShardPort();
         const TString& host = backendInfo.GetFastShardHost();
 
-        ui32 generation = 0;
-        with_lock (Lock) {
-            if (Host != host || Port != port) {
-                generation = EndpointPool->AddressChanged();
-                STORAGE_INFO("updated side channel connection params"
-                    << ": host=" << host
-                    << ", port=" << port
-                    << ", fileSystemId=" << backendInfo.GetActualFileSystemId()
-                    << ", generation=" << generation);
-            }
-
-            Host = host;
-            Port = port;
-        }
+        const ui32 generation =
+            DoUpdate(backendInfo.GetActualFileSystemId(), host, port);
 
         auto connection = TryConnect();
         if (!connection.Initialized()) {
@@ -279,11 +268,13 @@ public:
             return false;
         }
 
+        auto weakPtr = weak_from_this();
         connection.Subscribe([
             req = std::move(req),
             complete = std::move(complete),
             ep = EndpointPool,
-            generation
+            generation,
+            weakPtr
         ] (const TFuture<IAsyncEndpointPtr>& f) mutable {
             // Copy instead of UnsafeExtractValue: this is a secondary
             // subscriber (TryConnect attached a logging subscriber to the
@@ -293,6 +284,27 @@ public:
             IAsyncEndpointPtr e = f.GetValue();
 
             if (!e) {
+                if (auto self = weakPtr.lock()) {
+                    //
+                    // Failed connection attempt means that something might be
+                    // wrong with the address. Resetting the address here -
+                    // waiting for an update after one of the next requests gets
+                    // processed by the main channel.
+                    //
+                    // Connection pool generation could be used here to avoid
+                    // unneeded resets that may happen due to multiple
+                    // concurrent failures and reconnect attempts but those are
+                    // not a big issue - it will just slightly increase the
+                    // percentage of the requests that go through the main
+                    // channel if the number of connection attempts is high.
+                    //
+
+                    self->DoUpdate(
+                        self->ActualFileSystemId,
+                        {} /* host */,
+                        0 /* port */);
+                }
+
                 TResponse errorResponse;
                 errorResponse.MutableError()->SetCode(E_UNAVAILABLE);
                 complete(nullptr, 0, std::move(errorResponse));
@@ -358,9 +370,32 @@ private:
 
         return TStringBuilder() << "[" << host << "]:" << port;
     }
+
+    ui32 DoUpdate(
+        const TString& actualFileSystemId,
+        const TString& host,
+        ui32 port)
+    {
+        ui32 generation = 0;
+        with_lock (Lock) {
+            if (Host != host || Port != port) {
+                generation = EndpointPool->AddressChanged();
+                STORAGE_INFO("updated side channel connection params"
+                    << ": host=" << host
+                    << ", port=" << port
+                    << ", fileSystemId=" << actualFileSystemId
+                    << ", generation=" << generation);
+            }
+
+            Host = host;
+            Port = port;
+        }
+
+        return generation;
+    }
 };
 
-using TFileSystemTCPSideChannelPtr = TIntrusivePtr<TFileSystemTCPSideChannel>;
+using TFileSystemTCPSideChannelPtr = std::shared_ptr<TFileSystemTCPSideChannel>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -486,7 +521,7 @@ private:
             if (!channel) {
                 STORAGE_INFO("initializing channel for fileSystemId="
                     << actualFileSystemId);
-                channel = MakeIntrusive<TFileSystemTCPSideChannel>(
+                channel = std::make_shared<TFileSystemTCPSideChannel>(
                     actualFileSystemId,
                     Log,
                     Client);

--- a/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
@@ -358,6 +358,42 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
             E_UNAVAILABLE,
             writeResponse.GetValue().GetError().GetCode(),
             writeResponse.GetValue().GetError().GetMessage());
+
+        writeResponse = NewPromise<NProto::TWriteDataResponse>();
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(1, 1_KB, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(!success);
+
+        writeResponse = NewPromise<NProto::TWriteDataResponse>();
+        sideChannel->Update(BackendInfo());
+
+        auto e = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e);
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
+
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(1, 0, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(success);
+        UNIT_ASSERT(e->RequestReceived);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(1_KB, 'a'),
+            e->Req.GetWriteData().GetBuffer());
+        UNIT_ASSERT(!writeResponse.HasValue());
+
+        UNIT_ASSERT(e->Reply(WriteResp(MakeError(S_ALREADY))));
+
+        UNIT_ASSERT(writeResponse.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_ALREADY,
+            writeResponse.GetValue().GetError().GetCode(),
+            writeResponse.GetValue().GetError().GetMessage());
     }
 
     Y_UNIT_TEST(ShouldSendRequestsToCorrectEndpoint)

--- a/cloud/storage/core/libs/common/error.cpp
+++ b/cloud/storage/core/libs/common/error.cpp
@@ -56,6 +56,7 @@ EErrorKind GetErrorKind(const NProto::TError& e)
         case E_BS_THROTTLED:
         case E_FS_THROTTLED:
         case E_RDMA_UNAVAILABLE:
+        case E_UNAVAILABLE:
             return EErrorKind::ErrorRetriable;
 
         case E_BS_INVALID_SESSION:


### PR DESCRIPTION
### Notes
_Context: `TCPSideChannel` is a component used in our experimental datapath between `filestore-vhost` <-> `fastshard` that omits actor-system and ydb-interconnect to decrease the resulting e2e latency._

Whenever `TCPSideChannel` fails to establish a tcp connection with a fastshard endpoint, it returns `E_UNAVAILABLE`. There were 2 issues:
1. I forgot to make `E_UNAVAILABLE` retriable - fixing this now
2. the next request would trigger a connection attempt to the same endpoint which would fail in most of the cases - we need to force endpoint address update by resetting Host/Port because if we don't do that we will never get an up to date Host/Port pair since we can get it only through the "main" communication channel and we will never use the "main" channel if `TCPSideChannel` thinks that it knows the address of the endpoint

### Issue
https://github.com/ydb-platform/nbs/issues/5894
