### PR TITLE
[NBS] Fix TTimerHandleTest::ShouldTrigger under ubsan

### DIFF
--- a/cloud/storage/core/libs/rdma/impl/poll_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/poll_ut.cpp
@@ -20,7 +20,9 @@ TEST(TTimerHandleTest, ShouldTrigger)
 
     size_t signaled = pollHandle.Wait(TDuration::Seconds(1));
     ASSERT_EQ(signaled, 1u);
-    ASSERT_EQ(pollHandle.GetEvent(0).data.ptr, &timerHandle);
+
+    const void* eventData = pollHandle.GetEvent(0).data.ptr;
+    ASSERT_EQ(eventData, static_cast<const void*>(&timerHandle));
 
     signaled = pollHandle.Wait(TDuration::Seconds(1));
     ASSERT_EQ(signaled, 0u);


### PR DESCRIPTION
### Notes
TTimerHandleTest::ShouldTrigger failed in arcadia under ubsan:
```
[fail] TTimerHandleTest::ShouldTrigger [tags: sb:MULTISLOT, sb:cores=4, sb:logs_ttl=3, sb:ssd, sb:ttl=3] [default-linux-x86_64-release-usan] (0.00s)
Test crashed (return code: 100)
/place/sandbox-data/tasks/7/9/4453326197/__FUSE/mount_path_29bef7db-6fbb-4d9b-8afb-2b3b82a912fa/cloud/storage/core/libs/rdma/impl/poll_ut.cpp:23:5: runtime error: reference binding to misaligned address 0x7ffe77d0d8d4 for type 'void *const', which requires 8 byte alignment
0x7ffe77d0d8d4: note: pointer points here
  01 00 00 00 dc db d0 77  fe 7f 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
              ^ 
    #0 0x00000146bd0f in NCloud::NStorage::NRdma::TTimerHandleTest_ShouldTrigger_Test::TestBody() /-S/cloud/storage/core/libs/rdma/impl/poll_ut.cpp:23:5
    #1 0x0000017c0b09 in HandleSehExceptionsInMethodIfSupported<testing::Test, void> /-S/contrib/restricted/googletest/googletest/src/gtest.cc:2664:10
    #2 0x0000017c0b09 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /-S/contrib/restricted/googletest/googletest/src/gtest.cc:2700:14
    #3 0x0000017c07da in testing::Test::Run() /-S/contrib/restricted/googletest/googletest/src/gtest.cc:2739:5
    #4 0x0000017c2815 in testing::TestInfo::Run() /-S/contrib/restricted/googletest/googletest/src/gtest.cc:2885:11
    #5 0x0000017c55df in testing::TestSuite::Run() /-S/contrib/restricted/googletest/googletest/src/gtest.cc:3063:30
    #6 0x0000017e413f in testing::internal::UnitTestImpl::RunAllTests() /-S/contrib/restricted/googletest/googletest/src/gtest.cc:6054:44
    #7 0x0000017e2fc8 in HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> /-S/contrib/restricted/googletest/googletest/src/gtest.cc:2664:10
    #8 0x0000017e2fc8 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /-S/contrib/restricted/googletest/googletest/src/gtest.cc:2700:14
    #9 0x0000017e2d78 in testing::UnitTest::Run() /-S/contrib/restricted/googletest/googletest/src/gtest.cc:5594:10
    #10 0x000001853ab3 in RUN_ALL_TESTS /-S/contrib/restricted/googletest/googletest/include/gtest/gtest.h:2334:73
    #11 0x000001853ab3 in NGTest::Main(int, char**) /-S/library/cpp/testing/gtest/main.cpp:276:12
    #12 0x7f655f742082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
    #13 0x000001325028 in _start (http://proxy.sandbox.yandex-team.ru/13027644781/cloud/storage/core/libs/rdma/impl/ut/cloud-storage-core-libs-rdma-impl-ut+0x1325028) (BuildId: a280e0016c62c709b81633cc28a63709563a46f8)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /place/sandbox-data/tasks/7/9/4453326197/__FUSE/mount_path_29bef7db-6fbb-4d9b-8afb-2b3b82a912fa/cloud/storage/core/libs/rdma/impl/poll_ut.cpp:23:5
```
Cause: epoll_event is __packed__, so data.ptr sits at offset 4 and is not 8-byte aligned. ASSERT_EQ takes arguments by const&, which UBSan flags as a misaligned reference bind.

