### PR TITLE
issue-6208: [Filestore] Track latency in the filesystem (client + proto changes)

### DIFF
--- a/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
+++ b/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
@@ -46,7 +46,6 @@ private:
         double TotalNodeLatencyMs = 0;
         double AverageNodeLatencyMs = 0;
         ui64 LastUsedTimestampUs = 0;
-        ui64 NodeStatsCount = 0;
     };
 
     struct TShardLatencyRow
@@ -56,7 +55,6 @@ private:
         double TotalNodeLatencyMs = 0;
         double AverageNodeLatencyMs = 0;
         ui64 LastUsedTimestampUs = 0;
-        ui64 NodeStatsCount = 0;
     };
 
     struct TRequestLatencyComparator
@@ -65,10 +63,9 @@ private:
             const TRequestLatencyRow& lhs,
             const TRequestLatencyRow& rhs) const
         {
-            if (lhs.AverageNodeLatencyMs == rhs.AverageNodeLatencyMs) {
-                return lhs.LastUsedTimestampUs > rhs.LastUsedTimestampUs;
-            }
-            return lhs.AverageNodeLatencyMs < rhs.AverageNodeLatencyMs;
+            // TotalNodeLatencyMs DESC, LastUsedTimestamp DESC
+            return std::tie(rhs.TotalNodeLatencyMs, rhs.LastUsedTimestampUs) <
+                   std::tie(lhs.TotalNodeLatencyMs, lhs.LastUsedTimestampUs);
         }
     };
 
@@ -193,14 +190,14 @@ public:
                 latencyRow.ShardId = latencyStats.GetShardId();
             }
             latencyRow.RequestCount += latencyStats.GetRequestCount();
-            ++latencyRow.NodeStatsCount;
             latencyRow.LastUsedTimestampUs =
                 Max(latencyRow.LastUsedTimestampUs,
                     latencyStats.GetLastAccessedTimestampUs());
             latencyRow.TotalNodeLatencyMs +=
-                latencyStats.GetAverageLatencyDecayedMs();
+                latencyStats.GetAverageLatencyDecayedMs() *
+                latencyStats.GetRequestCount();
             latencyRow.AverageNodeLatencyMs =
-                latencyRow.TotalNodeLatencyMs / latencyRow.NodeStatsCount;
+                latencyRow.TotalNodeLatencyMs / latencyRow.RequestCount;
 
             auto [newRequestLatencyIt, inserted] =
                 requestRanking.insert(latencyRow);
@@ -215,15 +212,14 @@ public:
                 shardLatencyRow.ShardId = latencyStats.GetShardId();
             }
             shardLatencyRow.RequestCount += latencyStats.GetRequestCount();
-            ++shardLatencyRow.NodeStatsCount;
             shardLatencyRow.LastUsedTimestampUs =
                 Max(shardLatencyRow.LastUsedTimestampUs,
                     latencyStats.GetLastAccessedTimestampUs());
             shardLatencyRow.TotalNodeLatencyMs +=
-                latencyStats.GetAverageLatencyDecayedMs();
+                latencyStats.GetAverageLatencyDecayedMs() *
+                latencyStats.GetRequestCount();
             shardLatencyRow.AverageNodeLatencyMs =
-                shardLatencyRow.TotalNodeLatencyMs /
-                shardLatencyRow.NodeStatsCount;
+                shardLatencyRow.TotalNodeLatencyMs / latencyRow.RequestCount;
 
             shard2Latency[latencyStats.GetShardId()] = shardLatencyRow;
         }
@@ -237,8 +233,8 @@ public:
             [](const TShardLatencyRow& l, const TShardLatencyRow& r)
             {
                 // AverageNodeLatencyMs DESC, LastUsedTimestampUs DESC
-                return std::tie(r.AverageNodeLatencyMs, r.LastUsedTimestampUs) <
-                       std::tie(l.AverageNodeLatencyMs, l.LastUsedTimestampUs);
+                return std::tie(r.TotalNodeLatencyMs, r.LastUsedTimestampUs) <
+                       std::tie(l.TotalNodeLatencyMs, l.LastUsedTimestampUs);
             });
 
         Sort(

--- a/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
+++ b/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
@@ -238,7 +238,7 @@ public:
             {
                 // AverageNodeLatencyMs DESC, LastUsedTimestampUs DESC
                 return std::tie(r.AverageNodeLatencyMs, r.LastUsedTimestampUs) <
-                       std::tie(l.AverageNodeLatencyMs, r.LastUsedTimestampUs);
+                       std::tie(l.AverageNodeLatencyMs, l.LastUsedTimestampUs);
             });
 
         Sort(

--- a/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
+++ b/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
@@ -1,8 +1,10 @@
 #include "command.h"
 
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
+
 #include <library/cpp/json/json_writer.h>
 
-#include <cloud/filestore/private/api/protos/tablet.pb.h>
+#include <util/generic/set.h>
 
 #include <google/protobuf/util/json_util.h>
 
@@ -12,8 +14,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TDiagnoseFilesystemCommand final
-    : public TFileStoreCommand
+class TDiagnoseFilesystemCommand final: public TFileStoreCommand
 {
 private:
     struct TShardRow
@@ -24,6 +25,51 @@ private:
         ui64 UsedBlocksCount = 0;
         ui64 TotalBlocksCount = 0;
         ui64 UsedNodesCount = 0;
+    };
+
+    struct TNodeLatencyRow
+    {
+        TString ShardId;
+        TString RequestType = GetFileStoreRequestName(EFileStoreRequest::MAX);
+        ui64 NodeId = 0;
+        ui64 RequestCount = 0;
+        ui64 TotalLatencyMs = 0;
+        double AverageLatencyDecayedMs = 0;
+        ui64 LastAccessedTimestampUs = 0;
+    };
+
+    struct TRequestLatencyRow
+    {
+        TString ShardId;
+        TString RequestType = GetFileStoreRequestName(EFileStoreRequest::MAX);
+        ui64 RequestCount = 0;
+        double TotalNodeLatencyMs = 0;
+        double AverageNodeLatencyMs = 0;
+        ui64 LastUsedTimestampUs = 0;
+        ui64 NodeStatsCount = 0;
+    };
+
+    struct TShardLatencyRow
+    {
+        TString ShardId;
+        ui64 RequestCount = 0;
+        double TotalNodeLatencyMs = 0;
+        double AverageNodeLatencyMs = 0;
+        ui64 LastUsedTimestampUs = 0;
+        ui64 NodeStatsCount = 0;
+    };
+
+    struct TRequestLatencyComparator
+    {
+        bool operator()(
+            const TRequestLatencyRow& lhs,
+            const TRequestLatencyRow& rhs) const
+        {
+            if (lhs.AverageNodeLatencyMs == rhs.AverageNodeLatencyMs) {
+                return lhs.LastUsedTimestampUs > rhs.LastUsedTimestampUs;
+            }
+            return lhs.AverageNodeLatencyMs < rhs.AverageNodeLatencyMs;
+        }
     };
 
     ui32 Top;
@@ -72,14 +118,15 @@ private:
         }
 
         auto parsed = google::protobuf::util::JsonStringToMessage(
-            result.GetOutput(),
-            responseProto).ok();
+                          result.GetOutput(),
+                          responseProto)
+                          .ok();
 
         if (!parsed) {
             responseProto->MutableError()->CopyFrom(MakeError(
                 E_BADMSG,
                 TStringBuilder() << "failed to parse response json: "
-                    << result.GetOutput()));
+                                 << result.GetOutput()));
         }
     }
 
@@ -88,16 +135,26 @@ public:
     {
         NProtoPrivate::TGetStorageStatsRequest request;
         request.SetFileSystemId(FileSystemId);
-        request.SetCacheTTL(0); // disable caching
+        request.SetCacheTTL(0);   // disable caching
         request.SetMode(NProtoPrivate::STATS_REQUEST_MODE_FORCE_FETCH_SHARDS);
         NProtoPrivate::TGetStorageStatsResponse response;
         ExecuteAction("getstoragestats", request, &response);
         CheckResponse(response);
 
         TVector<TShardRow> rows;
+        TVector<TNodeLatencyRow> nodeLatencyRows;
+
+        using RequestKey = std::pair<TString, TString>;
+        TSet<TRequestLatencyRow, TRequestLatencyComparator> requestRanking;
+        THashMap<RequestKey, TSet<TRequestLatencyRow>::iterator>
+            request2Latency;
+
+        THashMap<TString, TShardLatencyRow> shard2Latency;
+        TVector<TShardLatencyRow> shardLatencyRows;
 
         const auto& stats = response.GetStats();
         rows.reserve(stats.ShardStatsSize());
+        shardLatencyRows.reserve(stats.ShardStatsSize());
 
         for (const auto& shardStats: stats.GetShardStats()) {
             TShardRow row;
@@ -110,23 +167,114 @@ public:
             rows.push_back(std::move(row));
         }
 
-        Sort(rows, [] (const TShardRow& l, const TShardRow& r) {
-            if (l.CurrentLoad != r.CurrentLoad) {
-                return l.CurrentLoad > r.CurrentLoad;
-            }
+        for (const auto& latencyStats: stats.GetLatencyStats()) {
+            TNodeLatencyRow row;
+            row.ShardId = latencyStats.GetShardId();
+            row.RequestType = latencyStats.GetRequestType();
+            row.NodeId = latencyStats.GetNodeId();
+            row.RequestCount = latencyStats.GetRequestCount();
+            row.TotalLatencyMs = latencyStats.GetTotalLatencyMs();
+            row.AverageLatencyDecayedMs =
+                latencyStats.GetAverageLatencyDecayedMs();
+            row.LastAccessedTimestampUs =
+                latencyStats.GetLastAccessedTimestampUs();
+            nodeLatencyRows.push_back(std::move(row));
 
-            if (l.Suffer != r.Suffer) {
-                return l.Suffer > r.Suffer;
+            RequestKey key = {
+                latencyStats.GetShardId(),
+                latencyStats.GetRequestType()};
+            auto it = request2Latency.find(key);
+            TRequestLatencyRow latencyRow;
+            if (it != request2Latency.end()) {
+                latencyRow = *it->second;
+                requestRanking.erase(it->second);
+            } else {
+                latencyRow.RequestType = latencyStats.GetRequestType();
+                latencyRow.ShardId = latencyStats.GetShardId();
             }
+            latencyRow.RequestCount += latencyStats.GetRequestCount();
+            ++latencyRow.NodeStatsCount;
+            latencyRow.LastUsedTimestampUs =
+                Max(latencyRow.LastUsedTimestampUs,
+                    latencyStats.GetLastAccessedTimestampUs());
+            latencyRow.TotalNodeLatencyMs +=
+                latencyStats.GetAverageLatencyDecayedMs();
+            latencyRow.AverageNodeLatencyMs =
+                latencyRow.TotalNodeLatencyMs / latencyRow.NodeStatsCount;
 
-            return l.ShardId < r.ShardId;
-        });
+            auto [newRequestLatencyIt, inserted] =
+                requestRanking.insert(latencyRow);
+            Y_ABORT_UNLESS(inserted);
+            request2Latency[key] = newRequestLatencyIt;
+
+            auto shardLatencyIt = shard2Latency.find(latencyStats.GetShardId());
+            TShardLatencyRow shardLatencyRow;
+            if (shardLatencyIt != shard2Latency.end()) {
+                shardLatencyRow = shardLatencyIt->second;
+            } else {
+                shardLatencyRow.ShardId = latencyStats.GetShardId();
+            }
+            shardLatencyRow.RequestCount += latencyStats.GetRequestCount();
+            ++shardLatencyRow.NodeStatsCount;
+            shardLatencyRow.LastUsedTimestampUs =
+                Max(shardLatencyRow.LastUsedTimestampUs,
+                    latencyStats.GetLastAccessedTimestampUs());
+            shardLatencyRow.TotalNodeLatencyMs +=
+                latencyStats.GetAverageLatencyDecayedMs();
+            shardLatencyRow.AverageNodeLatencyMs =
+                shardLatencyRow.TotalNodeLatencyMs /
+                shardLatencyRow.NodeStatsCount;
+
+            shard2Latency[latencyStats.GetShardId()] = shardLatencyRow;
+        }
+
+        for (auto const& shardIt: shard2Latency) {
+            shardLatencyRows.push_back(shardIt.second);
+        }
+
+        Sort(
+            shardLatencyRows,
+            [](const TShardLatencyRow& l, const TShardLatencyRow& r)
+            {
+                // AverageNodeLatencyMs DESC, LastUsedTimestampUs DESC
+                return std::tie(r.AverageNodeLatencyMs, r.LastUsedTimestampUs) <
+                       std::tie(l.AverageNodeLatencyMs, r.LastUsedTimestampUs);
+            });
+
+        Sort(
+            nodeLatencyRows,
+            [](const TNodeLatencyRow& l, TNodeLatencyRow& r)
+            {
+                // AverageNodeLatency DESC, NodeId ASC
+                return std::tie(r.AverageLatencyDecayedMs, l.NodeId) <
+                       std::tie(l.AverageLatencyDecayedMs, r.NodeId);
+            });
+
+        Sort(
+            rows,
+            [](const TShardRow& l, const TShardRow& r)
+            {
+                if (l.CurrentLoad != r.CurrentLoad) {
+                    return l.CurrentLoad > r.CurrentLoad;
+                }
+
+                if (l.Suffer != r.Suffer) {
+                    return l.Suffer > r.Suffer;
+                }
+
+                return l.ShardId < r.ShardId;
+            });
 
         const size_t limit = Min<size_t>(Top, rows.size());
+        const size_t nodeLatencyLimit =
+            Min<size_t>(Top, nodeLatencyRows.size());
 
         if (JsonOutput) {
             NJson::TJsonValue resultJson(NJson::JSON_MAP);
             NJson::TJsonValue shardsJson(NJson::JSON_ARRAY);
+            NJson::TJsonValue nodesLatencyJson(NJson::JSON_ARRAY);
+            NJson::TJsonValue requestsLatencyJson(NJson::JSON_ARRAY);
+            NJson::TJsonValue shardsLatencyJson(NJson::JSON_ARRAY);
 
             resultJson["filesystem_id"] = FileSystemId;
             resultJson["shard_count"] = rows.size();
@@ -146,6 +294,62 @@ public:
             }
 
             resultJson["shards"] = std::move(shardsJson);
+
+            for (size_t i = 0; i < nodeLatencyLimit; ++i) {
+                const auto& nodeLatencyRow = nodeLatencyRows[i];
+                NJson::TJsonValue nodeLatencyJson(NJson::JSON_MAP);
+                nodeLatencyJson["node_id"] = nodeLatencyRow.NodeId;
+                nodeLatencyJson["request_type"] = nodeLatencyRow.RequestType;
+                nodeLatencyJson["avg_latency_decayed"] =
+                    nodeLatencyRow.AverageLatencyDecayedMs;
+                nodeLatencyJson["total_latency"] =
+                    nodeLatencyRow.TotalLatencyMs;
+                nodeLatencyJson["request_count"] = nodeLatencyRow.RequestCount;
+                nodeLatencyJson["last_timestamp_us"] =
+                    nodeLatencyRow.LastAccessedTimestampUs;
+                nodeLatencyJson["shard_id"] = nodeLatencyRow.ShardId;
+
+                nodesLatencyJson.AppendValue(std::move(nodeLatencyJson));
+            }
+
+            resultJson["node_latency"] = std::move(nodesLatencyJson);
+
+            for (const auto& requestLatencyRow: requestRanking) {
+                NJson::TJsonValue requestLatencyJson(NJson::JSON_MAP);
+                requestLatencyJson["request_type"] =
+                    requestLatencyRow.RequestType;
+                requestLatencyJson["avg_node_latency"] =
+                    requestLatencyRow.AverageNodeLatencyMs;
+                requestLatencyJson["total_node_latency"] =
+                    requestLatencyRow.TotalNodeLatencyMs;
+                requestLatencyJson["request_count"] =
+                    requestLatencyRow.RequestCount;
+                requestLatencyJson["last_timestamp_us"] =
+                    requestLatencyRow.LastUsedTimestampUs;
+                requestLatencyJson["shard_id"] = requestLatencyRow.ShardId;
+
+                requestsLatencyJson.AppendValue(std::move(requestLatencyJson));
+            }
+
+            resultJson["request_latency"] = std::move(requestsLatencyJson);
+
+            for (const auto& shardLatencyRow: shardLatencyRows) {
+                NJson::TJsonValue shardLatencyJson(NJson::JSON_MAP);
+                shardLatencyJson["avg_node_latency"] =
+                    shardLatencyRow.AverageNodeLatencyMs;
+                shardLatencyJson["shard_id"] = shardLatencyRow.ShardId;
+                shardLatencyJson["last_timestamp_us"] =
+                    shardLatencyRow.LastUsedTimestampUs;
+                shardLatencyJson["total_node_latency"] =
+                    shardLatencyRow.TotalNodeLatencyMs;
+                shardLatencyJson["request_count"] =
+                    shardLatencyRow.RequestCount;
+
+                shardsLatencyJson.AppendValue(std::move(shardLatencyJson));
+            }
+
+            resultJson["shard_latency"] = std::move(shardsLatencyJson);
+
             NJson::WriteJson(&Cout, &resultJson, false, true, true);
 
             return true;
@@ -157,14 +361,11 @@ public:
 
         for (size_t i = 0; i < limit; ++i) {
             const auto& row = rows[i];
-            Cout << i + 1 << ". "
-                << row.ShardId
-                << "  load=" << row.CurrentLoad
-                << "  suffer=" << row.Suffer
-                << "  blocks=" << row.UsedBlocksCount
-                << "/" << row.TotalBlocksCount
-                << "  nodes=" << row.UsedNodesCount
-                << Endl;
+            Cout << i + 1 << ". " << row.ShardId << "  load=" << row.CurrentLoad
+                 << "  suffer=" << row.Suffer
+                 << "  blocks=" << row.UsedBlocksCount << "/"
+                 << row.TotalBlocksCount << "  nodes=" << row.UsedNodesCount
+                 << Endl;
         }
 
         return true;

--- a/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
+++ b/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
@@ -232,7 +232,7 @@ public:
             shardLatencyRows,
             [](const TShardLatencyRow& l, const TShardLatencyRow& r)
             {
-                // AverageNodeLatencyMs DESC, LastUsedTimestampUs DESC
+                // TotalNodeLatencyMs DESC, LastUsedTimestampUs DESC
                 return std::tie(r.TotalNodeLatencyMs, r.LastUsedTimestampUs) <
                        std::tie(l.TotalNodeLatencyMs, l.LastUsedTimestampUs);
             });

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -118,6 +118,17 @@ message TShardStats
     uint64 UsedNodesCount = 6;
 }
 
+message TNodeLatencyStats
+{
+    string ShardId = 1;
+    string RequestType = 2;
+    uint64 NodeId = 3;
+    uint64 RequestCount = 4;
+    uint64 TotalLatencyMs = 5;
+    double AverageLatencyDecayedMs = 6;
+    uint64 LastAccessedTimestampUs = 7;
+}
+
 message TStorageStats
 {
     // index stats
@@ -171,6 +182,8 @@ message TStorageStats
 
     // shard stats
     repeated TShardStats ShardStats = 6001;
+
+    repeated TNodeLatencyStats LatencyStats = 8001;
 }
 
 enum EStatsRequestMode


### PR DESCRIPTION
### Notes
This PR adds latency tracking to the filesystem. It only contains client and proto changes. Tablet changes are introduced in https://github.com/ydb-platform/nbs/pull/6674

### Issue
https://github.com/ydb-platform/nbs/issues/6208
> Per-file: most loaded files per shard and slowest (needs to be collected in tablet code) -> output for the whole filesystem

### Current response
(Here, the per-request-per-shard latency is ASC, this is fixed in the code already)
```json
jan.szumski@jan-szumski-ivm:~/nbs/cloud/filestore/bin$ ./filestore-client diagnosefilesystem --server-port 9021 --filesystem nfs --top 5  --json | jq
2026-08-04T23:08:58.956461Z :NFS_CLIENT WARN: cloud/filestore/apps/client/lib/command.cpp:202: Config file is not found
2026-08-04T23:08:58.956746Z :NFS_CLIENT INFO: cloud/filestore/libs/client/client.cpp:782: Connect to localhost:9021
2026-08-04T23:08:58.962568Z :NFS_CLIENT INFO: cloud/filestore/libs/client/client.cpp:656: Shutting down
{
  "filesystem_id": "nfs",
  "node_latency": [
    {
      "avg_latency_decayed": 3704.4641,
      "last_timestamp_us": 1785884929077552,
      "node_id": 432345564227567600,
      "request_count": 2,
      "request_type": "WriteData",
      "shard_id": "nfs_s6",
      "total_latency": 7495
    },
    {
      "avg_latency_decayed": 2310.995773,
      "last_timestamp_us": 1785884929644835,
      "node_id": 216172782113783800,
      "request_count": 2,
      "request_type": "WriteData",
      "shard_id": "nfs_s3",
      "total_latency": 4673
    },
    {
      "avg_latency_decayed": 2286.314103,
      "last_timestamp_us": 1785884933041699,
      "node_id": 504403158265495600,
      "request_count": 1,
      "request_type": "WriteData",
      "shard_id": "nfs_s7",
      "total_latency": 2302
    },
    {
      "avg_latency_decayed": 2218.214646,
      "last_timestamp_us": 1785884929727845,
      "node_id": 432345564227567600,
      "request_count": 1,
      "request_type": "WriteData",
      "shard_id": "nfs_s6",
      "total_latency": 2242
    },
    {
      "avg_latency_decayed": 2207.721981,
      "last_timestamp_us": 1785884929105379,
      "node_id": 504403158265495550,
      "request_count": 1,
      "request_type": "WriteData",
      "shard_id": "nfs_s7",
      "total_latency": 2233
    }
  ],
  "request_latency": [
    {
      "avg_node_latency": 0,
      "last_timestamp_us": 1785884921075363,
      "request_count": 1,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs",
      "total_node_latency": 0
    },
    {
      "avg_node_latency": 59.8881194,
      "last_timestamp_us": 1785884933226083,
      "request_count": 81,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs_s2",
      "total_node_latency": 2275.748537
    },
    {
      "avg_node_latency": 69.50299776,
      "last_timestamp_us": 1785884933216046,
      "request_count": 87,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs_s3",
      "total_node_latency": 2432.604922
    },
    {
      "avg_node_latency": 83.32845244,
      "last_timestamp_us": 1785884933252963,
      "request_count": 71,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs_s7",
      "total_node_latency": 2749.838931
    },
    {
      "avg_node_latency": 84.32521561,
      "last_timestamp_us": 1785884933261284,
      "request_count": 244,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs_s5",
      "total_node_latency": 2782.732115
    },
    {
      "avg_node_latency": 87.81563948,
      "last_timestamp_us": 1785884933232355,
      "request_count": 85,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs_s4",
      "total_node_latency": 2985.731742
    },
    {
      "avg_node_latency": 95.94963463,
      "last_timestamp_us": 1785884933246822,
      "request_count": 68,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs_s6",
      "total_node_latency": 3070.388308
    },
    {
      "avg_node_latency": 100.4108108,
      "last_timestamp_us": 1785884933261347,
      "request_count": 71,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs_s8",
      "total_node_latency": 3313.556756
    },
    {
      "avg_node_latency": 105.9633219,
      "last_timestamp_us": 1785884933225955,
      "request_count": 100,
      "request_type": "GetNodeAttr",
      "shard_id": "nfs_s1",
      "total_node_latency": 4238.532878
    },
    {
      "avg_node_latency": 1778.28293,
      "last_timestamp_us": 1785884932922862,
      "request_count": 3,
      "request_type": "WriteData",
      "shard_id": "nfs_s2",
      "total_node_latency": 5334.848791
    },
    {
      "avg_node_latency": 1826.571858,
      "last_timestamp_us": 1785884933065635,
      "request_count": 54,
      "request_type": "WriteData",
      "shard_id": "nfs_s8",
      "total_node_latency": 9132.859288
    },
    {
      "avg_node_latency": 1912.190589,
      "last_timestamp_us": 1785884932947428,
      "request_count": 4,
      "request_type": "WriteData",
      "shard_id": "nfs_s3",
      "total_node_latency": 5736.571767
    },
    {
      "avg_node_latency": 1939.06462,
      "last_timestamp_us": 1785884932996003,
      "request_count": 151,
      "request_type": "WriteData",
      "shard_id": "nfs_s5",
      "total_node_latency": 7756.258479
    },
    {
      "avg_node_latency": 1947.322193,
      "last_timestamp_us": 1785884938958115,
      "request_count": 2223,
      "request_type": "WriteData",
      "shard_id": "nfs_s1",
      "total_node_latency": 5841.96658
    },
    {
      "avg_node_latency": 1992.861052,
      "last_timestamp_us": 1785884933041699,
      "request_count": 4,
      "request_type": "WriteData",
      "shard_id": "nfs_s7",
      "total_node_latency": 7971.444209
    },
    {
      "avg_node_latency": 2028.125768,
      "last_timestamp_us": 1785884929674153,
      "request_count": 3,
      "request_type": "WriteData",
      "shard_id": "nfs_s4",
      "total_node_latency": 2028.125768
    },
    {
      "avg_node_latency": 2473.837229,
      "last_timestamp_us": 1785884933018339,
      "request_count": 54,
      "request_type": "WriteData",
      "shard_id": "nfs_s6",
      "total_node_latency": 9895.348916
    }
  ],
  "shard_count": 8,
  "shard_latency": [
    {
      "avg_node_latency": 360.1593673,
      "last_timestamp_us": 1785884933246822,
      "request_count": 122,
      "shard_id": "nfs_s6",
      "total_node_latency": 12965.73722
    },
    {
      "avg_node_latency": 327.5372643,
      "last_timestamp_us": 1785884933261347,
      "request_count": 125,
      "shard_id": "nfs_s8",
      "total_node_latency": 12446.41604
    },
    {
      "avg_node_latency": 289.7644092,
      "last_timestamp_us": 1785884933252963,
      "request_count": 75,
      "shard_id": "nfs_s7",
      "total_node_latency": 10721.28314
    },
    {
      "avg_node_latency": 284.8375836,
      "last_timestamp_us": 1785884933261284,
      "request_count": 395,
      "shard_id": "nfs_s5",
      "total_node_latency": 10538.99059
    },
    {
      "avg_node_latency": 234.4302199,
      "last_timestamp_us": 1785884938958115,
      "request_count": 2323,
      "shard_id": "nfs_s1",
      "total_node_latency": 10080.49946
    },
    {
      "avg_node_latency": 214.9783339,
      "last_timestamp_us": 1785884933216046,
      "request_count": 91,
      "shard_id": "nfs_s3",
      "total_node_latency": 8169.176689
    },
    {
      "avg_node_latency": 185.6243251,
      "last_timestamp_us": 1785884933226083,
      "request_count": 84,
      "shard_id": "nfs_s2",
      "total_node_latency": 7610.597329
    },
    {
      "avg_node_latency": 143.2530717,
      "last_timestamp_us": 1785884933232355,
      "request_count": 88,
      "shard_id": "nfs_s4",
      "total_node_latency": 5013.857511
    },
    {
      "avg_node_latency": 0,
      "last_timestamp_us": 1785884921075363,
      "request_count": 1,
      "shard_id": "nfs",
      "total_node_latency": 0
    }
  ],
  "shards": [
    {
      "current_load": 0,
      "shard_id": "nfs_s1",
      "suffer": 0,
      "total_blocks_count": 10485760,
      "used_blocks_count": 2224,
      "used_nodes_count": 56
    },
    {
      "current_load": 0,
      "shard_id": "nfs_s2",
      "suffer": 0,
      "total_blocks_count": 10485760,
      "used_blocks_count": 3,
      "used_nodes_count": 53
    },
    {
      "current_load": 0,
      "shard_id": "nfs_s3",
      "suffer": 0,
      "total_blocks_count": 10485760,
      "used_blocks_count": 4,
      "used_nodes_count": 50
    },
    {
      "current_load": 0,
      "shard_id": "nfs_s4",
      "suffer": 0,
      "total_blocks_count": 10485760,
      "used_blocks_count": 3,
      "used_nodes_count": 49
    },
    {
      "current_load": 0,
      "shard_id": "nfs_s5",
      "suffer": 0,
      "total_blocks_count": 10485760,
      "used_blocks_count": 151,
      "used_nodes_count": 48
    }
  ]
}
```