### PR TITLE
[Blockstore] fix tests with ubsan

### DIFF
--- a/cloud/blockstore/libs/notify/impl/https.cpp
+++ b/cloud/blockstore/libs/notify/impl/https.cpp
@@ -277,12 +277,12 @@ public:
             char* ptr,
             size_t size,
             size_t nitems,
-            TResponseInfo* responseInfo)
+            void* responseInfo)
         {
             TString line(ptr, size * nitems);
             if (!line.StartsWith("HTTP/") && line != "\r\n") {
                 THttpInputHeader h(line);
-                responseInfo->Headers.AddHeader(h);
+                static_cast<TResponseInfo*>(responseInfo)->Headers.AddHeader(h);
             }
             return size * nitems;
         }
@@ -486,13 +486,13 @@ public:
         CURL* easyHandle,
         curl_socket_t sock,
         int what,
-        TUserData* userp,
-        TEvent* socketp);
+        void* userp,
+        void* socketp);
 
     static int TimerFunction(
         CURLM* multi,
         long timeoutMs,
-        TInstant* userp);
+        void* userp);
 
     void InitMultiHolder();
 
@@ -786,12 +786,14 @@ int THttpsClient::TImpl::SocketFunction(
     CURL* easyHandle,
     curl_socket_t sock,
     int what,
-    TUserData* userp,
-    TEvent* e)
+    void* userp,
+    void* socketp)
 {
     Y_UNUSED(easyHandle);
 
-    auto* impl = userp->Impl;
+    TEvent* e = static_cast<TEvent*>(socketp);
+
+    auto* impl = static_cast<TUserData*>(userp)->Impl;
 
     if (what == CURL_POLL_REMOVE) {
         delete e;
@@ -807,19 +809,20 @@ int THttpsClient::TImpl::SocketFunction(
     return CURLM_OK;
 }
 
-int THttpsClient::TImpl::TimerFunction(CURLM*, long timeoutMs, TInstant* userp)
+int THttpsClient::TImpl::TimerFunction(CURLM*, long timeoutMs, void* userp)
 {
     Y_DEBUG_ABORT_UNLESS(userp != nullptr);
 
     switch (timeoutMs) {
         case -1:
-            *userp = TInstant::Max();
+            *static_cast<TInstant*>(userp) = TInstant::Max();
             break;
         case 0:
-            *userp = TInstant::Zero();
+            *static_cast<TInstant*>(userp) = TInstant::Zero();
             break;
         default:
-            *userp = TDuration::MilliSeconds(timeoutMs).ToDeadLine();
+            *static_cast<TInstant*>(userp) =
+                TDuration::MilliSeconds(timeoutMs).ToDeadLine();
             break;
     }
 

--- a/cloud/blockstore/libs/notify/impl/ya.make
+++ b/cloud/blockstore/libs/notify/impl/ya.make
@@ -6,6 +6,10 @@ SRCS(
     json_generator.cpp
 )
 
+CFLAGS(
+    -DBUILDING_LIBCURL
+)
+
 PEERDIR(
     cloud/blockstore/libs/common
     cloud/blockstore/libs/diagnostics


### PR DESCRIPTION
reproducible with ydb-25-1 toolchain e.g. [here](https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/PR-check/30718299675/1/nebius-x86-64-ubsan/logs/1/cloud/blockstore/libs/notify/impl/ut/test-results/unittest/chunk7/testing_out_stuff/TNotifyTestV2.ShouldNotifyDiskErrorV2.err)

```
/actions-runner/_work/nbs/nbs/contrib/libs/curl/lib/multi.c:3440:8: runtime error: call to function NCloud::NBlockStore::NNotify::THttpsClient::TImpl::TimerFunction(void*, long, TInstant*) through pointer to incorrect function type 'int (*)(struct Curl_multi *, long, void *)'
/actions-runner/_work/nbs/nbs/cloud/blockstore/libs/notify/impl/https.cpp:814:5: note: NCloud::NBlockStore::NNotify::THttpsClient::TImpl::TimerFunction(void*, long, TInstant*) defined here
    #0 0x327cf2a in Curl_update_timer /actions-runner/_work/nbs/nbs/contrib/libs/curl/lib/multi.c:3440:8
    #1 0x327aa27 in curl_multi_add_handle /actions-runner/_work/nbs/nbs/contrib/libs/curl/lib/multi.c:564:8
    #2 0x326e915 in NCloud::NBlockStore::NNotify::THttpsClient::TImpl::ProcessAddQueue() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/notify/impl/https.cpp:593:17
    #3 0x3279e55 in operator() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/notify/impl/https.cpp:856:13
    #4 0x3279e55 in __invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/notify/impl/https.cpp:852:45) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:150:25
    #5 0x3279e55 in __call<(lambda at /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/notify/impl/https.cpp:852:45) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:225:5
    #6 0x3279e55 in operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:169:12
    #7 0x3279e55 in std::__y1::__function::__func<NCloud::NBlockStore::NNotify::THttpsClient::TImpl::TImpl()::$_0, std::__y1::allocator<NCloud::NBlockStore::NNotify::THttpsClient::TImpl::TImpl()::$_0>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:311:10
    #8 0x18780bd in operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:987:10
    #9 0x18780bd in (anonymous namespace)::TThreadFactoryFuncObj::DoExecute() /actions-runner/_work/nbs/nbs/util/thread/factory.cpp:61:13
    #10 0x1878996 in Execute /actions-runner/_work/nbs/nbs/util/thread/factory.h:15:13
    #11 0x1878996 in (anonymous namespace)::TSystemThreadFactory::TPoolThread::ThreadProc(void*) /actions-runner/_work/nbs/nbs/util/thread/factory.cpp:36:41
    #12 0x11ea3d7 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20
    #13 0x7f06eba94a82  (/lib/x86_64-linux-gnu/libc.so.6+0x94a82) (BuildId: 22ca0a83a4004122e30a69b597be96e134068616)
    #14 0x7f06ebb2688f  (/lib/x86_64-linux-gnu/libc.so.6+0x12688f) (BuildId: 22ca0a83a4004122e30a69b597be96e134068616)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /actions-runner/_work/nbs/nbs/contrib/libs/curl/lib/multi.c:3440:8 `
```