### PR TITLE
Vhost server refactoring: move endpoint ownership from TExecutor to TServer; server.cpp is split among several translation units

### DIFF
--- a/cloud/blockstore/libs/vhost/app_context.h
+++ b/cloud/blockstore/libs/vhost/app_context.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "public.h"
+
+#include "server.h"
+
+#include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/service/public.h>
+
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <atomic>
+
+namespace NCloud::NBlockStore::NVhost {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Server-wide state shared with the objects the server creates. TServer derives
+// from it and passes itself by reference to its endpoints.
+struct TAppContext
+{
+    IServerStatsPtr ServerStats;
+    TLog Log;
+
+    std::atomic_flag ShouldStop = false;
+
+    virtual ~TAppContext() = default;
+};
+
+}   // namespace NCloud::NBlockStore::NVhost

--- a/cloud/blockstore/libs/vhost/endpoint.cpp
+++ b/cloud/blockstore/libs/vhost/endpoint.cpp
@@ -1,0 +1,345 @@
+#include "endpoint.h"
+
+#include <cloud/blockstore/libs/service/device_handler.h>
+#include <cloud/blockstore/libs/service/request_helpers.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <util/folder/path.h>
+#include <util/string/builder.h>
+#include <util/system/datetime.h>
+
+namespace NCloud::NBlockStore::NVhost {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TReadBlocksLocalMethod
+{
+    static TFuture<NProto::TReadBlocksLocalResponse> Execute(
+        IDeviceHandler& deviceHandler,
+        TCallContextPtr ctx,
+        TVhostRequest& vhostRequest)
+    {
+        TString checkpointId;
+        return deviceHandler.Read(
+            std::move(ctx),
+            vhostRequest.From,
+            vhostRequest.Length,
+            vhostRequest.SgList,
+            checkpointId);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TWriteBlocksLocalMethod
+{
+    static TFuture<NProto::TWriteBlocksLocalResponse> Execute(
+        IDeviceHandler& deviceHandler,
+        TCallContextPtr ctx,
+        TVhostRequest& vhostRequest)
+    {
+        return deviceHandler.Write(
+            std::move(ctx),
+            vhostRequest.From,
+            vhostRequest.Length,
+            vhostRequest.SgList);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TZeroBlocksMethod
+{
+    static TFuture<NProto::TZeroBlocksResponse> Execute(
+        IDeviceHandler& deviceHandler,
+        TCallContextPtr ctx,
+        TVhostRequest& vhostRequest)
+    {
+        return deviceHandler.Zero(
+            std::move(ctx),
+            vhostRequest.From,
+            vhostRequest.Length);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEndpoint::TEndpoint(
+    TAppContext& appCtx,
+    IDeviceHandlerPtr deviceHandler,
+    TString socketPath,
+    TStorageOptions options,
+    ui32 socketAccessMode,
+    TExecutor* executor)
+    : AppCtx(appCtx)
+    , DeviceHandler(std::move(deviceHandler))
+    , SocketPath(std::move(socketPath))
+    , Options(std::move(options))
+    , SocketAccessMode(socketAccessMode)
+    , Executor(executor)
+{
+    Y_ABORT_UNLESS(DeviceHandler);
+    Y_ABORT_UNLESS(Executor);
+}
+
+void TEndpoint::SetVhostDevice(IVhostDevicePtr vhostDevice)
+{
+    Y_ABORT_UNLESS(VhostDevice == nullptr);
+    VhostDevice = std::move(vhostDevice);
+}
+
+NProto::TError TEndpoint::Start()
+{
+    TFsPath(SocketPath).DeleteIfExists();
+
+    bool started = VhostDevice->Start();
+
+    if (!started) {
+        NProto::TError error;
+        error.SetCode(E_FAIL);
+        error.SetMessage(
+            TStringBuilder()
+            << "could not register block device " << SocketPath.Quote());
+        return error;
+    }
+
+    auto err = Chmod(SocketPath.c_str(), SocketAccessMode);
+
+    if (err != 0) {
+        NProto::TError error;
+        error.SetCode(MAKE_SYSTEM_ERROR(err));
+        error.SetMessage(
+            TStringBuilder()
+            << "failed to chmod socket " << SocketPath.Quote());
+        return error;
+    }
+
+    return NProto::TError();
+}
+
+TFuture<NProto::TError> TEndpoint::Stop(bool deleteSocket)
+{
+    if (Stopped.test_and_set()) {
+        return MakeFuture(MakeError(S_ALREADY));
+    }
+
+    auto future = VhostDevice->Stop();
+
+    auto cancelError = MakeError(E_CANCELLED, "Vhost endpoint is stopping");
+    with_lock (RequestsLock) {
+        TLog& Log = AppCtx.Log;
+        STORAGE_INFO(
+            "Stop endpoint " << SocketPath.Quote() << " with "
+                             << RequestsInFlight.Size()
+                             << " inflight requests");
+
+        RequestsInFlight.ForEach(
+            [&](TRequest* request)
+            {
+                CompleteRequest(*request, cancelError);
+                request->Unlink();
+            });
+    }
+
+    if (deleteSocket) {
+        TLog& Log = AppCtx.Log;
+        future = future.Apply(
+            [socketPath = SocketPath, Log](const auto& f)
+            {
+                STORAGE_INFO(
+                    "Deletion socket while stopping endpoint "
+                    << socketPath.Quote());
+                TFsPath(socketPath).DeleteIfExists();
+                return f.GetValue();
+            });
+    }
+
+    return future;
+}
+
+void TEndpoint::Update(ui64 blocksCount)
+{
+    TLog& Log = AppCtx.Log;
+    STORAGE_INFO(
+        "Update vhost endpoint " << SocketPath.Quote()
+                                 << " with blocks count = " << blocksCount);
+    VhostDevice->Update(blocksCount);
+}
+
+size_t TEndpoint::CollectRequests(const TIncompleteRequestsCollector& collector)
+{
+    ui64 now = GetCycleCount();
+    size_t count = 0;
+
+    with_lock (RequestsLock) {
+        for (auto& request: RequestsInFlight) {
+            ++count;
+            auto requestTime = request.CallContext->CalcRequestTime(now);
+            if (requestTime) {
+                collector(
+                    *request.CallContext,
+                    request.MetricRequest.VolumeInfo,
+                    request.MetricRequest.MediaKind,
+                    request.MetricRequest.RequestType,
+                    requestTime);
+            }
+        }
+    }
+    return count;
+}
+
+void TEndpoint::ProcessRequest(TVhostRequestPtr vhostRequest)
+{
+    const auto requestType = vhostRequest->Type;
+    auto request = RegisterRequest(std::move(vhostRequest));
+    if (!request) {
+        return;
+    }
+
+    switch (requestType) {
+        case EBlockStoreRequest::WriteBlocks:
+            ProcessRequest<TWriteBlocksLocalMethod>(std::move(request));
+            break;
+        case EBlockStoreRequest::ReadBlocks:
+            ProcessRequest<TReadBlocksLocalMethod>(std::move(request));
+            break;
+        case EBlockStoreRequest::ZeroBlocks:
+            ProcessRequest<TZeroBlocksMethod>(std::move(request));
+            break;
+        default:
+            Y_ABORT(
+                "Unexpected request type: %d",
+                static_cast<int>(requestType));
+            break;
+    }
+}
+
+template <typename TMethod>
+void TEndpoint::ProcessRequest(TRequestPtr request)
+{
+    auto future = TMethod::Execute(
+        *DeviceHandler,
+        request->CallContext,
+        *request->VhostRequest);
+
+    auto weakPtr = weak_from_this();
+    future.Apply(
+        [weakPtr, req = std::move(request)](const auto& f)
+        {
+            const auto& response = f.GetValue();
+            if (auto p = weakPtr.lock()) {
+                p->CompleteRequest(*req, response.GetError());
+                p->UnregisterRequest(*req);
+            }
+            return f.GetValue();
+        });
+}
+
+TRequestPtr TEndpoint::RegisterRequest(TVhostRequestPtr vhostRequest)
+{
+    auto startIndex = vhostRequest->From / Options.BlockSize;
+    auto endIndex =
+        (vhostRequest->From + vhostRequest->Length) / Options.BlockSize;
+    if (endIndex * Options.BlockSize <
+        vhostRequest->From + vhostRequest->Length)
+    {
+        ++endIndex;
+    }
+    bool unaligned = startIndex * Options.BlockSize != vhostRequest->From ||
+                     endIndex * Options.BlockSize !=
+                         vhostRequest->From + vhostRequest->Length;
+    bool shouldDrop =
+        Options.DropDiscardRequests && vhostRequest->IsDiscardRequest;
+
+    auto request =
+        MakeIntrusive<TRequest>(CreateRequestId(), std::move(vhostRequest));
+
+    const ui32 blockSize = AppCtx.ServerStats->GetBlockSize(Options.DiskId);
+
+    AppCtx.ServerStats->PrepareMetricRequest(
+        request->MetricRequest,
+        Options.ClientId,
+        Options.DiskId,
+        startIndex,
+        blockSize * (endIndex - startIndex),
+        unaligned);
+
+    AppCtx.ServerStats->RequestStarted(
+        AppCtx.Log,
+        request->MetricRequest,
+        *request->CallContext);
+
+    if (shouldDrop) {
+        CompleteRequest(*request, NProto::TError{});
+        return nullptr;
+    }
+
+    with_lock (RequestsLock) {
+        if (!Stopped.test()) {
+            RequestsInFlight.PushBack(request.Get());
+            return request;
+        }
+    }
+
+    auto error = MakeError(E_CANCELLED, "Vhost endpoint was stopped");
+    CompleteRequest(*request, error);
+    return nullptr;
+}
+
+void TEndpoint::CompleteRequest(TRequest& request, const NProto::TError& error)
+{
+    if (request.Completed.test_and_set()) {
+        return;
+    }
+
+    auto statsError = error;
+    auto vhostResult = GetResult(statsError);
+
+    AppCtx.ServerStats->RequestCompleted(
+        AppCtx.Log,
+        request.MetricRequest,
+        *request.CallContext,
+        statsError);
+
+    request.VhostRequest->Complete(vhostResult);
+}
+
+void TEndpoint::UnregisterRequest(TRequest& request)
+{
+    with_lock (RequestsLock) {
+        request.Unlink();
+    }
+}
+
+TVhostRequest::EResult TEndpoint::GetResult(NProto::TError& error)
+{
+    if (!HasError(error)) {
+        return TVhostRequest::SUCCESS;
+    }
+
+    // Keep the logic synchronized with
+    // TAlignedDeviceHandler::ReportCriticalError().
+    bool cancelError = error.GetCode() == E_CANCELLED ||
+                       GetErrorKind(error) == EErrorKind::ErrorRetriable;
+
+    bool stopEndpoint = AppCtx.ShouldStop.test() || Stopped.test();
+
+    if (stopEndpoint && cancelError) {
+        auto flags = error.GetFlags();
+        SetProtoFlag(flags, NProto::EF_SILENT);
+        error.SetFlags(flags);
+        return TVhostRequest::CANCELLED;
+    }
+
+    return TVhostRequest::IOERR;
+}
+
+}   // namespace NCloud::NBlockStore::NVhost

--- a/cloud/blockstore/libs/vhost/endpoint.h
+++ b/cloud/blockstore/libs/vhost/endpoint.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include "public.h"
+
+#include "app_context.h"
+#include "executor.h"
+#include "server.h"
+#include "vhost.h"
+
+#include <cloud/blockstore/libs/diagnostics/incomplete_requests.h>
+#include <cloud/blockstore/libs/diagnostics/server_stats.h>
+#include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/service/public.h>
+
+#include <library/cpp/threading/future/future.h>
+
+#include <util/generic/intrlist.h>
+#include <util/generic/string.h>
+#include <util/system/spinlock.h>
+
+#include <atomic>
+#include <memory>
+
+namespace NCloud::NBlockStore::NVhost {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TRequest
+    : public TIntrusiveListItem<TRequest>
+    , TAtomicRefCount<TRequest>
+{
+    const TVhostRequestPtr VhostRequest;
+    const TCallContextPtr CallContext;
+    TMetricRequest MetricRequest;
+
+    std::atomic_flag Completed = 0;
+
+    TRequest(ui64 requestId, TVhostRequestPtr vhostRequest)
+        : VhostRequest(std::move(vhostRequest))
+        , CallContext(MakeIntrusive<TCallContext>(requestId))
+        , MetricRequest(VhostRequest->Type)
+    {}
+};
+
+using TRequestPtr = TIntrusivePtr<TRequest>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// A single vhost block device exposed to the guest. Translates the vhost
+// requests dispatched to it by its executor into the IDeviceHandler API and
+// keeps track of the requests in flight.
+class TEndpoint final
+    : public IRequestProcessor
+    , public std::enable_shared_from_this<TEndpoint>
+{
+private:
+    TAppContext& AppCtx;
+    const IDeviceHandlerPtr DeviceHandler;
+    const TString SocketPath;
+    const TStorageOptions Options;
+    const ui32 SocketAccessMode;
+    TExecutor* const Executor;
+    IVhostDevicePtr VhostDevice;
+
+    TIntrusiveList<TRequest> RequestsInFlight;
+    TAdaptiveLock RequestsLock;
+
+    std::atomic_flag Stopped = false;
+
+public:
+    TEndpoint(
+        TAppContext& appCtx,
+        IDeviceHandlerPtr deviceHandler,
+        TString socketPath,
+        TStorageOptions options,
+        ui32 socketAccessMode,
+        TExecutor* executor);
+
+    void* GetCookie()
+    {
+        return static_cast<IRequestProcessor*>(this);
+    }
+
+    TExecutor* GetExecutor() const
+    {
+        return Executor;
+    }
+
+    void SetVhostDevice(IVhostDevicePtr vhostDevice);
+
+    NProto::TError Start();
+
+    NThreading::TFuture<NProto::TError> Stop(bool deleteSocket);
+
+    void Update(ui64 blocksCount);
+
+    ui32 GetVhostQueuesCount() const
+    {
+        return Options.VhostQueuesCount;
+    }
+
+    size_t CollectRequests(const TIncompleteRequestsCollector& collector);
+
+    void ProcessRequest(TVhostRequestPtr vhostRequest) override;
+
+private:
+    template <typename TMethod>
+    void ProcessRequest(TRequestPtr request);
+
+    TRequestPtr RegisterRequest(TVhostRequestPtr vhostRequest);
+
+    void CompleteRequest(TRequest& request, const NProto::TError& error);
+
+    void UnregisterRequest(TRequest& request);
+
+    TVhostRequest::EResult GetResult(NProto::TError& error);
+};
+
+using TEndpointPtr = std::shared_ptr<TEndpoint>;
+
+}   // namespace NCloud::NBlockStore::NVhost

--- a/cloud/blockstore/libs/vhost/executor.cpp
+++ b/cloud/blockstore/libs/vhost/executor.cpp
@@ -1,0 +1,70 @@
+#include "executor.h"
+
+#include "vhost.h"
+
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/server_stats.h>
+
+#include <cloud/storage/core/libs/common/thread.h>
+
+namespace NCloud::NBlockStore::NVhost {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TExecutor::TExecutor(
+    TString name,
+    IServerStats& serverStats,
+    IVhostQueuePtr vhostQueue,
+    TAffinity affinity)
+    : Name(std::move(name))
+    , ExecutorScope(serverStats.StartExecutor())
+    , VhostQueue(std::move(vhostQueue))
+    , Affinity(std::move(affinity))
+{}
+
+void TExecutor::Shutdown()
+{
+    VhostQueue->Stop();
+    Join();
+}
+
+void* TExecutor::ThreadProc()
+{
+    TAffinityGuard affinityGuard(Affinity);
+
+    ::NCloud::SetCurrentThreadName(Name);
+
+    while (true) {
+        int res = RunRequestQueue();
+        if (res != -EAGAIN) {
+            if (res < 0) {
+                ReportVhostQueueRunningError({{"return_code", -res}});
+            }
+            break;
+        }
+
+        while (auto req = VhostQueue->DequeueRequest()) {
+            ProcessRequest(std::move(req));
+        }
+    }
+
+    return nullptr;
+}
+
+int TExecutor::RunRequestQueue()
+{
+    auto activity = ExecutorScope.StartWait();
+
+    return VhostQueue->Run();
+}
+
+void TExecutor::ProcessRequest(TVhostRequestPtr vhostRequest)
+{
+    auto activity = ExecutorScope.StartExecute();
+
+    auto* processor = static_cast<IRequestProcessor*>(vhostRequest->Cookie);
+    Y_ABORT_UNLESS(processor);
+    processor->ProcessRequest(std::move(vhostRequest));
+}
+
+}   // namespace NCloud::NBlockStore::NVhost

--- a/cloud/blockstore/libs/vhost/executor.h
+++ b/cloud/blockstore/libs/vhost/executor.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/libs/diagnostics/public.h>
+
+#include <cloud/storage/core/libs/common/affinity.h>
+#include <cloud/storage/core/libs/diagnostics/executor_counters.h>
+
+#include <util/generic/string.h>
+#include <util/system/thread.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore::NVhost {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Implemented by TEndpoint. A pointer to it is used as the vhost device
+// cookie, so that an executor can dispatch a request dequeued from its request
+// queue to the endpoint the request belongs to.
+struct IRequestProcessor
+{
+    virtual ~IRequestProcessor() = default;
+
+    virtual void ProcessRequest(TVhostRequestPtr vhostRequest) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Owns a single vhost request queue and the thread that runs it. The queue is
+// shared by all endpoints assigned to this executor.
+class TExecutor final: public ISimpleThread
+{
+private:
+    const TString Name;
+    TExecutorCounters::TExecutorScope ExecutorScope;
+    const IVhostQueuePtr VhostQueue;
+    TAffinity Affinity;
+
+public:
+    TExecutor(
+        TString name,
+        IServerStats& serverStats,
+        IVhostQueuePtr vhostQueue,
+        TAffinity affinity);
+
+    void Shutdown();
+
+    const IVhostQueuePtr& GetQueue() const
+    {
+        return VhostQueue;
+    }
+
+private:
+    void* ThreadProc() override;
+
+    int RunRequestQueue();
+
+    void ProcessRequest(TVhostRequestPtr vhostRequest);
+};
+
+using TExecutorPtr = std::unique_ptr<TExecutor>;
+
+}   // namespace NCloud::NBlockStore::NVhost

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -1,25 +1,21 @@
 #include "server.h"
 
+#include "app_context.h"
+#include "endpoint.h"
+#include "executor.h"
 #include "vhost.h"
 
-#include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/diagnostics/server_stats.h>
-#include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/device_handler.h>
-#include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/storage.h>
+
 #include <cloud/storage/core/libs/common/error.h>
-#include <cloud/storage/core/libs/common/thread.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
-#include <util/folder/path.h>
-#include <util/generic/map.h>
+#include <util/generic/hash.h>
 #include <util/generic/vector.h>
 #include <util/string/builder.h>
 #include <util/system/mutex.h>
-#include <util/system/thread.h>
-
-#include <atomic>
 
 namespace NCloud::NBlockStore::NVhost {
 
@@ -29,570 +25,34 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TReadBlocksLocalMethod
-{
-    static TFuture<NProto::TReadBlocksLocalResponse> Execute(
-        IDeviceHandler& deviceHandler,
-        TCallContextPtr ctx,
-        TVhostRequest& vhostRequest)
-    {
-        TString checkpointId;
-        return deviceHandler.Read(
-            std::move(ctx),
-            vhostRequest.From,
-            vhostRequest.Length,
-            vhostRequest.SgList,
-            checkpointId);
-    }
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TWriteBlocksLocalMethod
-{
-    static TFuture<NProto::TWriteBlocksLocalResponse> Execute(
-        IDeviceHandler& deviceHandler,
-        TCallContextPtr ctx,
-        TVhostRequest& vhostRequest)
-    {
-        return deviceHandler.Write(
-            std::move(ctx),
-            vhostRequest.From,
-            vhostRequest.Length,
-            vhostRequest.SgList);
-    }
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TZeroBlocksMethod
-{
-    static TFuture<NProto::TZeroBlocksResponse> Execute(
-        IDeviceHandler& deviceHandler,
-        TCallContextPtr ctx,
-        TVhostRequest& vhostRequest)
-    {
-        return deviceHandler.Zero(
-            std::move(ctx),
-            vhostRequest.From,
-            vhostRequest.Length);
-    }
-};
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TRequest
-    : public TIntrusiveListItem<TRequest>
-    , TAtomicRefCount<TRequest>
-{
-    const TVhostRequestPtr VhostRequest;
-    const TCallContextPtr CallContext;
-    TMetricRequest MetricRequest;
-
-    std::atomic_flag Completed = 0;
-
-    TRequest(ui64 requestId, TVhostRequestPtr vhostRequest)
-        : VhostRequest(std::move(vhostRequest))
-        , CallContext(MakeIntrusive<TCallContext>(requestId))
-        , MetricRequest(VhostRequest->Type)
-    {}
-};
-
-using TRequestPtr = TIntrusivePtr<TRequest>;
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TAppContext
-{
-    IServerStatsPtr ServerStats;
-    IVhostQueueFactoryPtr VhostQueueFactory;
-    IDeviceHandlerFactoryPtr DeviceHandlerFactory;
-    TServerConfig Config;
-    TVhostCallbacks Callbacks;
-
-    TLog Log;
-
-    std::atomic_flag ShouldStop = false;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-class TEndpoint final
-    : public std::enable_shared_from_this<TEndpoint>
-{
-private:
-    TAppContext& AppCtx;
-    const IDeviceHandlerPtr DeviceHandler;
-    const TString SocketPath;
-    const TStorageOptions Options;
-    const ui32 SocketAccessMode;
-    IVhostDevicePtr VhostDevice;
-
-    TIntrusiveList<TRequest> RequestsInFlight;
-    TAdaptiveLock RequestsLock;
-
-    std::atomic_flag Stopped = false;
-
-public:
-    TEndpoint(
-            TAppContext& appCtx,
-            IDeviceHandlerPtr deviceHandler,
-            TString socketPath,
-            const TStorageOptions& options,
-            ui32 socketAccessMode)
-        : AppCtx(appCtx)
-        , DeviceHandler(std::move(deviceHandler))
-        , SocketPath(std::move(socketPath))
-        , Options(options)
-        , SocketAccessMode(socketAccessMode)
-    {}
-
-    void SetVhostDevice(IVhostDevicePtr vhostDevice)
-    {
-        Y_ABORT_UNLESS(VhostDevice == nullptr);
-        VhostDevice = std::move(vhostDevice);
-    }
-
-    NProto::TError Start()
-    {
-        TFsPath(SocketPath).DeleteIfExists();
-
-        bool started = VhostDevice->Start();
-
-        if (!started) {
-            NProto::TError error;
-            error.SetCode(E_FAIL);
-            error.SetMessage(TStringBuilder()
-                << "could not register block device "
-                << SocketPath.Quote());
-            return error;
-        }
-
-        auto err = Chmod(SocketPath.c_str(), SocketAccessMode);
-
-        if (err != 0) {
-            NProto::TError error;
-            error.SetCode(MAKE_SYSTEM_ERROR(err));
-            error.SetMessage(TStringBuilder()
-                << "failed to chmod socket "
-                << SocketPath.Quote());
-            return error;
-        }
-
-        return NProto::TError();
-    }
-
-    TFuture<NProto::TError> Stop(bool deleteSocket)
-    {
-        if (Stopped.test_and_set()) {
-            return MakeFuture(MakeError(S_ALREADY));
-        }
-
-        auto future = VhostDevice->Stop();
-
-        auto cancelError = MakeError(E_CANCELLED, "Vhost endpoint is stopping");
-        with_lock (RequestsLock) {
-            TLog& Log = AppCtx.Log;
-            STORAGE_INFO("Stop endpoint " << SocketPath.Quote()
-                << " with " << RequestsInFlight.Size() << " inflight requests");
-
-            RequestsInFlight.ForEach([&] (TRequest* request) {
-                CompleteRequest(*request, cancelError);
-                request->Unlink();
-            });
-        }
-
-        if (deleteSocket) {
-            TLog& Log = AppCtx.Log;
-            future = future.Apply(
-                [socketPath = SocketPath, Log](const auto& f)
-                {
-                    STORAGE_INFO(
-                        "Deletion socket while stopping endpoint "
-                        << socketPath.Quote());
-                    TFsPath(socketPath).DeleteIfExists();
-                    return f.GetValue();
-                });
-        }
-
-        return future;
-    }
-
-    void Update(ui64 blocksCount)
-    {
-        TLog& Log = AppCtx.Log;
-        STORAGE_INFO("Update vhost endpoint " << SocketPath.Quote()
-            << " with blocks count = " << blocksCount);
-        VhostDevice->Update(blocksCount);
-    }
-
-    ui32 GetVhostQueuesCount() const
-    {
-        return Options.VhostQueuesCount;
-    }
-
-    size_t CollectRequests(const TIncompleteRequestsCollector& collector)
-    {
-        ui64 now = GetCycleCount();
-        size_t count = 0;
-
-        with_lock (RequestsLock) {
-            for (auto& request: RequestsInFlight) {
-                ++count;
-                auto requestTime = request.CallContext->CalcRequestTime(now);
-                if (requestTime) {
-                    collector(
-                        *request.CallContext,
-                        request.MetricRequest.VolumeInfo,
-                        request.MetricRequest.MediaKind,
-                        request.MetricRequest.RequestType,
-                        requestTime);
-                }
-            }
-        }
-        return count;
-    }
-
-    void ProcessRequest(TVhostRequestPtr vhostRequest)
-    {
-        const auto requestType = vhostRequest->Type;
-        auto request = RegisterRequest(std::move(vhostRequest));
-        if (!request) {
-            return;
-        }
-
-        switch (requestType) {
-            case EBlockStoreRequest::WriteBlocks:
-                ProcessRequest<TWriteBlocksLocalMethod>(std::move(request));
-                break;
-            case EBlockStoreRequest::ReadBlocks:
-                ProcessRequest<TReadBlocksLocalMethod>(std::move(request));
-                break;
-            case EBlockStoreRequest::ZeroBlocks:
-                ProcessRequest<TZeroBlocksMethod>(std::move(request));
-                break;
-            default:
-                Y_ABORT("Unexpected request type: %d",
-                    static_cast<int>(requestType));
-                break;
-        }
-    }
-
-private:
-    template <typename TMethod>
-    void ProcessRequest(TRequestPtr request)
-    {
-        auto future = TMethod::Execute(
-            *DeviceHandler,
-            request->CallContext,
-            *request->VhostRequest);
-
-        auto weakPtr = weak_from_this();
-        future.Apply([weakPtr, req = std::move(request)] (const auto& f) {
-            const auto& response = f.GetValue();
-            if (auto p = weakPtr.lock()) {
-                p->CompleteRequest(*req, response.GetError());
-                p->UnregisterRequest(*req);
-            }
-            return f.GetValue();
-        });
-    }
-
-    TRequestPtr RegisterRequest(TVhostRequestPtr vhostRequest)
-    {
-        auto startIndex = vhostRequest->From / Options.BlockSize;
-        auto endIndex = (vhostRequest->From + vhostRequest->Length) / Options.BlockSize;
-        if (endIndex * Options.BlockSize < vhostRequest->From + vhostRequest->Length) {
-            ++endIndex;
-        }
-        bool unaligned =
-            startIndex * Options.BlockSize != vhostRequest->From ||
-            endIndex * Options.BlockSize != vhostRequest->From + vhostRequest->Length;
-        bool shouldDrop =
-            Options.DropDiscardRequests && vhostRequest->IsDiscardRequest;
-
-        auto request = MakeIntrusive<TRequest>(
-            CreateRequestId(),
-            std::move(vhostRequest));
-
-        const ui32 blockSize = AppCtx.ServerStats->GetBlockSize(Options.DiskId);
-
-        AppCtx.ServerStats->PrepareMetricRequest(
-            request->MetricRequest,
-            Options.ClientId,
-            Options.DiskId,
-            startIndex,
-            blockSize * (endIndex - startIndex),
-            unaligned);
-
-        AppCtx.ServerStats->RequestStarted(
-            AppCtx.Log,
-            request->MetricRequest,
-            *request->CallContext);
-
-        if (shouldDrop) {
-            CompleteRequest(*request, NProto::TError{});
-            return nullptr;
-        }
-
-        with_lock (RequestsLock) {
-            if (!Stopped.test()) {
-                RequestsInFlight.PushBack(request.Get());
-                return request;
-            }
-        }
-
-        auto error = MakeError(E_CANCELLED, "Vhost endpoint was stopped");
-        CompleteRequest(*request, error);
-        return nullptr;
-    }
-
-    void CompleteRequest(TRequest& request, const NProto::TError& error)
-    {
-        if (request.Completed.test_and_set()) {
-            return;
-        }
-
-        auto statsError = error;
-        auto vhostResult = GetResult(statsError);
-
-        AppCtx.ServerStats->RequestCompleted(
-            AppCtx.Log,
-            request.MetricRequest,
-            *request.CallContext,
-            statsError);
-
-        request.VhostRequest->Complete(vhostResult);
-    }
-
-    void UnregisterRequest(TRequest& request)
-    {
-        with_lock (RequestsLock) {
-            request.Unlink();
-        }
-    }
-
-    TVhostRequest::EResult GetResult(NProto::TError& error)
-    {
-        if (!HasError(error)) {
-            return TVhostRequest::SUCCESS;
-        }
-
-        // Keep the logic synchronized with
-        // TAlignedDeviceHandler::ReportCriticalError().
-        bool cancelError =
-            error.GetCode() == E_CANCELLED ||
-            GetErrorKind(error) == EErrorKind::ErrorRetriable;
-
-        bool stopEndpoint =
-            AppCtx.ShouldStop.test() ||
-            Stopped.test();
-
-        if (stopEndpoint && cancelError) {
-            auto flags = error.GetFlags();
-            SetProtoFlag(flags, NProto::EF_SILENT);
-            error.SetFlags(flags);
-            return TVhostRequest::CANCELLED;
-        }
-
-        return TVhostRequest::IOERR;
-    }
-};
-
-using TEndpointPtr = std::shared_ptr<TEndpoint>;
-
-////////////////////////////////////////////////////////////////////////////////
-
-class TExecutor final
-    : public ISimpleThread
-{
-private:
-    TAppContext& AppCtx;
-    const TString Name;
-    TExecutorCounters::TExecutorScope ExecutorScope;
-    const IVhostQueuePtr VhostQueue;
-    const ui32 SocketAccessMode;
-    TAffinity Affinity;
-
-    TMap<TString, TEndpointPtr> Endpoints;
-
-public:
-    TExecutor(
-            TAppContext& appCtx,
-            TString name,
-            IVhostQueuePtr vhostQueue,
-            ui32 socketAccessMode,
-            const TAffinity& affinity)
-        : AppCtx(appCtx)
-        , Name(std::move(name))
-        , ExecutorScope(AppCtx.ServerStats->StartExecutor())
-        , VhostQueue(std::move(vhostQueue))
-        , SocketAccessMode(socketAccessMode)
-        , Affinity(affinity)
-    {}
-
-    void Shutdown()
-    {
-        VhostQueue->Stop();
-        Join();
-    }
-
-    size_t CollectRequests(const TIncompleteRequestsCollector& collector)
-    {
-        size_t count = 0;
-        for (auto& it: Endpoints) {
-            count += it.second->CollectRequests(collector);
-        }
-        return count;
-    }
-
-    TEndpointPtr CreateEndpoint(
-        const TString& socketPath,
-        const TStorageOptions& options,
-        IStoragePtr storage)
-    {
-        TDeviceHandlerParams params{
-            .Storage = std::move(storage),
-            .DiskId = options.DiskId,
-            .ClientId = options.ClientId,
-            .BlockSize = options.BlockSize,
-            .MaxZeroBlocksSubRequestSize = options.MaxZeroBlocksSubRequestSize,
-            .UnalignedRequestsDisabled = options.UnalignedRequestsDisabled,
-            .StorageMediaKind = options.StorageMediaKind};
-
-        auto deviceHandler =
-            AppCtx.DeviceHandlerFactory->CreateDeviceHandler(std::move(params));
-
-        auto endpoint = std::make_shared<TEndpoint>(
-            AppCtx,
-            std::move(deviceHandler),
-            socketPath,
-            options,
-            SocketAccessMode);
-
-        auto vhostDevice = VhostQueue->CreateDevice(
-            socketPath,
-            options.DeviceName.empty() ? options.DiskId : options.DeviceName,
-            options.BlockSize,
-            options.BlocksCount,
-            options.VhostQueuesCount,
-            options.DiscardEnabled,
-            options.WriteZeroesEnabled,
-            options.OptimalIoSize,
-            endpoint.get(),
-            AppCtx.Callbacks);
-        endpoint->SetVhostDevice(std::move(vhostDevice));
-
-        return endpoint;
-    }
-
-    void AddEndpoint(const TString& socketPath, TEndpointPtr endpoint)
-    {
-        auto [it, inserted] = Endpoints.emplace(
-            socketPath,
-            std::move(endpoint));
-        Y_ABORT_UNLESS(inserted);
-    }
-
-    TEndpointPtr RemoveEndpoint(const TString& socketPath)
-    {
-        auto it = Endpoints.find(socketPath);
-        Y_ABORT_UNLESS(it != Endpoints.end());
-
-        auto endpoint = std::move(it->second);
-        Endpoints.erase(it);
-
-        return endpoint;
-    }
-
-    TEndpointPtr GetEndpoint(const TString& socketPath)
-    {
-        auto it = Endpoints.find(socketPath);
-        if (it == Endpoints.end()) {
-            return nullptr;
-        }
-
-        return it->second;
-    }
-
-    ui32 GetVhostQueuesCount() const
-    {
-        ui32 queuesCount = 0;
-        for (const auto& it: Endpoints) {
-            queuesCount += it.second->GetVhostQueuesCount();
-        }
-        return queuesCount;
-    }
-
-private:
-    void* ThreadProc() override
-    {
-        TAffinityGuard affinityGuard(Affinity);
-
-        ::NCloud::SetCurrentThreadName(Name);
-
-        while (true) {
-            int res = RunRequestQueue();
-            if (res != -EAGAIN) {
-                if (res < 0) {
-                    ReportVhostQueueRunningError({{"return_code", -res}});
-                }
-                break;
-            }
-
-            while (auto req = VhostQueue->DequeueRequest()) {
-                ProcessRequest(std::move(req));
-            }
-        }
-
-        return nullptr;
-    }
-
-    int RunRequestQueue()
-    {
-        auto activity = ExecutorScope.StartWait();
-
-        return VhostQueue->Run();
-    }
-
-    void ProcessRequest(TVhostRequestPtr vhostRequest)
-    {
-        auto activity = ExecutorScope.StartExecute();
-
-        auto* endpoint = reinterpret_cast<TEndpoint*>(vhostRequest->Cookie);
-        endpoint->ProcessRequest(std::move(vhostRequest));
-    }
-};
-
-using TExecutorPtr = std::unique_ptr<TExecutor>;
-
-////////////////////////////////////////////////////////////////////////////////
-
 class TServer final
     : public TAppContext
     , public IServer
     , public std::enable_shared_from_this<TServer>
 {
 private:
+    const IVhostQueueFactoryPtr VhostQueueFactory;
+    const IDeviceHandlerFactoryPtr DeviceHandlerFactory;
+    const TServerConfig Config;
+    const TVhostCallbacks Callbacks;
+
     TMutex Lock;
 
     TVector<TExecutorPtr> Executors;
 
-    TMap<TString, TExecutor*> EndpointMap;
-
-    TMap<TString, TEndpointPtr> StoppingEndpoints;
+    THashMap<TString, TEndpointPtr> Endpoints;
+    THashMap<TString, TEndpointPtr> StoppingEndpoints;
 
 public:
     TServer(
-        ILoggingServicePtr logging,
+        const ILoggingServicePtr& logging,
         IServerStatsPtr serverStats,
         IVhostQueueFactoryPtr vhostQueueFactory,
         IDeviceHandlerFactoryPtr deviceHandlerFactory,
         TServerConfig config,
         TVhostCallbacks callbacks);
 
-    ~TServer();
+    ~TServer() override;
 
     void Start() override;
     void Stop() override;
@@ -616,29 +76,35 @@ private:
 
     TExecutor* PickExecutor() const;
 
+    ui32 GetVhostQueuesCount(const TExecutor* executor) const;
+
     void StopAllEndpoints();
 
     void HandleStoppedEndpoint(
         const TString& socketPath,
         const NProto::TError& error);
+
+    IDeviceHandlerPtr CreateDeviceHandler(
+        const TStorageOptions& options,
+        IStoragePtr storage);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TServer::TServer(
-    ILoggingServicePtr logging,
+    const ILoggingServicePtr& logging,
     IServerStatsPtr serverStats,
     IVhostQueueFactoryPtr vhostQueueFactory,
     IDeviceHandlerFactoryPtr deviceHandlerFactory,
     TServerConfig config,
     TVhostCallbacks callbacks)
+    : VhostQueueFactory(std::move(vhostQueueFactory))
+    , DeviceHandlerFactory(std::move(deviceHandlerFactory))
+    , Config(std::move(config))
+    , Callbacks(std::move(callbacks))
 {
     Log = logging->CreateLog("BLOCKSTORE_VHOST");
     ServerStats = std::move(serverStats);
-    VhostQueueFactory = std::move(vhostQueueFactory);
-    DeviceHandlerFactory = std::move(deviceHandlerFactory);
-    Config = std::move(config);
-    Callbacks = std::move(callbacks);
 
     InitExecutors();
 }
@@ -676,8 +142,8 @@ size_t TServer::CollectRequests(const TIncompleteRequestsCollector& collector)
 {
     size_t count = 0;
     with_lock (Lock) {
-        for (auto& executor: Executors) {
-            count += executor->CollectRequests(collector);
+        for (auto& it: Endpoints) {
+            count += it.second->CollectRequests(collector);
         }
         for (auto& it: StoppingEndpoints) {
             count += it.second->CollectRequests(collector);
@@ -701,13 +167,13 @@ TFuture<NProto::TError> TServer::StartEndpoint(
     TExecutor* executor;
 
     with_lock (Lock) {
-        auto it = EndpointMap.find(socketPath);
-        if (it != EndpointMap.end()) {
+        auto it = Endpoints.find(socketPath);
+        if (it != Endpoints.end()) {
             NProto::TError error;
             error.SetCode(S_ALREADY);
-            error.SetMessage(TStringBuilder()
-                << "endpoint " << socketPath.Quote()
-                << " has already been started");
+            error.SetMessage(
+                TStringBuilder() << "endpoint " << socketPath.Quote()
+                                 << " has already been started");
             return MakeFuture(error);
         }
 
@@ -715,24 +181,35 @@ TFuture<NProto::TError> TServer::StartEndpoint(
         Y_ABORT_UNLESS(executor);
     }
 
-    auto endpoint = executor->CreateEndpoint(
+    auto endpoint = std::make_shared<TEndpoint>(
+        *this,
+        CreateDeviceHandler(options, std::move(storage)),
         socketPath,
         options,
-        std::move(storage));
+        Config.SocketAccessMode,
+        executor);
 
-    auto error = SafeExecute<NProto::TError>([&] {
-        return endpoint->Start();
-    });
+    auto vhostDevice = executor->GetQueue()->CreateDevice(
+        socketPath,
+        options.DeviceName.empty() ? options.DiskId : options.DeviceName,
+        options.BlockSize,
+        options.BlocksCount,
+        options.VhostQueuesCount,
+        options.DiscardEnabled,
+        options.WriteZeroesEnabled,
+        options.OptimalIoSize,
+        endpoint->GetCookie(),
+        Callbacks);
+    endpoint->SetVhostDevice(std::move(vhostDevice));
+
+    auto error = SafeExecute<NProto::TError>([&] { return endpoint->Start(); });
     if (HasError(error)) {
         return MakeFuture(error);
     }
 
     with_lock (Lock) {
-        executor->AddEndpoint(socketPath, std::move(endpoint));
-
-        auto [it, inserted] = EndpointMap.emplace(
-            std::move(socketPath),
-            executor);
+        auto [it, inserted] =
+            Endpoints.emplace(std::move(socketPath), std::move(endpoint));
         Y_ABORT_UNLESS(inserted);
     }
 
@@ -751,26 +228,26 @@ TFuture<NProto::TError> TServer::StopEndpoint(const TString& socketPath)
     TEndpointPtr endpoint;
 
     with_lock (Lock) {
-        auto it = EndpointMap.find(socketPath);
-        if (it == EndpointMap.end()) {
+        auto it = Endpoints.find(socketPath);
+        if (it == Endpoints.end()) {
             NProto::TError error;
             error.SetCode(S_ALREADY);
-            error.SetMessage(TStringBuilder()
-                << "endpoint " << socketPath.Quote()
-                << " has already been stopped");
+            error.SetMessage(
+                TStringBuilder() << "endpoint " << socketPath.Quote()
+                                 << " has already been stopped");
             return MakeFuture(error);
         }
 
-        auto* executor = it->second;
-        EndpointMap.erase(it);
+        endpoint = std::move(it->second);
+        Endpoints.erase(it);
 
-        endpoint = executor->RemoveEndpoint(socketPath);
         StoppingEndpoints.emplace(socketPath, endpoint);
     }
 
     auto ptr = shared_from_this();
     return endpoint->Stop(true).Apply(
-        [ptr = std::move(ptr), socketPath] (const auto& future) {
+        [ptr = std::move(ptr), socketPath](const auto& future)
+        {
             const auto& error = future.GetValue();
             ptr->HandleStoppedEndpoint(socketPath, error);
             return error;
@@ -791,18 +268,17 @@ NProto::TError TServer::UpdateEndpoint(
     TEndpointPtr endpoint;
 
     with_lock (Lock) {
-        auto it = EndpointMap.find(socketPath);
-        if (it == EndpointMap.end()) {
+        auto it = Endpoints.find(socketPath);
+        if (it == Endpoints.end()) {
             NProto::TError error;
             error.SetCode(S_FALSE);
-            error.SetMessage(TStringBuilder()
-                << "endpoint " << socketPath.Quote()
-                << " not started");
+            error.SetMessage(
+                TStringBuilder()
+                << "endpoint " << socketPath.Quote() << " not started");
             return error;
         }
 
-        auto* executor = it->second;
-        endpoint = executor->GetEndpoint(socketPath);
+        endpoint = it->second;
     }
 
     if (endpoint) {
@@ -817,19 +293,17 @@ void TServer::StopAllEndpoints()
     TVector<TFuture<NProto::TError>> futures;
 
     with_lock (Lock) {
-        for (const auto& it: EndpointMap) {
+        for (auto& it: Endpoints) {
             const auto& socketPath = it.first;
-            auto* executor = it.second;
+            auto endpoint = std::move(it.second);
 
-            auto endpoint = executor->RemoveEndpoint(socketPath);
             StoppingEndpoints.emplace(socketPath, endpoint);
 
-            auto future = endpoint->Stop(false);
             sockets.push_back(socketPath);
-            futures.push_back(future);
+            futures.push_back(endpoint->Stop(false));
         }
 
-        EndpointMap.clear();
+        Endpoints.clear();
     }
 
     WaitAll(futures).Wait();
@@ -846,9 +320,9 @@ void TServer::HandleStoppedEndpoint(
     const NProto::TError& error)
 {
     if (HasError(error)) {
-        STORAGE_ERROR("Failed to stop endpoint: "
-            << socketPath.Quote()
-            << ". Error: " << error);
+        STORAGE_ERROR(
+            "Failed to stop endpoint: " << socketPath.Quote()
+                                        << ". Error: " << error);
     }
 
     with_lock (Lock) {
@@ -865,10 +339,9 @@ void TServer::InitExecutors()
         auto vhostQueue = VhostQueueFactory->CreateQueue();
 
         auto executor = std::make_unique<TExecutor>(
-            *this,
             TStringBuilder() << "VHOST" << i,
+            *ServerStats,
             std::move(vhostQueue),
-            Config.SocketAccessMode,
             Config.Affinity);
 
         Executors.push_back(std::move(executor));
@@ -878,16 +351,46 @@ void TServer::InitExecutors()
 TExecutor* TServer::PickExecutor() const
 {
     TExecutor* result = nullptr;
+    ui32 resultQueuesCount = 0;
 
     for (const auto& executor: Executors) {
-        if (result == nullptr ||
-            executor->GetVhostQueuesCount() < result->GetVhostQueuesCount())
-        {
+        const ui32 queuesCount = GetVhostQueuesCount(executor.get());
+        if (result == nullptr || queuesCount < resultQueuesCount) {
             result = executor.get();
+            resultQueuesCount = queuesCount;
         }
     }
 
     return result;
+}
+
+ui32 TServer::GetVhostQueuesCount(const TExecutor* executor) const
+{
+    ui32 queuesCount = 0;
+
+    for (const auto& it: Endpoints) {
+        if (it.second->GetExecutor() == executor) {
+            queuesCount += it.second->GetVhostQueuesCount();
+        }
+    }
+
+    return queuesCount;
+}
+
+IDeviceHandlerPtr TServer::CreateDeviceHandler(
+    const TStorageOptions& options,
+    IStoragePtr storage)
+{
+    TDeviceHandlerParams params{
+        .Storage = std::move(storage),
+        .DiskId = options.DiskId,
+        .ClientId = options.ClientId,
+        .BlockSize = options.BlockSize,
+        .MaxZeroBlocksSubRequestSize = options.MaxZeroBlocksSubRequestSize,
+        .UnalignedRequestsDisabled = options.UnalignedRequestsDisabled,
+        .StorageMediaKind = options.StorageMediaKind};
+
+    return DeviceHandlerFactory->CreateDeviceHandler(std::move(params));
 }
 
 }   // namespace
@@ -895,7 +398,7 @@ TExecutor* TServer::PickExecutor() const
 ////////////////////////////////////////////////////////////////////////////////
 
 IServerPtr CreateServer(
-    ILoggingServicePtr logging,
+    const ILoggingServicePtr& logging,
     IServerStatsPtr serverStats,
     IVhostQueueFactoryPtr vhostQueueFactory,
     IDeviceHandlerFactoryPtr deviceHandlerFactory,
@@ -903,7 +406,7 @@ IServerPtr CreateServer(
     TVhostCallbacks callbacks)
 {
     return std::make_shared<TServer>(
-        std::move(logging),
+        logging,
         std::move(serverStats),
         std::move(vhostQueueFactory),
         std::move(deviceHandlerFactory),

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -67,7 +67,7 @@ struct TServerConfig
 ////////////////////////////////////////////////////////////////////////////////
 
 IServerPtr CreateServer(
-    ILoggingServicePtr logging,
+    const ILoggingServicePtr& logging,
     IServerStatsPtr serverStats,
     IVhostQueueFactoryPtr vhostQueueFactory,
     IDeviceHandlerFactoryPtr deviceHandlerFactory,

--- a/cloud/blockstore/libs/vhost/ya.make
+++ b/cloud/blockstore/libs/vhost/ya.make
@@ -1,6 +1,8 @@
 LIBRARY()
 
 SRCS(
+    endpoint.cpp
+    executor.cpp
     server.cpp
     vhost.cpp
     vhost_test.cpp


### PR DESCRIPTION
### Notes

Preparation for serving a single vhost endpoint by several executors. **No behaviour changes**.

1) Move the endpoint map, endpoint and device handler creation from TExecutor to TServer. TExecutor is now just a request queue plus the thread that runs it.
2) PickExecutor keeps choosing the executor with the smallest number of assigned vhost queues, but counts them over TServer::Endpoints instead of a per-executor map.
3) server.cpp had grown to hold every class of the vhost server. Move them into separate translation units.

### Issue
#6694
