### PR TITLE
[NBS] Load Mixed blocks filter from mixed index asynchronously after tablet start 

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1656,4 +1656,10 @@ message TStorageServiceConfig
     // if block is present in mixed index. If filter says that block is not present
     // in mixed index, we skip reading mixed index.
     optional bool MixedBlocksFilterEnabled = 520;
+
+    // Maximum number of compaction ranges to load per 1 transaction.
+    optional uint64 MixedBlocksFilterRangesToLoadPerTx = 521;
+
+    // Allowed CPU time spent on loading filter per second (in ms).
+    optional uint64 MixedBlocksFilterAllowedCpuTimePerSecond = 522;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1660,4 +1660,10 @@ message TStorageServiceConfig
     // Wait for all in-flight fresh writes started before a flush to complete
     // before building flush blobs.
     optional bool WaitForFreshWritesBeforeFlushEnabled = 521;
+
+    // Maximum number of compaction ranges to load per 1 transaction.
+    optional uint64 MixedBlocksFilterRangesToLoadPerTx = 522;
+
+    // Allowed CPU time spent on loading filter per second (in ms).
+    optional uint64 MixedBlocksFilterAllowedCpuTimePerSecond = 523;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -727,6 +727,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
                                                                                \
     xxx(MixedBlocksFilterEnabled,                   bool,       false         )\
     xxx(WaitForFreshWritesBeforeFlushEnabled,       bool,       false         )\
+    xxx(MixedBlocksFilterRangesToLoadPerTx,         ui64,       100           )\
+    xxx(MixedBlocksFilterAllowedCpuTimePerSecond,   TDuration,  MSeconds(10)  )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -726,6 +726,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(AllowGentlePreemptionForRebindVolumesAction,    bool,   false         )\
                                                                                \
     xxx(MixedBlocksFilterEnabled,                   bool,       false         )\
+    xxx(MixedBlocksFilterRangesToLoadPerTx,         ui64,       100           )\
+    xxx(MixedBlocksFilterAllowedCpuTimePerSecond,   TDuration,  MSeconds(10)  )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -874,7 +874,7 @@ public:
     [[nodiscard]] bool GetMixedBlocksFilterEnabled() const;
 
     [[nodiscard]] bool GetWaitForFreshWritesBeforeFlushEnabled() const;
-    
+
     [[nodiscard]] ui64 GetMixedBlocksFilterRangesToLoadPerTx() const;
 
     [[nodiscard]] TDuration GetMixedBlocksFilterAllowedCpuTimePerSecond() const;

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -874,6 +874,10 @@ public:
     [[nodiscard]] bool GetMixedBlocksFilterEnabled() const;
 
     [[nodiscard]] bool GetWaitForFreshWritesBeforeFlushEnabled() const;
+    
+    [[nodiscard]] ui64 GetMixedBlocksFilterRangesToLoadPerTx() const;
+
+    [[nodiscard]] TDuration GetMixedBlocksFilterAllowedCpuTimePerSecond() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -872,6 +872,10 @@ public:
     [[nodiscard]] bool GetAllowGentlePreemptionForRebindVolumesAction() const;
 
     [[nodiscard]] bool GetMixedBlocksFilterEnabled() const;
+
+    [[nodiscard]] ui64 GetMixedBlocksFilterRangesToLoadPerTx() const;
+
+    [[nodiscard]] TDuration GetMixedBlocksFilterAllowedCpuTimePerSecond() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter.cpp
@@ -187,7 +187,14 @@ void TMixedBlocksFilter::InitializeCompactionRange(
         TWellKnownEntityTypes::TABLET,
         TabletId);
 
-    CompactionRangeCommitIds[compactionRangeIndex] = commitId;
+    STORAGE_VERIFY_DEBUG(
+        !CompactionRangeCommitIds[compactionRangeIndex],
+        TWellKnownEntityTypes::TABLET,
+        TabletId);
+
+    if (!CompactionRangeCommitIds[compactionRangeIndex]) {
+        CompactionRangeCommitIds[compactionRangeIndex] = commitId;
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter.cpp
@@ -167,4 +167,27 @@ ui64 TMixedBlocksFilter::GetMemoryUsage() const
            (CompactionRangeCommitIds.capacity() * sizeof(std::optional<ui64>));
 }
 
+bool TMixedBlocksFilter::IsCompactionRangeInitialized(
+    ui64 compactionRangeIndex) const
+{
+    STORAGE_VERIFY(
+        compactionRangeIndex < CompactionRangeCommitIds.size(),
+        TWellKnownEntityTypes::TABLET,
+        TabletId);
+
+    return CompactionRangeCommitIds[compactionRangeIndex].has_value();
+}
+
+void TMixedBlocksFilter::InitializeCompactionRange(
+    ui64 compactionRangeIndex,
+    ui64 commitId)
+{
+    STORAGE_VERIFY(
+        compactionRangeIndex < CompactionRangeCommitIds.size(),
+        TWellKnownEntityTypes::TABLET,
+        TabletId);
+
+    CompactionRangeCommitIds[compactionRangeIndex] = commitId;
+}
+
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter.h
@@ -120,6 +120,25 @@ public:
      * Transient in-flight compaction state is intentionally excluded.
      */
     [[nodiscard]] ui64 GetMemoryUsage() const;
+
+    /**
+     * Checks if the range is initialized.
+     *
+     * @param compactionRangeIndex - Index of the compaction range to check.
+     *
+     * @return - True if the compaction range is initialized, false otherwise.
+     */
+    [[nodiscard]] bool IsCompactionRangeInitialized(
+        ui64 compactionRangeIndex) const;
+
+    /**
+     * Initializes the compaction range.
+     *
+     * @param compactionRangeIndex - Index of the compaction range to
+     * initialize.
+     * @param commitId - Commit ID at which the compaction range is initialized.
+     */
+    void InitializeCompactionRange(ui64 compactionRangeIndex, ui64 commitId);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.cpp
@@ -1,0 +1,66 @@
+#include "mixed_blocks_filter_load_state.h"
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TMixedBlocksFilterLoadState::TMixedBlocksFilterLoadState(
+    const TMixedBlocksFilter& mixedBlocksFilter,
+    ui64 rangesCount,
+    ui64 rangesToLoadPerTx,
+    TDuration allowedCpuTimePerSecond)
+    : MixedBlocksFilter(mixedBlocksFilter)
+    , RangesCount(rangesCount)
+    , RangesToLoadPerTx(rangesToLoadPerTx)
+    , Throttling(
+          allowedCpuTimePerSecond.SecondsFloat(),
+          allowedCpuTimePerSecond.SecondsFloat(),
+          allowedCpuTimePerSecond.SecondsFloat())
+{}
+
+[[nodiscard]] bool TMixedBlocksFilterLoadState::IsAllRangesLoaded() const
+{
+    return CompactionRangeToLoadIndex >= RangesCount;
+}
+
+auto TMixedBlocksFilterLoadState::LoadNextRanges(
+    TInstant now,
+    TDuration cpuTimeSpentDuringLastTx) -> TLoadNextRangesResult
+{
+    auto waitTimeRaw =
+        Throttling.Register(now, cpuTimeSpentDuringLastTx.SecondsFloat());
+    TDuration waitTime = TDuration::MicroSeconds(waitTimeRaw * 1e6);
+
+    while (!IsAllRangesLoaded()) {
+        auto compactionRanges = TBlockRange32::MakeClosedIntervalWithLimit(
+            CompactionRangeToLoadIndex,
+            CompactionRangeToLoadIndex + RangesToLoadPerTx - 1,
+            RangesCount - 1);
+
+        CompactionRangeToLoadIndex =
+            static_cast<ui64>(compactionRanges.End) + 1;
+
+        bool compactionRangesAlreadyInitialized = true;
+        for (ui64 compactionRangeIndex = compactionRanges.Start;
+             compactionRangeIndex <= compactionRanges.End;
+             ++compactionRangeIndex)
+        {
+            if (!MixedBlocksFilter.IsCompactionRangeInitialized(
+                    compactionRangeIndex))
+            {
+                compactionRangesAlreadyInitialized = false;
+                break;
+            }
+        }
+
+        if (compactionRangesAlreadyInitialized) {
+            continue;
+        }
+
+        return {.CompactionRanges = compactionRanges, .Throttling = waitTime};
+    }
+
+    return {.CompactionRanges = std::nullopt, .Throttling = TDuration::Zero()};
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.cpp
@@ -34,26 +34,21 @@ TMixedBlocksFilterLoadState::TMixedBlocksFilterLoadState(
     return CompactionRangeToLoadIndex >= RangesCount;
 }
 
-[[nodiscard]] std::optional<TBlockRange32>
+[[nodiscard]] std::optional<TCompactionRangesToLoad>
 TMixedBlocksFilterLoadState::LoadNextRanges()
 {
     while (!IsAllRangesLoaded()) {
-        const auto endIndex =
-            Max<ui64>() - RangesToLoadPerTx + 1 <= CompactionRangeToLoadIndex
-                ? Max<ui64>()
-                : CompactionRangeToLoadIndex + RangesToLoadPerTx - 1;
+        const TCompactionRangesToLoad compactionRanges{
+            .RangeIndex = CompactionRangeToLoadIndex,
+            .RangeCount =
+                Min(RangesToLoadPerTx,
+                    RangesCount - CompactionRangeToLoadIndex)};
 
-        auto compactionRanges = TBlockRange32::MakeClosedIntervalWithLimit(
-            CompactionRangeToLoadIndex,
-            endIndex,
-            RangesCount - 1);
-
-        CompactionRangeToLoadIndex =
-            static_cast<ui64>(compactionRanges.End) + 1;
+        CompactionRangeToLoadIndex += compactionRanges.RangeCount;
 
         bool allRangesInitialized = true;
-        for (ui64 rangeIndex = compactionRanges.Start;
-             rangeIndex <= compactionRanges.End;
+        for (ui64 rangeIndex = compactionRanges.RangeIndex;
+             rangeIndex < CompactionRangeToLoadIndex;
              ++rangeIndex)
         {
             if (!MixedBlocksFilter.IsCompactionRangeInitialized(rangeIndex)) {

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.cpp
@@ -12,17 +12,20 @@ TMixedBlocksFilterLoadState::TMixedBlocksFilterLoadState(
     : MixedBlocksFilter(mixedBlocksFilter)
     , RangesCount(rangesCount)
     , RangesToLoadPerTx(rangesToLoadPerTx)
+    , AllowedCpuTimePerSecond(
+          allowedCpuTimePerSecond ? allowedCpuTimePerSecond
+                                  : TDuration::Seconds(1))
     , Throttling(
-          allowedCpuTimePerSecond.SecondsFloat(),
-          allowedCpuTimePerSecond.SecondsFloat(),
-          allowedCpuTimePerSecond.SecondsFloat())
+          AllowedCpuTimePerSecond.SecondsFloat(),
+          AllowedCpuTimePerSecond.SecondsFloat(),
+          AllowedCpuTimePerSecond.SecondsFloat())
 {
-    Y_ABORT_UNLESS(rangesCount > 0, "Ranges count must be greater than 0");
+    Y_ABORT_UNLESS(RangesCount > 0, "Ranges count must be greater than 0");
     Y_ABORT_UNLESS(
-        rangesToLoadPerTx > 0,
+        RangesToLoadPerTx > 0,
         "Ranges to load per tx must be greater than 0");
     Y_ABORT_UNLESS(
-        allowedCpuTimePerSecond.SecondsFloat() > 0,
+        AllowedCpuTimePerSecond.SecondsFloat() > 0,
         "Allowed cpu time per second must be greater than 0");
 }
 
@@ -35,33 +38,31 @@ TMixedBlocksFilterLoadState::TMixedBlocksFilterLoadState(
 TMixedBlocksFilterLoadState::LoadNextRanges()
 {
     while (!IsAllRangesLoaded()) {
-        const auto endCompactionRange =
+        const auto endIndex =
             Max<ui64>() - RangesToLoadPerTx + 1 <= CompactionRangeToLoadIndex
                 ? Max<ui64>()
                 : CompactionRangeToLoadIndex + RangesToLoadPerTx - 1;
 
         auto compactionRanges = TBlockRange32::MakeClosedIntervalWithLimit(
             CompactionRangeToLoadIndex,
-            endCompactionRange,
+            endIndex,
             RangesCount - 1);
 
         CompactionRangeToLoadIndex =
             static_cast<ui64>(compactionRanges.End) + 1;
 
-        bool compactionRangesAlreadyInitialized = true;
-        for (ui64 compactionRangeIndex = compactionRanges.Start;
-             compactionRangeIndex <= compactionRanges.End;
-             ++compactionRangeIndex)
+        bool allRangesInitialized = true;
+        for (ui64 rangeIndex = compactionRanges.Start;
+             rangeIndex <= compactionRanges.End;
+             ++rangeIndex)
         {
-            if (!MixedBlocksFilter.IsCompactionRangeInitialized(
-                    compactionRangeIndex))
-            {
-                compactionRangesAlreadyInitialized = false;
+            if (!MixedBlocksFilter.IsCompactionRangeInitialized(rangeIndex)) {
+                allRangesInitialized = false;
                 break;
             }
         }
 
-        if (compactionRangesAlreadyInitialized) {
+        if (allRangesInitialized) {
             continue;
         }
 

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.cpp
@@ -16,25 +16,33 @@ TMixedBlocksFilterLoadState::TMixedBlocksFilterLoadState(
           allowedCpuTimePerSecond.SecondsFloat(),
           allowedCpuTimePerSecond.SecondsFloat(),
           allowedCpuTimePerSecond.SecondsFloat())
-{}
+{
+    Y_ABORT_UNLESS(rangesCount > 0, "Ranges count must be greater than 0");
+    Y_ABORT_UNLESS(
+        rangesToLoadPerTx > 0,
+        "Ranges to load per tx must be greater than 0");
+    Y_ABORT_UNLESS(
+        allowedCpuTimePerSecond.SecondsFloat() > 0,
+        "Allowed cpu time per second must be greater than 0");
+}
 
 [[nodiscard]] bool TMixedBlocksFilterLoadState::IsAllRangesLoaded() const
 {
     return CompactionRangeToLoadIndex >= RangesCount;
 }
 
-auto TMixedBlocksFilterLoadState::LoadNextRanges(
-    TInstant now,
-    TDuration cpuTimeSpentDuringLastTx) -> TLoadNextRangesResult
+[[nodiscard]] std::optional<TBlockRange32>
+TMixedBlocksFilterLoadState::LoadNextRanges()
 {
-    auto waitTimeRaw =
-        Throttling.Register(now, cpuTimeSpentDuringLastTx.SecondsFloat());
-    TDuration waitTime = TDuration::MicroSeconds(waitTimeRaw * 1e6);
-
     while (!IsAllRangesLoaded()) {
+        const auto endCompactionRange =
+            Max<ui64>() - RangesToLoadPerTx + 1 <= CompactionRangeToLoadIndex
+                ? Max<ui64>()
+                : CompactionRangeToLoadIndex + RangesToLoadPerTx - 1;
+
         auto compactionRanges = TBlockRange32::MakeClosedIntervalWithLimit(
             CompactionRangeToLoadIndex,
-            CompactionRangeToLoadIndex + RangesToLoadPerTx - 1,
+            endCompactionRange,
             RangesCount - 1);
 
         CompactionRangeToLoadIndex =
@@ -57,10 +65,27 @@ auto TMixedBlocksFilterLoadState::LoadNextRanges(
             continue;
         }
 
-        return {.CompactionRanges = compactionRanges, .Throttling = waitTime};
+        return compactionRanges;
     }
 
-    return {.CompactionRanges = std::nullopt, .Throttling = TDuration::Zero()};
+    return std::nullopt;
+}
+
+[[nodiscard]] TDuration TMixedBlocksFilterLoadState::RegisterTransaction(
+    TInstant now,
+    TDuration cpuTimeSpentDuringLastTx)
+{
+    auto postponeTime = TDuration::MicroSeconds(
+        Throttling.CalculatePostponeTime(
+            now,
+            cpuTimeSpentDuringLastTx.SecondsFloat()) *
+        1e6);
+
+    Throttling.Register(
+        now + postponeTime,
+        cpuTimeSpentDuringLastTx.SecondsFloat());
+
+    return postponeTime;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "mixed_blocks_filter.h"
+
+#include <cloud/blockstore/libs/common/block_range.h>
+
+#include <cloud/storage/core/libs/common/compressed_bitmap.h>
+#include <cloud/storage/core/libs/throttling/leaky_bucket.h>
+
+#include <utility>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TMixedBlocksFilterLoadState
+{
+private:
+    const TMixedBlocksFilter& MixedBlocksFilter;
+    const ui64 RangesCount = 0;
+    const ui64 RangesToLoadPerTx = 0;
+
+    ui64 CompactionRangeToLoadIndex = 0;
+
+    TLeakyBucket Throttling;
+
+public:
+    TMixedBlocksFilterLoadState(
+        const TMixedBlocksFilter& mixedBlocksFilter,
+        ui64 rangesCount,
+        ui64 rangesToLoadPerTx,
+        TDuration allowedCpuTimePerSecond);
+
+    [[nodiscard]] bool IsAllRangesLoaded() const;
+
+    struct TLoadNextRangesResult
+    {
+        // nullopt means that all compaction ranges are loaded.
+        std::optional<TBlockRange32> CompactionRanges;
+
+        // Load transaction should be executed after this duration.
+        TDuration Throttling;
+    };
+
+    [[nodiscard]] TLoadNextRangesResult LoadNextRanges(
+        TInstant now,
+        TDuration cpuTimeSpentDuringLastTx);
+};
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
@@ -4,10 +4,7 @@
 
 #include <cloud/blockstore/libs/common/block_range.h>
 
-#include <cloud/storage/core/libs/common/compressed_bitmap.h>
 #include <cloud/storage/core/libs/throttling/leaky_bucket.h>
-
-#include <utility>
 
 namespace NCloud::NBlockStore::NStorage::NPartition {
 

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
@@ -33,16 +33,10 @@ public:
 
     [[nodiscard]] bool IsAllRangesLoaded() const;
 
-    struct TLoadNextRangesResult
-    {
-        // nullopt means that all compaction ranges are loaded.
-        std::optional<TBlockRange32> CompactionRanges;
+    // nullopt means that all compaction ranges are loaded.
+    [[nodiscard]] std::optional<TBlockRange32> LoadNextRanges();
 
-        // Load transaction should be executed after this duration.
-        TDuration Throttling;
-    };
-
-    [[nodiscard]] TLoadNextRangesResult LoadNextRanges(
+    [[nodiscard]] TDuration RegisterTransaction(
         TInstant now,
         TDuration cpuTimeSpentDuringLastTx);
 };

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
@@ -16,6 +16,7 @@ private:
     const TMixedBlocksFilter& MixedBlocksFilter;
     const ui64 RangesCount = 0;
     const ui64 RangesToLoadPerTx = 0;
+    const TDuration AllowedCpuTimePerSecond;
 
     ui64 CompactionRangeToLoadIndex = 0;
 
@@ -33,6 +34,8 @@ public:
     // nullopt means that all compaction ranges are loaded.
     [[nodiscard]] std::optional<TBlockRange32> LoadNextRanges();
 
+    // Register a transaction in leaky bucket and return the time to wait before
+    // the next transaction.
     [[nodiscard]] TDuration RegisterTransaction(
         TInstant now,
         TDuration cpuTimeSpentDuringLastTx);

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h
@@ -2,11 +2,19 @@
 
 #include "mixed_blocks_filter.h"
 
-#include <cloud/blockstore/libs/common/block_range.h>
-
 #include <cloud/storage/core/libs/throttling/leaky_bucket.h>
 
+#include <optional>
+
 namespace NCloud::NBlockStore::NStorage::NPartition {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCompactionRangesToLoad
+{
+    ui64 RangeIndex = 0;
+    ui64 RangeCount = 0;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -32,7 +40,7 @@ public:
     [[nodiscard]] bool IsAllRangesLoaded() const;
 
     // nullopt means that all compaction ranges are loaded.
-    [[nodiscard]] std::optional<TBlockRange32> LoadNextRanges();
+    [[nodiscard]] std::optional<TCompactionRangesToLoad> LoadNextRanges();
 
     // Register a transaction in leaky bucket and return the time to wait before
     // the next transaction.

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state_ut.cpp
@@ -24,15 +24,13 @@ void InitializeRanges(
 }
 
 void AssertRange(
-    const TMixedBlocksFilterLoadState::TLoadNextRangesResult& result,
+    const std::optional<TBlockRange32>& range,
     ui32 start,
-    ui32 end,
-    TDuration throttling = TDuration::Zero())
+    ui32 end)
 {
-    UNIT_ASSERT(result.CompactionRanges);
-    UNIT_ASSERT_VALUES_EQUAL(start, result.CompactionRanges->Start);
-    UNIT_ASSERT_VALUES_EQUAL(end, result.CompactionRanges->End);
-    UNIT_ASSERT_VALUES_EQUAL(throttling, result.Throttling);
+    UNIT_ASSERT(range);
+    UNIT_ASSERT_VALUES_EQUAL(start, range->Start);
+    UNIT_ASSERT_VALUES_EQUAL(end, range->End);
 }
 
 }   // namespace
@@ -51,19 +49,15 @@ Y_UNIT_TEST_SUITE(TMixedBlocksFilterLoadStateTest)
             3,
             TDuration::MilliSeconds(100));
 
-        const auto now = TInstant::Seconds(1);
-
         UNIT_ASSERT(!state.IsAllRangesLoaded());
-        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 0, 2);
+        AssertRange(state.LoadNextRanges(), 0, 2);
         UNIT_ASSERT(!state.IsAllRangesLoaded());
-        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 3, 5);
+        AssertRange(state.LoadNextRanges(), 3, 5);
         UNIT_ASSERT(!state.IsAllRangesLoaded());
-        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 6, 6);
+        AssertRange(state.LoadNextRanges(), 6, 6);
         UNIT_ASSERT(state.IsAllRangesLoaded());
 
-        const auto result = state.LoadNextRanges(now, TDuration::Zero());
-        UNIT_ASSERT(!result.CompactionRanges);
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), result.Throttling);
+        UNIT_ASSERT(!state.LoadNextRanges());
     }
 
     Y_UNIT_TEST(ShouldSkipInitializedBatches)
@@ -78,31 +72,30 @@ Y_UNIT_TEST_SUITE(TMixedBlocksFilterLoadStateTest)
             3,
             TDuration::MilliSeconds(100));
 
-        const auto now = TInstant::Seconds(1);
-        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 3, 5);
+        AssertRange(state.LoadNextRanges(), 3, 5);
 
-        const auto result = state.LoadNextRanges(now, TDuration::Zero());
-        UNIT_ASSERT(!result.CompactionRanges);
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), result.Throttling);
+        UNIT_ASSERT(!state.LoadNextRanges());
         UNIT_ASSERT(state.IsAllRangesLoaded());
     }
 
-    Y_UNIT_TEST(ShouldStartCompletedWhenThereAreNoRanges)
+    Y_UNIT_TEST(ShouldSkipRangesInitializedAfterTransactionRegistration)
     {
-        auto filter = MakeFilter(1);
+        constexpr ui64 RangeCount = 3;
+        auto filter = MakeFilter(RangeCount);
         TMixedBlocksFilterLoadState state(
             filter,
-            0,
+            RangeCount,
             1,
             TDuration::MilliSeconds(100));
 
-        UNIT_ASSERT(state.IsAllRangesLoaded());
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            state.RegisterTransaction(
+                TInstant::Seconds(1),
+                TDuration::Zero()));
 
-        const auto result = state.LoadNextRanges(
-            TInstant::Seconds(1),
-            TDuration::Seconds(1));
-        UNIT_ASSERT(!result.CompactionRanges);
-        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), result.Throttling);
+        InitializeRanges(filter, {0});
+        AssertRange(state.LoadNextRanges(), 1, 1);
     }
 
     Y_UNIT_TEST(ShouldThrottleAccordingToCpuTime)
@@ -116,18 +109,22 @@ Y_UNIT_TEST_SUITE(TMixedBlocksFilterLoadStateTest)
             TDuration::MilliSeconds(100));
 
         const auto now = TInstant::Seconds(1);
-        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 0, 0);
-        AssertRange(
-            state.LoadNextRanges(now, TDuration::MilliSeconds(150)),
-            1,
-            1,
-            TDuration::MilliSeconds(500));
-        AssertRange(
-            state.LoadNextRanges(
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            state.RegisterTransaction(now, TDuration::Zero()));
+        AssertRange(state.LoadNextRanges(), 0, 0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(500),
+            state.RegisterTransaction(now, TDuration::MilliSeconds(150)));
+        AssertRange(state.LoadNextRanges(), 1, 1);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(1500),
+            state.RegisterTransaction(
                 now + TDuration::MilliSeconds(500),
-                TDuration::MilliSeconds(150)),
-            2,
-            2);
+                TDuration::MilliSeconds(150)));
+        AssertRange(state.LoadNextRanges(), 2, 2);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state_ut.cpp
@@ -1,0 +1,134 @@
+#include "mixed_blocks_filter_load_state.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui64 BlocksPerRange = TCompressedBitmap::CHUNK_SIZE;
+
+TMixedBlocksFilter MakeFilter(ui64 rangeCount)
+{
+    return TMixedBlocksFilter(0, BlocksPerRange, rangeCount * BlocksPerRange);
+}
+
+void InitializeRanges(
+    TMixedBlocksFilter& filter,
+    TVector<ui32> rangeIndices)
+{
+    filter.CompactionStarted(std::move(rangeIndices), 1);
+    filter.CompactionFinished();
+}
+
+void AssertRange(
+    const TMixedBlocksFilterLoadState::TLoadNextRangesResult& result,
+    ui32 start,
+    ui32 end,
+    TDuration throttling = TDuration::Zero())
+{
+    UNIT_ASSERT(result.CompactionRanges);
+    UNIT_ASSERT_VALUES_EQUAL(start, result.CompactionRanges->Start);
+    UNIT_ASSERT_VALUES_EQUAL(end, result.CompactionRanges->End);
+    UNIT_ASSERT_VALUES_EQUAL(throttling, result.Throttling);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TMixedBlocksFilterLoadStateTest)
+{
+    Y_UNIT_TEST(ShouldLoadRangesInBoundedBatches)
+    {
+        constexpr ui64 RangeCount = 7;
+        auto filter = MakeFilter(RangeCount);
+        TMixedBlocksFilterLoadState state(
+            filter,
+            RangeCount,
+            3,
+            TDuration::MilliSeconds(100));
+
+        const auto now = TInstant::Seconds(1);
+
+        UNIT_ASSERT(!state.IsAllRangesLoaded());
+        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 0, 2);
+        UNIT_ASSERT(!state.IsAllRangesLoaded());
+        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 3, 5);
+        UNIT_ASSERT(!state.IsAllRangesLoaded());
+        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 6, 6);
+        UNIT_ASSERT(state.IsAllRangesLoaded());
+
+        const auto result = state.LoadNextRanges(now, TDuration::Zero());
+        UNIT_ASSERT(!result.CompactionRanges);
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), result.Throttling);
+    }
+
+    Y_UNIT_TEST(ShouldSkipInitializedBatches)
+    {
+        constexpr ui64 RangeCount = 10;
+        auto filter = MakeFilter(RangeCount);
+        InitializeRanges(filter, {0, 1, 2, 3, 6, 7, 8, 9});
+
+        TMixedBlocksFilterLoadState state(
+            filter,
+            RangeCount,
+            3,
+            TDuration::MilliSeconds(100));
+
+        const auto now = TInstant::Seconds(1);
+        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 3, 5);
+
+        const auto result = state.LoadNextRanges(now, TDuration::Zero());
+        UNIT_ASSERT(!result.CompactionRanges);
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), result.Throttling);
+        UNIT_ASSERT(state.IsAllRangesLoaded());
+    }
+
+    Y_UNIT_TEST(ShouldStartCompletedWhenThereAreNoRanges)
+    {
+        auto filter = MakeFilter(1);
+        TMixedBlocksFilterLoadState state(
+            filter,
+            0,
+            1,
+            TDuration::MilliSeconds(100));
+
+        UNIT_ASSERT(state.IsAllRangesLoaded());
+
+        const auto result = state.LoadNextRanges(
+            TInstant::Seconds(1),
+            TDuration::Seconds(1));
+        UNIT_ASSERT(!result.CompactionRanges);
+        UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), result.Throttling);
+    }
+
+    Y_UNIT_TEST(ShouldThrottleAccordingToCpuTime)
+    {
+        constexpr ui64 RangeCount = 3;
+        auto filter = MakeFilter(RangeCount);
+        TMixedBlocksFilterLoadState state(
+            filter,
+            RangeCount,
+            1,
+            TDuration::MilliSeconds(100));
+
+        const auto now = TInstant::Seconds(1);
+        AssertRange(state.LoadNextRanges(now, TDuration::Zero()), 0, 0);
+        AssertRange(
+            state.LoadNextRanges(now, TDuration::MilliSeconds(150)),
+            1,
+            1,
+            TDuration::MilliSeconds(500));
+        AssertRange(
+            state.LoadNextRanges(
+                now + TDuration::MilliSeconds(500),
+                TDuration::MilliSeconds(150)),
+            2,
+            2);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state_ut.cpp
@@ -23,14 +23,14 @@ void InitializeRanges(
     filter.CompactionFinished();
 }
 
-void AssertRange(
-    const std::optional<TBlockRange32>& range,
-    ui32 start,
-    ui32 end)
+void AssertRanges(
+    const std::optional<TCompactionRangesToLoad>& ranges,
+    ui64 rangeIndex,
+    ui64 rangeCount)
 {
-    UNIT_ASSERT(range);
-    UNIT_ASSERT_VALUES_EQUAL(start, range->Start);
-    UNIT_ASSERT_VALUES_EQUAL(end, range->End);
+    UNIT_ASSERT(ranges);
+    UNIT_ASSERT_VALUES_EQUAL(rangeIndex, ranges->RangeIndex);
+    UNIT_ASSERT_VALUES_EQUAL(rangeCount, ranges->RangeCount);
 }
 
 }   // namespace
@@ -50,11 +50,11 @@ Y_UNIT_TEST_SUITE(TMixedBlocksFilterLoadStateTest)
             TDuration::MilliSeconds(100));
 
         UNIT_ASSERT(!state.IsAllRangesLoaded());
-        AssertRange(state.LoadNextRanges(), 0, 2);
+        AssertRanges(state.LoadNextRanges(), 0, 3);
         UNIT_ASSERT(!state.IsAllRangesLoaded());
-        AssertRange(state.LoadNextRanges(), 3, 5);
+        AssertRanges(state.LoadNextRanges(), 3, 3);
         UNIT_ASSERT(!state.IsAllRangesLoaded());
-        AssertRange(state.LoadNextRanges(), 6, 6);
+        AssertRanges(state.LoadNextRanges(), 6, 1);
         UNIT_ASSERT(state.IsAllRangesLoaded());
 
         UNIT_ASSERT(!state.LoadNextRanges());
@@ -72,7 +72,7 @@ Y_UNIT_TEST_SUITE(TMixedBlocksFilterLoadStateTest)
             3,
             TDuration::MilliSeconds(100));
 
-        AssertRange(state.LoadNextRanges(), 3, 5);
+        AssertRanges(state.LoadNextRanges(), 3, 3);
 
         UNIT_ASSERT(!state.LoadNextRanges());
         UNIT_ASSERT(state.IsAllRangesLoaded());
@@ -95,7 +95,7 @@ Y_UNIT_TEST_SUITE(TMixedBlocksFilterLoadStateTest)
                 TDuration::Zero()));
 
         InitializeRanges(filter, {0});
-        AssertRange(state.LoadNextRanges(), 1, 1);
+        AssertRanges(state.LoadNextRanges(), 1, 1);
     }
 
     Y_UNIT_TEST(ShouldThrottleAccordingToCpuTime)
@@ -112,19 +112,19 @@ Y_UNIT_TEST_SUITE(TMixedBlocksFilterLoadStateTest)
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::Zero(),
             state.RegisterTransaction(now, TDuration::Zero()));
-        AssertRange(state.LoadNextRanges(), 0, 0);
+        AssertRanges(state.LoadNextRanges(), 0, 1);
 
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(500),
             state.RegisterTransaction(now, TDuration::MilliSeconds(150)));
-        AssertRange(state.LoadNextRanges(), 1, 1);
+        AssertRanges(state.LoadNextRanges(), 1, 1);
 
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(1500),
             state.RegisterTransaction(
                 now + TDuration::MilliSeconds(500),
                 TDuration::MilliSeconds(150)));
-        AssertRange(state.LoadNextRanges(), 2, 2);
+        AssertRanges(state.LoadNextRanges(), 2, 1);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ut/ya.make
@@ -16,6 +16,7 @@ SRCS(
     garbage_queue_ut.cpp
     group_downtimes_ut.cpp
     mixed_blocks_filter_ut.cpp
+    mixed_blocks_filter_load_state_ut.cpp
     mixed_index_cache_ut.cpp
 )
 

--- a/cloud/blockstore/libs/storage/partition/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ya.make
@@ -22,6 +22,7 @@ SRCS(
     garbage_queue.cpp
     group_downtimes.cpp
     mixed_blocks_filter.cpp
+    mixed_blocks_filter_load_state.cpp
     mixed_index_cache.cpp
     operation_status.cpp
     part_counters_wrapper.cpp

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1154,6 +1154,7 @@ STFUNC(TPartitionActor::StateInit)
             TEvPartitionPrivate::TEvConfirmBlobsCompleted,
             HandleConfirmBlobsCompleted);
         HFunc(TEvPartitionPrivate::TEvLoadCompactionMapChunkRequest, HandleLoadCompactionMapChunk);
+        HFunc(TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest, HandleLoadMixedBlocksFilterChunk);
 
         HFunc(TEvVolume::TEvGetUsedBlocksResponse, HandleGetUsedBlocksResponse);
 
@@ -1234,6 +1235,7 @@ STFUNC(TPartitionActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddConfirmedBlobsCompleted, HandleAddConfirmedBlobsCompleted);
         HFunc(TEvPartitionCommonPrivate::TEvDescribeBlocksCompleted, HandleDescribeBlocksCompleted);
         HFunc(TEvPartitionPrivate::TEvLoadCompactionMapChunkRequest, HandleLoadCompactionMapChunk);
+        HFunc(TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest, HandleLoadMixedBlocksFilterChunk);
         HFunc(
             TEvPartitionCommonPrivate::TEvGetPartCountersRequest,
             HandleGetPartCountersRequest);
@@ -1324,6 +1326,7 @@ STFUNC(TPartitionActor::StateZombie)
         IgnoreFunc(TEvPartitionPrivate::TEvAddConfirmedBlobsCompleted);
         IgnoreFunc(TEvPartitionCommonPrivate::TEvDescribeBlocksCompleted);
         IgnoreFunc(TEvPartitionPrivate::TEvLoadCompactionMapChunkRequest);
+        IgnoreFunc(TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest);
 
         IgnoreFunc(TEvPartitionPrivate::TEvCleanupResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvCollectGarbageResponse);

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1154,6 +1154,7 @@ STFUNC(TPartitionActor::StateInit)
             TEvPartitionPrivate::TEvConfirmBlobsCompleted,
             HandleConfirmBlobsCompleted);
         HFunc(TEvPartitionPrivate::TEvLoadCompactionMapChunkRequest, HandleLoadCompactionMapChunk);
+        HFunc(TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest, HandleLoadMixedBlocksFilterChunk);
 
         HFunc(TEvVolume::TEvGetUsedBlocksResponse, HandleGetUsedBlocksResponse);
 
@@ -1234,6 +1235,7 @@ STFUNC(TPartitionActor::StateWork)
         HFunc(TEvPartitionPrivate::TEvAddConfirmedBlobsCompleted, HandleAddConfirmedBlobsCompleted);
         HFunc(TEvPartitionCommonPrivate::TEvDescribeBlocksCompleted, HandleDescribeBlocksCompleted);
         HFunc(TEvPartitionPrivate::TEvLoadCompactionMapChunkRequest, HandleLoadCompactionMapChunk);
+        HFunc(TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest, HandleLoadMixedBlocksFilterChunk);
         HFunc(
             TEvPartitionCommonPrivate::TEvGetPartCountersRequest,
             HandleGetPartCountersRequest);
@@ -1322,6 +1324,7 @@ STFUNC(TPartitionActor::StateZombie)
         IgnoreFunc(TEvPartitionPrivate::TEvAddConfirmedBlobsCompleted);
         IgnoreFunc(TEvPartitionCommonPrivate::TEvDescribeBlocksCompleted);
         IgnoreFunc(TEvPartitionPrivate::TEvLoadCompactionMapChunkRequest);
+        IgnoreFunc(TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest);
 
         IgnoreFunc(TEvPartitionPrivate::TEvCleanupResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvCollectGarbageResponse);

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -778,6 +778,13 @@ private:
         const TEvPartitionPrivate::TEvLoadCompactionMapChunkRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void LoadNextMixedBlocksFilterChunkIfNeeded(
+        const NActors::TActorContext& ctx,
+        TDuration cpuTimeSpentDuringLastTx);
+    void HandleLoadMixedBlocksFilterChunk(
+        const TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleWakeupOnBoot(
         const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -777,6 +777,13 @@ private:
         const TEvPartitionPrivate::TEvLoadCompactionMapChunkRequest::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void LoadNextMixedBlocksFilterChunkIfNeeded(
+        const NActors::TActorContext& ctx,
+        TDuration cpuTimeSpentDuringLastTx);
+    void HandleLoadMixedBlocksFilterChunk(
+        const TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleWakeupOnBoot(
         const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -40,6 +40,31 @@ ui32 GetMaxIORequestsInFlight(
     }
 }
 
+class TMixedBlocksFilterLoadVisitor final
+    : public IMixedBlocksIndexVisitor
+{
+private:
+    TVector<TBlock>& Blocks;
+
+public:
+    explicit TMixedBlocksFilterLoadVisitor(TVector<TBlock>& blocks)
+        : Blocks(blocks)
+    {}
+
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui8 compactionRangeCount) override
+    {
+        Y_UNUSED(blobId, blobOffset, compactionRangeCount);
+
+        Blocks.emplace_back(blockIndex, commitId, false);
+        return true;
+    }
+};
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -235,7 +260,9 @@ void TPartitionActor::CompleteLoadState(
         Config->GetCompactionRangeCountPerRun(),
         SharedState,
         TabletID(),
-        IsMixedBlocksFilterEnabled());
+        IsMixedBlocksFilterEnabled(),
+        Config->GetMixedBlocksFilterRangesToLoadPerTx(),
+        Config->GetMixedBlocksFilterAllowedCpuTimePerSecond());
 
     CreateFreshBlocksCompanionClient();
 
@@ -284,6 +311,8 @@ void TPartitionActor::CompleteLoadState(
             args.CompactionMap,
             &State->GetUsedBlocks());
     }
+
+    LoadNextMixedBlocksFilterChunkIfNeeded(ctx, TDuration::Zero());
 
     State->AccessCheckpoints().Add(args.Checkpoints);
     State->AccessCheckpoints().SetCheckpointMappings(
@@ -515,6 +544,126 @@ void TPartitionActor::HandleLoadCompactionMapChunk(
         ev->Get()->Range.Print().c_str());
 
     ExecuteTx<TLoadCompactionMapChunk>(ctx, ev->Get()->Range);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TPartitionActor::LoadNextMixedBlocksFilterChunkIfNeeded(
+    const TActorContext& ctx,
+    TDuration cpuTimeSpentDuringLastTx)
+{
+    auto* loadState = State->AccessMixedBlocksFilterLoadState();
+
+    if (!loadState) {
+        return;
+    }
+
+    auto [nextRange, throttlingTime] = loadState->LoadNextRanges(
+        ctx.Now(),
+        cpuTimeSpentDuringLastTx);
+
+    if (!nextRange) {
+        State->FinishMixedBlocksFilterLoad();
+
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::PARTITION,
+            "%s Mixed blocks filter loaded",
+            LogTitle.GetWithTime().c_str());
+
+        return;
+    }
+
+    auto request = std::make_unique<
+        TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>(*nextRange);
+
+    ctx.Schedule(throttlingTime, request.release());
+}
+
+void TPartitionActor::HandleLoadMixedBlocksFilterChunk(
+    const TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Loading mixed blocks filter chunk %s",
+        LogTitle.GetWithTime().c_str(),
+        msg->Range.Print().c_str());
+
+    ExecuteTx<TLoadMixedBlocksFilterChunk>(
+        ctx,
+        msg->Range,
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TPartitionActor::PrepareLoadMixedBlocksFilterChunk(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxPartition::TLoadMixedBlocksFilterChunk& args)
+{
+    Y_UNUSED(ctx);
+    TRequestScope timer(*args.RequestInfo);
+
+    TPartitionDatabase db(tx.DB);
+    TMixedBlocksFilterLoadVisitor visitor(args.Blocks);
+    const auto rangeSize = State->GetCompactionMap().GetRangeSize();
+    return db.FindMixedBlocks(
+        visitor,
+        TBlockRange32::WithLength(
+            args.Range.Start * rangeSize,
+            args.Range.Size() * rangeSize),
+        false);   // precharge
+}
+
+void TPartitionActor::ExecuteLoadMixedBlocksFilterChunk(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxPartition::TLoadMixedBlocksFilterChunk& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+
+    TRequestScope timer(*args.RequestInfo);
+
+    auto* filter = State->AccessMixedBlocksFilter();
+    STORAGE_VERIFY_C(
+        filter,
+        TWellKnownEntityTypes::TABLET,
+        TabletID(),
+        "Mixed blocks filter is disabled");
+
+    for (const auto& block: args.Blocks) {
+        filter->BlocksAddedToMixedIndex(block.BlockIndex, block.CommitId);
+    }
+
+    for (ui64 rangeIndex = args.Range.Start; rangeIndex <= args.Range.End;
+         ++rangeIndex)
+    {
+        if (!filter->IsCompactionRangeInitialized(rangeIndex)) {
+            filter->InitializeCompactionRange(rangeIndex, 0);
+        }
+    }
+}
+
+void TPartitionActor::CompleteLoadMixedBlocksFilterChunk(
+    const TActorContext& ctx,
+    TTxPartition::TLoadMixedBlocksFilterChunk& args)
+{
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Mixed blocks filter chunk %s updated",
+        LogTitle.GetWithTime().c_str(),
+        args.Range.Print().c_str());
+
+    LoadNextMixedBlocksFilterChunkIfNeeded(
+        ctx,
+        CyclesToDurationSafe(args.RequestInfo->ExecCycles));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -240,6 +240,13 @@ void TPartitionActor::CompleteLoadState(
 
     SharedState->Init(SelfId(), Executor()->Generation(), 0);
 
+    std::optional<TMixedBlocksFilterConfig> mixedBlocksFilterConfig;
+    if (IsMixedBlocksFilterEnabled()) {
+        mixedBlocksFilterConfig = TMixedBlocksFilterConfig{
+            Config->GetMixedBlocksFilterRangesToLoadPerTx(),
+            Config->GetMixedBlocksFilterAllowedCpuTimePerSecond()};
+    }
+
     State = std::make_unique<TPartitionState>(
         *args.Meta,
         BuildCompactionPolicy(partitionConfig, *Config, SiblingCount),
@@ -260,9 +267,7 @@ void TPartitionActor::CompleteLoadState(
         Config->GetCompactionRangeCountPerRun(),
         SharedState,
         TabletID(),
-        IsMixedBlocksFilterEnabled(),
-        Config->GetMixedBlocksFilterRangesToLoadPerTx(),
-        Config->GetMixedBlocksFilterAllowedCpuTimePerSecond());
+        mixedBlocksFilterConfig);
 
     CreateFreshBlocksCompanionClient();
 
@@ -555,6 +560,8 @@ void TPartitionActor::LoadNextMixedBlocksFilterChunkIfNeeded(
     auto* loadState = State->AccessMixedBlocksFilterLoadState();
 
     if (!loadState) {
+        // Mixed blocks filter load from mixed index is disabled or already
+        // finished.
         return;
     }
 
@@ -584,7 +591,7 @@ void TPartitionActor::HandleLoadMixedBlocksFilterChunk(
     auto nextRange = loadState->LoadNextRanges();
 
     if (!nextRange) {
-        State->FinishMixedBlocksFilterLoad();
+        State->MixedBlocksFilterLoaded();
 
         LOG_INFO(
             ctx,
@@ -626,7 +633,7 @@ bool TPartitionActor::PrepareLoadMixedBlocksFilterChunk(
         TBlockRange32::WithLength(
             args.Range.Start * rangeSize,
             args.Range.Size() * rangeSize),
-        false);   // precharge
+        true);   // precharge
 }
 
 void TPartitionActor::ExecuteLoadMixedBlocksFilterChunk(
@@ -634,8 +641,7 @@ void TPartitionActor::ExecuteLoadMixedBlocksFilterChunk(
     TTransactionContext& tx,
     TTxPartition::TLoadMixedBlocksFilterChunk& args)
 {
-    Y_UNUSED(ctx);
-    Y_UNUSED(tx);
+    Y_UNUSED(ctx, tx);
 
     TRequestScope timer(*args.RequestInfo);
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -646,6 +646,8 @@ void TPartitionActor::ExecuteLoadMixedBlocksFilterChunk(
         TabletID(),
         "Mixed blocks filter is disabled");
 
+    // We atommically readed blocks from mixed index, so it is safe to update
+    // blocks filter here.
     for (const auto& block: args.Blocks) {
         filter->BlocksAddedToMixedIndex(block.BlockIndex, block.CommitId);
     }
@@ -654,6 +656,8 @@ void TPartitionActor::ExecuteLoadMixedBlocksFilterChunk(
          ++rangeIndex)
     {
         if (!filter->IsCompactionRangeInitialized(rangeIndex)) {
+            // We read all mixed blocks from range, so we can choose zero as
+            // baseline commit.
             filter->InitializeCompactionRange(rangeIndex, 0);
         }
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -558,9 +558,30 @@ void TPartitionActor::LoadNextMixedBlocksFilterChunkIfNeeded(
         return;
     }
 
-    auto [nextRange, throttlingTime] = loadState->LoadNextRanges(
-        ctx.Now(),
-        cpuTimeSpentDuringLastTx);
+    auto postponeTime =
+        loadState->RegisterTransaction(ctx.Now(), cpuTimeSpentDuringLastTx);
+
+    auto request = std::make_unique<
+        TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>();
+
+    ctx.Schedule(postponeTime, request.release());
+}
+
+void TPartitionActor::HandleLoadMixedBlocksFilterChunk(
+    const TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    auto* loadState = State->AccessMixedBlocksFilterLoadState();
+
+    STORAGE_VERIFY_C(
+        loadState,
+        TWellKnownEntityTypes::TABLET,
+        TabletID(),
+        "Mixed blocks filter load state is not initialized");
+
+    auto nextRange = loadState->LoadNextRanges();
 
     if (!nextRange) {
         State->FinishMixedBlocksFilterLoad();
@@ -574,28 +595,16 @@ void TPartitionActor::LoadNextMixedBlocksFilterChunkIfNeeded(
         return;
     }
 
-    auto request = std::make_unique<
-        TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>(*nextRange);
-
-    ctx.Schedule(throttlingTime, request.release());
-}
-
-void TPartitionActor::HandleLoadMixedBlocksFilterChunk(
-    const TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr& ev,
-    const TActorContext& ctx)
-{
-    auto* msg = ev->Get();
-
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
         "%s Loading mixed blocks filter chunk %s",
         LogTitle.GetWithTime().c_str(),
-        msg->Range.Print().c_str());
+        nextRange->Print().c_str());
 
     ExecuteTx<TLoadMixedBlocksFilterChunk>(
         ctx,
-        msg->Range,
+        *nextRange,
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext));
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -588,9 +588,9 @@ void TPartitionActor::HandleLoadMixedBlocksFilterChunk(
         TabletID(),
         "Mixed blocks filter load state is not initialized");
 
-    auto nextRange = loadState->LoadNextRanges();
+    auto nextRanges = loadState->LoadNextRanges();
 
-    if (!nextRange) {
+    if (!nextRanges) {
         State->MixedBlocksFilterLoaded();
 
         LOG_INFO(
@@ -605,13 +605,14 @@ void TPartitionActor::HandleLoadMixedBlocksFilterChunk(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "%s Loading mixed blocks filter chunk %s",
+        "%s Loading mixed blocks filter chunk: range index=%lu, range count=%lu",
         LogTitle.GetWithTime().c_str(),
-        nextRange->Print().c_str());
+        nextRanges->RangeIndex,
+        nextRanges->RangeCount);
 
     ExecuteTx<TLoadMixedBlocksFilterChunk>(
         ctx,
-        *nextRange,
+        *nextRanges,
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext));
 }
 
@@ -631,8 +632,8 @@ bool TPartitionActor::PrepareLoadMixedBlocksFilterChunk(
     return db.FindMixedBlocks(
         visitor,
         TBlockRange32::WithLength(
-            args.Range.Start * rangeSize,
-            args.Range.Size() * rangeSize),
+            SafeIntegerCast<ui32>(args.Ranges.RangeIndex * rangeSize),
+            SafeIntegerCast<ui32>(args.Ranges.RangeCount * rangeSize)),
         true);   // precharge
 }
 
@@ -658,9 +659,8 @@ void TPartitionActor::ExecuteLoadMixedBlocksFilterChunk(
         filter->BlocksAddedToMixedIndex(block.BlockIndex, block.CommitId);
     }
 
-    for (ui64 rangeIndex = args.Range.Start; rangeIndex <= args.Range.End;
-         ++rangeIndex)
-    {
+    for (ui64 offset = 0; offset < args.Ranges.RangeCount; ++offset) {
+        const ui64 rangeIndex = args.Ranges.RangeIndex + offset;
         if (!filter->IsCompactionRangeInitialized(rangeIndex)) {
             // We read all mixed blocks from range, so we can choose zero as
             // baseline commit.
@@ -676,9 +676,10 @@ void TPartitionActor::CompleteLoadMixedBlocksFilterChunk(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "%s Mixed blocks filter chunk %s updated",
+        "%s Mixed blocks filter chunk updated: range index=%lu, range count=%lu",
         LogTitle.GetWithTime().c_str(),
-        args.Range.Print().c_str());
+        args.Ranges.RangeIndex,
+        args.Ranges.RangeCount);
 
     LoadNextMixedBlocksFilterChunkIfNeeded(
         ctx,

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -83,9 +83,7 @@ TPartitionState MakeState(size_t blockCount = 2048)
         1,             // compactionRangeCountPerRun
         std::move(threadSafeState),
         TTestExecutor::TabletId,
-        false,             // mixedBlocksFilterEnabled
-        0,                 // mixedBlocksFilterRangesToLoadPerTx
-        TDuration::Zero()  // mixedBlocksFilterAllowedCpuTimePerSecond
+        std::nullopt   // mixedBlocksFilterConfig
     );
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -83,7 +83,10 @@ TPartitionState MakeState(size_t blockCount = 2048)
         1,             // compactionRangeCountPerRun
         std::move(threadSafeState),
         TTestExecutor::TabletId,
-        false);        // mixedBlocksFilterEnabled
+        false,             // mixedBlocksFilterEnabled
+        0,                 // mixedBlocksFilterRangesToLoadPerTx
+        TDuration::Zero()  // mixedBlocksFilterAllowedCpuTimePerSecond
+    );
 }
 
 NProto::TBlobMeta MakeMixedBlobMeta(

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -82,7 +82,10 @@ TPartitionState MakeState(size_t blockCount = 2048, bool mixedBlocksFilterEnable
         1,             // compactionRangeCountPerRun
         std::move(threadSafeState),
         TTestExecutor::TabletId,
-        mixedBlocksFilterEnabled);   // mixedBlocksFilterEnabled
+        mixedBlocksFilterEnabled,   // mixedBlocksFilterEnabled
+        0,                          // mixedBlocksFilterRangesToLoadPerTx
+        TDuration::Zero()           // mixedBlocksFilterAllowedCpuTimePerSecond
+    );
 }
 
 std::shared_ptr<TStorageConfig> MakeStorageConfig(

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -82,10 +82,9 @@ TPartitionState MakeState(size_t blockCount = 2048, bool mixedBlocksFilterEnable
         1,             // compactionRangeCountPerRun
         std::move(threadSafeState),
         TTestExecutor::TabletId,
-        mixedBlocksFilterEnabled,   // mixedBlocksFilterEnabled
-        0,                          // mixedBlocksFilterRangesToLoadPerTx
-        TDuration::Zero()           // mixedBlocksFilterAllowedCpuTimePerSecond
-    );
+        mixedBlocksFilterEnabled
+            ? std::make_optional(TMixedBlocksFilterConfig{})
+            : std::nullopt);
 }
 
 std::shared_ptr<TStorageConfig> MakeStorageConfig(

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -145,6 +145,7 @@ struct TAffectedBlob
     ui64 MinCommitIdInCompactionRange = Max<ui64>();
     // Filled only for merged blobs.
     TMaybe<TMergedBlobsSpecificInfo> MergedBlobsSpecificInfo;
+
     std::optional<EChannelDataKind> IndexKind;
 
     TVector<ui16> Offsets;
@@ -810,6 +811,15 @@ struct TEvPartitionPrivate
     };
 
     //
+    // LoadMixedBlocksFilterChunkRequest
+    //
+
+    struct TLoadMixedBlocksFilterChunkRequest
+    {
+        TBlockRange32 Range;
+    };
+
+    //
     // ZeroBlocksCompleted
     //
 
@@ -859,6 +869,7 @@ struct TEvPartitionPrivate
         EvAddConfirmedBlobsCompleted,
         EvConfirmBlobsCompleted,
         EvLoadCompactionMapChunkRequest,
+        EvLoadMixedBlocksFilterChunkRequest,
         EvUpdateResourceMetrics,
 
         EvEnd
@@ -874,6 +885,7 @@ struct TEvPartitionPrivate
     using TEvSendBackpressureReport = TRequestEvent<TEmpty, EvSendBackpressureReport>;
     using TEvProcessWriteQueue = TRequestEvent<TEmpty, EvProcessWriteQueue>;
     using TEvLoadCompactionMapChunkRequest = TRequestEvent<TLoadCompactionMapChunkRequest, EvLoadCompactionMapChunkRequest>;
+    using TEvLoadMixedBlocksFilterChunkRequest = TRequestEvent<TLoadMixedBlocksFilterChunkRequest, EvLoadMixedBlocksFilterChunkRequest>;
 
     using TEvReadBlocksCompleted = TResponseEvent<TReadBlocksCompleted, EvReadBlocksCompleted>;
     using TEvWriteBlocksCompleted = TResponseEvent<TWriteBlocksCompleted, EvWriteBlocksCompleted>;

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -815,7 +815,6 @@ struct TEvPartitionPrivate
 
     struct TLoadMixedBlocksFilterChunkRequest
     {
-        TBlockRange32 Range;
     };
 
     //

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -146,6 +146,7 @@ struct TAffectedBlob
     ui64 MinCommitIdInCompactionRange = Max<ui64>();
     // Filled only for merged blobs.
     TMaybe<TMergedBlobsSpecificInfo> MergedBlobsSpecificInfo;
+
     std::optional<EChannelDataKind> IndexKind;
 
     TVector<ui16> Offsets;
@@ -809,6 +810,15 @@ struct TEvPartitionPrivate
     };
 
     //
+    // LoadMixedBlocksFilterChunkRequest
+    //
+
+    struct TLoadMixedBlocksFilterChunkRequest
+    {
+        TBlockRange32 Range;
+    };
+
+    //
     // ZeroBlocksCompleted
     //
 
@@ -862,6 +872,7 @@ struct TEvPartitionPrivate
         EvAddConfirmedBlobsCompleted,
         EvConfirmBlobsCompleted,
         EvLoadCompactionMapChunkRequest,
+        EvLoadMixedBlocksFilterChunkRequest,
         EvUpdateResourceMetrics,
         EvResumeFlush,
 
@@ -878,6 +889,7 @@ struct TEvPartitionPrivate
     using TEvSendBackpressureReport = TRequestEvent<TEmpty, EvSendBackpressureReport>;
     using TEvProcessWriteQueue = TRequestEvent<TEmpty, EvProcessWriteQueue>;
     using TEvLoadCompactionMapChunkRequest = TRequestEvent<TLoadCompactionMapChunkRequest, EvLoadCompactionMapChunkRequest>;
+    using TEvLoadMixedBlocksFilterChunkRequest = TRequestEvent<TLoadMixedBlocksFilterChunkRequest, EvLoadMixedBlocksFilterChunkRequest>;
 
     using TEvReadBlocksCompleted = TResponseEvent<TReadBlocksCompleted, EvReadBlocksCompleted>;
     using TEvWriteBlocksCompleted = TResponseEvent<TWriteBlocksCompleted, EvWriteBlocksCompleted>;

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -65,9 +65,8 @@ TPartitionState::TPartitionState(
         ui32 compactionRangeCountPerRun,
         TPartitionThreadSafeStatePtr threadSafeState,
         ui64 tabletId,
-        const bool mixedBlocksFilterEnabled,
-        const ui64 mixedBlocksFilterRangesToLoadPerTx,
-        const TDuration mixedBlocksFilterAllowedCpuTimePerSecond)
+        const std::optional<TMixedBlocksFilterConfig>
+            mixedBlocksFilterConfig)
     : TPartitionChannelsState(
           meta.GetConfig(),
           freeSpaceConfig,
@@ -101,20 +100,19 @@ TPartitionState::TPartitionState(
     , CleanupQueue(GetBlockSize())
     , CleanupScoreHistory(cleanupScoreHistorySize)
 {
-    if (mixedBlocksFilterEnabled) {
+    if (mixedBlocksFilterConfig) {
         MixedBlocksFilter.emplace(
             tabletId,
             GetMaxBlocksInBlob(),
             Config.GetBlocksCount());
 
-        if (mixedBlocksFilterRangesToLoadPerTx) {
+        if (mixedBlocksFilterConfig->MixedBlocksFilterRangesToLoadPerTx) {
             MixedBlocksFilterLoadState.emplace(
                 *MixedBlocksFilter,
                 CeilDiv<ui64>(Config.GetBlocksCount(), GetMaxBlocksInBlob()),
-                mixedBlocksFilterRangesToLoadPerTx,
-                mixedBlocksFilterAllowedCpuTimePerSecond
-                    ? mixedBlocksFilterAllowedCpuTimePerSecond
-                    : TDuration::Seconds(1));
+                mixedBlocksFilterConfig->MixedBlocksFilterRangesToLoadPerTx,
+                mixedBlocksFilterConfig
+                    ->MixedBlocksFilterAllowedCpuTimePerSecond);
         }
     }
     InitChannels();

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -65,7 +65,9 @@ TPartitionState::TPartitionState(
         ui32 compactionRangeCountPerRun,
         TPartitionThreadSafeStatePtr threadSafeState,
         ui64 tabletId,
-        const bool mixedBlocksFilterEnabled)
+        const bool mixedBlocksFilterEnabled,
+        const ui64 mixedBlocksFilterRangesToLoadPerTx,
+        const TDuration mixedBlocksFilterAllowedCpuTimePerSecond)
     : TPartitionChannelsState(
           meta.GetConfig(),
           freeSpaceConfig,
@@ -103,6 +105,14 @@ TPartitionState::TPartitionState(
             tabletId,
             GetMaxBlocksInBlob(),
             Config.GetBlocksCount());
+
+        if (mixedBlocksFilterRangesToLoadPerTx) {
+            MixedBlocksFilterLoadState.emplace(
+                *MixedBlocksFilter,
+                CeilDiv<ui64>(Config.GetBlocksCount(), GetMaxBlocksInBlob()),
+                mixedBlocksFilterRangesToLoadPerTx,
+                mixedBlocksFilterAllowedCpuTimePerSecond);
+        }
     }
     InitChannels();
 }

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -112,7 +112,9 @@ TPartitionState::TPartitionState(
                 *MixedBlocksFilter,
                 CeilDiv<ui64>(Config.GetBlocksCount(), GetMaxBlocksInBlob()),
                 mixedBlocksFilterRangesToLoadPerTx,
-                mixedBlocksFilterAllowedCpuTimePerSecond);
+                mixedBlocksFilterAllowedCpuTimePerSecond
+                    ? mixedBlocksFilterAllowedCpuTimePerSecond
+                    : TDuration::Seconds(1));
         }
     }
     InitChannels();

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -65,7 +65,9 @@ TPartitionState::TPartitionState(
         ui32 compactionRangeCountPerRun,
         TPartitionThreadSafeStatePtr threadSafeState,
         ui64 tabletId,
-        const bool mixedBlocksFilterEnabled)
+        const bool mixedBlocksFilterEnabled,
+        const ui64 mixedBlocksFilterRangesToLoadPerTx,
+        const TDuration mixedBlocksFilterAllowedCpuTimePerSecond)
     : TPartitionChannelsState(
           meta.GetConfig(),
           freeSpaceConfig,
@@ -104,6 +106,14 @@ TPartitionState::TPartitionState(
             tabletId,
             GetMaxBlocksInBlob(),
             Config.GetBlocksCount());
+
+        if (mixedBlocksFilterRangesToLoadPerTx) {
+            MixedBlocksFilterLoadState.emplace(
+                *MixedBlocksFilter,
+                CeilDiv<ui64>(Config.GetBlocksCount(), GetMaxBlocksInBlob()),
+                mixedBlocksFilterRangesToLoadPerTx,
+                mixedBlocksFilterAllowedCpuTimePerSecond);
+        }
     }
     InitChannels();
 }

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -25,6 +25,7 @@
 #include <cloud/blockstore/libs/storage/partition/model/commit_queue.h>
 #include <cloud/blockstore/libs/storage/partition/model/garbage_queue.h>
 #include <cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter.h>
+#include <cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h>
 #include <cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h>
 #include <cloud/blockstore/libs/storage/partition/model/operation_status.h>
 #include <cloud/blockstore/libs/storage/partition/model/part_counters_wrapper.h>
@@ -319,7 +320,9 @@ public:
         ui32 compactionRangeCountPerRun,
         TPartitionThreadSafeStatePtr threadSafeState,
         ui64 tabletId,
-        const bool mixedBlocksFilterEnabled);
+        const bool mixedBlocksFilterEnabled,
+        const ui64 mixedBlocksFilterRangesToLoadPerTx,
+        const TDuration mixedBlocksFilterAllowedCpuTimePerSecond);
 
 private:
     bool LoadStateFinished = false;
@@ -566,6 +569,8 @@ private:
     TProfilingAllocator MixedIndexCacheAllocator;
     TMixedIndexCache MixedIndexCache;
     std::optional<TMixedBlocksFilter> MixedBlocksFilter;
+    std::optional<TMixedBlocksFilterLoadState>
+        MixedBlocksFilterLoadState;
 
 public:
     void WriteMixedBlock(TPartitionDatabase& db, TMixedBlock block);
@@ -597,6 +602,17 @@ public:
     TMixedBlocksFilter* AccessMixedBlocksFilter()
     {
         return MixedBlocksFilter ? &*MixedBlocksFilter : nullptr;
+    }
+
+    TMixedBlocksFilterLoadState* AccessMixedBlocksFilterLoadState()
+    {
+        return MixedBlocksFilterLoadState ? &*MixedBlocksFilterLoadState
+                                          : nullptr;
+    }
+
+    void FinishMixedBlocksFilterLoad()
+    {
+        MixedBlocksFilterLoadState = std::nullopt;
     }
 
     //

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -283,6 +283,14 @@ struct TBackpressureFeaturesConfig
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TMixedBlocksFilterConfig
+{
+    ui64 MixedBlocksFilterRangesToLoadPerTx = 0;
+    TDuration MixedBlocksFilterAllowedCpuTimePerSecond;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TPartitionState
     : public TPartitionChannelsState
     , public TCommitIdsState
@@ -320,9 +328,7 @@ public:
         ui32 compactionRangeCountPerRun,
         TPartitionThreadSafeStatePtr threadSafeState,
         ui64 tabletId,
-        const bool mixedBlocksFilterEnabled,
-        const ui64 mixedBlocksFilterRangesToLoadPerTx,
-        const TDuration mixedBlocksFilterAllowedCpuTimePerSecond);
+        const std::optional<TMixedBlocksFilterConfig> mixedBlocksFilterConfig);
 
 private:
     bool LoadStateFinished = false;
@@ -610,7 +616,7 @@ public:
                                           : nullptr;
     }
 
-    void FinishMixedBlocksFilterLoad()
+    void MixedBlocksFilterLoaded()
     {
         MixedBlocksFilterLoadState = std::nullopt;
     }

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -25,6 +25,7 @@
 #include <cloud/blockstore/libs/storage/partition/model/commit_queue.h>
 #include <cloud/blockstore/libs/storage/partition/model/garbage_queue.h>
 #include <cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter.h>
+#include <cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h>
 #include <cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h>
 #include <cloud/blockstore/libs/storage/partition/model/operation_status.h>
 #include <cloud/blockstore/libs/storage/partition/model/part_counters_wrapper.h>
@@ -319,7 +320,9 @@ public:
         ui32 compactionRangeCountPerRun,
         TPartitionThreadSafeStatePtr threadSafeState,
         ui64 tabletId,
-        const bool mixedBlocksFilterEnabled);
+        const bool mixedBlocksFilterEnabled,
+        const ui64 mixedBlocksFilterRangesToLoadPerTx,
+        const TDuration mixedBlocksFilterAllowedCpuTimePerSecond);
 
 private:
     bool LoadStateFinished = false;
@@ -561,6 +564,8 @@ private:
     TProfilingAllocator MixedIndexCacheAllocator;
     TMixedIndexCache MixedIndexCache;
     std::optional<TMixedBlocksFilter> MixedBlocksFilter;
+    std::optional<TMixedBlocksFilterLoadState>
+        MixedBlocksFilterLoadState;
 
 public:
     void WriteMixedBlock(TPartitionDatabase& db, TMixedBlock block);
@@ -592,6 +597,17 @@ public:
     TMixedBlocksFilter* AccessMixedBlocksFilter()
     {
         return MixedBlocksFilter ? &*MixedBlocksFilter : nullptr;
+    }
+
+    TMixedBlocksFilterLoadState* AccessMixedBlocksFilterLoadState()
+    {
+        return MixedBlocksFilterLoadState ? &*MixedBlocksFilterLoadState
+                                          : nullptr;
+    }
+
+    void FinishMixedBlocksFilterLoad()
+    {
+        MixedBlocksFilterLoadState = std::nullopt;
     }
 
     //

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -102,26 +102,24 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TPartitionState state(
             DefaultConfig(1, 1000),
             BuildDefaultCompactionPolicy(5),
-            0,  // compactionScoreHistorySize
-            0,  // cleanupScoreHistorySize
+            0,   // compactionScoreHistorySize
+            0,   // cleanupScoreHistorySize
             DefaultBPConfig(),
             DefaultFreeSpaceConfig(),
-            Max(),  // maxIORequestsInFlight
-            0,      // reassignChannelsPercentageThreshold
-            100,    // reassignFreshChannelsPercentageThreshold
-            100,    // reassignMixedChannelsPercentageThreshold
-            false,  // reassignSystemChannelsImmediately
-            5,      // channelCount
-            0,      // mixedIndexCacheSize
-            10000,  // allocationUnit
-            100,    // maxBlobsPerUnit
-            10,     // maxBlobsPerRange,
-            1,      // compactionRangeCountPerRun
+            Max(),   // maxIORequestsInFlight
+            0,       // reassignChannelsPercentageThreshold
+            100,     // reassignFreshChannelsPercentageThreshold
+            100,     // reassignMixedChannelsPercentageThreshold
+            false,   // reassignSystemChannelsImmediately
+            5,       // channelCount
+            0,       // mixedIndexCacheSize
+            10000,   // allocationUnit
+            100,     // maxBlobsPerUnit
+            10,      // maxBlobsPerRange,
+            1,       // compactionRangeCountPerRun
             threadSafeState,
-            0,      // tabletId
-            false,  // mixedBlocksFilterEnabled
-            0,      // mixedBlocksFilterRangesToLoadPerTx
-            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
+            0,             // tabletId
+            std::nullopt   // mixedBlocksFilterConfig
         );
 
         const auto initialBackpressure = state.CalculateCurrentBackpressure();
@@ -176,26 +174,24 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TPartitionState state(
             DefaultConfig(1, 1000),
             std::make_shared<TNoBackpressurePolicy>(),
-            0,  // compactionScoreHistorySize
-            0,  // cleanupScoreHistorySize
+            0,   // compactionScoreHistorySize
+            0,   // cleanupScoreHistorySize
             DefaultBPConfig(),
             DefaultFreeSpaceConfig(),
-            Max(),  // maxIORequestsInFlight
-            0,      // reassignChannelsPercentageThreshold
-            100,    // reassignFreshChannelsPercentageThreshold
-            100,    // reassignMixedChannelsPercentageThreshold
-            false,  // reassignSystemChannelsImmediately
-            5,      // channelCount
-            0,      // mixedIndexCacheSize
-            10000,  // allocationUnit
-            100,    // maxBlobsPerUnit
-            10,     // maxBlobsPerRange,
-            1,      // compactionRangeCountPerRun
+            Max(),   // maxIORequestsInFlight
+            0,       // reassignChannelsPercentageThreshold
+            100,     // reassignFreshChannelsPercentageThreshold
+            100,     // reassignMixedChannelsPercentageThreshold
+            false,   // reassignSystemChannelsImmediately
+            5,       // channelCount
+            0,       // mixedIndexCacheSize
+            10000,   // allocationUnit
+            100,     // maxBlobsPerUnit
+            10,      // maxBlobsPerRange,
+            1,       // compactionRangeCountPerRun
             threadSafeState,
-            0,      // tabletId
-            false,  // mixedBlocksFilterEnabled
-            0,      // mixedBlocksFilterRangesToLoadPerTx
-            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
+            0,             // tabletId
+            std::nullopt   // mixedBlocksFilterConfig
         );
 
         state.GetCompactionMap().Update(0, 30, 30, 30, 0, false);
@@ -216,26 +212,24 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TPartitionState state(
             config,
             BuildDefaultCompactionPolicy(5),
-            0,  // compactionScoreHistorySize
-            0,  // cleanupScoreHistorySize
+            0,   // compactionScoreHistorySize
+            0,   // cleanupScoreHistorySize
             DefaultBPConfig(),
             DefaultFreeSpaceConfig(),
-            Max(),  // maxIORequestsInFlight
-            0,      // reassignChannelsPercentageThreshold
-            100,    // reassignFreshChannelsPercentageThreshold
-            100,    // reassignMixedChannelsPercentageThreshold
-            false,  // reassignSystemChannelsImmediately
-            5,      // channelCount
-            0,      // mixedIndexCacheSize
-            10000,  // allocationUnit
-            100,    // maxBlobsPerUnit
-            10,     // maxBlobsPerRange,
-            1,      // compactionRangeCountPerRun
+            Max(),   // maxIORequestsInFlight
+            0,       // reassignChannelsPercentageThreshold
+            100,     // reassignFreshChannelsPercentageThreshold
+            100,     // reassignMixedChannelsPercentageThreshold
+            false,   // reassignSystemChannelsImmediately
+            5,       // channelCount
+            0,       // mixedIndexCacheSize
+            10000,   // allocationUnit
+            100,     // maxBlobsPerUnit
+            10,      // maxBlobsPerRange,
+            1,       // compactionRangeCountPerRun
             threadSafeState,
-            0,      // tabletId
-            false,  // mixedBlocksFilterEnabled
-            0,      // mixedBlocksFilterRangesToLoadPerTx
-            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
+            0,             // tabletId
+            std::nullopt   // mixedBlocksFilterConfig
         );
 
         state.GetLogicalUsedBlocks().Set(0, 9);
@@ -306,26 +300,24 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TPartitionState state(
             config,
             BuildDefaultCompactionPolicy(5),
-            0,  // compactionScoreHistorySize
-            0,  // cleanupScoreHistorySize
+            0,   // compactionScoreHistorySize
+            0,   // cleanupScoreHistorySize
             DefaultBPConfig(),
             DefaultFreeSpaceConfig(),
-            Max(),  // maxIORequestsInFlight
-            0,      // reassignChannelsPercentageThreshold
-            100,    // reassignFreshChannelsPercentageThreshold
-            100,    // reassignMixedChannelsPercentageThreshold
-            false,  // reassignSystemChannelsImmediately
-            1,      // channelCount
-            0,      // mixedIndexCacheSize
-            10000,  // allocationUnit
-            100,    // maxBlobsPerUnit
-            10,     // maxBlobsPerRange,
-            1,      // compactionRangeCountPerRun
+            Max(),   // maxIORequestsInFlight
+            0,       // reassignChannelsPercentageThreshold
+            100,     // reassignFreshChannelsPercentageThreshold
+            100,     // reassignMixedChannelsPercentageThreshold
+            false,   // reassignSystemChannelsImmediately
+            1,       // channelCount
+            0,       // mixedIndexCacheSize
+            10000,   // allocationUnit
+            100,     // maxBlobsPerUnit
+            10,      // maxBlobsPerRange,
+            1,       // compactionRangeCountPerRun
             threadSafeState,
-            0,      // tabletId
-            false,  // mixedBlocksFilterEnabled
-            0,      // mixedBlocksFilterRangesToLoadPerTx
-            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
+            0,             // tabletId
+            std::nullopt   // mixedBlocksFilterConfig
         );
 
         state.IncrementMergedBlocksCount(5_GB / DefaultBlockSize);
@@ -354,26 +346,24 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TPartitionState state(
             config,
             BuildDefaultCompactionPolicy(5),
-            0,  // compactionScoreHistorySize
-            0,  // cleanupScoreHistorySize
+            0,   // compactionScoreHistorySize
+            0,   // cleanupScoreHistorySize
             DefaultBPConfig(),
             DefaultFreeSpaceConfig(),
-            Max(),  // maxIORequestsInFlight
-            0,      // reassignChannelsPercentageThreshold
-            100,    // reassignFreshChannelsPercentageThreshold
-            100,    // reassignMixedChannelsPercentageThreshold
-            false,  // reassignSystemChannelsImmediately
-            5,      // channelCount
-            1,      // mixedIndexCacheSize
-            10000,  // allocationUnit
-            100,    // maxBlobsPerUnit
-            10,     // maxBlobsPerRange,
-            1,      // compactionRangeCountPerRun
+            Max(),   // maxIORequestsInFlight
+            0,       // reassignChannelsPercentageThreshold
+            100,     // reassignFreshChannelsPercentageThreshold
+            100,     // reassignMixedChannelsPercentageThreshold
+            false,   // reassignSystemChannelsImmediately
+            5,       // channelCount
+            1,       // mixedIndexCacheSize
+            10000,   // allocationUnit
+            100,     // maxBlobsPerUnit
+            10,      // maxBlobsPerRange,
+            1,       // compactionRangeCountPerRun
             threadSafeState,
-            0,      // tabletId
-            false,  // mixedBlocksFilterEnabled
-            0,      // mixedBlocksFilterRangesToLoadPerTx
-            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
+            0,             // tabletId
+            std::nullopt   // mixedBlocksFilterConfig
         );
 
         TTestExecutor executor;
@@ -514,10 +504,8 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             10,                // maxBlobsPerRange,
             1,                 // compactionRangeCountPerRun
             threadSafeState,
-            0,      // tabletId
-            false,  // mixedBlocksFilterEnabled
-            0,      // mixedBlocksFilterRangesToLoadPerTx
-            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
+            0,             // tabletId
+            std::nullopt   // mixedBlocksFilterConfig
         );
         UNIT_ASSERT_VALUES_EQUAL(maxBlobsPerDisk, state.GetMaxBlobsPerDisk());
     }
@@ -536,26 +524,24 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TPartitionState state(
             DefaultConfig(1, 1000),
             BuildDefaultCompactionPolicy(5),
-            0,  // compactionScoreHistorySize
-            0,  // cleanupScoreHistorySize
+            0,   // compactionScoreHistorySize
+            0,   // cleanupScoreHistorySize
             DefaultBPConfig(),
             DefaultFreeSpaceConfig(),
-            Max(),  // maxIORequestsInFlight
-            0,      // reassignChannelsPercentageThreshold
-            100,    // reassignFreshChannelsPercentageThreshold
-            100,    // reassignMixedChannelsPercentageThreshold
-            false,  // reassignSystemChannelsImmediately
-            5,      // channelCount
-            0,      // mixedIndexCacheSize
-            10000,  // allocationUnit
-            100,    // maxBlobsPerUnit
-            10,     // maxBlobsPerRange,
-            1,      // compactionRangeCountPerRun
+            Max(),   // maxIORequestsInFlight
+            0,       // reassignChannelsPercentageThreshold
+            100,     // reassignFreshChannelsPercentageThreshold
+            100,     // reassignMixedChannelsPercentageThreshold
+            false,   // reassignSystemChannelsImmediately
+            5,       // channelCount
+            0,       // mixedIndexCacheSize
+            10000,   // allocationUnit
+            100,     // maxBlobsPerUnit
+            10,      // maxBlobsPerRange,
+            1,       // compactionRangeCountPerRun
             threadSafeState,
-            0,      // tabletId
-            false,  // mixedBlocksFilterEnabled
-            0,      // mixedBlocksFilterRangesToLoadPerTx
-            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
+            0,             // tabletId
+            std::nullopt   // mixedBlocksFilterConfig
         );
 
         TCleanupQueueItem b1 {{1, 1, 4, 4_MB, 0, 0}, 111, {}};
@@ -586,26 +572,24 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TPartitionState state(
             DefaultConfig(1, DefaultBlockCount),
             BuildDefaultCompactionPolicy(5),
-            0,  // compactionScoreHistorySize
-            0,  // cleanupScoreHistorySize
+            0,   // compactionScoreHistorySize
+            0,   // cleanupScoreHistorySize
             DefaultBPConfig(),
             DefaultFreeSpaceConfig(),
-            Max(),  // maxIORequestsInFlight
-            0,      // reassignChannelsPercentageThreshold
-            100,    // reassignFreshChannelsPercentageThreshold
-            100,    // reassignMixedChannelsPercentageThreshold
-            false,  // reassignSystemChannelsImmediately
-            5,      // channelCount
-            0,      // mixedIndexCacheSize
-            10000,  // allocationUnit
-            100,    // maxBlobsPerUnit
-            10,     // maxBlobsPerRange,
-            1,      // compactionRangeCountPerRun
+            Max(),   // maxIORequestsInFlight
+            0,       // reassignChannelsPercentageThreshold
+            100,     // reassignFreshChannelsPercentageThreshold
+            100,     // reassignMixedChannelsPercentageThreshold
+            false,   // reassignSystemChannelsImmediately
+            5,       // channelCount
+            0,       // mixedIndexCacheSize
+            10000,   // allocationUnit
+            100,     // maxBlobsPerUnit
+            10,      // maxBlobsPerRange,
+            1,       // compactionRangeCountPerRun
             threadSafeState,
-            0,      // tabletId
-            false,  // mixedBlocksFilterEnabled
-            0,      // mixedBlocksFilterRangesToLoadPerTx
-            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
+            0,             // tabletId
+            std::nullopt   // mixedBlocksFilterConfig
         );
 
         const ui32 blockIndex = 0;

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -119,7 +119,9 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             1,      // compactionRangeCountPerRun
             threadSafeState,
             0,      // tabletId
-            false   // mixedBlocksFilterEnabled
+            false,  // mixedBlocksFilterEnabled
+            0,      // mixedBlocksFilterRangesToLoadPerTx
+            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
         );
 
         const auto initialBackpressure = state.CalculateCurrentBackpressure();
@@ -191,7 +193,9 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             1,      // compactionRangeCountPerRun
             threadSafeState,
             0,      // tabletId
-            false   // mixedBlocksFilterEnabled
+            false,  // mixedBlocksFilterEnabled
+            0,      // mixedBlocksFilterRangesToLoadPerTx
+            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
         );
 
         state.GetCompactionMap().Update(0, 30, 30, 30, 0, false);
@@ -229,7 +233,9 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             1,      // compactionRangeCountPerRun
             threadSafeState,
             0,      // tabletId
-            false   // mixedBlocksFilterEnabled
+            false,  // mixedBlocksFilterEnabled
+            0,      // mixedBlocksFilterRangesToLoadPerTx
+            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
         );
 
         state.GetLogicalUsedBlocks().Set(0, 9);
@@ -317,7 +323,9 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             1,      // compactionRangeCountPerRun
             threadSafeState,
             0,      // tabletId
-            false   // mixedBlocksFilterEnabled
+            false,  // mixedBlocksFilterEnabled
+            0,      // mixedBlocksFilterRangesToLoadPerTx
+            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
         );
 
         state.IncrementMergedBlocksCount(5_GB / DefaultBlockSize);
@@ -363,7 +371,9 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             1,      // compactionRangeCountPerRun
             threadSafeState,
             0,      // tabletId
-            false   // mixedBlocksFilterEnabled
+            false,  // mixedBlocksFilterEnabled
+            0,      // mixedBlocksFilterRangesToLoadPerTx
+            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
         );
 
         TTestExecutor executor;
@@ -488,24 +498,26 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TPartitionState state(
             config,
             BuildDefaultCompactionPolicy(5),
-            0,  // compactionScoreHistorySize
-            0,  // cleanupScoreHistorySize
+            0,   // compactionScoreHistorySize
+            0,   // cleanupScoreHistorySize
             DefaultBPConfig(),
             DefaultFreeSpaceConfig(),
-            Max(),  // maxIORequestsInFlight
-            0,      // reassignChannelsPercentageThreshold
-            100,    // reassignFreshChannelsPercentageThreshold
-            100,    // reassignMixedChannelsPercentageThreshold
-            false,  // reassignSystemChannelsImmediately
-            5,      // channelCount
-            1,      // mixedIndexCacheSize
-            allocationUnit,  // allocationUnit
-            maxBlobsPerUnit, // maxBlobsPerUnit
-            10,  // maxBlobsPerRange,
-            1,   // compactionRangeCountPerRun
+            Max(),             // maxIORequestsInFlight
+            0,                 // reassignChannelsPercentageThreshold
+            100,               // reassignFreshChannelsPercentageThreshold
+            100,               // reassignMixedChannelsPercentageThreshold
+            false,             // reassignSystemChannelsImmediately
+            5,                 // channelCount
+            1,                 // mixedIndexCacheSize
+            allocationUnit,    // allocationUnit
+            maxBlobsPerUnit,   // maxBlobsPerUnit
+            10,                // maxBlobsPerRange,
+            1,                 // compactionRangeCountPerRun
             threadSafeState,
             0,      // tabletId
-            false   // mixedBlocksFilterEnabled
+            false,  // mixedBlocksFilterEnabled
+            0,      // mixedBlocksFilterRangesToLoadPerTx
+            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
         );
         UNIT_ASSERT_VALUES_EQUAL(maxBlobsPerDisk, state.GetMaxBlobsPerDisk());
     }
@@ -541,7 +553,9 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             1,      // compactionRangeCountPerRun
             threadSafeState,
             0,      // tabletId
-            false   // mixedBlocksFilterEnabled
+            false,  // mixedBlocksFilterEnabled
+            0,      // mixedBlocksFilterRangesToLoadPerTx
+            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
         );
 
         TCleanupQueueItem b1 {{1, 1, 4, 4_MB, 0, 0}, 111, {}};
@@ -589,7 +603,9 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             1,      // compactionRangeCountPerRun
             threadSafeState,
             0,      // tabletId
-            false   // mixedBlocksFilterEnabled
+            false,  // mixedBlocksFilterEnabled
+            0,      // mixedBlocksFilterRangesToLoadPerTx
+            TDuration::Zero()       // mixedBlocksFilterAllowedCpuTimePerSecond
         );
 
         const ui32 blockIndex = 0;

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -1295,8 +1295,9 @@ struct TTxPartition
     struct TLoadMixedBlocksFilterChunk
     {
         const TBlockRange32 Range;
-
         const TRequestInfoPtr RequestInfo;
+
+        // Blocks loaded from mixed index.
         TVector<TBlock> Blocks;
 
         TLoadMixedBlocksFilterChunk(

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -65,6 +65,7 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
     xxx(ConfirmBlobs,               __VA_ARGS__)                               \
     xxx(DeleteUnconfirmedBlobs,     __VA_ARGS__)                               \
     xxx(LoadCompactionMapChunk,     __VA_ARGS__)                               \
+    xxx(LoadMixedBlocksFilterChunk, __VA_ARGS__)                               \
 // BLOCKSTORE_PARTITION_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1284,6 +1285,30 @@ struct TTxPartition
         void Clear()
         {
             Counters.clear();
+        }
+    };
+
+    //
+    // LoadMixedBlocksFilterChunk
+    //
+
+    struct TLoadMixedBlocksFilterChunk
+    {
+        const TBlockRange32 Range;
+
+        const TRequestInfoPtr RequestInfo;
+        TVector<TBlock> Blocks;
+
+        TLoadMixedBlocksFilterChunk(
+            TBlockRange32 range,
+            TRequestInfoPtr requestInfo)
+            : Range(range)
+            , RequestInfo(std::move(requestInfo))
+        {}
+
+        void Clear()
+        {
+            Blocks.clear();
         }
     };
 };

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -16,6 +16,7 @@
 #include <cloud/blockstore/libs/storage/partition/model/checkpoint.h>
 #include <cloud/blockstore/libs/storage/partition/model/cleanup_queue.h>
 #include <cloud/blockstore/libs/storage/partition/model/garbage_queue.h>
+#include <cloud/blockstore/libs/storage/partition/model/mixed_blocks_filter_load_state.h>
 #include <cloud/blockstore/libs/storage/partition_common/model/blob_markers.h>
 #include <cloud/blockstore/libs/storage/protos/part.pb.h>
 
@@ -1294,16 +1295,16 @@ struct TTxPartition
 
     struct TLoadMixedBlocksFilterChunk
     {
-        const TBlockRange32 Range;
+        const TCompactionRangesToLoad Ranges;
         const TRequestInfoPtr RequestInfo;
 
         // Blocks loaded from mixed index.
         TVector<TBlock> Blocks;
 
         TLoadMixedBlocksFilterChunk(
-            TBlockRange32 range,
+            TCompactionRangesToLoad ranges,
             TRequestInfoPtr requestInfo)
-            : Range(range)
+            : Ranges(ranges)
             , RequestInfo(std::move(requestInfo))
         {}
 

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -65,6 +65,7 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
     xxx(ConfirmBlobs,               __VA_ARGS__)                               \
     xxx(DeleteUnconfirmedBlobs,     __VA_ARGS__)                               \
     xxx(LoadCompactionMapChunk,     __VA_ARGS__)                               \
+    xxx(LoadMixedBlocksFilterChunk, __VA_ARGS__)                               \
 // BLOCKSTORE_PARTITION_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1279,6 +1280,30 @@ struct TTxPartition
         void Clear()
         {
             Counters.clear();
+        }
+    };
+
+    //
+    // LoadMixedBlocksFilterChunk
+    //
+
+    struct TLoadMixedBlocksFilterChunk
+    {
+        const TBlockRange32 Range;
+
+        const TRequestInfoPtr RequestInfo;
+        TVector<TBlock> Blocks;
+
+        TLoadMixedBlocksFilterChunk(
+            TBlockRange32 range,
+            TRequestInfoPtr requestInfo)
+            : Range(range)
+            , RequestInfo(std::move(requestInfo))
+        {}
+
+        void Clear()
+        {
+            Blocks.clear();
         }
     };
 };

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13321,6 +13321,45 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_GE(rangesLoaded, rangeCount);
     }
 
+    Y_UNIT_TEST(ShouldLoadMixedBlocksFilterByCompactionRanges)
+    {
+        constexpr ui32 rangeSize = 1024;
+
+        auto config = DefaultConfig();
+        config.SetMixedBlocksFilterEnabled(true);
+        config.SetMixedBlocksFilterRangesToLoadPerTx(2);
+
+        auto runtime = PrepareTestActorRuntime(config, 5 * rangeSize);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(4 * rangeSize, 1), 2);
+        partition.Flush();
+
+        TVector<TBlockRange32> ranges;
+        auto observer = runtime->AddObserver<
+            TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>(
+            [&](TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr&
+                    event)
+            {
+                ranges.push_back(event->Get()->Range);
+            });
+
+        partition.RebootTablet();
+        partition.WaitReady();
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(3, ranges.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, ranges[0].Start);
+        UNIT_ASSERT_VALUES_EQUAL(2, ranges[0].Size());
+        UNIT_ASSERT_VALUES_EQUAL(2, ranges[1].Start);
+        UNIT_ASSERT_VALUES_EQUAL(2, ranges[1].Size());
+        UNIT_ASSERT_VALUES_EQUAL(4, ranges[2].Start);
+        UNIT_ASSERT_VALUES_EQUAL(1, ranges[2].Size());
+    }
+
     Y_UNIT_TEST(ShouldRejectWriteIfCompactionMapIsNotLoaded1)
     {
         const ui32 rangeSize = 1024;

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13202,12 +13202,37 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.Flush();
 
         TVector<TBlockRange32> ranges;
+        TVector<std::pair<ui32, char>> writtenBlocks;
+        const auto writeClient = runtime->AllocateEdgeActor();
+        ui32 flushCount = 0;
         auto observer = runtime->AddObserver<
             TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>(
             [&](TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr&
                     event)
             {
-                ranges.push_back(event->Get()->Range);
+                const auto range = event->Get()->Range;
+                ranges.push_back(range);
+
+                for (ui32 rangeIndex = range.Start;
+                     rangeIndex <= range.End;
+                     ++rangeIndex)
+                {
+                    const ui32 blockIndex = rangeIndex * rangeSize + 1;
+                    const char fill = rangeIndex + 1;
+                    runtime->Send(new IEventHandle(
+                        event->GetRecipientRewrite(),
+                        writeClient,
+                        partition
+                            .CreateWriteBlocksRequest(blockIndex, fill)
+                            .release()));
+                    writtenBlocks.emplace_back(blockIndex, fill);
+                }
+
+                runtime->Send(new IEventHandle(
+                    event->GetRecipientRewrite(),
+                    writeClient,
+                    partition.CreateFlushRequest().release()));
+                ++flushCount;
             });
 
         partition.RebootTablet();
@@ -13221,6 +13246,29 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(2, ranges[1].Size());
         UNIT_ASSERT_VALUES_EQUAL(4, ranges[2].Start);
         UNIT_ASSERT_VALUES_EQUAL(1, ranges[2].Size());
+
+        for (size_t i = 0; i < writtenBlocks.size(); ++i) {
+            const auto response = runtime->GrabEdgeEventRethrow<
+                TEvService::TEvWriteBlocksResponse>(writeClient);
+            UNIT_ASSERT(response);
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->Get()->GetStatus()),
+                response->Get()->GetErrorReason());
+        }
+        for (ui32 i = 0; i < flushCount; ++i) {
+            const auto response = runtime->GrabEdgeEventRethrow<
+                TEvPartitionPrivate::TEvFlushResponse>(writeClient);
+            UNIT_ASSERT(response);
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->Get()->GetStatus()),
+                response->Get()->GetErrorReason());
+        }
+
+        for (const auto& [blockIndex, fill]: writtenBlocks) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(fill),
+                GetBlockContent(partition.ReadBlocks(blockIndex)));
+        }
     }
 
     Y_UNIT_TEST(ShouldRejectWriteIfCompactionMapIsNotLoaded1)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13339,12 +13339,37 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.Flush();
 
         TVector<TBlockRange32> ranges;
+        TVector<std::pair<ui32, char>> writtenBlocks;
+        const auto writeClient = runtime->AllocateEdgeActor();
+        ui32 flushCount = 0;
         auto observer = runtime->AddObserver<
             TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>(
             [&](TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr&
                     event)
             {
-                ranges.push_back(event->Get()->Range);
+                const auto range = event->Get()->Range;
+                ranges.push_back(range);
+
+                for (ui32 rangeIndex = range.Start;
+                     rangeIndex <= range.End;
+                     ++rangeIndex)
+                {
+                    const ui32 blockIndex = rangeIndex * rangeSize + 1;
+                    const char fill = rangeIndex + 1;
+                    runtime->Send(new IEventHandle(
+                        event->GetRecipientRewrite(),
+                        writeClient,
+                        partition
+                            .CreateWriteBlocksRequest(blockIndex, fill)
+                            .release()));
+                    writtenBlocks.emplace_back(blockIndex, fill);
+                }
+
+                runtime->Send(new IEventHandle(
+                    event->GetRecipientRewrite(),
+                    writeClient,
+                    partition.CreateFlushRequest().release()));
+                ++flushCount;
             });
 
         partition.RebootTablet();
@@ -13358,6 +13383,29 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(2, ranges[1].Size());
         UNIT_ASSERT_VALUES_EQUAL(4, ranges[2].Start);
         UNIT_ASSERT_VALUES_EQUAL(1, ranges[2].Size());
+
+        for (size_t i = 0; i < writtenBlocks.size(); ++i) {
+            const auto response = runtime->GrabEdgeEventRethrow<
+                TEvService::TEvWriteBlocksResponse>(writeClient);
+            UNIT_ASSERT(response);
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->Get()->GetStatus()),
+                response->Get()->GetErrorReason());
+        }
+        for (ui32 i = 0; i < flushCount; ++i) {
+            const auto response = runtime->GrabEdgeEventRethrow<
+                TEvPartitionPrivate::TEvFlushResponse>(writeClient);
+            UNIT_ASSERT(response);
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->Get()->GetStatus()),
+                response->Get()->GetErrorReason());
+        }
+
+        for (const auto& [blockIndex, fill]: writtenBlocks) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(fill),
+                GetBlockContent(partition.ReadBlocks(blockIndex)));
+        }
     }
 
     Y_UNIT_TEST(ShouldRejectWriteIfCompactionMapIsNotLoaded1)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13184,6 +13184,45 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_GE(rangesLoaded, rangeCount);
     }
 
+    Y_UNIT_TEST(ShouldLoadMixedBlocksFilterByCompactionRanges)
+    {
+        constexpr ui32 rangeSize = 1024;
+
+        auto config = DefaultConfig();
+        config.SetMixedBlocksFilterEnabled(true);
+        config.SetMixedBlocksFilterRangesToLoadPerTx(2);
+
+        auto runtime = PrepareTestActorRuntime(config, 5 * rangeSize);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(4 * rangeSize, 1), 2);
+        partition.Flush();
+
+        TVector<TBlockRange32> ranges;
+        auto observer = runtime->AddObserver<
+            TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>(
+            [&](TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr&
+                    event)
+            {
+                ranges.push_back(event->Get()->Range);
+            });
+
+        partition.RebootTablet();
+        partition.WaitReady();
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(3, ranges.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, ranges[0].Start);
+        UNIT_ASSERT_VALUES_EQUAL(2, ranges[0].Size());
+        UNIT_ASSERT_VALUES_EQUAL(2, ranges[1].Start);
+        UNIT_ASSERT_VALUES_EQUAL(2, ranges[1].Size());
+        UNIT_ASSERT_VALUES_EQUAL(4, ranges[2].Start);
+        UNIT_ASSERT_VALUES_EQUAL(1, ranges[2].Size());
+    }
+
     Y_UNIT_TEST(ShouldRejectWriteIfCompactionMapIsNotLoaded1)
     {
         const ui32 rangeSize = 1024;

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13338,17 +13338,28 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.WriteBlocks(TBlockRange32::WithLength(4 * rangeSize, 1), 2);
         partition.Flush();
 
-        TVector<TBlockRange32> ranges;
         TVector<std::pair<ui32, char>> writtenBlocks;
         const auto writeClient = runtime->AllocateEdgeActor();
         ui32 flushCount = 0;
+        ui32 loadRequestCount = 0;
         auto observer = runtime->AddObserver<
             TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>(
             [&](TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr&
                     event)
             {
-                const auto range = event->Get()->Range;
-                ranges.push_back(range);
+                ++loadRequestCount;
+
+                // The last request only discovers that all ranges have been
+                // loaded. The ranges themselves are selected by its handler,
+                // not carried by the scheduled event.
+                if (loadRequestCount > 3) {
+                    return;
+                }
+
+                const auto range = TBlockRange32::MakeClosedIntervalWithLimit(
+                    (loadRequestCount - 1) * 2,
+                    loadRequestCount * 2 - 1,
+                    4);
 
                 for (ui32 rangeIndex = range.Start;
                      rangeIndex <= range.End;
@@ -13376,13 +13387,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.WaitReady();
         runtime->DispatchEvents({}, TDuration::Seconds(1));
 
-        UNIT_ASSERT_VALUES_EQUAL(3, ranges.size());
-        UNIT_ASSERT_VALUES_EQUAL(0, ranges[0].Start);
-        UNIT_ASSERT_VALUES_EQUAL(2, ranges[0].Size());
-        UNIT_ASSERT_VALUES_EQUAL(2, ranges[1].Start);
-        UNIT_ASSERT_VALUES_EQUAL(2, ranges[1].Size());
-        UNIT_ASSERT_VALUES_EQUAL(4, ranges[2].Start);
-        UNIT_ASSERT_VALUES_EQUAL(1, ranges[2].Size());
+        UNIT_ASSERT_VALUES_EQUAL(4, loadRequestCount);
 
         for (size_t i = 0; i < writtenBlocks.size(); ++i) {
             const auto response = runtime->GrabEdgeEventRethrow<

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -186,6 +186,9 @@ def storage_config_with_mixed_blocks_filter_enabled():
     storage = ordinary_prod_storage_config()
     storage.MixedBlocksFilterEnabled = True
 
+    storage.MixedBlocksFilterRangesToLoadPerTx = 1
+    storage.MixedBlocksFilterAllowedCpuTimePerSecond = 1000
+
     return storage
 
 
@@ -196,8 +199,12 @@ def storage_config_with_new_features_enabled():
     storage.FreshChannelZeroRequestsEnabled = True
     storage.FreshBlocksWriterEnabled = True
     storage.IgnoringZeroedCompactionEnabled = True
+
     storage.MixedBlocksFilterEnabled = True
     storage.WaitForFreshWritesBeforeFlushEnabled = True
+
+    storage.MixedBlocksFilterRangesToLoadPerTx = 1
+    storage.MixedBlocksFilterAllowedCpuTimePerSecond = 1000
 
     return storage
 

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -186,6 +186,9 @@ def storage_config_with_mixed_blocks_filter_enabled():
     storage = ordinary_prod_storage_config()
     storage.MixedBlocksFilterEnabled = True
 
+    storage.MixedBlocksFilterRangesToLoadPerTx = 1
+    storage.MixedBlocksFilterAllowedCpuTimePerSecond = 1000
+
     return storage
 
 
@@ -196,7 +199,10 @@ def storage_config_with_new_features_enabled():
     storage.FreshChannelZeroRequestsEnabled = True
     storage.FreshBlocksWriterEnabled = True
     storage.IgnoringZeroedCompactionEnabled = True
+
     storage.MixedBlocksFilterEnabled = True
+    storage.MixedBlocksFilterRangesToLoadPerTx = 1
+    storage.MixedBlocksFilterAllowedCpuTimePerSecond = 1000
 
     return storage
 

--- a/cloud/storage/core/libs/throttling/leaky_bucket.h
+++ b/cloud/storage/core/libs/throttling/leaky_bucket.h
@@ -58,6 +58,21 @@ public:
         return (update - State.Budget) / (Rate * 1e6);
     }
 
+    [[nodiscard]] double CalculatePostponeTime(TInstant ts, double update) const
+    {
+        double budget = State.Budget;
+        if (Y_LIKELY(State.LastUpdateTs.GetValue())) {
+            double timePassed = (ts - State.LastUpdateTs).MicroSeconds();
+            budget += Rate * timePassed;
+        }
+
+        if (budget + 1e-10 >= update) {
+            return 0;
+        }
+
+        return (update - budget) / (Rate * 1e6);
+    }
+
     void Flush()
     {
         State.Budget = 0;

--- a/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
+++ b/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
@@ -103,6 +103,27 @@ Y_UNIT_TEST_SUITE(TLeakyBucketTest)
             lb.Register(now + SecondsToDuration(delay), 42.0));
     }
 
+    Y_UNIT_TEST(ShouldCalculatePostponeTimeWithoutChangingState)
+    {
+        TLeakyBucket lb(0.5, 0.5, 0);
+
+        const auto now = TInstant::Seconds(1);
+        UNIT_ASSERT_VALUES_EQUAL(0, lb.Register(now, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0.5,
+            lb.CalculatePostponeTime(now, 0.25));
+        UNIT_ASSERT_VALUES_EQUAL(0, lb.Budget());
+        UNIT_ASSERT_VALUES_EQUAL(0, lb.TimePassed());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0.5,
+            lb.CalculatePostponeTime(now, 0.25));
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            lb.Register(now + TDuration::MilliSeconds(500), 0.25));
+    }
+
     Y_UNIT_TEST(ShouldCorrectlyCalculateBoostedTimeBucket)
     {
         TBoostedTimeBucket lb(


### PR DESCRIPTION
### Notes
Added loading mixed filter from the mixed index.

We are loading MixedBlockFilterRangesToLoadPerTX compaction ranges for each transaction and we try not to spend more than the MixedBlocksFilterAllowCpuTimePerSec of CPU time per second loading the filter - We register the CPU time of the last load in a leaky bucket, and if there isn't enough budget to cover that transaction, we postpone the next transaction until the budget is refilled.

Filter loading can be disabled by setting MixedBlocksFilterRangeToLoadToTX to 0

### Issue
#6390 