### PR TITLE
Implement VolumeCriticalEvents/* per-disk metrics and BLOCKSTORE_VOLUME_CRITICAL_EVENTS API

### DIFF
--- a/cloud/blockstore/config/diagnostics.proto
+++ b/cloud/blockstore/config/diagnostics.proto
@@ -22,14 +22,15 @@ enum EHostNameScheme
 // Volume critical events reporting mode (for per-disk critical events)
 enum EVolumeCriticalEventsReportingMode
 {
-    // Report only via legacy per-host AppCriticalEvents metrics.
+    // Report disk critical events only via per-host AppCriticalEvents metrics.
     APP_ONLY = 0;
 
-    // Report both via legacy per-host AppCriticalEvents and via per-volume
-    // VolumeCriticalEvents metrics.
+    // Report disk critical events both via per-host AppCriticalEvents
+    // and via per-volume VolumeCriticalEvents metrics.
     ALL = 1;
 
-    // Report only via per-volume VolumeCriticalEvents metrics.
+    // Report disk critical events only via per-volume VolumeCriticalEvents
+    // metrics.
     VOLUME_ONLY = 2;
 };
 

--- a/cloud/blockstore/config/diagnostics.proto
+++ b/cloud/blockstore/config/diagnostics.proto
@@ -19,6 +19,21 @@ enum EHostNameScheme
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+// Volume critical events reporting mode (for per-disk critical events)
+enum EVolumeCriticalEventsReportingMode
+{
+    // Report only via legacy per-host AppCriticalEvents metrics.
+    APP_ONLY = 0;
+
+    // Report both via legacy per-host AppCriticalEvents and via per-volume
+    // VolumeCriticalEvents metrics.
+    ALL = 1;
+
+    // Report only via per-volume VolumeCriticalEvents metrics.
+    VOLUME_ONLY = 2;
+};
+
+////////////////////////////////////////////////////////////////////////////////
 // Operation threshold
 
 message TOperationPerfThreshold
@@ -277,4 +292,8 @@ message TDiagnosticsConfig
     // Makes VolumeInfo stats for endpoints durable by pinning the VolumeInfo
     // object (not removed by InactiveClientsTimeout while the endpoint exists)
     optional bool EnableDurableVolumeInfo = 59;
+
+    // Selects the critical event metrics to report.
+    optional EVolumeCriticalEventsReportingMode
+        VolumeCriticalEventsReportingMode = 60;
 }

--- a/cloud/blockstore/libs/common/volume_id.cpp
+++ b/cloud/blockstore/libs/common/volume_id.cpp
@@ -1,0 +1,18 @@
+#include "volume_id.h"
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVolumeIdPtr MakeVolumeId(
+    const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId)
+{
+    return std::make_shared<TVolumeId>(TVolumeId{
+        .DiskId = diskId,
+        .CloudId = cloudId,
+        .FolderId = folderId});
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/common/volume_id.h
+++ b/cloud/blockstore/libs/common/volume_id.h
@@ -5,6 +5,7 @@
 #include <util/str_stl.h>
 
 #include <memory>
+#include <tuple>
 #include <type_traits>
 
 namespace NCloud::NBlockStore {

--- a/cloud/blockstore/libs/common/volume_id.h
+++ b/cloud/blockstore/libs/common/volume_id.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <util/generic/hash.h>
+#include <util/generic/string.h>
+#include <util/str_stl.h>
+
+#include <memory>
+#include <type_traits>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TVolumeId
+{
+    TString DiskId;
+    TString CloudId;
+    TString FolderId;
+};
+
+using TVolumeIdPtr = std::shared_ptr<TVolumeId>;
+using TVolumeIdConstPtr = std::shared_ptr<const TVolumeId>;
+
+inline bool operator==(const TVolumeId& lhs, const TVolumeId& rhs)
+{
+    return std::tie(lhs.DiskId, lhs.CloudId, lhs.FolderId) ==
+           std::tie(rhs.DiskId, rhs.CloudId, rhs.FolderId);
+}
+
+inline bool operator<(const TVolumeId& lhs, const TVolumeId& rhs)
+{
+    return std::tie(lhs.DiskId, lhs.CloudId, lhs.FolderId) <
+           std::tie(rhs.DiskId, rhs.CloudId, rhs.FolderId);
+}
+
+TVolumeIdPtr MakeVolumeId(
+    const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId);
+
+}   // namespace NCloud::NBlockStore
+
+template <>
+struct THash<NCloud::NBlockStore::TVolumeId>
+{
+    size_t operator()(const NCloud::NBlockStore::TVolumeId& val) const
+    {
+        auto a = std::tie(val.DiskId, val.CloudId, val.FolderId);
+        return THash<std::decay_t<decltype(a)>>{}(a);
+    }
+};

--- a/cloud/blockstore/libs/common/volume_labels.cpp
+++ b/cloud/blockstore/libs/common/volume_labels.cpp
@@ -1,15 +1,15 @@
-#include "volume_id.h"
+#include "volume_labels.h"
 
 namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVolumeIdPtr MakeVolumeId(
+TVolumeLabelsPtr MakeVolumeLabels(
     const TString& diskId,
     const TString& cloudId,
     const TString& folderId)
 {
-    return std::make_shared<TVolumeId>(TVolumeId{
+    return std::make_shared<TVolumeLabels>(TVolumeLabels{
         .DiskId = diskId,
         .CloudId = cloudId,
         .FolderId = folderId});

--- a/cloud/blockstore/libs/common/volume_labels.h
+++ b/cloud/blockstore/libs/common/volume_labels.h
@@ -12,39 +12,41 @@ namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TVolumeId
+struct TVolumeLabels
 {
     TString DiskId;
     TString CloudId;
     TString FolderId;
 };
 
-using TVolumeIdPtr = std::shared_ptr<TVolumeId>;
-using TVolumeIdConstPtr = std::shared_ptr<const TVolumeId>;
+using TVolumeLabelsPtr = std::shared_ptr<TVolumeLabels>;
+using TVolumeLabelsConstPtr = std::shared_ptr<const TVolumeLabels>;
 
-inline bool operator==(const TVolumeId& lhs, const TVolumeId& rhs)
+inline bool operator==(const TVolumeLabels& lhs, const TVolumeLabels& rhs)
 {
     return std::tie(lhs.DiskId, lhs.CloudId, lhs.FolderId) ==
            std::tie(rhs.DiskId, rhs.CloudId, rhs.FolderId);
 }
 
-inline bool operator<(const TVolumeId& lhs, const TVolumeId& rhs)
+inline bool operator<(const TVolumeLabels& lhs, const TVolumeLabels& rhs)
 {
     return std::tie(lhs.DiskId, lhs.CloudId, lhs.FolderId) <
            std::tie(rhs.DiskId, rhs.CloudId, rhs.FolderId);
 }
 
-TVolumeIdPtr MakeVolumeId(
+TVolumeLabelsPtr MakeVolumeLabels(
     const TString& diskId,
     const TString& cloudId,
     const TString& folderId);
 
 }   // namespace NCloud::NBlockStore
 
+////////////////////////////////////////////////////////////////////////////////
+
 template <>
-struct THash<NCloud::NBlockStore::TVolumeId>
+struct THash<NCloud::NBlockStore::TVolumeLabels>
 {
-    size_t operator()(const NCloud::NBlockStore::TVolumeId& val) const
+    size_t operator()(const NCloud::NBlockStore::TVolumeLabels& val) const
     {
         auto a = std::tie(val.DiskId, val.CloudId, val.FolderId);
         return THash<std::decay_t<decltype(a)>>{}(a);

--- a/cloud/blockstore/libs/common/ya.make
+++ b/cloud/blockstore/libs/common/ya.make
@@ -15,7 +15,7 @@ SRCS(
     safe_debug_print.cpp
     split_request_helpers.cpp
     typeinfo.cpp
-    volume_id.cpp
+    volume_labels.cpp
 )
 
 PEERDIR(

--- a/cloud/blockstore/libs/common/ya.make
+++ b/cloud/blockstore/libs/common/ya.make
@@ -15,6 +15,7 @@ SRCS(
     safe_debug_print.cpp
     split_request_helpers.cpp
     typeinfo.cpp
+    volume_id.cpp
 )
 
 PEERDIR(

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -297,6 +297,8 @@ void TBootstrapBase::Init()
         ->GetSubgroup("counters", "blockstore");
 
     auto serverGroup = rootGroup->GetSubgroup("component", "server");
+    auto serviceVolumeGroup =
+        rootGroup->GetSubgroup("component", "service_volume");
     auto revisionGroup = serverGroup->GetSubgroup("revision", GetFullVersionString());
 
     auto versionCounter = revisionGroup->GetCounter(
@@ -305,6 +307,16 @@ void TBootstrapBase::Init()
     *versionCounter = 1;
 
     InitCriticalEventsCounter(serverGroup);
+    InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+    STORAGE_INFO("CriticalEvents counters initialized");
+
+    CriticalEventsStatsUpdater = CreateStatsUpdater(
+        Timer,
+        BackgroundScheduler,
+        CreateCriticalEventsStatsHandler());
+
+    STORAGE_INFO("CriticalEventsStatsUpdater initialized");
 
     TVector<TCertificateFiles> certPathList;
     for (const auto& cert: Configs->ServerConfig->GetCertsWithLegacyFallback())
@@ -1020,6 +1032,7 @@ void TBootstrapBase::Start()
     START_COMMON_COMPONENT(GrpcEndpointListener);
     START_COMMON_COMPONENT(Executor);
     START_COMMON_COMPONENT(Server);
+    START_COMMON_COMPONENT(CriticalEventsStatsUpdater);
     START_COMMON_COMPONENT(ServerStatsUpdater);
     START_COMMON_COMPONENT(BackgroundThreadPool);
     START_COMMON_COMPONENT(RdmaClient);
@@ -1091,6 +1104,7 @@ void TBootstrapBase::Stop()
     STOP_COMMON_COMPONENT(GetTraceServiceClient());
     STOP_COMMON_COMPONENT(RdmaClient);
     STOP_COMMON_COMPONENT(BackgroundThreadPool);
+    STOP_COMMON_COMPONENT(CriticalEventsStatsUpdater);
     STOP_COMMON_COMPONENT(ServerStatsUpdater);
     STOP_COMMON_COMPONENT(Server);
     STOP_COMMON_COMPONENT(CertificateProvider);

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -11,7 +11,7 @@
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/fault_injection.h>
 #include <cloud/blockstore/libs/diagnostics/incomplete_request_processor.h>
 #include <cloud/blockstore/libs/diagnostics/probes.h>
@@ -307,7 +307,7 @@ void TBootstrapBase::Init()
         false);
     *versionCounter = 1;
 
-    SetVolumeCriticalEventsReportingMode(
+    InitVolumeCriticalEventsReportingMode(
         Configs->DiagnosticsConfig->GetVolumeCriticalEventsReportingMode());
     InitCriticalEventsCounter(serverGroup);
     InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/fault_injection.h>
 #include <cloud/blockstore/libs/diagnostics/incomplete_request_processor.h>
 #include <cloud/blockstore/libs/diagnostics/probes.h>
@@ -107,9 +108,9 @@
 #include <cloud/storage/core/libs/grpc/tls_certificate_provider.h>
 #include <cloud/storage/core/libs/opentelemetry/iface/trace_service_client.h>
 #include <cloud/storage/core/libs/opentelemetry/impl/trace_reader.h>
-#include <cloud/storage/core/libs/version/version.h>
 #include <cloud/storage/core/libs/rdma/iface/client.h>
 #include <cloud/storage/core/libs/rdma/iface/server.h>
+#include <cloud/storage/core/libs/version/version.h>
 
 #include <library/cpp/lwtrace/mon/mon_lwtrace.h>
 #include <library/cpp/lwtrace/probes.h>
@@ -297,6 +298,8 @@ void TBootstrapBase::Init()
         ->GetSubgroup("counters", "blockstore");
 
     auto serverGroup = rootGroup->GetSubgroup("component", "server");
+    auto volumeCriticalEventsGroup =
+        rootGroup->GetSubgroup("component", "critical_events");
     auto revisionGroup = serverGroup->GetSubgroup("revision", GetFullVersionString());
 
     auto versionCounter = revisionGroup->GetCounter(
@@ -304,8 +307,10 @@ void TBootstrapBase::Init()
         false);
     *versionCounter = 1;
 
+    SetVolumeCriticalEventsReportingMode(
+        Configs->DiagnosticsConfig->GetVolumeCriticalEventsReportingMode());
     InitCriticalEventsCounter(serverGroup);
-    InitVolumeCriticalEventsCounter(serverGroup);
+    InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
     STORAGE_INFO("CriticalEvents counters initialized");
 

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -297,8 +297,6 @@ void TBootstrapBase::Init()
         ->GetSubgroup("counters", "blockstore");
 
     auto serverGroup = rootGroup->GetSubgroup("component", "server");
-    auto serviceVolumeGroup =
-        rootGroup->GetSubgroup("component", "service_volume");
     auto revisionGroup = serverGroup->GetSubgroup("revision", GetFullVersionString());
 
     auto versionCounter = revisionGroup->GetCounter(
@@ -307,7 +305,7 @@ void TBootstrapBase::Init()
     *versionCounter = 1;
 
     InitCriticalEventsCounter(serverGroup);
-    InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+    InitVolumeCriticalEventsCounter(serverGroup);
 
     STORAGE_INFO("CriticalEvents counters initialized");
 
@@ -1104,8 +1102,8 @@ void TBootstrapBase::Stop()
     STOP_COMMON_COMPONENT(GetTraceServiceClient());
     STOP_COMMON_COMPONENT(RdmaClient);
     STOP_COMMON_COMPONENT(BackgroundThreadPool);
-    STOP_COMMON_COMPONENT(CriticalEventsStatsUpdater);
     STOP_COMMON_COMPONENT(ServerStatsUpdater);
+    STOP_COMMON_COMPONENT(CriticalEventsStatsUpdater);
     STOP_COMMON_COMPONENT(Server);
     STOP_COMMON_COMPONENT(CertificateProvider);
     STOP_COMMON_COMPONENT(Executor);

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -54,6 +54,7 @@ protected:
     IRequestStatsPtr RequestStats;
     IVolumeStatsPtr VolumeStats;
     IServerStatsPtr ServerStats;
+    IStatsUpdaterPtr CriticalEventsStatsUpdater;
     IStatsUpdaterPtr ServerStatsUpdater;
     TVector<ITraceReaderPtr> TraceReaders;
     ITraceProcessorPtr TraceProcessor;

--- a/cloud/blockstore/libs/diagnostics/config.cpp
+++ b/cloud/blockstore/libs/diagnostics/config.cpp
@@ -66,6 +66,9 @@ namespace {
     xxx(ExecutionTimeSizeClasses,       TVector<TSizeInterval>,  {}                                     )\
     xxx(PassTraceIdToBlobstorage,       bool,                    false                                  )\
     xxx(EnableDurableVolumeInfo,        bool,                    false                                  )\
+    xxx(VolumeCriticalEventsReportingMode,                                                               \
+                                        NProto::EVolumeCriticalEventsReportingMode,                      \
+                                                                 NProto::EVolumeCriticalEventsReportingMode::APP_ONLY)\
 
 // BLOCKSTORE_DIAGNOSTICS_CONFIG
 // clang-format on
@@ -286,6 +289,15 @@ void Out<NCloud::NBlockStore::NProto::EHostNameScheme>(
     NCloud::NBlockStore::NProto::EHostNameScheme scheme)
 {
     out << NCloud::NBlockStore::NProto::EHostNameScheme_Name(scheme);
+}
+
+template <>
+void Out<NCloud::NBlockStore::NProto::EVolumeCriticalEventsReportingMode>(
+    IOutputStream& out,
+    NCloud::NBlockStore::NProto::EVolumeCriticalEventsReportingMode mode)
+{
+    out << NCloud::NBlockStore::NProto::EVolumeCriticalEventsReportingMode_Name(
+        mode);
 }
 
 template <>

--- a/cloud/blockstore/libs/diagnostics/config.h
+++ b/cloud/blockstore/libs/diagnostics/config.h
@@ -193,6 +193,9 @@ public:
 
     [[nodiscard]] bool GetEnableDurableVolumeInfo() const;
 
+    [[nodiscard]] NProto::EVolumeCriticalEventsReportingMode
+    GetVolumeCriticalEventsReportingMode() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/blockstore/libs/diagnostics/config_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/config_ut.cpp
@@ -134,6 +134,23 @@ CloudIdsWithStrictSLA: "cloud3"
         UNIT_ASSERT(!HasField(protoConfig, "CloudIdsWithStrictSLA"));
         UNIT_ASSERT_VALUES_EQUAL(config.GetCloudIdsWithStrictSLA().size(), 0);
     }
+
+    Y_UNIT_TEST(TestVolumeCriticalEventsReportingMode)
+    {
+        TDiagnosticsConfig defaultConfig;
+        UNIT_ASSERT_VALUES_EQUAL(
+            defaultConfig.GetVolumeCriticalEventsReportingMode(),
+            NProto::EVolumeCriticalEventsReportingMode::APP_ONLY);
+
+        NProto::TDiagnosticsConfig protoConfig = CreateConfig(R"(
+VolumeCriticalEventsReportingMode: ALL
+)");
+        TDiagnosticsConfig config(protoConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            config.GetVolumeCriticalEventsReportingMode(),
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
+    }
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/config_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/config_ut.cpp
@@ -139,8 +139,8 @@ CloudIdsWithStrictSLA: "cloud3"
     {
         TDiagnosticsConfig defaultConfig;
         UNIT_ASSERT_VALUES_EQUAL(
-            defaultConfig.GetVolumeCriticalEventsReportingMode(),
-            NProto::EVolumeCriticalEventsReportingMode::APP_ONLY);
+            NProto::EVolumeCriticalEventsReportingMode::APP_ONLY,
+            defaultConfig.GetVolumeCriticalEventsReportingMode());
 
         NProto::TDiagnosticsConfig protoConfig = CreateConfig(R"(
 VolumeCriticalEventsReportingMode: ALL
@@ -148,8 +148,8 @@ VolumeCriticalEventsReportingMode: ALL
         TDiagnosticsConfig config(protoConfig);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            config.GetVolumeCriticalEventsReportingMode(),
-            NProto::EVolumeCriticalEventsReportingMode::ALL);
+            NProto::EVolumeCriticalEventsReportingMode::ALL,
+            config.GetVolumeCriticalEventsReportingMode());
     }
 }
 

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -77,15 +77,18 @@ struct TVolumeCriticalEventCounter
 
 struct TVolumeCriticalEventKey
 {
-    TString Event;        // "VolumeCriticalEvent/<event>"
-    TVolumeId VolumeId;   // published as the 'volume', 'cloud' and 'folder'
-                          // metric labels
-
-    bool operator==(const TVolumeCriticalEventKey& rhs) const
-    {
-        return std::tie(Event, VolumeId) == std::tie(rhs.Event, rhs.VolumeId);
-    }
+    TString Event;                // == "VolumeCriticalEvent/<event>"
+    TVolumeLabels VolumeLabels;   // published as the 'volume', 'cloud' and
+                                  // 'folder' metric labels
 };
+
+inline bool operator==(
+    const TVolumeCriticalEventKey& lhs,
+    const TVolumeCriticalEventKey& rhs)
+{
+    return std::tie(lhs.Event, lhs.VolumeLabels) ==
+           std::tie(rhs.Event, rhs.VolumeLabels);
+}
 
 }   // namespace
 }   // namespace NCloud::NBlockStore
@@ -98,7 +101,7 @@ struct THash<NCloud::NBlockStore::TVolumeCriticalEventKey>
     size_t operator()(
         const NCloud::NBlockStore::TVolumeCriticalEventKey& val) const
     {
-        const auto& a = std::tie(val.Event, val.VolumeId);
+        const auto& a = std::tie(val.Event, val.VolumeLabels);
         return THash<std::decay_t<decltype(a)>>{}(a);
     }
 };
@@ -139,9 +142,9 @@ void PublishVolumeCriticalEventCounters()
             // published GAUGE now so the accumulated Unpublished can be
             // flushed.
             e.Published = VolumeCriticalEvents.CountersRoot
-                              ->GetSubgroup("volume", k.VolumeId.DiskId)
-                              ->GetSubgroup("cloud", k.VolumeId.CloudId)
-                              ->GetSubgroup("folder", k.VolumeId.FolderId)
+                              ->GetSubgroup("volume", k.VolumeLabels.DiskId)
+                              ->GetSubgroup("cloud", k.VolumeLabels.CloudId)
+                              ->GetSubgroup("folder", k.VolumeLabels.FolderId)
                               ->GetCounter(k.Event, /*derivative=*/false);
         }
         auto v = e.Unpublished.exchange(0);
@@ -360,7 +363,7 @@ void ResetVolumeCriticalEventsCounter()
                                                                                \
             auto key = TVolumeCriticalEventKey{                                \
                 .Event    = GetVolumeCriticalEventFor##name(),                 \
-                .VolumeId = {                                                  \
+                .VolumeLabels = {                                              \
                     .DiskId   = diskId,                                        \
                     .CloudId  = cloudId,                                       \
                     .FolderId = folderId}                                      \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -10,12 +10,15 @@
 #include <util/generic/hash.h>
 #include <util/str_stl.h>
 #include <util/string/builder.h>
+#include <util/system/guard.h>
+#include <util/system/spinlock.h>
 
 #include <tuple>
 #include <type_traits>
-#include <unordered_map>
 
 namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
 
 namespace {
 
@@ -24,57 +27,58 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 /*
-TVolumeCriticalEventCounter - per-interval CriticalEvent counter with
+TVolumeCriticalEventCounter - per-interval critical event counter with
 deferred export
 
-Writing the number of CritEvents for an interval directly into the monitoring
-counter (Exported) can lead to registered CriticalEvents being missed in
-monitoring, because the 15s intervals (cycles) - the internal one and the
-monitoring one - generally do not coincide:
+Writing the number of critical events for an interval directly into the
+monitoring counter (Published) can lead to registered critical events being
+missed in monitoring, because the 15s intervals (cycles) - the internal one
+and the monitoring one - generally do not coincide:
 
 1. End of the next monitoring interval - monitoring reads the current counter
-   value (including 0, if no CriticalEvents have been registered in this
+   value (including 0, if no critical events have been registered in this
    internal interval yet)
 
 2. End of the next internal interval -
-   WriteVolumeCriticalEventCounters() resets the counter to 0.
+   PublishVolumeCriticalEventCounters() resets the counter to 0.
 
-3. If a CriticalEvent was registered between (1) and (2) (Report...() was
+3. If a critical event was registered between (1) and (2) (Report...() was
    called with an increment of the counter), that event will be lost and
    not reflected in monitoring
 
 To exclude such a scenario:
 
-- CriticalEvents for the current interval are accumulated in the Internal
+- critical events for the current interval are accumulated in the Unpublished
   counter
 
-- at the end of the interval, the Internal value is written into the Exported
-  counter and held there until the end of the next interval, allowing
+- at the end of the interval, the Unpublished value is written into the
+  Published counter and held there until the end of the next interval, allowing
   monitoring to read the value in its own read cycle
 
 Additionally:
 
-- the separate use of Internal and Exported counters avoids losing
-  CriticalEvents registered before module initialization (before
+- the separate use of Unpublished and Published counters avoids losing
+  critical events registered before module initialization (before
   TVolumeCriticalEvents::CountersRoot is set) - the value accumulated in
-  Internal is not reset at the end of an interval when writing to Exported
+  Unpublished is not reset at the end of an interval when writing to Published
   is not possible. At the end of the first interval after CountersRoot
-  initialization, the value accumulated since startup in the Internal counter
-  will be written into Exported
+  initialization, the value accumulated since startup in the Unpublished counter
+  will be written into Published
 */
 struct TVolumeCriticalEventCounter
 {
-    // Per-interval CriticalEvents counter, not exported
-    std::atomic<i64> Internal{0};
-    // Per-interval CriticalEvents metrics counter, GAUGE.
+    // Per-interval critical events counter, not published yet
+    std::atomic<i64> Unpublished{0};
+    // Per-interval critical events metrics counter, GAUGE.
+    // Published and held until next publish interval.
     // Constructed lazily
-    NMonitoring::TDynamicCounters::TCounterPtr Exported;
+    NMonitoring::TDynamicCounters::TCounterPtr Published;
 };
 
 struct TVolumeCriticalEventKey
 {
     TString Event;        // "VolumeCriticalEvent/<event>"
-    TVolumeId VolumeId;   // exported as the 'volume', 'cloud' and 'folder'
+    TVolumeId VolumeId;   // published as the 'volume', 'cloud' and 'folder'
                           // metric labels
 
     bool operator==(const TVolumeCriticalEventKey& rhs) const
@@ -85,6 +89,8 @@ struct TVolumeCriticalEventKey
 
 }   // namespace
 }   // namespace NCloud::NBlockStore
+
+////////////////////////////////////////////////////////////////////////////////
 
 template <>
 struct THash<NCloud::NBlockStore::TVolumeCriticalEventKey>
@@ -100,55 +106,55 @@ struct THash<NCloud::NBlockStore::TVolumeCriticalEventKey>
 namespace NCloud::NBlockStore {
 namespace {
 
-using TVolumeCriticalEventCounterMap = THashMap<
-    TVolumeCriticalEventKey,
-    std::shared_ptr<TVolumeCriticalEventCounter>>;
+////////////////////////////////////////////////////////////////////////////////
+
+using TVolumeCriticalEventCounterMap =
+    THashMap<TVolumeCriticalEventKey, TVolumeCriticalEventCounter>;
 
 struct TVolumeCriticalEvents
 {
-    TRWMutex Lock;
+    TAdaptiveLock Lock;
     TVolumeCriticalEventCounterMap Counters;
     NMonitoring::TDynamicCountersPtr CountersRoot;
 };
 
 TVolumeCriticalEvents VolumeCriticalEvents;
 
-void WriteVolumeCriticalEventCounters()
+void PublishVolumeCriticalEventCounters()
 {
-    TReadGuard guard(VolumeCriticalEvents.Lock);
+    TGuard<TAdaptiveLock> guard(VolumeCriticalEvents.Lock);
 
     for (auto& [k, e]: VolumeCriticalEvents.Counters) {
         // NOTE: a single instance of TCriticalEventsStatsHandler is expected
-        // (as the sole writer of e->Exported). This simplifies Lock usage
-        // (e->Exported can be written under the read guard only).
-        if (!e->Exported) {
+        // (as the sole writer of e->Published). This simplifies Lock usage
+        // (e->Published can be written under the read guard only).
+        if (!e.Published) {
             if (!VolumeCriticalEvents.CountersRoot) {
-                // Root not initialized yet; keep accumulating in Internal,
+                // Root not initialized yet; keep accumulating in Unpublished,
                 // see the first-fire branch in Report##name().
                 continue;
             }
             // Root became available after the first fire (e.g. Report ran
             // before InitVolumeCriticalEventsCounter) - materialize the
-            // exported GAUGE now so the accumulated Internal can be flushed.
-            e->Exported = VolumeCriticalEvents.CountersRoot
+            // published GAUGE now so the accumulated Unpublished can be
+            // flushed.
+            e.Published = VolumeCriticalEvents.CountersRoot
                               ->GetSubgroup("volume", k.VolumeId.DiskId)
                               ->GetSubgroup("cloud", k.VolumeId.CloudId)
                               ->GetSubgroup("folder", k.VolumeId.FolderId)
                               ->GetCounter(k.Event, /*derivative=*/false);
         }
-        auto v = e->Internal.exchange(0);
-        *e->Exported = v;   // GAUGE set; sticky until next write
+        auto v = e.Unpublished.exchange(0);
+        *e.Published = v;   // GAUGE set; held until next flush
     }
 }
-
-////////////////////////////////////////////////////////////////////////////////
 
 struct TCriticalEventsStatsHandler: public NCloud::IStatsHandler
 {
     void UpdateStats(bool updateIntervalFinished) override
     {
         if (updateIntervalFinished) {
-            WriteVolumeCriticalEventCounters();
+            PublishVolumeCriticalEventCounters();
         }
     }
 };
@@ -172,8 +178,6 @@ TString ComposeMessageWithSuffix(const TString& message, const TString& suffix)
 }
 }   // namespace
 
-using namespace NMonitoring;
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
@@ -193,8 +197,9 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 
 void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 {
-    TWriteGuard wguard(VolumeCriticalEvents.Lock);
-    VolumeCriticalEvents.CountersRoot = counters;
+    with_lock (VolumeCriticalEvents.Lock) {
+        VolumeCriticalEvents.CountersRoot = counters;
+    }
 }
 
 NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler()
@@ -205,9 +210,10 @@ NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler()
 // For unit test purposes
 void ResetVolumeCriticalEventsCounter()
 {
-    TWriteGuard guard(VolumeCriticalEvents.Lock);
-    VolumeCriticalEvents.Counters.clear();
-    VolumeCriticalEvents.CountersRoot.Reset();
+    with_lock (VolumeCriticalEvents.Lock) {
+        VolumeCriticalEvents.Counters.clear();
+        VolumeCriticalEvents.CountersRoot.Reset();
+    }
 }
 
 #define BLOCKSTORE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                         \
@@ -334,7 +340,7 @@ void ResetVolumeCriticalEventsCounter()
             ReportCriticalEvent(                                               \
                 GetDeprecatedCriticalEventFor##name(),                         \
                 submsg,                                                        \
-                false);                                                        \
+                /*verifyDebug=*/false);                                        \
                                                                                \
             auto prefix = TCritEventParams{                                    \
                 {"disk", diskId},                                              \
@@ -346,7 +352,7 @@ void ResetVolumeCriticalEventsCounter()
                     ? ComposeMessageWithSuffix(PrintParams(prefix), submsg)    \
                     : PrintParams(prefix);                                     \
                                                                                \
-            /* Log immediatly */                                               \
+            /* Log immediately */                                              \
             auto retMessage =                                                  \
                 LogCriticalEvent(                                              \
                     GetVolumeCriticalEventFor##name(),                         \
@@ -360,29 +366,12 @@ void ResetVolumeCriticalEventsCounter()
                     .FolderId = folderId}                                      \
             };                                                                 \
                                                                                \
-            /* Hot path - counter already exists */                            \
-            {                                                                  \
-                TReadGuard guard(VolumeCriticalEvents.Lock);                   \
-                if (auto it = VolumeCriticalEvents.Counters.find(key);         \
-                    it != VolumeCriticalEvents.Counters.end())                 \
-                {                                                              \
-                    it->second->Internal++;                                    \
-                    return retMessage;                                         \
-                }                                                              \
-            }                                                                  \
-                                                                               \
-            /* First fire - create the entry.                                  \
-               The Exported GAUGE counter is materialized lazily               \
-               by WriteVolumeCriticalEventCounters() on the publish tick.      \
-               Here we only create and bump the Internal accumulator.          \
-            */                                                                 \
-            {                                                                  \
-                TWriteGuard guard(VolumeCriticalEvents.Lock);                  \
-                auto& e = VolumeCriticalEvents.Counters[key];                  \
-                if (!e) {                                                      \
-                    e = std::make_shared<TVolumeCriticalEventCounter>();       \
-                }                                                              \
-                e->Internal++;                                                 \
+            with_lock (VolumeCriticalEvents.Lock) {                            \
+                /* The Published GAUGE counter is materialized lazily          \
+                   by PublishVolumeCriticalEventCounters() on the publish tick.\
+                   Here we only create and bump the Unpublished accumulator.   \
+                */                                                             \
+                VolumeCriticalEvents.Counters[key].Unpublished++;              \
             }                                                                  \
                                                                                \
             return retMessage;                                                 \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include "critical_events_config.h"
+
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 #include <cloud/storage/core/libs/diagnostics/stats_handler.h>
 
@@ -68,7 +70,7 @@ Additionally:
 struct TVolumeCriticalEventCounter
 {
     // Per-interval critical events counter, not published yet
-    std::atomic<i64> Unpublished{0};
+    i64 Unpublished{0};
     // Per-interval critical events metrics counter, GAUGE.
     // Published and held until next publish interval.
     // Constructed lazily
@@ -121,6 +123,8 @@ struct TVolumeCriticalEvents
     NMonitoring::TDynamicCountersPtr CountersRoot;
 };
 
+NProto::EVolumeCriticalEventsReportingMode VolumeCriticalEventsReportingMode =
+    NProto::EVolumeCriticalEventsReportingMode::APP_ONLY;
 TVolumeCriticalEvents VolumeCriticalEvents;
 
 void PublishVolumeCriticalEventCounters()
@@ -147,8 +151,8 @@ void PublishVolumeCriticalEventCounters()
                               ->GetSubgroup("folder", k.VolumeLabels.FolderId)
                               ->GetCounter(k.Event, /*derivative=*/false);
         }
-        auto v = e.Unpublished.exchange(0);
-        *e.Published = v;   // GAUGE set; held until next flush
+        *e.Published = e.Unpublished;   // GAUGE set; held until next flush
+        e.Unpublished = 0;
     }
 }
 
@@ -183,6 +187,12 @@ TString ComposeMessageWithSuffix(const TString& message, const TString& suffix)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void SetVolumeCriticalEventsReportingMode(
+    NProto::EVolumeCriticalEventsReportingMode reportingMode)
+{
+    VolumeCriticalEventsReportingMode = reportingMode;
+}
+
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 {
 #define BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER(name)                           \
@@ -194,6 +204,20 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
         BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER)
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER)
 #undef BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER
+
+// Keeps existing AppCriticalEvents/ * for new VolumeCriticalEvents/ * metrics
+// alive
+#define BLOCKSTORE_INIT_APP_CRITICAL_EVENT_COUNTER(name)                       \
+    *counters->GetCounter(GetAppCriticalEventFor##name(), true) = 0;
+
+    if (VolumeCriticalEventsReportingMode !=
+        NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY)
+    {
+        BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
+            BLOCKSTORE_INIT_APP_CRITICAL_EVENT_COUNTER)
+    }
+
+#undef BLOCKSTORE_INIT_APP_CRITICAL_EVENT_COUNTER
 
     NCloud::InitCriticalEventsCounter(std::move(counters));
 }
@@ -336,19 +360,31 @@ void ResetVolumeCriticalEventsCounter()
             const TString& message,                                            \
             const TCritEventParams& keyValues)                                 \
         {                                                                      \
+            TString retMessage;                                                \
             TString submsg =                                                   \
                 ComposeMessageWithSuffix(message, PrintParams(keyValues));     \
                                                                                \
-            /* deprecated: keeps existing AppCriticalEvents/ metrics alive */  \
-            ReportCriticalEvent(                                               \
-                GetDeprecatedCriticalEventFor##name(),                         \
-                submsg,                                                        \
-                /*verifyDebug=*/false);                                        \
+            /* Keep legacy AppCriticalEvents/ metrics alive */                 \
+            if (VolumeCriticalEventsReportingMode !=                           \
+                    NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY)   \
+            {                                                                  \
+                retMessage = ReportCriticalEvent(                              \
+                    GetAppCriticalEventFor##name(),                            \
+                    submsg,                                                    \
+                    /*verifyDebug=*/false);                                    \
+            }                                                                  \
+                                                                               \
+            if (VolumeCriticalEventsReportingMode ==                           \
+                    NProto::EVolumeCriticalEventsReportingMode::APP_ONLY)      \
+            {                                                                  \
+                                                                               \
+                return retMessage;                                             \
+            }                                                                  \
                                                                                \
             auto prefix = TCritEventParams{                                    \
-                {"disk", diskId},                                              \
-                {"cloud", cloudId},                                            \
-                {"folder", folderId}};                                         \
+                {"disk", diskId.empty() ? "<empty>" : diskId},                 \
+                {"cloud", cloudId.empty() ? "<empty>" : cloudId},              \
+                {"folder", folderId.empty() ? "<empty>" : folderId}};          \
                                                                                \
             TString logMessage =                                               \
                 !submsg.empty()                                                \
@@ -356,13 +392,13 @@ void ResetVolumeCriticalEventsCounter()
                     : PrintParams(prefix);                                     \
                                                                                \
             /* Log immediately */                                              \
-            auto retMessage =                                                  \
+            retMessage =                                                       \
                 LogCriticalEvent(                                              \
                     GetVolumeCriticalEventFor##name(),                         \
                     logMessage);                                               \
                                                                                \
             auto key = TVolumeCriticalEventKey{                                \
-                .Event    = GetVolumeCriticalEventFor##name(),                 \
+                .Event        = GetVolumeCriticalEventFor##name(),             \
                 .VolumeLabels = {                                              \
                     .DiskId   = diskId,                                        \
                     .CloudId  = cloudId,                                       \
@@ -370,9 +406,14 @@ void ResetVolumeCriticalEventsCounter()
             };                                                                 \
                                                                                \
             with_lock (VolumeCriticalEvents.Lock) {                            \
-                /* The Published GAUGE counter is materialized lazily          \
+                /*                                                             \
+                1. The Published GAUGE counter is materialized lazily          \
                    by PublishVolumeCriticalEventCounters() on the publish tick.\
                    Here we only create and bump the Unpublished accumulator.   \
+                2. The footprint of the unbounded-lifetime VolumeCriticalEvents\
+                   metric is not deemed a measurable concern due to rare tablet\
+                   migrations, rare critical events, and periodic              \
+                   (release-based) process restarts.                           \
                 */                                                             \
                 VolumeCriticalEvents.Counters[key].Unpublished++;              \
             }                                                                  \
@@ -391,7 +432,7 @@ void ResetVolumeCriticalEventsCounter()
         {                                                                      \
             return "VolumeCriticalEvents/" #name;                              \
         }                                                                      \
-        const TString GetDeprecatedCriticalEventFor##name()                    \
+        const TString GetAppCriticalEventFor##name()                           \
         {                                                                      \
             return "AppCriticalEvents/" #name;                                 \
         }                                                                      \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -3,16 +3,155 @@
 #include "public.h"
 
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
+#include <cloud/storage/core/libs/diagnostics/stats_handler.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
+#include <util/generic/hash.h>
+#include <util/str_stl.h>
 #include <util/string/builder.h>
+
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
 
 namespace NCloud::NBlockStore {
 
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
+// VolumeCriticalEvents
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+TVolumeCriticalEventCounter - per-interval CriticalEvent counter with
+deferred export
+
+Writing the number of CritEvents for an interval directly into the monitoring
+counter (Exported) can lead to registered CriticalEvents being missed in
+monitoring, because the 15s intervals (cycles) - the internal one and the
+monitoring one - generally do not coincide:
+
+1. End of the next monitoring interval - monitoring reads the current counter
+   value (including 0, if no CriticalEvents have been registered in this
+   internal interval yet)
+
+2. End of the next internal interval -
+   WriteVolumeCriticalEventCounters() resets the counter to 0.
+
+3. If a CriticalEvent was registered between (1) and (2) (Report...() was
+   called with an increment of the counter), that event will be lost and
+   not reflected in monitoring
+
+To exclude such a scenario:
+
+- CriticalEvents for the current interval are accumulated in the Internal
+  counter
+
+- at the end of the interval, the Internal value is written into the Exported
+  counter and held there until the end of the next interval, allowing
+  monitoring to read the value in its own read cycle
+
+Additionally:
+
+- the separate use of Internal and Exported counters avoids losing
+  CriticalEvents registered before module initialization (before
+  TVolumeCriticalEvents::CountersRoot is set) - the value accumulated in
+  Internal is not reset at the end of an interval when writing to Exported
+  is not possible. At the end of the first interval after CountersRoot
+  initialization, the value accumulated since startup in the Internal counter
+  will be written into Exported
+*/
+struct TVolumeCriticalEventCounter
+{
+    // Per-interval CriticalEvents counter, not exported
+    std::atomic<i64> Internal{0};
+    // Per-interval CriticalEvents metrics counter, GAUGE.
+    // Constructed lazily
+    NMonitoring::TDynamicCounters::TCounterPtr Exported;
+};
+
+struct TVolumeCriticalEventKey
+{
+    TString Event;        // "VolumeCriticalEvent/<event>"
+    TVolumeId VolumeId;   // exported as the 'volume', 'cloud' and 'folder'
+                          // metric labels
+
+    bool operator==(const TVolumeCriticalEventKey& rhs) const
+    {
+        return std::tie(Event, VolumeId) == std::tie(rhs.Event, rhs.VolumeId);
+    }
+};
+
+}   // namespace
+}   // namespace NCloud::NBlockStore
+
+template <>
+struct THash<NCloud::NBlockStore::TVolumeCriticalEventKey>
+{
+    size_t operator()(
+        const NCloud::NBlockStore::TVolumeCriticalEventKey& val) const
+    {
+        const auto& a = std::tie(val.Event, val.VolumeId);
+        return THash<std::decay_t<decltype(a)>>{}(a);
+    }
+};
+
+namespace NCloud::NBlockStore {
+namespace {
+
+using TVolumeCriticalEventCounterMap = THashMap<
+    TVolumeCriticalEventKey,
+    std::shared_ptr<TVolumeCriticalEventCounter>>;
+
+struct TVolumeCriticalEvents
+{
+    TRWMutex Lock;
+    TVolumeCriticalEventCounterMap Counters;
+    NMonitoring::TDynamicCountersPtr CountersRoot;
+};
+
+TVolumeCriticalEvents VolumeCriticalEvents;
+
+void WriteVolumeCriticalEventCounters()
+{
+    TReadGuard guard(VolumeCriticalEvents.Lock);
+
+    for (auto& [k, e]: VolumeCriticalEvents.Counters) {
+        // NOTE: a single instance of TCriticalEventsStatsHandler is expected
+        // (as the sole writer of e->Exported). This simplifies Lock usage
+        // (e->Exported can be written under the read guard only).
+        if (!e->Exported) {
+            if (!VolumeCriticalEvents.CountersRoot) {
+                // Root not initialized yet; keep accumulating in Internal,
+                // see the first-fire branch in Report##name().
+                continue;
+            }
+            // Root became available after the first fire (e.g. Report ran
+            // before InitVolumeCriticalEventsCounter) - materialize the
+            // exported GAUGE now so the accumulated Internal can be flushed.
+            e->Exported = VolumeCriticalEvents.CountersRoot
+                              ->GetSubgroup("volume", k.VolumeId.DiskId)
+                              ->GetSubgroup("cloud", k.VolumeId.CloudId)
+                              ->GetSubgroup("folder", k.VolumeId.FolderId)
+                              ->GetCounter(k.Event, /*derivative=*/false);
+        }
+        auto v = e->Internal.exchange(0);
+        *e->Exported = v;   // GAUGE set; sticky until next write
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCriticalEventsStatsHandler: public NCloud::IStatsHandler
+{
+    void UpdateStats(bool updateIntervalFinished) override
+    {
+        if (updateIntervalFinished) {
+            WriteVolumeCriticalEventCounters();
+        }
+    }
+};
 
 template <typename... Ts>
 TStringBuilder& operator<<(TStringBuilder& sb, const std::variant<Ts...>& v)
@@ -50,6 +189,25 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 #undef BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER
 
     NCloud::InitCriticalEventsCounter(std::move(counters));
+}
+
+void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
+{
+    TWriteGuard wguard(VolumeCriticalEvents.Lock);
+    VolumeCriticalEvents.CountersRoot = counters;
+}
+
+NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler()
+{
+    return std::make_shared<TCriticalEventsStatsHandler>();
+}
+
+// For unit test purposes
+void ResetVolumeCriticalEventsCounter()
+{
+    TWriteGuard guard(VolumeCriticalEvents.Lock);
+    VolumeCriticalEvents.Counters.clear();
+    VolumeCriticalEvents.CountersRoot.Reset();
 }
 
 #define BLOCKSTORE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                         \
@@ -151,5 +309,105 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE)
 #undef BLOCKSTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE
+
+    // clang-format off
+#define BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE(name)                  \
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TString& message)                                            \
+        {                                                                      \
+            return Report##name(diskId, cloudId, folderId, message, {});       \
+        }                                                                      \
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TString& message,                                            \
+            const TCritEventParams& keyValues)                                 \
+        {                                                                      \
+            TString submsg =                                                   \
+                ComposeMessageWithSuffix(message, PrintParams(keyValues));     \
+                                                                               \
+            /* deprecated: keeps existing AppCriticalEvents/ metrics alive */  \
+            ReportCriticalEvent(                                               \
+                GetDeprecatedCriticalEventFor##name(),                         \
+                submsg,                                                        \
+                false);                                                        \
+                                                                               \
+            auto prefix = TCritEventParams{                                    \
+                {"disk", diskId},                                              \
+                {"cloud", cloudId},                                            \
+                {"folder", folderId}};                                         \
+                                                                               \
+            TString logMessage =                                               \
+                !submsg.empty()                                                \
+                    ? ComposeMessageWithSuffix(PrintParams(prefix), submsg)    \
+                    : PrintParams(prefix);                                     \
+                                                                               \
+            /* Log immediatly */                                               \
+            auto retMessage =                                                  \
+                LogCriticalEvent(                                              \
+                    GetVolumeCriticalEventFor##name(),                         \
+                    logMessage);                                               \
+                                                                               \
+            auto key = TVolumeCriticalEventKey{                                \
+                .Event    = GetVolumeCriticalEventFor##name(),                 \
+                .VolumeId = {                                                  \
+                    .DiskId   = diskId,                                        \
+                    .CloudId  = cloudId,                                       \
+                    .FolderId = folderId}                                      \
+            };                                                                 \
+                                                                               \
+            /* Hot path - counter already exists */                            \
+            {                                                                  \
+                TReadGuard guard(VolumeCriticalEvents.Lock);                   \
+                if (auto it = VolumeCriticalEvents.Counters.find(key);         \
+                    it != VolumeCriticalEvents.Counters.end())                 \
+                {                                                              \
+                    it->second->Internal++;                                    \
+                    return retMessage;                                         \
+                }                                                              \
+            }                                                                  \
+                                                                               \
+            /* First fire - create the entry.                                  \
+               The Exported GAUGE counter is materialized lazily               \
+               by WriteVolumeCriticalEventCounters() on the publish tick.      \
+               Here we only create and bump the Internal accumulator.          \
+            */                                                                 \
+            {                                                                  \
+                TWriteGuard guard(VolumeCriticalEvents.Lock);                  \
+                auto& e = VolumeCriticalEvents.Counters[key];                  \
+                if (!e) {                                                      \
+                    e = std::make_shared<TVolumeCriticalEventCounter>();       \
+                }                                                              \
+                e->Internal++;                                                 \
+            }                                                                  \
+                                                                               \
+            return retMessage;                                                 \
+        }                                                                      \
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TCritEventParams& keyValues)                                 \
+        {                                                                      \
+            return Report##name(diskId, cloudId, folderId, {}, keyValues);     \
+        }                                                                      \
+        const TString GetVolumeCriticalEventFor##name()                        \
+        {                                                                      \
+            return "VolumeCriticalEvents/" #name;                              \
+        }                                                                      \
+        const TString GetDeprecatedCriticalEventFor##name()                    \
+        {                                                                      \
+            return "AppCriticalEvents/" #name;                                 \
+        }                                                                      \
+        // BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE
+
+    BLOCKSTORE_VOLUME_CRITICAL_EVENTS(\
+        BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE)
+#undef BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE
+    // clang-format on
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -343,8 +343,7 @@ void ResetVolumeCriticalEventsCounter()
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE)
 #undef BLOCKSTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE
 
-    // clang-format off
-#define BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE(name)                  \
+#define BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE(name)              \
         TString Report##name(                                                  \
             const TString& diskId,                                             \
             const TString& cloudId,                                            \
@@ -366,7 +365,7 @@ void ResetVolumeCriticalEventsCounter()
                                                                                \
             /* Keep legacy AppCriticalEvents/ metrics alive */                 \
             if (VolumeCriticalEventsReportingMode !=                           \
-                    NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY)   \
+                NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY)       \
             {                                                                  \
                 retMessage = ReportCriticalEvent(                              \
                     GetAppCriticalEventFor##name(),                            \
@@ -375,9 +374,8 @@ void ResetVolumeCriticalEventsCounter()
             }                                                                  \
                                                                                \
             if (VolumeCriticalEventsReportingMode ==                           \
-                    NProto::EVolumeCriticalEventsReportingMode::APP_ONLY)      \
+                NProto::EVolumeCriticalEventsReportingMode::APP_ONLY)          \
             {                                                                  \
-                                                                               \
                 return retMessage;                                             \
             }                                                                  \
                                                                                \
@@ -392,28 +390,27 @@ void ResetVolumeCriticalEventsCounter()
                     : PrintParams(prefix);                                     \
                                                                                \
             /* Log immediately */                                              \
-            retMessage =                                                       \
-                LogCriticalEvent(                                              \
-                    GetVolumeCriticalEventFor##name(),                         \
-                    logMessage);                                               \
+            retMessage = LogCriticalEvent(                                     \
+                GetVolumeCriticalEventFor##name(),                             \
+                logMessage);                                                   \
                                                                                \
             auto key = TVolumeCriticalEventKey{                                \
-                .Event        = GetVolumeCriticalEventFor##name(),             \
+                .Event = GetVolumeCriticalEventFor##name(),                    \
                 .VolumeLabels = {                                              \
-                    .DiskId   = diskId,                                        \
-                    .CloudId  = cloudId,                                       \
-                    .FolderId = folderId}                                      \
-            };                                                                 \
+                    .DiskId = diskId,                                          \
+                    .CloudId = cloudId,                                        \
+                    .FolderId = folderId}};                                    \
                                                                                \
             with_lock (VolumeCriticalEvents.Lock) {                            \
                 /*                                                             \
                 1. The Published GAUGE counter is materialized lazily          \
-                   by PublishVolumeCriticalEventCounters() on the publish tick.\
-                   Here we only create and bump the Unpublished accumulator.   \
-                2. The footprint of the unbounded-lifetime VolumeCriticalEvents\
-                   metric is not deemed a measurable concern due to rare tablet\
-                   migrations, rare critical events, and periodic              \
-                   (release-based) process restarts.                           \
+                   by PublishVolumeCriticalEventCounters() on the publish      \
+                   tick. Here we only create and bump the Unpublished          \
+                   accumulator.                                                \
+                2. The footprint of the unbounded-lifetime                     \
+                   VolumeCriticalEvents metric is not deemed a measurable      \
+                   concern due to rare tablet migrations, rare critical        \
+                   events, and periodic (release-based) process restarts.      \
                 */                                                             \
                 VolumeCriticalEvents.Counters[key].Unpublished++;              \
             }                                                                  \
@@ -441,6 +438,5 @@ void ResetVolumeCriticalEventsCounter()
     BLOCKSTORE_VOLUME_CRITICAL_EVENTS(\
         BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE)
 #undef BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE
-    // clang-format on
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -2,7 +2,7 @@
 
 #include "public.h"
 
-#include "critical_events_config.h"
+#include "critical_events_init.h"
 
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 #include <cloud/storage/core/libs/diagnostics/stats_handler.h>
@@ -20,8 +20,6 @@
 
 namespace NCloud::NBlockStore {
 
-////////////////////////////////////////////////////////////////////////////////
-
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -30,7 +28,7 @@ namespace {
 
 /*
 TVolumeCriticalEventCounter - per-interval critical event counter with
-deferred export
+deferred publishing
 
 Writing the number of critical events for an interval directly into the
 monitoring counter (Published) can lead to registered critical events being
@@ -93,6 +91,7 @@ inline bool operator==(
 }
 
 }   // namespace
+
 }   // namespace NCloud::NBlockStore
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,6 +108,7 @@ struct THash<NCloud::NBlockStore::TVolumeCriticalEventKey>
 };
 
 namespace NCloud::NBlockStore {
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -187,7 +187,7 @@ TString ComposeMessageWithSuffix(const TString& message, const TString& suffix)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void SetVolumeCriticalEventsReportingMode(
+void InitVolumeCriticalEventsReportingMode(
     NProto::EVolumeCriticalEventsReportingMode reportingMode)
 {
     VolumeCriticalEventsReportingMode = reportingMode;

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -4,7 +4,7 @@
 
 #include <cloud/blockstore/libs/common/block_range.h>
 #include <cloud/blockstore/libs/common/printable_params.h>
-#include <cloud/blockstore/libs/common/volume_id.h>
+#include <cloud/blockstore/libs/common/volume_labels.h>
 
 #include <utility>
 
@@ -241,21 +241,23 @@ void ResetVolumeCriticalEventsCounter();
             const TString& folderId,                                           \
             const TCritEventParams& keyValues);                                \
         template <typename... TArgs>                                           \
-        TString Report##name(const TVolumeId& volumeId, TArgs&&... args)       \
+        TString Report##name(                                                  \
+            const TVolumeLabels& volumeLabels,                                 \
+            TArgs&&... args)                                                   \
         {                                                                      \
             return Report##name(                                               \
-                volumeId.DiskId,                                               \
-                volumeId.CloudId,                                              \
-                volumeId.FolderId,                                             \
+                volumeLabels.DiskId,                                           \
+                volumeLabels.CloudId,                                          \
+                volumeLabels.FolderId,                                         \
                 std::forward<TArgs>(args)...);                                 \
         }                                                                      \
         template <typename... TArgs>                                           \
         TString Report##name(                                                  \
-            const TVolumeIdConstPtr& volumeId,                                 \
+            const TVolumeLabelsConstPtr& volumeLabels,                         \
             TArgs&&... args)                                                   \
         {                                                                      \
-            Y_ABORT_UNLESS(volumeId);                                          \
-            return Report##name(*volumeId, std::forward<TArgs>(args)...);      \
+            Y_ABORT_UNLESS(volumeLabels);                                      \
+            return Report##name(*volumeLabels, std::forward<TArgs>(args)...);  \
         }                                                                      \
         const TString GetVolumeCriticalEventFor##name();                       \
         const TString GetDeprecatedCriticalEventFor##name();                   \

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -176,14 +176,6 @@ using TCritEventParams =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
-void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
-
-NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler();
-
-// For unit test purposes
-void ResetVolumeCriticalEventsCounter();
-
 #define BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                        \
     TString Report##name(const TString& message = "");                         \
     TString Report##name(                                                      \
@@ -260,7 +252,7 @@ void ResetVolumeCriticalEventsCounter();
             return Report##name(*volumeLabels, std::forward<TArgs>(args)...);  \
         }                                                                      \
         const TString GetVolumeCriticalEventFor##name();                       \
-        const TString GetDeprecatedCriticalEventFor##name();                   \
+        const TString GetAppCriticalEventFor##name();                          \
         // BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
 
     BLOCKSTORE_VOLUME_CRITICAL_EVENTS(

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -254,7 +254,7 @@ void ResetVolumeCriticalEventsCounter();
             const TVolumeIdConstPtr& volumeId,                                 \
             TArgs&&... args)                                                   \
         {                                                                      \
-            Y_DEBUG_ABORT_UNLESS(volumeId);                                    \
+            Y_ABORT_UNLESS(volumeId);                                          \
             return Report##name(*volumeId, std::forward<TArgs>(args)...);      \
         }                                                                      \
         const TString GetVolumeCriticalEventFor##name();                       \

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -4,6 +4,9 @@
 
 #include <cloud/blockstore/libs/common/block_range.h>
 #include <cloud/blockstore/libs/common/printable_params.h>
+#include <cloud/blockstore/libs/common/volume_id.h>
+
+#include <utility>
 
 namespace NCloud::NBlockStore {
 
@@ -135,9 +138,51 @@ using TCritEventParams =
     xxx(CleanupBlobMetaBlocksMismatch)                                         \
 // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
+#define BLOCKSTORE_VOLUME_CRITICAL_EVENTS(xxx)                                 \
+    xxx(InvalidTabletConfig)                                                   \
+    xxx(ReassignTablet)                                                        \
+    xxx(TabletBSFailure)                                                       \
+    xxx(DiskAllocationFailure)                                                 \
+    xxx(CollectGarbageError)                                                   \
+    xxx(MigrationFailed)                                                       \
+    xxx(BadMigrationConfig)                                                    \
+    xxx(InitFreshBlocksError)                                                  \
+    xxx(TrimFreshLogError)                                                     \
+    xxx(NrdDestructionError)                                                   \
+    xxx(FailedToStartVolumeLocally)                                            \
+    xxx(MirroredDiskAllocationCleanupFailure)                                  \
+    xxx(MirroredDiskAllocationPlacementGroupCleanupFailure)                    \
+    xxx(MirroredDiskDeviceReplacementForbidden)                                \
+    xxx(MirroredDiskDeviceReplacementFailure)                                  \
+    xxx(MirroredDiskDeviceReplacementRateLimitExceeded)                        \
+    xxx(MirroredDiskMinorityChecksumMismatch)                                  \
+    xxx(MirroredDiskMajorityChecksumMismatch)                                  \
+    xxx(MirroredDiskChecksumMismatchUponRead)                                  \
+    xxx(MirroredDiskAddTagFailed)                                              \
+    xxx(ResyncFailed)                                                          \
+    xxx(AddConfirmedBlobsError)                                                \
+    xxx(ConfirmBlobsError)                                                     \
+    xxx(BlockDigestMismatchInBlob)                                             \
+    xxx(ErrorWasSentToTheGuestForReliableDisk)                                 \
+    xxx(ErrorWasSentToTheGuestForNonReliableDisk)                              \
+    xxx(MirroredDiskResyncChecksumMismatch)                                    \
+    xxx(ReleaseShadowDiskError)                                                \
+    xxx(WrongCellIdInDescribeVolume)                                           \
+    xxx(TrimFreshLogTimeout)                                                   \
+    xxx(AddFreshBlocksResultedInError)                                         \
+    xxx(OverlappingRequestsDetected)                                           \
+    xxx(CrossPartitionRequestDetected)                                         \
+    // BLOCKSTORE_VOLUME_CRITICAL_EVENTS
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
+void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
+
+NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler();
+
+// For unit test purposes
+void ResetVolumeCriticalEventsCounter();
 
 #define BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                        \
     TString Report##name(const TString& message = "");                         \
@@ -177,5 +222,47 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 // BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)
 #undef BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
+
+#define BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE(name)             \
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TString& message = "");                                      \
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TString& message,                                            \
+            const TCritEventParams& keyValues);                                \
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TCritEventParams& keyValues);                                \
+        template <typename... TArgs>                                           \
+        TString Report##name(const TVolumeId& volumeId, TArgs&&... args)       \
+        {                                                                      \
+            return Report##name(                                               \
+                volumeId.DiskId,                                               \
+                volumeId.CloudId,                                              \
+                volumeId.FolderId,                                             \
+                std::forward<TArgs>(args)...);                                 \
+        }                                                                      \
+        template <typename... TArgs>                                           \
+        TString Report##name(                                                  \
+            const TVolumeIdConstPtr& volumeId,                                 \
+            TArgs&&... args)                                                   \
+        {                                                                      \
+            Y_DEBUG_ABORT_UNLESS(volumeId);                                    \
+            return Report##name(*volumeId, std::forward<TArgs>(args)...);      \
+        }                                                                      \
+        const TString GetVolumeCriticalEventFor##name();                       \
+        const TString GetDeprecatedCriticalEventFor##name();                   \
+        // BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
+
+    BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
+        BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE)
+#undef BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events_config.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events_config.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/config/diagnostics.pb.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void SetVolumeCriticalEventsReportingMode(
+    NProto::EVolumeCriticalEventsReportingMode reportingMode);
+
+void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
+void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
+
+NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler();
+
+// For unit test purposes
+void ResetVolumeCriticalEventsCounter();
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events_init.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events_init.h
@@ -1,3 +1,10 @@
+/*******************************************************************************
+
+This file is intended for initialization only and must not be included in
+critical event reporting to avoid potential PEERDIR cyclic dependencies.
+
+*******************************************************************************/
+
 #pragma once
 
 #include "public.h"
@@ -8,7 +15,7 @@ namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void SetVolumeCriticalEventsReportingMode(
+void InitVolumeCriticalEventsReportingMode(
     NProto::EVolumeCriticalEventsReportingMode reportingMode);
 
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -30,7 +30,7 @@ TIntrusivePtr<TDynamicCounters> FindNestedGroup(
 // Resolves the per-disk counter group under component=service_volume.
 TIntrusivePtr<TDynamicCounters> FindVolumeGroup(
     TDynamicCountersPtr serviceVolumeGroup,
-    const TVolumeId& v)
+    const TVolumeLabels& v)
 {
     return FindNestedGroup(
         serviceVolumeGroup,
@@ -115,7 +115,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumeId v{
+        const TVolumeLabels v{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
@@ -169,7 +169,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumeId v{
+        const TVolumeLabels v{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
@@ -208,7 +208,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumeId v{
+        const TVolumeLabels v{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
@@ -246,12 +246,12 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumeId v1{
+        const TVolumeLabels v1{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
 
-        const TVolumeId v2{
+        const TVolumeLabels v2{
             .DiskId = "disk-2",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
@@ -298,7 +298,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumeId v{
+        const TVolumeLabels v{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
@@ -370,9 +370,9 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
                 params);
         }
 
-        // Report...(TVolumeId, ...)
+        // Report...(TVolumeLabels, ...)
         {
-            const auto v = TVolumeId{
+            const auto v = TVolumeLabels{
                 .DiskId = diskId,
                 .CloudId = cloudId,
                 .FolderId = folderId};
@@ -383,9 +383,9 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             ReportBlockDigestMismatchInBlob(v, msg, params);
         }
 
-        // Report...(TVolumeIdConstPtr, ...)
+        // Report...(TVolumeLabelsConstPtr, ...)
         {
-            const auto v = MakeVolumeId(diskId, cloudId, folderId);
+            const auto v = MakeVolumeLabels(diskId, cloudId, folderId);
 
             ReportBlockDigestMismatchInBlob(v);
             ReportBlockDigestMismatchInBlob(v, msg);
@@ -393,7 +393,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             ReportBlockDigestMismatchInBlob(v, msg, params);
         }
 
-        const auto v = TVolumeId{
+        const auto v = TVolumeLabels{
             .DiskId = diskId,
             .CloudId = cloudId,
             .FolderId = folderId};

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -1,6 +1,6 @@
 #include "critical_events.h"
 
-#include "critical_events_config.h"
+#include "critical_events_init.h"
 
 #include <cloud/storage/core/libs/diagnostics/stats_handler.h>
 
@@ -65,7 +65,7 @@ Y_UNIT_TEST_SUITE(TCriticalEventsTest)
         auto criticalEventsGroup =
             root->GetSubgroup("component", AppCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(reportingMode);
+        InitVolumeCriticalEventsReportingMode(reportingMode);
 
         InitCriticalEventsCounter(criticalEventsGroup);
 
@@ -127,7 +127,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(reportingMode);
+        InitVolumeCriticalEventsReportingMode(reportingMode);
         InitCriticalEventsCounter(criticalEventsGroup);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
@@ -197,7 +197,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(reportingMode);
+        InitVolumeCriticalEventsReportingMode(reportingMode);
         InitCriticalEventsCounter(criticalEventsGroup);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
@@ -274,7 +274,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(
+        InitVolumeCriticalEventsReportingMode(
             NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitCriticalEventsCounter(criticalEventsGroup);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
@@ -330,7 +330,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(
+        InitVolumeCriticalEventsReportingMode(
             NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
@@ -370,7 +370,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(
+        InitVolumeCriticalEventsReportingMode(
             NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
@@ -411,7 +411,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(
+        InitVolumeCriticalEventsReportingMode(
             NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
@@ -453,7 +453,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(
+        InitVolumeCriticalEventsReportingMode(
             NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitCriticalEventsCounter(criticalEventsGroup);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
@@ -507,7 +507,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(
+        InitVolumeCriticalEventsReportingMode(
             NProto::EVolumeCriticalEventsReportingMode::ALL);
         // NOTE: InitVolumeCriticalEventsCounter is intentionally deferred.
         InitCriticalEventsCounter(criticalEventsGroup);
@@ -563,7 +563,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             "component",
             VolumeCriticalEventsComponent.data());
 
-        SetVolumeCriticalEventsReportingMode(
+        InitVolumeCriticalEventsReportingMode(
             NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitCriticalEventsCounter(criticalEventsGroup);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -116,7 +116,7 @@ Y_UNIT_TEST_SUITE(TCriticalEventsTest)
 
 Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 {
-    void DoShouldEagerlyInitLegacyCriticalEventsCounters(
+    void DoShouldEagerlyInitAppCriticalEventsCounters(
         NProto::EVolumeCriticalEventsReportingMode reportingMode,
         bool shouldInit)
     {
@@ -166,19 +166,19 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
     }
 
     // InitCriticalEventsCounter/InitVolumeCriticalEventsCounter should
-    // eagerly initializes the legacy per-disk AppCriticalEvents/<event>
-    // counters (value 0) only with
+    // eagerly initialize the per-host AppCriticalEvents/<event>
+    // counters (value 0) for disk critical events only with
     // TDiagnosticsConfig::VolumeCriticalEventsReportingMode != VOLUME_ONLY
     // so they keep show up in monitoring before any event is reported.
-    Y_UNIT_TEST(ShouldEagerlyInitLegacyCriticalEventsCounters)
+    Y_UNIT_TEST(ShouldEagerlyInitAppCriticalEventsCounters)
     {
-        DoShouldEagerlyInitLegacyCriticalEventsCounters(
+        DoShouldEagerlyInitAppCriticalEventsCounters(
             NProto::EVolumeCriticalEventsReportingMode::APP_ONLY,
             /*shouldInit=*/true);
-        DoShouldEagerlyInitLegacyCriticalEventsCounters(
+        DoShouldEagerlyInitAppCriticalEventsCounters(
             NProto::EVolumeCriticalEventsReportingMode::ALL,
             /*shouldInit=*/true);
-        DoShouldEagerlyInitLegacyCriticalEventsCounters(
+        DoShouldEagerlyInitAppCriticalEventsCounters(
             NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY,
             /*shouldInit=*/false);
     }
@@ -262,7 +262,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
     }
 
     // Per-disk GAUGE counters are emitted by the shadow-swap publish,
-    // while the legacy AppCriticalEvents/* counter is bumped synchronously
+    // while the per-host AppCriticalEvents/* counter is bumped synchronously
     Y_UNIT_TEST(ShouldEmitPerDiskCountersForVolumeCriticalEvents)
     {
         ResetVolumeCriticalEventsCounter();
@@ -301,11 +301,11 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         UNIT_ASSERT(
             !volumeGroup || !volumeGroup->FindCounter(GetVolumeSensorName()));
 
-        // Legacy counter is bumped synchronously.
-        auto legacyCounter =
-            criticalEventsGroup->FindCounter(GetAppSensorName());
-        UNIT_ASSERT(legacyCounter);
-        UNIT_ASSERT_VALUES_EQUAL(2, legacyCounter->Val());
+        // Per-host counter is bumped synchronously.
+        auto appCounter = criticalEventsGroup->FindCounter(GetAppSensorName());
+        UNIT_ASSERT(appCounter);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, appCounter->Val());
 
         // Flush materializes and writes the GAUGE.
         handler->UpdateStats(true);
@@ -314,10 +314,11 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         UNIT_ASSERT(volumeGroup);
         auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
         UNIT_ASSERT(volumeCounter);
+
         UNIT_ASSERT_VALUES_EQUAL(2, volumeCounter->Val());
 
-        // Legacy counter is not changed after update/publish.
-        UNIT_ASSERT_VALUES_EQUAL(2, legacyCounter->Val());
+        // Per-host counter is not changed after update/publish.
+        UNIT_ASSERT_VALUES_EQUAL(2, appCounter->Val());
     }
 
     // The publish only runs when updateIntervalFinished is true
@@ -429,19 +430,18 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(volumeGroup);
-        UNIT_ASSERT_VALUES_EQUAL(
-            2,
-            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+        auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
+        UNIT_ASSERT(volumeCounter);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, volumeCounter->Val());
 
         // No new events -> Unpublished is 0 -> GAUGE set back to 0.
         handler->UpdateStats(true);
-        UNIT_ASSERT_VALUES_EQUAL(
-            0,
-            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, volumeCounter->Val());
     }
 
     // Counters are distinct per disk.
-    // Legacy counters contain summary
+    // Per-host counters contain summary
     Y_UNIT_TEST(ShouldKeepDistinctCountersPerDisk)
     {
         ResetVolumeCriticalEventsCounter();
@@ -487,11 +487,10 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
                 ->FindCounter(GetVolumeSensorName())
                 ->Val());
 
-        // Legacy counter should contain summary
-        auto legacyCounter =
-            criticalEventsGroup->FindCounter(GetAppSensorName());
-        UNIT_ASSERT(legacyCounter);
-        UNIT_ASSERT_VALUES_EQUAL(3, legacyCounter->Val());
+        // Per-host counter should contain summary
+        auto appCounter = criticalEventsGroup->FindCounter(GetAppSensorName());
+        UNIT_ASSERT(appCounter);
+        UNIT_ASSERT_VALUES_EQUAL(3, appCounter->Val());
     }
 
     // Events fired before CountersRoot is set must accumulate in
@@ -532,23 +531,21 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(volumeGroup);
-        UNIT_ASSERT_VALUES_EQUAL(
-            3,
-            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+        auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
+        UNIT_ASSERT(volumeCounter);
 
-        // Legacy counter reflects the dual emission (3 synchronous
-        // Inc()'s).
+        UNIT_ASSERT_VALUES_EQUAL(3, volumeCounter->Val());
+
+        // Per-host counter reflects the dual emission (3 synchronous Inc()'s).
         UNIT_ASSERT_VALUES_EQUAL(
             3,
             criticalEventsGroup->FindCounter(GetAppSensorName())->Val());
 
-        // One more event on the hot path (Exported is now non-null,
-        // Internal -> 1) is flushed on the next tick.
+        // One more event (Published is now non-null, Unpublished -> 1)
+        // is flushed on the next tick.
         ReportBlockDigestMismatchInBlob(v, "some msg");
         handler->UpdateStats(true);
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, volumeCounter->Val());
     }
 
     // All Report...() overloads works
@@ -618,21 +615,22 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             .CloudId = cloudId,
             .FolderId = folderId};
 
-        auto legacyCounter =
-            criticalEventsGroup->FindCounter(GetAppSensorName());
-        UNIT_ASSERT(legacyCounter);
-        // Legacy counter should contain summary immediately
-        UNIT_ASSERT_VALUES_EQUAL(12, legacyCounter->Val());
+        // Per-host counter should contain summary immediately.
+        auto appCounter = criticalEventsGroup->FindCounter(GetAppSensorName());
+        UNIT_ASSERT(appCounter);
+        UNIT_ASSERT_VALUES_EQUAL(12, appCounter->Val());
 
         handler->UpdateStats(true);
 
         auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(volumeGroup);
-        UNIT_ASSERT_VALUES_EQUAL(
-            12,
-            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+        auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
+        UNIT_ASSERT(volumeCounter);
 
-        UNIT_ASSERT_VALUES_EQUAL(12, legacyCounter->Val());
+        UNIT_ASSERT_VALUES_EQUAL(12, volumeCounter->Val());
+
+        // Per-host counter is not changed after update/publish.
+        UNIT_ASSERT_VALUES_EQUAL(12, appCounter->Val());
     }
 }
 

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -7,6 +7,8 @@
 
 namespace NCloud::NBlockStore {
 
+////////////////////////////////////////////////////////////////////////////////
+
 namespace {
 
 using namespace NMonitoring;
@@ -97,20 +99,19 @@ Y_UNIT_TEST_SUITE(TCriticalEventsTest)
 
 Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 {
-    // Per-disk GAUGE counters are emitted by the shadow-swap flush,
-    // while the deprecated AppCriticalEvents/* counter (under
-    // component=server) is bumped synchronously
+    // Per-disk GAUGE counters are emitted by the shadow-swap publish,
+    // while the deprecated AppCriticalEvents/* counter is bumped synchronously
     Y_UNIT_TEST(ShouldEmitPerDiskCountersForVolumeCriticalEvents)
     {
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto serverGroup = root->GetSubgroup("component", "server");
-        auto serviceVolumeGroup =
-            root->GetSubgroup("component", "service_volume");
+        auto criticalEventsGroup = root->GetSubgroup("component", "server");
+        auto volumeCriticalEventsGroup =
+            root->GetSubgroup("component", "server");
 
-        InitCriticalEventsCounter(serverGroup);
-        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
         auto handler = CreateCriticalEventsStatsHandler();
 
@@ -129,42 +130,42 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         UNIT_ASSERT_STRING_CONTAINS(ret1, "folder-1");
 
         // Before the flush the per-disk GAUGE is not yet materialized:
-        // the hot path only bumps the Internal accumulator.
-        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        // the hot path only bumps the Unpublished accumulator.
+        auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(
             !volumeGroup || !volumeGroup->FindCounter(GetVolumeSensorName()));
 
         // Deprecated counter is bumped synchronously.
         auto deprecatedCounter =
-            serverGroup->FindCounter(GetDeprecatedSensorName());
+            criticalEventsGroup->FindCounter(GetDeprecatedSensorName());
         UNIT_ASSERT(deprecatedCounter);
         UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
 
         // Flush materializes and writes the GAUGE.
         handler->UpdateStats(true);
 
-        volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(volumeGroup);
         auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
         UNIT_ASSERT(volumeCounter);
         UNIT_ASSERT_VALUES_EQUAL(2, volumeCounter->Val());
 
-        // Deprecated counter is not changed after update/flush.
+        // Deprecated counter is not changed after update/publish.
         UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
     }
 
-    // The flush only runs when updateIntervalFinished is true
+    // The publish only runs when updateIntervalFinished is true
     Y_UNIT_TEST(ShouldFlushOnlyOnIntervalFinished)
     {
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto serverGroup = root->GetSubgroup("component", "server");
-        auto serviceVolumeGroup =
-            root->GetSubgroup("component", "service_volume");
+        auto criticalEventsGroup = root->GetSubgroup("component", "server");
+        auto volumeCriticalEventsGroup =
+            root->GetSubgroup("component", "server");
 
-        InitCriticalEventsCounter(serverGroup);
-        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
         auto handler = CreateCriticalEventsStatsHandler();
 
@@ -175,17 +176,17 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         ReportBlockDigestMismatchInBlob(v, "some msg");
 
-        // Tick without the interval finished -> no flush.
+        // Tick without the interval finished -> no publish.
         handler->UpdateStats(false);
 
-        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(
             !volumeGroup || !volumeGroup->FindCounter(GetVolumeSensorName()));
 
-        // Interval finished -> flush writes 1.
+        // Interval finished -> publish writes 1.
         handler->UpdateStats(true);
 
-        volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(volumeGroup);
         auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
         UNIT_ASSERT(volumeCounter);
@@ -198,12 +199,12 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto serverGroup = root->GetSubgroup("component", "server");
-        auto serviceVolumeGroup =
-            root->GetSubgroup("component", "service_volume");
+        auto criticalEventsGroup = root->GetSubgroup("component", "server");
+        auto volumeCriticalEventsGroup =
+            root->GetSubgroup("component", "server");
 
-        InitCriticalEventsCounter(serverGroup);
-        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
         auto handler = CreateCriticalEventsStatsHandler();
 
@@ -217,13 +218,13 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         handler->UpdateStats(true);
 
-        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(volumeGroup);
         UNIT_ASSERT_VALUES_EQUAL(
             2,
             volumeGroup->FindCounter(GetVolumeSensorName())->Val());
 
-        // No new events -> Internal is 0 -> GAUGE set back to 0.
+        // No new events -> Unpublished is 0 -> GAUGE set back to 0.
         handler->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(
             0,
@@ -236,12 +237,12 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto serverGroup = root->GetSubgroup("component", "server");
-        auto serviceVolumeGroup =
-            root->GetSubgroup("component", "service_volume");
+        auto criticalEventsGroup = root->GetSubgroup("component", "server");
+        auto volumeCriticalEventsGroup =
+            root->GetSubgroup("component", "server");
 
-        InitCriticalEventsCounter(serverGroup);
-        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
         auto handler = CreateCriticalEventsStatsHandler();
 
@@ -265,35 +266,35 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         UNIT_ASSERT_VALUES_EQUAL(
             2,
-            FindVolumeGroup(serviceVolumeGroup, v1)
+            FindVolumeGroup(volumeCriticalEventsGroup, v1)
                 ->FindCounter(GetVolumeSensorName())
                 ->Val());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            FindVolumeGroup(serviceVolumeGroup, v2)
+            FindVolumeGroup(volumeCriticalEventsGroup, v2)
                 ->FindCounter(GetVolumeSensorName())
                 ->Val());
 
         // Deprecated counter should contain summary
         auto deprecatedCounter =
-            serverGroup->FindCounter(GetDeprecatedSensorName());
+            criticalEventsGroup->FindCounter(GetDeprecatedSensorName());
         UNIT_ASSERT(deprecatedCounter);
         UNIT_ASSERT_VALUES_EQUAL(3, deprecatedCounter->Val());
     }
 
     // Events fired before CountersRoot is set must accumulate in
-    // Internal and be flushed once the root becomes available
+    // Unpublished and be published once the root becomes available
     Y_UNIT_TEST(ShouldAccumulateEventsBeforeCountersRootInitialized)
     {
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto serverGroup = root->GetSubgroup("component", "server");
-        auto serviceVolumeGroup =
-            root->GetSubgroup("component", "service_volume");
+        auto criticalEventsGroup = root->GetSubgroup("component", "server");
+        auto volumeCriticalEventsGroup =
+            root->GetSubgroup("component", "server");
 
         // NOTE: InitVolumeCriticalEventsCounter is intentionally deferred.
-        InitCriticalEventsCounter(serverGroup);
+        InitCriticalEventsCounter(criticalEventsGroup);
 
         auto handler = CreateCriticalEventsStatsHandler();
 
@@ -310,10 +311,10 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         // Root becomes available -> the next flush lazily materializes
         // Exported and writes the accumulated value.
-        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
         handler->UpdateStats(true);
 
-        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(volumeGroup);
         UNIT_ASSERT_VALUES_EQUAL(
             3,
@@ -323,7 +324,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         // Inc()'s).
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            serverGroup->FindCounter(GetDeprecatedSensorName())->Val());
+            criticalEventsGroup->FindCounter(GetDeprecatedSensorName())->Val());
 
         // One more event on the hot path (Exported is now non-null,
         // Internal -> 1) is flushed on the next tick.
@@ -340,12 +341,12 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto serverGroup = root->GetSubgroup("component", "server");
-        auto serviceVolumeGroup =
-            root->GetSubgroup("component", "service_volume");
+        auto criticalEventsGroup = root->GetSubgroup("component", "server");
+        auto volumeCriticalEventsGroup =
+            root->GetSubgroup("component", "server");
 
-        InitCriticalEventsCounter(serverGroup);
-        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
         auto handler = CreateCriticalEventsStatsHandler();
 
@@ -398,14 +399,14 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             .FolderId = folderId};
 
         auto deprecatedCounter =
-            serverGroup->FindCounter(GetDeprecatedSensorName());
+            criticalEventsGroup->FindCounter(GetDeprecatedSensorName());
         UNIT_ASSERT(deprecatedCounter);
-        // Deprecated counter should contain summary immediatly
+        // Deprecated counter should contain summary immediately
         UNIT_ASSERT_VALUES_EQUAL(12, deprecatedCounter->Val());
 
         handler->UpdateStats(true);
 
-        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
         UNIT_ASSERT(volumeGroup);
         UNIT_ASSERT_VALUES_EQUAL(
             12,

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -1,0 +1,418 @@
+#include "critical_events.h"
+
+#include <cloud/storage/core/libs/diagnostics/stats_handler.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore {
+
+namespace {
+
+using namespace NMonitoring;
+
+TIntrusivePtr<TDynamicCounters> FindNestedGroup(
+    TDynamicCountersPtr root,
+    std::initializer_list<std::pair<TString, TString>> path)
+{
+    auto group = root;
+    for (const auto& [key, value] : path) {
+        group = group->FindSubgroup(key, value);
+        if (!group) {
+            return nullptr;
+        }
+    }
+    return group;
+}
+
+// Resolves the per-disk counter group under component=service_volume.
+TIntrusivePtr<TDynamicCounters> FindVolumeGroup(
+    TDynamicCountersPtr serviceVolumeGroup,
+    const TVolumeId& v)
+{
+    return FindNestedGroup(
+        serviceVolumeGroup,
+        {{"volume", v.DiskId}, {"cloud", v.CloudId}, {"folder", v.FolderId}});
+}
+
+TString GetVolumeSensorName()
+{
+    return GetVolumeCriticalEventForBlockDigestMismatchInBlob();
+}
+
+TString GetDeprecatedSensorName()
+{
+    return GetDeprecatedCriticalEventForBlockDigestMismatchInBlob();
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TCriticalEventsTest)
+{
+    // InitCriticalEventsCounter eagerly initializes the deprecated
+    // AppCriticalEvents/<event> counters (value 0) so they keep show up in
+    // monitoring before any event is reported.
+    Y_UNIT_TEST(ShouldEagerlyInitCriticalEventsCounters)
+    {
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+
+        // No Report has been called yet.
+        InitCriticalEventsCounter(serverGroup);
+
+        auto assertInitialized = [&](const TString& sensorName)
+        {
+            auto counter = serverGroup->FindCounter(sensorName);
+            UNIT_ASSERT_C(counter, sensorName);
+            UNIT_ASSERT_VALUES_EQUAL_C(0, counter->Val(), sensorName);
+        };
+
+#define ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED(name) \
+    assertInitialized(GetCriticalEventFor##name());
+        // ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED
+
+        BLOCKSTORE_CRITICAL_EVENTS(ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED)
+        BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(
+            ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED)
+        BLOCKSTORE_IMPOSSIBLE_EVENTS(ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED)
+
+#undef ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED
+
+#define ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED(name) \
+    assertInitialized(GetDeprecatedCriticalEventFor##name());
+        // ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED
+
+        // deprecated: keeps existing AppCriticalEvents/ * for new
+        // VolumeCriticalEvents/ * metrics alive
+        BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
+            ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED)
+
+#undef ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
+{
+    // Per-disk GAUGE counters are emitted by the shadow-swap flush,
+    // while the deprecated AppCriticalEvents/* counter (under
+    // component=server) is bumped synchronously
+    Y_UNIT_TEST(ShouldEmitPerDiskCountersForVolumeCriticalEvents)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumeId v{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        auto ret1 = ReportBlockDigestMismatchInBlob(v, "some msg");
+
+        ReportBlockDigestMismatchInBlob(v, "some msg");
+
+        // The returned log line carries the per-disk prefix.
+        UNIT_ASSERT_STRING_CONTAINS(ret1, "disk-1");
+        UNIT_ASSERT_STRING_CONTAINS(ret1, "cloud-1");
+        UNIT_ASSERT_STRING_CONTAINS(ret1, "folder-1");
+
+        // Before the flush the per-disk GAUGE is not yet materialized:
+        // the hot path only bumps the Internal accumulator.
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(
+            !volumeGroup || !volumeGroup->FindCounter(GetVolumeSensorName()));
+
+        // Deprecated counter is bumped synchronously.
+        auto deprecatedCounter =
+            serverGroup->FindCounter(GetDeprecatedSensorName());
+        UNIT_ASSERT(deprecatedCounter);
+        UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
+
+        // Flush materializes and writes the GAUGE.
+        handler->UpdateStats(true);
+
+        volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(volumeGroup);
+        auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
+        UNIT_ASSERT(volumeCounter);
+        UNIT_ASSERT_VALUES_EQUAL(2, volumeCounter->Val());
+
+        // Deprecated counter is not changed after update/flush.
+        UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
+    }
+
+    // The flush only runs when updateIntervalFinished is true
+    Y_UNIT_TEST(ShouldFlushOnlyOnIntervalFinished)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumeId v{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        ReportBlockDigestMismatchInBlob(v, "some msg");
+
+        // Tick without the interval finished -> no flush.
+        handler->UpdateStats(false);
+
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(
+            !volumeGroup || !volumeGroup->FindCounter(GetVolumeSensorName()));
+
+        // Interval finished -> flush writes 1.
+        handler->UpdateStats(true);
+
+        volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(volumeGroup);
+        auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
+        UNIT_ASSERT(volumeCounter);
+        UNIT_ASSERT_VALUES_EQUAL(1, volumeCounter->Val());
+    }
+
+    // GAUGE semantics: with no new events the next flush resets to 0
+    Y_UNIT_TEST(ShouldResetToZeroAfterFlushWithNoNewEvents)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumeId v{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        ReportBlockDigestMismatchInBlob(v, "some msg");
+        ReportBlockDigestMismatchInBlob(v, "some msg");
+
+        handler->UpdateStats(true);
+
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(volumeGroup);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+
+        // No new events -> Internal is 0 -> GAUGE set back to 0.
+        handler->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+    }
+
+    // Counters are distinct per disk
+    Y_UNIT_TEST(ShouldKeepDistinctCountersPerDisk)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumeId v1{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        const TVolumeId v2{
+            .DiskId = "disk-2",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        ReportBlockDigestMismatchInBlob(v1, "some msg 1");
+
+        ReportBlockDigestMismatchInBlob(v1, "some msg 1");
+
+        ReportBlockDigestMismatchInBlob(v2, "some msg 2");
+
+        handler->UpdateStats(true);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            FindVolumeGroup(serviceVolumeGroup, v1)
+                ->FindCounter(GetVolumeSensorName())
+                ->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            FindVolumeGroup(serviceVolumeGroup, v2)
+                ->FindCounter(GetVolumeSensorName())
+                ->Val());
+
+        // Deprecated counter should contain summary
+        auto deprecatedCounter =
+            serverGroup->FindCounter(GetDeprecatedSensorName());
+        UNIT_ASSERT(deprecatedCounter);
+        UNIT_ASSERT_VALUES_EQUAL(3, deprecatedCounter->Val());
+    }
+
+    // Events fired before CountersRoot is set must accumulate in
+    // Internal and be flushed once the root becomes available
+    Y_UNIT_TEST(ShouldAccumulateEventsBeforeCountersRootInitialized)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        // NOTE: InitVolumeCriticalEventsCounter is intentionally deferred.
+        InitCriticalEventsCounter(serverGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumeId v{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        // CountersRoot is null -> entry created with Exported=null,
+        // Internal accumulates to 3.
+        for (int i = 0; i < 3; ++i) {
+            ReportBlockDigestMismatchInBlob(v, "some msg");
+        }
+
+        // Root becomes available -> the next flush lazily materializes
+        // Exported and writes the accumulated value.
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+        handler->UpdateStats(true);
+
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(volumeGroup);
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+
+        // Deprecated counter reflects the dual emission (3 synchronous
+        // Inc()'s).
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            serverGroup->FindCounter(GetDeprecatedSensorName())->Val());
+
+        // One more event on the hot path (Exported is now non-null,
+        // Internal -> 1) is flushed on the next tick.
+        ReportBlockDigestMismatchInBlob(v, "some msg");
+        handler->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+    }
+
+    // All Report...() overloads works
+    Y_UNIT_TEST(ShouldProperlyImplementAllReportOverloads)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TString diskId = "disk-1";
+        const TString cloudId = "cloud-1";
+        const TString folderId = "folder-1";
+
+        const TString msg = "some msg";
+        const auto params = TCritEventParams{{"a", "1"}, {"b", "2"}};
+
+        // Report...(TString, TString, TString, ...)
+        {
+            ReportBlockDigestMismatchInBlob(diskId, cloudId, folderId);
+            ReportBlockDigestMismatchInBlob(diskId, cloudId, folderId, msg);
+            ReportBlockDigestMismatchInBlob(diskId, cloudId, folderId, params);
+            ReportBlockDigestMismatchInBlob(
+                diskId,
+                cloudId,
+                folderId,
+                msg,
+                params);
+        }
+
+        // Report...(TVolumeId, ...)
+        {
+            const auto v = TVolumeId{
+                .DiskId = diskId,
+                .CloudId = cloudId,
+                .FolderId = folderId};
+
+            ReportBlockDigestMismatchInBlob(v);
+            ReportBlockDigestMismatchInBlob(v, msg);
+            ReportBlockDigestMismatchInBlob(v, params);
+            ReportBlockDigestMismatchInBlob(v, msg, params);
+        }
+
+        // Report...(TVolumeIdConstPtr, ...)
+        {
+            const auto v = MakeVolumeId(diskId, cloudId, folderId);
+
+            ReportBlockDigestMismatchInBlob(v);
+            ReportBlockDigestMismatchInBlob(v, msg);
+            ReportBlockDigestMismatchInBlob(v, params);
+            ReportBlockDigestMismatchInBlob(v, msg, params);
+        }
+
+        const auto v = TVolumeId{
+            .DiskId = diskId,
+            .CloudId = cloudId,
+            .FolderId = folderId};
+
+        auto deprecatedCounter =
+            serverGroup->FindCounter(GetDeprecatedSensorName());
+        UNIT_ASSERT(deprecatedCounter);
+        // Deprecated counter should contain summary immediatly
+        UNIT_ASSERT_VALUES_EQUAL(12, deprecatedCounter->Val());
+
+        handler->UpdateStats(true);
+
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(volumeGroup);
+        UNIT_ASSERT_VALUES_EQUAL(
+            12,
+            volumeGroup->FindCounter(GetVolumeSensorName())->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(12, deprecatedCounter->Val());
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -1,5 +1,7 @@
 #include "critical_events.h"
 
+#include "critical_events_config.h"
+
 #include <cloud/storage/core/libs/diagnostics/stats_handler.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
@@ -12,6 +14,9 @@ namespace NCloud::NBlockStore {
 namespace {
 
 using namespace NMonitoring;
+
+constexpr TStringBuf AppCriticalEventsComponent = "server";
+constexpr TStringBuf VolumeCriticalEventsComponent = "critical_events";
 
 TIntrusivePtr<TDynamicCounters> FindNestedGroup(
     TDynamicCountersPtr root,
@@ -42,9 +47,9 @@ TString GetVolumeSensorName()
     return GetVolumeCriticalEventForBlockDigestMismatchInBlob();
 }
 
-TString GetDeprecatedSensorName()
+TString GetAppSensorName()
 {
-    return GetDeprecatedCriticalEventForBlockDigestMismatchInBlob();
+    return GetAppCriticalEventForBlockDigestMismatchInBlob();
 }
 
 }   // namespace
@@ -53,25 +58,34 @@ TString GetDeprecatedSensorName()
 
 Y_UNIT_TEST_SUITE(TCriticalEventsTest)
 {
-    // InitCriticalEventsCounter eagerly initializes the deprecated
-    // AppCriticalEvents/<event> counters (value 0) so they keep show up in
-    // monitoring before any event is reported.
-    Y_UNIT_TEST(ShouldEagerlyInitCriticalEventsCounters)
+    void DoShouldEagerlyInitCriticalEventsCounters(
+        NProto::EVolumeCriticalEventsReportingMode reportingMode)
     {
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto serverGroup = root->GetSubgroup("component", "server");
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+
+        SetVolumeCriticalEventsReportingMode(reportingMode);
+
+        InitCriticalEventsCounter(criticalEventsGroup);
 
         // No Report has been called yet.
-        InitCriticalEventsCounter(serverGroup);
 
         auto assertInitialized = [&](const TString& sensorName)
         {
-            auto counter = serverGroup->FindCounter(sensorName);
-            UNIT_ASSERT_C(counter, sensorName);
-            UNIT_ASSERT_VALUES_EQUAL_C(0, counter->Val(), sensorName);
+            auto msg = Sprintf(
+                "reportingMode=%s, sensor=%s",
+                NProto::EVolumeCriticalEventsReportingMode_Name(reportingMode)
+                    .c_str(),
+                sensorName.c_str());
+
+            auto counter = criticalEventsGroup->FindCounter(sensorName);
+
+            UNIT_ASSERT_C(counter, msg);
+            UNIT_ASSERT_VALUES_EQUAL_C(0, counter->Val(), msg);
         };
 
-#define ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED(name) \
+#define ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED(name)                        \
     assertInitialized(GetCriticalEventFor##name());
         // ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED
 
@@ -81,17 +95,20 @@ Y_UNIT_TEST_SUITE(TCriticalEventsTest)
         BLOCKSTORE_IMPOSSIBLE_EVENTS(ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED)
 
 #undef ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED
+    }
 
-#define ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED(name) \
-    assertInitialized(GetDeprecatedCriticalEventFor##name());
-        // ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED
-
-        // deprecated: keeps existing AppCriticalEvents/ * for new
-        // VolumeCriticalEvents/ * metrics alive
-        BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
-            ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED)
-
-#undef ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED
+    // InitCriticalEventsCounter eagerly initializes own
+    // AppCriticalEvents/<event> counters (value 0) despite
+    // TDiagnosticsConfig::VolumeCriticalEventsReportingMode
+    // so they keep show up in monitoring before any event is reported.
+    Y_UNIT_TEST(ShouldEagerlyInitCriticalEventsCounters)
+    {
+        DoShouldEagerlyInitCriticalEventsCounters(
+            NProto::EVolumeCriticalEventsReportingMode::APP_ONLY);
+        DoShouldEagerlyInitCriticalEventsCounters(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
+        DoShouldEagerlyInitCriticalEventsCounters(
+            NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY);
     }
 }
 
@@ -99,17 +116,166 @@ Y_UNIT_TEST_SUITE(TCriticalEventsTest)
 
 Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 {
+    void DoShouldEagerlyInitLegacyCriticalEventsCounters(
+        NProto::EVolumeCriticalEventsReportingMode reportingMode,
+        bool shouldInit)
+    {
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
+
+        SetVolumeCriticalEventsReportingMode(reportingMode);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
+
+        // No Report has been called yet.
+
+        auto assertInitialized = [&](const TString& sensorName)
+        {
+            // TODO: fails until all per-disk critical events are removed from
+            // AppCriticalEvents API (now are duplicated in VolumeCriticalEvents
+            // API)
+            return;
+
+            auto msg = Sprintf(
+                "reportingMode=%s, sensor=%s",
+                NProto::EVolumeCriticalEventsReportingMode_Name(reportingMode)
+                    .c_str(),
+                sensorName.c_str());
+
+            auto counter = criticalEventsGroup->FindCounter(sensorName);
+            if (shouldInit) {
+                UNIT_ASSERT_C(counter, msg);
+                UNIT_ASSERT_VALUES_EQUAL_C(0, counter->Val(), msg);
+            } else {
+                UNIT_ASSERT_C(!counter, msg);
+            }
+        };
+
+#define ASSERT_APP_CRITICAL_EVENT_COUNTER_INITIALIZED(name)                    \
+    assertInitialized(GetAppCriticalEventFor##name());
+        // ASSERT_APP_CRITICAL_EVENT_COUNTER_INITIALIZED
+
+        BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
+            ASSERT_APP_CRITICAL_EVENT_COUNTER_INITIALIZED)
+
+#undef ASSERT_APP_CRITICAL_EVENT_COUNTER_INITIALIZED
+    }
+
+    // InitCriticalEventsCounter/InitVolumeCriticalEventsCounter should
+    // eagerly initializes the legacy per-disk AppCriticalEvents/<event>
+    // counters (value 0) only with
+    // TDiagnosticsConfig::VolumeCriticalEventsReportingMode != VOLUME_ONLY
+    // so they keep show up in monitoring before any event is reported.
+    Y_UNIT_TEST(ShouldEagerlyInitLegacyCriticalEventsCounters)
+    {
+        DoShouldEagerlyInitLegacyCriticalEventsCounters(
+            NProto::EVolumeCriticalEventsReportingMode::APP_ONLY,
+            /*shouldInit=*/true);
+        DoShouldEagerlyInitLegacyCriticalEventsCounters(
+            NProto::EVolumeCriticalEventsReportingMode::ALL,
+            /*shouldInit=*/true);
+        DoShouldEagerlyInitLegacyCriticalEventsCounters(
+            NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY,
+            /*shouldInit=*/false);
+    }
+
+    void DoShouldReportCriticalEventsAccordingToReportingMode(
+        NProto::EVolumeCriticalEventsReportingMode reportingMode,
+        bool shouldReportApp,
+        bool shouldReportVolume)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
+
+        SetVolumeCriticalEventsReportingMode(reportingMode);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumeLabels v{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        ReportBlockDigestMismatchInBlob(v, "some msg");
+
+        auto msg = Sprintf(
+            "reportingMode=%s",
+            NProto::EVolumeCriticalEventsReportingMode_Name(reportingMode)
+                .c_str());
+
+        auto appCounter = criticalEventsGroup->FindCounter(GetAppSensorName());
+        if (shouldReportApp) {
+            UNIT_ASSERT_C(appCounter, msg);
+            UNIT_ASSERT_VALUES_EQUAL_C(1, appCounter->Val(), msg);
+        } else {
+            // TODO: fails until all per-disk critical events are removed from
+            // AppCriticalEvents API (now are duplicated in VolumeCriticalEvents
+            // API)
+
+            // Restore after removed
+            // UNIT_ASSERT_C(!appCounter, msg);
+
+            // Remove after removed
+            UNIT_ASSERT_VALUES_EQUAL_C(0, appCounter->Val(), msg);
+        }
+
+        handler->UpdateStats(true);
+
+        auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
+        auto volumeCounter =
+            volumeGroup ? volumeGroup->FindCounter(GetVolumeSensorName())
+                        : nullptr;
+        if (shouldReportVolume) {
+            UNIT_ASSERT_C(volumeCounter, msg);
+            UNIT_ASSERT_VALUES_EQUAL_C(1, volumeCounter->Val(), msg);
+        } else {
+            UNIT_ASSERT_C(!volumeCounter, msg);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldReportCriticalEventsAccordingToReportingMode)
+    {
+        DoShouldReportCriticalEventsAccordingToReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::APP_ONLY,
+            /*shouldReportApp=*/true,
+            /*shouldReportVolume=*/false);
+        DoShouldReportCriticalEventsAccordingToReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL,
+            /*shouldReportApp=*/true,
+            /*shouldReportVolume=*/true);
+        DoShouldReportCriticalEventsAccordingToReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY,
+            /*shouldReportApp=*/false,
+            /*shouldReportVolume=*/true);
+    }
+
     // Per-disk GAUGE counters are emitted by the shadow-swap publish,
-    // while the deprecated AppCriticalEvents/* counter is bumped synchronously
+    // while the legacy AppCriticalEvents/* counter is bumped synchronously
     Y_UNIT_TEST(ShouldEmitPerDiskCountersForVolumeCriticalEvents)
     {
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto criticalEventsGroup = root->GetSubgroup("component", "server");
-        auto volumeCriticalEventsGroup =
-            root->GetSubgroup("component", "server");
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
 
+        SetVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitCriticalEventsCounter(criticalEventsGroup);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
@@ -135,11 +301,11 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         UNIT_ASSERT(
             !volumeGroup || !volumeGroup->FindCounter(GetVolumeSensorName()));
 
-        // Deprecated counter is bumped synchronously.
-        auto deprecatedCounter =
-            criticalEventsGroup->FindCounter(GetDeprecatedSensorName());
-        UNIT_ASSERT(deprecatedCounter);
-        UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
+        // Legacy counter is bumped synchronously.
+        auto legacyCounter =
+            criticalEventsGroup->FindCounter(GetAppSensorName());
+        UNIT_ASSERT(legacyCounter);
+        UNIT_ASSERT_VALUES_EQUAL(2, legacyCounter->Val());
 
         // Flush materializes and writes the GAUGE.
         handler->UpdateStats(true);
@@ -150,21 +316,22 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         UNIT_ASSERT(volumeCounter);
         UNIT_ASSERT_VALUES_EQUAL(2, volumeCounter->Val());
 
-        // Deprecated counter is not changed after update/publish.
-        UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
+        // Legacy counter is not changed after update/publish.
+        UNIT_ASSERT_VALUES_EQUAL(2, legacyCounter->Val());
     }
 
     // The publish only runs when updateIntervalFinished is true
-    Y_UNIT_TEST(ShouldFlushOnlyOnIntervalFinished)
+    Y_UNIT_TEST(ShouldPublishOnlyOnIntervalFinished)
     {
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto criticalEventsGroup = root->GetSubgroup("component", "server");
-        auto volumeCriticalEventsGroup =
-            root->GetSubgroup("component", "server");
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
 
-        InitCriticalEventsCounter(criticalEventsGroup);
+        SetVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
         auto handler = CreateCriticalEventsStatsHandler();
@@ -193,17 +360,59 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         UNIT_ASSERT_VALUES_EQUAL(1, volumeCounter->Val());
     }
 
+    // The publish materializes only affected metrics
+    Y_UNIT_TEST(ShouldNotCreateUnaffectedEventsMetricsOnPublish)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
+
+        SetVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumeLabels v{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        ReportBlockDigestMismatchInBlob(v, "some msg");
+
+        // Interval finished -> publish affected metric
+        handler->UpdateStats(true);
+
+        auto volumeGroup = FindVolumeGroup(volumeCriticalEventsGroup, v);
+        UNIT_ASSERT(volumeGroup);
+        auto volumeCounter = volumeGroup->FindCounter(GetVolumeSensorName());
+        UNIT_ASSERT(volumeCounter);
+        UNIT_ASSERT_VALUES_EQUAL(1, volumeCounter->Val());
+
+        // No unaffected metrics are materialized
+        UNIT_ASSERT(!volumeGroup->FindCounter(
+            GetVolumeCriticalEventForMigrationFailed()));
+        UNIT_ASSERT(!volumeGroup->FindCounter(
+            GetVolumeCriticalEventForMirroredDiskMajorityChecksumMismatch()));
+        UNIT_ASSERT(!volumeGroup->FindCounter(
+            GetVolumeCriticalEventForOverlappingRequestsDetected()));
+    }
+
     // GAUGE semantics: with no new events the next flush resets to 0
     Y_UNIT_TEST(ShouldResetToZeroAfterFlushWithNoNewEvents)
     {
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto criticalEventsGroup = root->GetSubgroup("component", "server");
-        auto volumeCriticalEventsGroup =
-            root->GetSubgroup("component", "server");
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
 
-        InitCriticalEventsCounter(criticalEventsGroup);
+        SetVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
         auto handler = CreateCriticalEventsStatsHandler();
@@ -231,16 +440,21 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             volumeGroup->FindCounter(GetVolumeSensorName())->Val());
     }
 
-    // Counters are distinct per disk
+    // Counters are distinct per disk.
+    // Legacy counters contain summary
     Y_UNIT_TEST(ShouldKeepDistinctCountersPerDisk)
     {
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto criticalEventsGroup = root->GetSubgroup("component", "server");
-        auto volumeCriticalEventsGroup =
-            root->GetSubgroup("component", "server");
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
 
+        SetVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitCriticalEventsCounter(criticalEventsGroup);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
@@ -257,9 +471,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             .FolderId = "folder-1"};
 
         ReportBlockDigestMismatchInBlob(v1, "some msg 1");
-
         ReportBlockDigestMismatchInBlob(v1, "some msg 1");
-
         ReportBlockDigestMismatchInBlob(v2, "some msg 2");
 
         handler->UpdateStats(true);
@@ -275,11 +487,11 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
                 ->FindCounter(GetVolumeSensorName())
                 ->Val());
 
-        // Deprecated counter should contain summary
-        auto deprecatedCounter =
-            criticalEventsGroup->FindCounter(GetDeprecatedSensorName());
-        UNIT_ASSERT(deprecatedCounter);
-        UNIT_ASSERT_VALUES_EQUAL(3, deprecatedCounter->Val());
+        // Legacy counter should contain summary
+        auto legacyCounter =
+            criticalEventsGroup->FindCounter(GetAppSensorName());
+        UNIT_ASSERT(legacyCounter);
+        UNIT_ASSERT_VALUES_EQUAL(3, legacyCounter->Val());
     }
 
     // Events fired before CountersRoot is set must accumulate in
@@ -289,10 +501,14 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto criticalEventsGroup = root->GetSubgroup("component", "server");
-        auto volumeCriticalEventsGroup =
-            root->GetSubgroup("component", "server");
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
 
+        SetVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
         // NOTE: InitVolumeCriticalEventsCounter is intentionally deferred.
         InitCriticalEventsCounter(criticalEventsGroup);
 
@@ -320,11 +536,11 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             3,
             volumeGroup->FindCounter(GetVolumeSensorName())->Val());
 
-        // Deprecated counter reflects the dual emission (3 synchronous
+        // Legacy counter reflects the dual emission (3 synchronous
         // Inc()'s).
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            criticalEventsGroup->FindCounter(GetDeprecatedSensorName())->Val());
+            criticalEventsGroup->FindCounter(GetAppSensorName())->Val());
 
         // One more event on the hot path (Exported is now non-null,
         // Internal -> 1) is flushed on the next tick.
@@ -341,10 +557,14 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         ResetVolumeCriticalEventsCounter();
 
         auto root = MakeIntrusive<TDynamicCounters>();
-        auto criticalEventsGroup = root->GetSubgroup("component", "server");
-        auto volumeCriticalEventsGroup =
-            root->GetSubgroup("component", "server");
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
 
+        SetVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
         InitCriticalEventsCounter(criticalEventsGroup);
         InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
 
@@ -398,11 +618,11 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             .CloudId = cloudId,
             .FolderId = folderId};
 
-        auto deprecatedCounter =
-            criticalEventsGroup->FindCounter(GetDeprecatedSensorName());
-        UNIT_ASSERT(deprecatedCounter);
-        // Deprecated counter should contain summary immediately
-        UNIT_ASSERT_VALUES_EQUAL(12, deprecatedCounter->Val());
+        auto legacyCounter =
+            criticalEventsGroup->FindCounter(GetAppSensorName());
+        UNIT_ASSERT(legacyCounter);
+        // Legacy counter should contain summary immediately
+        UNIT_ASSERT_VALUES_EQUAL(12, legacyCounter->Val());
 
         handler->UpdateStats(true);
 
@@ -412,7 +632,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             12,
             volumeGroup->FindCounter(GetVolumeSensorName())->Val());
 
-        UNIT_ASSERT_VALUES_EQUAL(12, deprecatedCounter->Val());
+        UNIT_ASSERT_VALUES_EQUAL(12, legacyCounter->Val());
     }
 }
 

--- a/cloud/blockstore/libs/diagnostics/ut/ya.make
+++ b/cloud/blockstore/libs/diagnostics/ut/ya.make
@@ -4,6 +4,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 PEERDIR(
     cloud/blockstore/tools/analytics/libs/event-log
+    cloud/blockstore/libs/common
     cloud/storage/core/libs/common
 
     library/cpp/eventlog/dumper

--- a/cloud/blockstore/libs/diagnostics/ut/ya.make
+++ b/cloud/blockstore/libs/diagnostics/ut/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
 SRCS(
     config_ut.cpp
     block_digest_ut.cpp
+    critical_events_ut.cpp
     fault_injection_ut.cpp
     hostname_ut.cpp
     profile_log_ut.cpp

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -7,7 +7,7 @@
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/fault_injection.h>
 #include <cloud/blockstore/libs/diagnostics/probes.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
@@ -315,7 +315,7 @@ void TBootstrap::Init()
         false);
     *versionCounter = 1;
 
-    SetVolumeCriticalEventsReportingMode(
+    InitVolumeCriticalEventsReportingMode(
         Configs->DiagnosticsConfig->GetVolumeCriticalEventsReportingMode());
     InitCriticalEventsCounter(serverGroup);
     InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -7,6 +7,7 @@
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/fault_injection.h>
 #include <cloud/blockstore/libs/diagnostics/probes.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
@@ -53,9 +54,9 @@
 #include <cloud/storage/core/libs/io_uring/service.h>
 #include <cloud/storage/core/libs/kikimr/actorsystem.h>
 #include <cloud/storage/core/libs/kikimr/node.h>
-#include <cloud/storage/core/libs/version/version.h>
 #include <cloud/storage/core/libs/rdma/iface/probes.h>
 #include <cloud/storage/core/libs/rdma/iface/server.h>
+#include <cloud/storage/core/libs/version/version.h>
 
 #include <contrib/ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <contrib/ydb/core/protos/config.pb.h>
@@ -305,6 +306,8 @@ void TBootstrap::Init()
         ->GetSubgroup("counters", "blockstore");
 
     auto serverGroup = rootGroup->GetSubgroup("component", "server");
+    auto volumeCriticalEventsGroup =
+        rootGroup->GetSubgroup("component", "critical_events");
     auto revisionGroup = serverGroup->GetSubgroup("revision", GetFullVersionString());
 
     auto versionCounter = revisionGroup->GetCounter(
@@ -312,7 +315,19 @@ void TBootstrap::Init()
         false);
     *versionCounter = 1;
 
+    SetVolumeCriticalEventsReportingMode(
+        Configs->DiagnosticsConfig->GetVolumeCriticalEventsReportingMode());
     InitCriticalEventsCounter(serverGroup);
+    InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
+
+    STORAGE_INFO("CriticalEvents counters initialized");
+
+    CriticalEventsStatsUpdater = CreateStatsUpdater(
+        Timer,
+        Scheduler,
+        CreateCriticalEventsStatsHandler());
+
+    STORAGE_INFO("CriticalEventsStatsUpdater initialized");
 
     for (auto& event: PostponedCriticalEvents) {
         ReportCriticalEvent(
@@ -673,6 +688,7 @@ void TBootstrap::Start()
     START_COMPONENT(FileIOServiceProvider);
     START_COMPONENT(LocalNVMeService);
     START_COMPONENT(ActorSystem);
+    START_COMPONENT(CriticalEventsStatsUpdater);
 
     // we need to start scheduler after all other components for 2 reasons:
     // 1) any component can schedule a task that uses a dependency that hasn't
@@ -708,6 +724,7 @@ void TBootstrap::Stop()
     // stopping scheduler before all other components to avoid races between
     // scheduled tasks and shutting down of component dependencies
     STOP_COMPONENT(Scheduler);
+    STOP_COMPONENT(CriticalEventsStatsUpdater);
 
     STOP_COMPONENT(ActorSystem);
     // stop FileIOServiceProvider after ActorSystem to ensure that there are no

--- a/cloud/blockstore/libs/disk_agent/bootstrap.h
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.h
@@ -65,6 +65,7 @@ private:
     IAsyncLoggerPtr AsyncLogger;
     ILoggingServicePtr Logging;
     NCloud::NStorage::IStatsFetcherPtr StatsFetcher;
+    IStatsUpdaterPtr CriticalEventsStatsUpdater;
     IMonitoringServicePtr Monitoring;
     TVector<ITraceReaderPtr> TraceReaders;
     ITraceProcessorPtr TraceProcessor;

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/client/session.h>
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/request_stats.h>
 #include <cloud/blockstore/libs/diagnostics/server_stats_test.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -5,21 +5,20 @@
 #include "session_manager.h"
 
 #include <cloud/blockstore/config/server.pb.h>
-
 #include <cloud/blockstore/libs/cells/iface/cell_manager.h>
 #include <cloud/blockstore/libs/client/config.h>
 #include <cloud/blockstore/libs/client/session.h>
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/request_stats.h>
 #include <cloud/blockstore/libs/diagnostics/server_stats_test.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/encryption/encryption_client.h>
 #include <cloud/blockstore/libs/encryption/encryption_key.h>
 #include <cloud/blockstore/libs/endpoints_grpc/socket_endpoint_listener.h>
-#include <cloud/blockstore/libs/nbd/error_handler.h>
 #include <cloud/blockstore/libs/nbd/device.h>
+#include <cloud/blockstore/libs/nbd/error_handler.h>
 #include <cloud/blockstore/libs/server/client_storage_factory.h>
 #include <cloud/blockstore/libs/service/device_handler.h>
 #include <cloud/blockstore/libs/service/service_test.h>
@@ -38,12 +37,12 @@
 #include <library/cpp/testing/gmock_in_unittest/gmock.h>
 #include <library/cpp/testing/unittest/registar.h>
 
-#include <google/protobuf/util/message_differencer.h>
-
-#include <util/generic/guid.h>
 #include <util/folder/path.h>
 #include <util/folder/tempdir.h>
+#include <util/generic/guid.h>
 #include <util/generic/scope.h>
+
+#include <google/protobuf/util/message_differencer.h>
 
 namespace NCloud::NBlockStore::NServer {
 

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -6,6 +6,7 @@
 #include "session_manager.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/request_stats.h>
 #include <cloud/blockstore/libs/diagnostics/server_stats.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -6,7 +6,7 @@
 #include "session_manager.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/request_stats.h>
 #include <cloud/blockstore/libs/diagnostics/server_stats.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
@@ -15,23 +15,24 @@
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/blockstore/libs/service/service_test.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/coroutine/executor.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
-#include <cloud/storage/core/libs/endpoints/keyring/keyring_endpoints.h>
 #include <cloud/storage/core/libs/endpoints/fs/fs_endpoints.h>
+#include <cloud/storage/core/libs/endpoints/keyring/keyring_endpoints.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
-
-#include <google/protobuf/util/message_differencer.h>
 
 #include <util/folder/path.h>
 #include <util/folder/tempdir.h>
 #include <util/generic/guid.h>
 #include <util/generic/scope.h>
+
+#include <google/protobuf/util/message_differencer.h>
 
 namespace NCloud::NBlockStore::NServer {
 

--- a/cloud/blockstore/libs/server/server_ut.cpp
+++ b/cloud/blockstore/libs/server/server_ut.cpp
@@ -4,7 +4,7 @@
 
 #include <cloud/blockstore/libs/client/client.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats_test.h>
 #include <cloud/blockstore/libs/service/service_test.h>
 

--- a/cloud/blockstore/libs/server/server_ut.cpp
+++ b/cloud/blockstore/libs/server/server_ut.cpp
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/client/client.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats_test.h>
 #include <cloud/blockstore/libs/service/service_test.h>
 

--- a/cloud/blockstore/libs/service/device_handler_ut.cpp
+++ b/cloud/blockstore/libs/service/device_handler_ut.cpp
@@ -1,9 +1,10 @@
 #include "device_handler.h"
 
 #include <cloud/blockstore/libs/common/iovector.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/storage_test.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/sglist.h>
 #include <cloud/storage/core/libs/common/sglist_test.h>

--- a/cloud/blockstore/libs/service/device_handler_ut.cpp
+++ b/cloud/blockstore/libs/service/device_handler_ut.cpp
@@ -1,6 +1,7 @@
 #include "device_handler.h"
 
 #include <cloud/blockstore/libs/common/iovector.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/storage_test.h>
 #include <cloud/storage/core/libs/common/error.h>

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/config/server.pb.h>
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/blockstore/libs/service_kikimr/ut/kikimr_test_env.h>

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
@@ -1,9 +1,8 @@
 #include "service_kikimr.h"
 
 #include <cloud/blockstore/config/server.pb.h>
-
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/blockstore/libs/service_kikimr/ut/kikimr_test_env.h>

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stress_test.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stress_test.cpp
@@ -2,6 +2,7 @@
 
 #include "disk_agent_actor.h"
 
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h>
 
 #include <cloud/storage/core/libs/common/proto_helpers.h>

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stress_test.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_stress_test.cpp
@@ -2,7 +2,7 @@
 
 #include "disk_agent_actor.h"
 
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h>
 
 #include <cloud/storage/core/libs/common/proto_helpers.h>

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/common/block_checksum.h>
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/nvme/nvme.h>
 #include <cloud/blockstore/libs/storage/disk_agent/actors/device_integrity_check_actor.h>
 #include <cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_handler.h>

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -5,7 +5,7 @@
 #include <cloud/blockstore/libs/common/block_checksum.h>
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/nvme/nvme.h>
 #include <cloud/blockstore/libs/storage/disk_agent/actors/device_integrity_check_actor.h>
 #include <cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_handler.h>

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/nvme/nvme.h>
 #include <cloud/blockstore/libs/service_local/storage_null.h>

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -6,11 +6,11 @@
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/nvme/nvme.h>
-#include <cloud/blockstore/libs/service_local/storage_null.h>
 #include <cloud/blockstore/libs/service/storage_provider.h>
+#include <cloud/blockstore/libs/service_local/storage_null.h>
 #include <cloud/blockstore/libs/spdk/iface/env_stub.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/config.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -3,6 +3,7 @@
 #include "disk_registry_database.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
 #include <cloud/blockstore/libs/storage/testlib/test_executor.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -3,11 +3,12 @@
 #include "disk_registry_database.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
 #include <cloud/blockstore/libs/storage/testlib/test_executor.h>
 #include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
@@ -2,6 +2,7 @@
 
 #include "disk_registry_database.h"
 
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
 #include <cloud/blockstore/libs/storage/testlib/test_executor.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
@@ -2,11 +2,12 @@
 
 #include "disk_registry_database.h"
 
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
 #include <cloud/blockstore/libs/storage/testlib/test_executor.h>
 #include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -3,19 +3,21 @@
 #include "disk_registry_database.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
 #include <cloud/blockstore/libs/storage/testlib/test_executor.h>
 #include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 
-#include <google/protobuf/util/message_differencer.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/guid.h>
 #include <util/generic/size_literals.h>
+
+#include <google/protobuf/util/message_differencer.h>
 
 namespace NCloud::NBlockStore::NStorage {
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -3,6 +3,7 @@
 #include "disk_registry_database.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
 #include <cloud/blockstore/libs/storage/testlib/test_executor.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
@@ -2,6 +2,7 @@
 
 #include "disk_registry_database.h"
 
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
 #include <cloud/blockstore/libs/storage/testlib/test_executor.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
@@ -2,11 +2,12 @@
 
 #include "disk_registry_database.h"
 
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_state.h>
 #include <cloud/blockstore/libs/storage/testlib/test_executor.h>
 #include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_cms.cpp
@@ -4,7 +4,7 @@
 
 #include <cloud/blockstore/config/disk.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_cms.cpp
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/config/disk.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_config.cpp
@@ -1,17 +1,16 @@
 #include "disk_registry.h"
+
 #include "disk_registry_actor.h"
 
 #include <cloud/blockstore/config/disk.pb.h>
-
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h>
 #include <cloud/blockstore/libs/storage/testlib/ss_proxy_client.h>
-
 
 #include <contrib/ydb/core/testlib/basics/runtime.h>
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_config.cpp
@@ -4,6 +4,7 @@
 #include <cloud/blockstore/config/disk.pb.h>
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -1,9 +1,10 @@
 #include "disk_registry.h"
+
 #include "disk_registry_actor.h"
 
 #include <cloud/blockstore/config/disk.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -3,6 +3,7 @@
 
 #include <cloud/blockstore/config/disk.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_notify.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_notify.cpp
@@ -3,6 +3,7 @@
 
 #include <cloud/blockstore/config/disk.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/notify/iface/notify.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h>
 #include <cloud/blockstore/libs/storage/testlib/ss_proxy_client.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_notify.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_notify.cpp
@@ -1,9 +1,10 @@
 #include "disk_registry.h"
+
 #include "disk_registry_actor.h"
 
 #include <cloud/blockstore/config/disk.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/notify/iface/notify.h>
 #include <cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h>
 #include <cloud/blockstore/libs/storage/testlib/ss_proxy_client.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_suspend.cpp
@@ -3,6 +3,7 @@
 
 #include <cloud/blockstore/config/disk.pb.h>
 
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_suspend.cpp
@@ -1,9 +1,9 @@
 #include "disk_registry.h"
+
 #include "disk_registry_actor.h"
 
 #include <cloud/blockstore/config/disk.pb.h>
-
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>

--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list_ut.cpp
@@ -2,9 +2,10 @@
 
 #include "agent_list.h"
 
-#include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
+
+#include <cloud/storage/core/libs/diagnostics/monitoring.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 

--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list_ut.cpp
@@ -4,6 +4,7 @@
 
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -5,7 +5,7 @@
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/api/partition2.h>

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -6,7 +6,7 @@
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/api/partition2.h>

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor_ut.cpp
@@ -2,6 +2,7 @@
 
 #include "ut_env.h"
 
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/storage/core/libs/kikimr/helpers.h>
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/migration_request_actor_ut.cpp
@@ -2,8 +2,9 @@
 
 #include "ut_env.h"
 
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
+
 #include <cloud/storage/core/libs/kikimr/helpers.h>
 
 #include <contrib/ydb/core/mind/bscontroller/bsc.h>

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/blockstore/config/storage.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/config.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state_ut.cpp
@@ -2,12 +2,13 @@
 
 #include <cloud/blockstore/config/storage.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/config.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 
 #include <contrib/ydb/library/actors/core/actorid.h>
+
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -8,6 +8,7 @@
 #include <cloud/blockstore/libs/common/constants.h>
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/rdma_test/client_test.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_ut.cpp
@@ -8,7 +8,7 @@
 #include <cloud/blockstore/libs/common/constants.h>
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/rdma_test/client_test.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/common/block_checksum.h>
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/stats_service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -6,7 +6,7 @@
 #include <cloud/blockstore/libs/common/block_checksum.h>
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/stats_service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>

--- a/cloud/blockstore/libs/storage/stats_fetcher/stats_fetcher_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_fetcher/stats_fetcher_ut.cpp
@@ -1,7 +1,7 @@
 #include "stats_fetcher.h"
 
 #include <cloud/blockstore/config/storage.pb.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/testlib/test_env.h>

--- a/cloud/blockstore/libs/storage/stats_fetcher/stats_fetcher_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_fetcher/stats_fetcher_ut.cpp
@@ -1,6 +1,7 @@
 #include "stats_fetcher.h"
 
 #include <cloud/blockstore/config/storage.pb.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/testlib/test_env.h>

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -1,7 +1,7 @@
 #include "volume_ut.h"
 
 #include <cloud/blockstore/libs/common/constants.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/api/fresh_blocks_writer.h>
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
 #include <cloud/blockstore/libs/storage/core/volume_model.h>

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -1,6 +1,7 @@
 #include "volume_ut.h"
 
 #include <cloud/blockstore/libs/common/constants.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/storage/api/fresh_blocks_writer.h>
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
 #include <cloud/blockstore/libs/storage/core/volume_model.h>

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -1,5 +1,5 @@
 #include <cloud/blockstore/config/storage.pb.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/volume_balancer_switch.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/storage/api/service.h>

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -1,4 +1,5 @@
 #include <cloud/blockstore/config/storage.pb.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/volume_balancer_switch.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/storage/api/service.h>

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -3,11 +3,12 @@
 #include "vhost_test.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
-#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/diagnostics/server_stats_test.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats_test.h>
 #include <cloud/blockstore/libs/service/device_handler.h>
 #include <cloud/blockstore/libs/service/storage_test.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/sglist_test.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -3,6 +3,7 @@
 #include "vhost_test.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events_config.h>
 #include <cloud/blockstore/libs/diagnostics/server_stats_test.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats_test.h>
 #include <cloud/blockstore/libs/service/device_handler.h>

--- a/cloud/blockstore/vhost-server/critical_event.cpp
+++ b/cloud/blockstore/vhost-server/critical_event.cpp
@@ -30,7 +30,7 @@ void ReportCriticalEvent(TString sensorName, TString message)
         TStringBuilder fullMessage;
         fullMessage << "CRITICAL_EVENT:" << sensorName;
         if (message) {
-            fullMessage << ":" << message;
+            fullMessage << ": " << message;
         }
         STORAGE_ERROR(fullMessage);
     }

--- a/cloud/storage/core/libs/diagnostics/critical_events.cpp
+++ b/cloud/storage/core/libs/diagnostics/critical_events.cpp
@@ -68,17 +68,25 @@ TString ReportCriticalEvent(
             message.c_str());
     }
 
+    ReportCriticalEventWithoutLogging(sensorName);
+
+    return LogCriticalEvent(sensorName, message);
+}
+
+void ReportCriticalEventWithoutLogging(const TString& sensorName)
+{
     if (CriticalEvents) {
-        auto counter = CriticalEvents->GetCounter(
-            sensorName,
-            true);
+        auto counter = CriticalEvents->GetCounter(sensorName, true);
         counter->Inc();
     }
+}
 
+TString LogCriticalEvent(const TString& sensorName, const TString& message)
+{
     TStringBuilder fullMessage;
     fullMessage << "CRITICAL_EVENT:" << sensorName;
     if (message) {
-        fullMessage << ":" << message;
+        fullMessage << ": " << message;
     }
 
     if (Log.IsNotNullLog()) {
@@ -91,16 +99,6 @@ TString ReportCriticalEvent(
     }
 
     return fullMessage;
-}
-
-void ReportCriticalEventWithoutLogging(const TString& sensorName)
-{
-    if (CriticalEvents) {
-        auto counter = CriticalEvents->GetCounter(
-            sensorName,
-            true);
-        counter->Inc();
-    }
 }
 
 #define STORAGE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                            \

--- a/cloud/storage/core/libs/diagnostics/critical_events.h
+++ b/cloud/storage/core/libs/diagnostics/critical_events.h
@@ -42,6 +42,8 @@ TString ReportCriticalEvent(
 
 void ReportCriticalEventWithoutLogging(const TString& sensorName);
 
+TString LogCriticalEvent(const TString& sensorName, const TString& message);
+
 #define STORAGE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                           \
     TString Report##name(const TString& message = "");                         \
     const TString GetCriticalEventFor##name();                                 \


### PR DESCRIPTION
### Notes

This PR is part of #6582 implementation.

1. Introduce **VolumeCriticalEvent** reporting API with required **diskId**, **cloudId**, **folderId**, which are put into corresponding metrics and log messages
2. New **VolumeCriticalEvent/*** metrics has next shape:
```
  { project = "nbs",
    cluster = "...",
    host    = <FQDN>,
    service = "critical_events",
    sensor  = "VolumeCriticalEvent/...",
    volume  = "<diskId>",
    cloud   = "<cloudId>",
    folder  = "<folderId>" }
```
3. New **VolumeCriticalEvent/*** are created lazily upon the first occurrence of a specific CriticalEvent for a specific disk due to large amount of disks per cluster. The metric type has been changed to GAUGE and is now reset to 0 after each 15-second scrape interval. This (in contrast to RATE metric) prevents missing the first event (alert) after metric creation or during monitoring scrape gaps / NO_DATA intervals. Consequently, the metric reflects the event count per scrape interval.
4. Keep forming corresponding **AppCriticalEvent/*** metrics within **VolumeCriticalEvent** API calls until all alerts are reconfigured for new **VolumeCriticalEvent/*** metrics
5. New behavior is under `TDiagnosticsConfig::VolumeCriticalEventsReportingMode` (NCloud.NBlockStore.NProto) with thee possible modes of metrics reporting via new API:
    - **APP_ONLY** - Report disk critical events only via per-host AppCriticalEvents metrics.
    - **ALL** - Report disk critical events both via per-host AppCriticalEvents and via per-volume VolumeCriticalEvents metrics.
    - **VOLUME_ONLY** - Report disk critical events only via per-volume VolumeCriticalEvents metrics.
7. No existing behavior changed - no new API calls used yet, no new metrics formed.

Logs with new API used (from tests):
```
CRITICAL_EVENT:AppCriticalEvents/BlockDigestMismatchInBlob
CRITICAL_EVENT:VolumeCriticalEvents/BlockDigestMismatchInBlob: disk:disk-1 cloud:cloud-1 folder:folder-1

CRITICAL_EVENT:AppCriticalEvents/BlockDigestMismatchInBlob: some msg
CRITICAL_EVENT:VolumeCriticalEvents/BlockDigestMismatchInBlob: disk:disk-1 cloud:cloud-1 folder:folder-1; some msg

CRITICAL_EVENT:AppCriticalEvents/BlockDigestMismatchInBlob: a:1 b:2
CRITICAL_EVENT:VolumeCriticalEvents/BlockDigestMismatchInBlob: disk:disk-1 cloud:cloud-1 folder:folder-1; a:1 b:2

CRITICAL_EVENT:AppCriticalEvents/BlockDigestMismatchInBlob: some msg; a:1 b:2
CRITICAL_EVENT:VolumeCriticalEvents/BlockDigestMismatchInBlob: disk:disk-1 cloud:cloud-1 folder:folder-1; some msg; a:1 b:2
```

### Issue

#6582 (detailed analysis and implementation description)
