### PR TITLE
[Filestore] Decrease the default value of LargeDeletionMarkersCleanupThreshold from 1_TB / 4_KB to 256_GB / 4_KB

### DIFF
--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -87,7 +87,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(LargeDeletionMarkersEnabled,                    bool,   false         )\
     xxx(LargeDeletionMarkerBlocks,                      ui64,   1_GB / 4_KB   )\
     xxx(LargeDeletionMarkersThreshold,                  ui64,   128_GB / 4_KB )\
-    xxx(LargeDeletionMarkersCleanupThreshold,           ui64,   1_TB / 4_KB   )\
+    xxx(LargeDeletionMarkersCleanupThreshold,           ui64,   256_GB / 4_KB )\
     xxx(LargeDeletionMarkersThresholdForBackpressure,   ui64,   10_TB / 4_KB  )\
                                                                                \
     xxx(CompactionRetryTimeout,             TDuration, TDuration::Seconds(1)  )\


### PR DESCRIPTION
### Notes
Motivation: we have high garbage percentage caused by large deletion markers not being cleaned.
The threshold is applied per-shard so for filesystems with high shards count the total amount of garbage becomes high.
Decreasing the threshold in 4 times is safe.

