### PR TITLE
Add missing blockstore-disk-agent.inc recipe

### DIFF
--- a/cloud/filestore/tests/recipes/blockstore-disk-agent.inc
+++ b/cloud/filestore/tests/recipes/blockstore-disk-agent.inc
@@ -1,0 +1,13 @@
+DEPENDS(
+    cloud/filestore/tests/recipes/blockstore-disk-agent
+)
+
+SET(RECIPE_ARGS
+    --device-count $FASTSHARD_DA_DEVICE_COUNT
+    --device-size $FASTSHARD_DA_DEVICE_SIZE
+)
+
+USE_RECIPE(
+    cloud/filestore/tests/recipes/blockstore-disk-agent/blockstore-disk-agent-recipe
+    ${RECIPE_ARGS}
+)


### PR DESCRIPTION
### Notes
Add missing `blockstore-disk-agent.inc` recipe #6702 

### Issue
```
file $S/cloud/filestore/tests/recipes/blockstore-disk-agent.inc specified in INCLUDE command (in $S/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/ya.make) doesn't exist.
```
