### PR TITLE
issue-6608: add ability to set QuotaId for node using filestore-client

### DIFF
--- a/cloud/filestore/apps/client/lib/set_node_attr.cpp
+++ b/cloud/filestore/apps/client/lib/set_node_attr.cpp
@@ -25,6 +25,7 @@ private:
     std::optional<ui64> ATimeAttr;
     std::optional<ui64> MTimeAttr;
     std::optional<ui64> CTimeAttr;
+    std::optional<ui32> QuotaIdAttr;
 
 public:
     TSetNodeAttrCommand()
@@ -60,6 +61,12 @@ public:
         Opts.AddLongOption("ctime")
             .Optional()
             .StoreResult(&CTimeAttr);
+
+        Opts.AddLongOption("quota-id")
+            .Optional()
+            .Help("attach the node (must be an empty directory) to the "
+                "quota with this id")
+            .StoreResult(&QuotaIdAttr);
     }
 
     bool Execute() override
@@ -110,6 +117,11 @@ public:
         if (CTimeAttr) {
             addFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_CTIME);
             request->MutableUpdate()->SetCTime(*CTimeAttr);
+        }
+
+        if (QuotaIdAttr) {
+            addFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_QUOTA_ID);
+            request->MutableUpdate()->SetQuotaId(*QuotaIdAttr);
         }
 
         auto response = WaitFor(

--- a/cloud/filestore/libs/storage/tablet/helpers.cpp
+++ b/cloud/filestore/libs/storage/tablet/helpers.cpp
@@ -138,6 +138,7 @@ void ConvertNodeFromAttrs(
     dst.SetSize(src.GetSize());
     dst.SetLinks(src.GetLinks());
     dst.SetDevId(src.GetDevId());
+    dst.SetQuotaId(src.GetQuotaId());
 }
 
 void ConvertAttrsToNode(const NProto::TNodeAttr& src, NProto::TNode* dst)
@@ -152,6 +153,7 @@ void ConvertAttrsToNode(const NProto::TNodeAttr& src, NProto::TNode* dst)
     dst->SetSize(src.GetSize());
     dst->SetLinks(src.GetLinks());
     dst->SetDevId(src.GetDevId());
+    dst->SetQuotaId(src.GetQuotaId());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -2172,6 +2172,60 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         UNIT_ASSERT_VALUES_EQUAL(target, readLinkResponse->Record.GetSymLink());
     }
 
+    TABLET_TEST_4K_ONLY(ShouldSetAttrsViaUnsafeCreateNode)
+    {
+        TTestEnv env(testEnvConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        const ui64 nodeId = 111;
+
+        auto request = tablet.CreateUnsafeCreateNodeRequest(nodeId, 0);
+        auto* node = request->Record.MutableNode();
+        node->SetType(NProto::E_DIRECTORY_NODE);
+        node->SetMode(0755);
+        node->SetUid(100);
+        node->SetGid(200);
+        node->SetATime(1000);
+        node->SetMTime(2000);
+        node->SetCTime(3000);
+        node->SetSize(4096);
+        node->SetLinks(3);
+        node->SetDevId(42);
+        node->SetQuotaId(24);
+
+        tablet.SendRequest(std::move(request));
+        auto response = tablet.RecvUnsafeCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->GetStatus(),
+            FormatError(response->GetError()));
+
+        const auto attr = tablet.GetNodeAttr(nodeId)->Record.GetNode();
+        UNIT_ASSERT_VALUES_EQUAL(nodeId, attr.GetId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<ui32>(NProto::E_DIRECTORY_NODE),
+            attr.GetType());
+        UNIT_ASSERT_VALUES_EQUAL(0755u, attr.GetMode());
+        UNIT_ASSERT_VALUES_EQUAL(100u, attr.GetUid());
+        UNIT_ASSERT_VALUES_EQUAL(200u, attr.GetGid());
+        UNIT_ASSERT_VALUES_EQUAL(1000u, attr.GetATime());
+        UNIT_ASSERT_VALUES_EQUAL(2000u, attr.GetMTime());
+        UNIT_ASSERT_VALUES_EQUAL(3000u, attr.GetCTime());
+        UNIT_ASSERT_VALUES_EQUAL(4096u, attr.GetSize());
+        UNIT_ASSERT_VALUES_EQUAL(3u, attr.GetLinks());
+        UNIT_ASSERT_VALUES_EQUAL(42u, attr.GetDevId());
+        UNIT_ASSERT_VALUES_EQUAL(24u, attr.GetQuotaId());
+    }
+
     TABLET_TEST_4K_ONLY(ShouldSendGetNodeAttrRequestWithoutBehaveAsDirectoryTabletFlagUponCreateNode)
     {
         TTestEnv env(testEnvConfig);

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -71,6 +71,9 @@ message TNodeAttr
     bytes ShardNodeName = 12;
 
     uint64 DevId = 13;
+
+    // Id of the quota this node (a directory) is attached to, or 0 if none.
+    uint32 QuotaId = 14;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/tests/client/canondata/result.json
+++ b/cloud/filestore/tests/client/canondata/result.json
@@ -53,6 +53,9 @@
     "test.test_rm": {
         "uri": "file://test.test_rm/results.txt"
     },
+    "test.test_set_node_attr_quota_id": {
+        "uri": "file://test.test_set_node_attr_quota_id/results.txt"
+    },
     "test.test_stat": {
         "uri": "file://test.test_stat/results.txt"
     },

--- a/cloud/filestore/tests/client/canondata/test.test_set_node_attr_quota_id/results.txt
+++ b/cloud/filestore/tests/client/canondata/test.test_set_node_attr_quota_id/results.txt
@@ -1,0 +1,2 @@
+{"Id": 2, "Type": 2, "Mode": 511, "Links": 1}
+{"Id": 2, "Type": 2, "Mode": 511, "Links": 1, "QuotaId": 42}

--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -467,6 +467,33 @@ def test_set_node_attr():
     assert ctime == stat["CTime"]
 
 
+def test_set_node_attr_quota_id():
+    client, results_path = __init_test()
+    client.create("fs0", "test_cloud", "test_folder", BLOCK_SIZE, BLOCKS_COUNT)
+    client.mkdir("fs0", "/aaa")
+
+    out = client.stat("fs0", "/aaa")
+    stat = json.loads(out)
+    node_id = stat["Id"]
+    result = json.dumps(__process_stat(stat))
+    result += "\n"
+
+    client.set_node_attr("fs0", node_id, "--quota-id", 42)
+
+    out = client.stat("fs0", "/aaa")
+    stat = json.loads(out)
+    result += json.dumps(__process_stat(stat))
+    result += "\n"
+
+    client.destroy("fs0")
+
+    with open(results_path, "w") as results_file:
+        results_file.write(result)
+
+    ret = common.canonical_file(results_path, local=True)
+    return ret
+
+
 def test_partial_set_node_attr():
     client, results_path = __init_test()
     client.create("fs0", "test_cloud", "test_folder", BLOCK_SIZE, BLOCKS_COUNT)


### PR DESCRIPTION
### Notes
Also adding QuotaId to the TNodeAttr proto from `cloud/filestore/public/api/protos/node.proto` 

### Issue
#6608
