### PR TITLE
fix ShouldNotFreezeSocketReadingDueToLimiter by implementing connection negotiation

### DIFF
--- a/cloud/blockstore/libs/nbd/server.cpp
+++ b/cloud/blockstore/libs/nbd/server.cpp
@@ -72,6 +72,7 @@ private:
     TContLockFreeQueue<TServerResponsePtr> ResponseQueue;
 
     size_t InFlightBytes = 0;
+    std::atomic_bool ReportErrors = false;
     std::atomic_flag ShuttingDown = false;
 
 public:
@@ -105,6 +106,7 @@ public:
 
     void Stop() override
     {
+        ReportErrors.store(false, std::memory_order_release);
         ShutDown();
     }
 
@@ -185,7 +187,7 @@ private:
             if (!IsShuttingDown() && !c->Cancelled()) {
                 STORAGE_INFO("lost connection with client, failed to receive: "
                     << CurrentExceptionMessage());
-                Handler->ProcessException(std::current_exception());
+                ReportException(std::current_exception());
             }
         }
 
@@ -199,6 +201,7 @@ private:
         if (Handler->NegotiateClient(io, io) &&
             ConnectionNegotiatedHandler(this))
         {
+            ReportErrors.store(true, std::memory_order_release);
             Handler->ProcessRequests(this, io, io, c);
         }
     }
@@ -211,7 +214,7 @@ private:
         while (ResponseQueue.Dequeue(&response)) {
             if (!response) {
                 // stop signal received
-                Handler->ProcessException(
+                ReportException(
                     std::make_exception_ptr(TSystemError(-ESHUTDOWN)));
                 break;
             }
@@ -221,7 +224,7 @@ private:
             } catch (...) {
                 STORAGE_INFO("lost connection with client, failed to send: "
                     << CurrentExceptionMessage());
-                Handler->ProcessException(std::current_exception());
+                ReportException(std::current_exception());
             }
 
             ReleaseRequest(response->RequestBytes);
@@ -257,6 +260,15 @@ private:
         }
 
         return false;
+    }
+
+    void ReportException(std::exception_ptr e)
+    {
+        if (ReportErrors.load(std::memory_order_acquire) &&
+            !IsShuttingDown())
+        {
+            Handler->ProcessException(std::move(e));
+        }
     }
 
     void ShutDown()

--- a/cloud/blockstore/libs/nbd/server.cpp
+++ b/cloud/blockstore/libs/nbd/server.cpp
@@ -23,6 +23,7 @@
 #include <util/thread/singleton.h>
 
 #include <atomic>
+#include <functional>
 
 namespace NCloud::NBlockStore::NBD {
 
@@ -65,6 +66,7 @@ private:
     TContExecutor* Executor;
     ILimiterPtr Limiter;
     IServerHandlerPtr Handler;
+    std::function<bool(TConnection*)> ConnectionNegotiatedHandler;
     TSocketHolder Socket;
 
     TContLockFreeQueue<TServerResponsePtr> ResponseQueue;
@@ -78,12 +80,14 @@ public:
             TContExecutor* e,
             ILimiterPtr limiter,
             IServerHandlerPtr handler,
+            std::function<bool(TConnection*)> connectionNegotiatedHandler,
             TSocketHolder socket)
         : AppCtx(appCtx)
         , Log(appCtx.Log)
         , Executor(e)
         , Limiter(std::move(limiter))
         , Handler(std::move(handler))
+        , ConnectionNegotiatedHandler(std::move(connectionNegotiatedHandler))
         , Socket(std::move(socket))
         , ResponseQueue(e)
     {}
@@ -192,7 +196,9 @@ private:
     {
         TContIO io(Socket, c);
 
-        if (Handler->NegotiateClient(io, io)) {
+        if (Handler->NegotiateClient(io, io) &&
+            ConnectionNegotiatedHandler(this))
+        {
             Handler->ProcessRequests(this, io, io, c);
         }
     }
@@ -284,6 +290,7 @@ private:
 
     std::unique_ptr<TContListener> Listener;
     TConnectionPtr Connection;
+    TConnectionPtr CandidateConnection;
 
 public:
     TEndpoint(
@@ -337,6 +344,10 @@ public:
                 Connection->Stop();
             };
 
+            if (CandidateConnection) {
+                CandidateConnection->Stop();
+            }
+
             if (Listener) {
                 Listener->Stop();
             }
@@ -363,25 +374,43 @@ private:
     {
         TSocketHolder socket(accept.S->Release());
 
-        auto address = NAddr::GetSockAddr(socket);
+        auto address = NAddr::GetPeerAddr(socket);
         STORAGE_DEBUG("new connection from " << PrintHostAndPort(*address));
 
         if (IsTcpAddress(*address)) {
             SetNoDelay(socket, true);
         }
 
-        if (Connection) {
-            Connection->Stop();
+        if (CandidateConnection) {
+            CandidateConnection->Stop();
         }
 
-        Connection = MakeIntrusive<TConnection>(
+        CandidateConnection = MakeIntrusive<TConnection>(
             AppCtx,
             Executor,
             Limiter,
             HandlerFactory->CreateHandler(),
+            [this](TConnection* connection) {
+                return ActivateConnection(connection);
+            },
             std::move(socket));
 
-        Connection->Start();
+        CandidateConnection->Start();
+    }
+
+    bool ActivateConnection(TConnection* connection)
+    {
+        if (CandidateConnection.Get() != connection) {
+            return false;
+        }
+
+        if (Connection) {
+            Connection->Stop();
+        }
+
+        Connection = CandidateConnection;
+        CandidateConnection.Reset();
+        return true;
     }
 
     void OnError() override

--- a/cloud/blockstore/libs/nbd/server_ut.cpp
+++ b/cloud/blockstore/libs/nbd/server_ut.cpp
@@ -45,6 +45,19 @@ constexpr bool UseNbsErrors = true;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TTestErrorHandler final
+    : IErrorHandler
+{
+    TManualEvent ErrorReported;
+
+    void ProcessException(std::exception_ptr) override
+    {
+        ErrorReported.Signal();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 void ConnectInvalidClient(ui16 port)
 {
     TInet6StreamSocket socket;
@@ -64,6 +77,13 @@ void ConnectInvalidClient(ui16 port)
     TStreamSocketOutput output(&socket);
     TRequestWriter writer(output);
     writer.WriteClientHello(0);
+
+    SetSocketTimeout(socket, 3);
+    char c;
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        0,
+        socket.Recv(&c, sizeof(c)),
+        "invalid client connection was not closed");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -284,7 +304,8 @@ std::unique_ptr<TBootstrap> CreateBootstrap(
     IStoragePtr storage,
     const TStorageOptions& options = DefaultStorageOptions,
     TServerConfig serverConfig = Default<TServerConfig>(),
-    IBlockStorePtr grpcClientEndpoint = nullptr)
+    IBlockStorePtr grpcClientEndpoint = nullptr,
+    IErrorHandlerPtr errorHandler = nullptr)
 {
     const ui32 clientThreadsCount = 1;
 
@@ -295,12 +316,16 @@ std::unique_ptr<TBootstrap> CreateBootstrap(
 
     auto server = CreateServer(logging, serverConfig);
 
+    if (!errorHandler) {
+        errorHandler = CreateErrorHandlerStub();
+    }
+
     auto handlerFactory = CreateServerHandlerFactory(
         CreateDefaultDeviceHandlerFactory(),
         logging,
         std::move(storage),
         CreateServerStatsStub(),
-        CreateErrorHandlerStub(),
+        std::move(errorHandler),
         options);
 
     auto client = CreateClient(
@@ -1157,7 +1182,14 @@ Y_UNIT_TEST_SUITE(TServerTest)
         auto port = portManager.GetPort(9001);
         TNetworkAddress connectAddress(port);
 
-        auto bootstrap = CreateBootstrap(connectAddress, storage);
+        auto errorHandler = std::make_shared<TTestErrorHandler>();
+        auto bootstrap = CreateBootstrap(
+            connectAddress,
+            storage,
+            DefaultStorageOptions,
+            Default<TServerConfig>(),
+            nullptr,
+            errorHandler);
 
         auto error = bootstrap->Start();
         UNIT_ASSERT_C(!HasError(error), error);
@@ -1174,6 +1206,10 @@ Y_UNIT_TEST_SUITE(TServerTest)
         UNIT_ASSERT(!future.HasValue());
 
         ConnectInvalidClient(port);
+        UNIT_ASSERT_C(
+            !errorHandler->ErrorReported.WaitT(TDuration::Zero()),
+            "invalid client error was reported to the endpoint");
+
         trigger.SetValue({});
 
         auto response = future.GetValue(TDuration::Seconds(3));

--- a/cloud/blockstore/libs/nbd/server_ut.cpp
+++ b/cloud/blockstore/libs/nbd/server_ut.cpp
@@ -3,6 +3,7 @@
 #include "client.h"
 #include "client_handler.h"
 #include "error_handler.h"
+#include "protocol.h"
 #include "server_handler.h"
 
 #include <cloud/blockstore/libs/client/config.h>
@@ -28,6 +29,7 @@
 
 #include <util/generic/guid.h>
 #include <util/generic/scope.h>
+#include <util/network/sock.h>
 
 namespace NCloud::NBlockStore::NBD {
 
@@ -40,6 +42,29 @@ namespace {
 
 constexpr bool StructuredReply = true;
 constexpr bool UseNbsErrors = true;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ConnectInvalidClient(ui16 port)
+{
+    TInet6StreamSocket socket;
+    TSockAddrInet6 address("::1", port);
+
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        0,
+        socket.Connect(&address),
+        "failed to connect invalid client");
+
+    TStreamSocketInput input(&socket);
+    TRequestReader reader(input);
+
+    TServerHello hello;
+    UNIT_ASSERT(reader.ReadServerHello(hello));
+
+    TStreamSocketOutput output(&socket);
+    TRequestWriter writer(output);
+    writer.WriteClientHello(0);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1102,6 +1127,57 @@ Y_UNIT_TEST_SUITE(TServerTest)
         UNIT_ASSERT(!HasError(future1.GetValue(TDuration::Seconds(3))));
         UNIT_ASSERT(!HasError(future2.GetValue(TDuration::Seconds(3))));
         UNIT_ASSERT(!HasError(future3.GetValue(TDuration::Seconds(3))));
+
+        bootstrap->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldNotDropActiveConnectionOnInvalidConnection)
+    {
+        const ui32 startIndex = 13;
+        const ui32 blocksCount = 1;
+
+        TManualEvent requestReceived;
+        auto trigger = NewPromise<NProto::TZeroBlocksResponse>();
+
+        auto storage = std::make_shared<TTestStorage>();
+        storage->ZeroBlocksHandler = [&] (
+            TCallContextPtr callContext,
+            std::shared_ptr<NProto::TZeroBlocksRequest> request)
+        {
+            Y_UNUSED(callContext);
+
+            UNIT_ASSERT_VALUES_EQUAL(startIndex, request->GetStartIndex());
+            UNIT_ASSERT_VALUES_EQUAL(blocksCount, request->GetBlocksCount());
+
+            requestReceived.Signal();
+            return trigger.GetFuture();
+        };
+
+        TPortManager portManager;
+        auto port = portManager.GetPort(9001);
+        TNetworkAddress connectAddress(port);
+
+        auto bootstrap = CreateBootstrap(connectAddress, storage);
+
+        auto error = bootstrap->Start();
+        UNIT_ASSERT_C(!HasError(error), error);
+
+        auto request = std::make_shared<NProto::TZeroBlocksRequest>();
+        request->SetStartIndex(startIndex);
+        request->SetBlocksCount(blocksCount);
+
+        auto future = bootstrap->GetClientEndpoint()->ZeroBlocks(
+            MakeIntrusive<TCallContext>(),
+            std::move(request));
+
+        requestReceived.Wait();
+        UNIT_ASSERT(!future.HasValue());
+
+        ConnectInvalidClient(port);
+        trigger.SetValue({});
+
+        auto response = future.GetValue(TDuration::Seconds(3));
+        UNIT_ASSERT_C(!HasError(response), response);
 
         bootstrap->Stop();
     }


### PR DESCRIPTION
### What happened
Invalid NBS connection disconnected active client
```
2026-08-07T08:33:43.024097Z :BLOCKSTORE_NBD DEBUG: cloud/blockstore/libs/nbd/client_handler.cpp:233: [d:TestDiskId]  SEND Request type:6 handle:1093403632696175061 from:53248 length:4096
2026-08-07T08:33:43.257456Z :BLOCKSTORE_NBD DEBUG: cloud/blockstore/libs/nbd/server.cpp:367: new connection from [::1]:14851
2026-08-07T08:33:43.257727Z :BLOCKSTORE_NBD INFO: cloud/blockstore/libs/nbd/server.cpp:183: lost connection with client, failed to receive: (yexception) cloud/blockstore/libs/nbd/server_handler.cpp:313: Condition violated: `client.Flags == (NBD_FLAG_C_FIXED_NEWSTYLE | NBD_FLAG_C_NO_ZEROES)'
...
[[bad]]assertion failed at cloud/blockstore/libs/nbd/server_ut.cpp:1104, virtual void NCloud::NBlockStore::NBD::NTestSuiteTServerTest::TTestCaseShouldNotFreezeSocketReadingDueToLimiter::Execute_(NUnitTest::TTestContext &): (!HasError(future3.GetValue(TDuration::Seconds(3)))) [[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char>> const&, bool)+136 (0x10C5398)
NCloud::NBlockStore::NBD::NTestSuiteTServerTest::TTestCaseShouldNotFreezeSocketReadingDueToLimiter::Execute_(NUnitTest::TTestContext&)+8138 (0xF596CA)
NCloud::NBlockStore::NBD::NTestSuiteTServerTest::TCurrentTest::Execute()::'lambda'()::operator()() const+71 (0xF5C567)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+127 (0x10C734F)
NCloud::NBlockStore::NBD::NTestSuiteTServerTest::TCurrentTest::Execute()+429 (0xF5BF1D)
NUnitTest::TTestFactory::Execute()+780 (0x10C7AAC)
NUnitTest::RunMain(int, char**)+3005 (0x10DAA7D)
??+0 (0x75283DE29D90)
__libc_start_main+128 (0x75283DE29E40)
??+0 (0xF0E029)
[[rst]]
```
###  Issue
The server replaced its active connection immediately after accepting a new socket, before NBD negotiation completed. A malformed, incomplete, or unrelated connection could therefore terminate a valid client and cancel its in-flight requests with server is unavailable.
This caused ShouldNotFreezeSocketReadingDueToLimiter to fail when unexpected IPv6 connections reached the test endpoint. The limiter itself operated correctly; the active client had already been displaced before receiving its response.

### Fix

New sockets are now treated as candidate connections:

- The active connection remains usable during negotiation.
- Invalid candidates are discarded without affecting it.
- A candidate replaces the active connection only after successful NBD negotiation.
- Shutdown handles both active and candidate connections.
- Connection logs now report the peer address.