### PR TITLE
issue-6706: prevent debug crash on retryable silent errors and increment ErrorsSilent

### DIFF
--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -815,9 +815,11 @@ struct TRequestCounters::TStatCounters
             case EDiagnosticsErrorKind::Success:
             case EDiagnosticsErrorKind::ErrorAborted:
             case EDiagnosticsErrorKind::ErrorFatal:
-            case EDiagnosticsErrorKind::ErrorSilent:
                 Y_DEBUG_ABORT_UNLESS(false);
                 return;
+            case EDiagnosticsErrorKind::ErrorSilent:
+                ErrorsSilent->Inc();
+                break;
             case EDiagnosticsErrorKind::Max:
                 Y_DEBUG_ABORT_UNLESS(false);
                 return;


### PR DESCRIPTION
#6706

