### PR TITLE
issue-5894, issue-5895: NaiveMirroredFileSystemShard - fixed Names.Get error handling in CreateHandle

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -803,6 +803,7 @@ class TFiberShardImpl
 {
 private:
     const ui32 ShardNo;
+    const IStorageGroupFactoryPtr StorageGroupFactory;
     const NProtoPrivate::TPersistentFastShardConfig Config;
 
     IStorageGroupPtr Storage;
@@ -818,26 +819,17 @@ private:
 public:
     TFiberShardImpl(
         ui32 shardNo,
+        IStorageGroupFactoryPtr storageGroupFactory,
         NProtoPrivate::TPersistentFastShardConfig config)
         : ShardNo(shardNo)
+        , StorageGroupFactory(std::move(storageGroupFactory))
         , Config(std::move(config))
     {
-        //
-        // Overall it's better to pass the group into this code via dependency
-        // injection but for now it's not necessary.
         //
         // Using only one storage group for now.
         //
 
-        TVector<TStorageDevice> devices;
-        const auto& sg = Config.GetStorageGroups(0);
-        for (const auto& d: sg.GetDevices()) {
-            devices.push_back({
-                .Node = CreateStorageNodeClient(d.GetHost(), d.GetPort()),
-                .DeviceUUID = d.GetDeviceId(),
-            });
-        }
-        Storage = CreateNaiveMirroredStorageGroup(std::move(devices));
+        Storage = StorageGroupFactory->MakeStorageGroup(Config);
         PageStore = CreatePageStore(Storage, PageSize);
 
         ui64 firstPageNo = 0;
@@ -1218,6 +1210,11 @@ public:
                         request.GetNodeId(),
                         request.GetName());
                 }
+            } else if (HasError(error)) {
+                SILK_DEBUG(
+                    "CreateHandle::Names.Get error=%s",
+                    FormatError(error).c_str());
+                *response.MutableError() = std::move(error);
             } else {
                 if (HasFlag(flags, createFlag) && HasFlag(flags, exclFlag)) {
                     *response.MutableError() =
@@ -1861,7 +1858,34 @@ FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
 
 #undef FAST_SHARD_DEFINE_METHOD
 
+////////////////////////////////////////////////////////////////////////////////
+
+struct TNaiveMirroredStorageGroupFactory: IStorageGroupFactory
+{
+    IStorageGroupPtr MakeStorageGroup(
+        const NProtoPrivate::TPersistentFastShardConfig& config)
+    {
+        TVector<TStorageDevice> devices;
+        const auto& sg = config.GetStorageGroups(0);
+        for (const auto& d: sg.GetDevices()) {
+            devices.push_back({
+                .Node = CreateStorageNodeClient(d.GetHost(), d.GetPort()),
+                .DeviceUUID = d.GetDeviceId(),
+            });
+        }
+
+        return CreateNaiveMirroredStorageGroup(std::move(devices));
+    }
+};
+
 }   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IStorageGroupFactoryPtr CreateNaiveMirroredStorageGroupFactory()
+{
+    return std::make_shared<TNaiveMirroredStorageGroupFactory>();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1875,9 +1899,13 @@ private:
 public:
     TNaiveMirroredFileSystemShard(
         ui32 shardNo,
+        IStorageGroupFactoryPtr storageGroupFactory,
         NProtoPrivate::TPersistentFastShardConfig config)
         : FiberShard(
-              std::make_shared<TFiberShardImpl>(shardNo, std::move(config)))
+              std::make_shared<TFiberShardImpl>(
+                  shardNo,
+                  std::move(storageGroupFactory),
+                  std::move(config)))
     {}
 
 public:
@@ -1920,9 +1948,23 @@ public:
 
 IFileSystemShardPtr CreateNaiveMirroredFileSystemShard(
     ui32 shardNo,
+    IStorageGroupFactoryPtr storageGroupFactory,
     const NProtoPrivate::TPersistentFastShardConfig& config)
 {
-    return std::make_shared<TNaiveMirroredFileSystemShard>(shardNo, config);
+    return std::make_shared<TNaiveMirroredFileSystemShard>(
+        shardNo,
+        std::move(storageGroupFactory),
+        config);
+}
+
+IFileSystemShardPtr CreateNaiveMirroredFileSystemShard(
+    ui32 shardNo,
+    const NProtoPrivate::TPersistentFastShardConfig& config)
+{
+    return std::make_shared<TNaiveMirroredFileSystemShard>(
+        shardNo,
+        CreateNaiveMirroredStorageGroupFactory(),
+        config);
 }
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cloud/filestore/libs/storage/fastshard/iface/public.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h>
 
 namespace NCloud::NFileStore::NProtoPrivate {
 
@@ -13,6 +14,24 @@ class TPersistentFastShardConfig;
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+struct IStorageGroupFactory
+{
+    virtual ~IStorageGroupFactory() = default;
+    virtual IStorageGroupPtr MakeStorageGroup(
+        const NProtoPrivate::TPersistentFastShardConfig& config) = 0;
+};
+
+using IStorageGroupFactoryPtr = std::shared_ptr<IStorageGroupFactory>;
+
+IStorageGroupFactoryPtr CreateNaiveMirroredStorageGroupFactory();
+
+////////////////////////////////////////////////////////////////////////////////
+
+IFileSystemShardPtr CreateNaiveMirroredFileSystemShard(
+    ui32 shardNo,
+    IStorageGroupFactoryPtr storageGroupFactory,
+    const NProtoPrivate::TPersistentFastShardConfig& config);
 
 IFileSystemShardPtr CreateNaiveMirroredFileSystemShard(
     ui32 shardNo,

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_error.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_error.cpp
@@ -1,0 +1,289 @@
+#include <cloud/filestore/libs/service/filestore.h>
+#include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/silk_env.h>
+#include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <silk/util/logger.h>
+
+#include <gtest/gtest.h>
+
+using namespace NCloud;
+using namespace NFileStore;
+using namespace NFileStore::NProto;
+using namespace NStorage::NFastShard;
+
+////////////////////////////////////////////////////////////////////////////////
+// This is deliberately not a unit test now. This test deliberately bootstraps
+// the whole stack:
+// * several storage nodes on top of files
+// * storage node server
+// * storage node clients
+// * storage group
+// * shard implementation on top of this group
+//
+// This could've been an integration pytest but that would require adding a
+// storage node daemon as well and also it's less convenient to debug pytests
+// than to debug gtests.
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 ShardNo = 1;
+constexpr size_t PageSize = 4_KB;
+constexpr size_t PageCount = 128_MB / PageSize;
+constexpr size_t NodesPerGroup = 64;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTempError
+{
+    NCloud::NProto::TError E;
+    ui64 Ttl = 0;
+
+    void Set(NCloud::NProto::TError e, ui64 ttl)
+    {
+        E = std::move(e);
+        Ttl = ttl;
+    }
+
+    auto Get()
+    {
+        if (!Ttl) {
+            return MakeError(S_OK);
+        }
+
+        --Ttl;
+        return E;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestStorageGroup: IStorageGroup
+{
+    TVector<TString> Pages{PageCount};
+    TTempError ReadError;
+    TTempError WriteError;
+
+    NCloud::NProto::TError AcquireDevices() override
+    {
+        return {};
+    }
+
+    NCloud::NProto::TError ReleaseDevices() override
+    {
+        return {};
+    }
+
+    NCloud::NProto::TError WriteLogRecord(
+        NCloud::NProto::TDeviceRequestHeaders headers,
+        TVector<TPageGroup> pageGroups) override
+    {
+        Y_UNUSED(headers);
+
+        auto e = WriteError.Get();
+        if (HasError(e)) {
+            return e;
+        }
+
+        for (auto& pg: pageGroups) {
+            for (ui64 i = 0; i < pg.Content.size(); ++i) {
+                Pages[pg.FirstPageNo + i] = std::move(pg.Content[i]);
+            }
+        }
+
+        return {};
+    }
+
+    NCloud::NProto::TError ReadPages(
+        NCloud::NProto::TDeviceRequestHeaders headers,
+        const TVector<TPageGroupRef>& pageGroupRefs,
+        TVector<TPageGroup>* pageGroups) override
+    {
+        Y_UNUSED(headers);
+
+        auto e = ReadError.Get();
+        if (HasError(e)) {
+            return e;
+        }
+
+        for (const auto& pgr: pageGroupRefs) {
+            auto& pg = pageGroups->emplace_back();
+            pg.FirstPageNo = pgr.FirstPageNo;
+            for (ui64 i = 0; i < pgr.PageCount; ++i) {
+                pg.Content.push_back(Pages[pgr.FirstPageNo + i]);
+                if (pg.Content.back().empty()) {
+                    pg.Content.back().resize(PageSize, 0);
+                }
+            }
+        }
+
+        return {};
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestStorageGroupFactory: IStorageGroupFactory
+{
+    std::shared_ptr<TTestStorageGroup> Group =
+        std::make_shared<TTestStorageGroup>();
+
+    IStorageGroupPtr MakeStorageGroup(
+        const NProtoPrivate::TPersistentFastShardConfig& config) override
+    {
+        Y_UNUSED(config);
+
+        return Group;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TStorageFixture
+{
+    NProtoPrivate::TPersistentFastShardConfig Config;
+    std::shared_ptr<TTestStorageGroupFactory> Factory =
+        std::make_shared<TTestStorageGroupFactory>();
+
+    TStorageFixture()
+    {
+        Config.SetNodesPerGroup(NodesPerGroup);
+        Config.SetExpectedGroupCapacity(64_MB);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(NaiveMirroredShardErrorTest, CreatesHandles)
+{
+    silk::Logger::setLevel(silk::LogLevel::DEBUG);
+
+    TStorageFixture fx;
+
+    auto shard =
+        CreateNaiveMirroredFileSystemShard(ShardNo, fx.Factory, fx.Config);
+
+    const TString file1 = "file1";
+    const ui32 mode = 0644;
+    const ui32 expectedMode = S_IFREG | 0644;
+    const ui64 uid = 111;
+    const ui64 gid = 222;
+
+    const ui32 create = ProtoFlag(TCreateHandleRequest::E_CREATE);
+    const ui32 createExcl =
+        create | ProtoFlag(TCreateHandleRequest::E_EXCLUSIVE);
+
+    fx.Factory->Group->ReadError.Set(MakeError(E_REJECTED), 1 /* ttl */);
+
+    {
+        TCreateHandleRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        request.SetMode(mode);
+        request.SetUid(uid);
+        request.SetGid(gid);
+        request.SetFlags(createExcl);
+        auto f = shard->CreateHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(E_REJECTED, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    ui64 nodeId = 0;
+    ui64 handle1 = 0;
+    {
+        TCreateHandleRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        request.SetMode(mode);
+        request.SetUid(uid);
+        request.SetGid(gid);
+        request.SetFlags(createExcl);
+        auto f = shard->CreateHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        EXPECT_EQ(uid, response.GetNodeAttr().GetUid());
+        EXPECT_EQ(gid, response.GetNodeAttr().GetGid());
+        EXPECT_EQ(
+            static_cast<ui32>(E_REGULAR_NODE),
+            response.GetNodeAttr().GetType());
+        EXPECT_EQ(expectedMode, response.GetNodeAttr().GetMode());
+        nodeId = response.GetNodeAttr().GetId();
+        handle1 = response.GetHandle();
+    }
+
+    {
+        TGetNodeAttrRequest request;
+        request.SetNodeId(nodeId);
+        auto f = shard->GetNodeAttr(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        EXPECT_EQ(nodeId, response.GetNode().GetId());
+        EXPECT_EQ(uid, response.GetNode().GetUid());
+        EXPECT_EQ(gid, response.GetNode().GetGid());
+        EXPECT_EQ(
+            static_cast<ui32>(E_REGULAR_NODE),
+            response.GetNode().GetType());
+        EXPECT_EQ(expectedMode, response.GetNode().GetMode());
+    }
+
+    ui64 handle2 = 0;
+    {
+        TCreateHandleRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        request.SetMode(mode);
+        request.SetUid(uid);
+        request.SetGid(gid);
+        request.SetFlags(create);
+        auto f = shard->CreateHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        EXPECT_EQ(nodeId, response.GetNodeAttr().GetId());
+        EXPECT_EQ(uid, response.GetNodeAttr().GetUid());
+        EXPECT_EQ(gid, response.GetNodeAttr().GetGid());
+        EXPECT_EQ(
+            static_cast<ui32>(E_REGULAR_NODE),
+            response.GetNodeAttr().GetType());
+        EXPECT_EQ(expectedMode, response.GetNodeAttr().GetMode());
+        handle2 = response.GetHandle();
+        EXPECT_NE(handle2, handle1);
+    }
+
+    {
+        TDestroyHandleRequest request;
+        request.SetHandle(handle1);
+        auto f = shard->DestroyHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        TDestroyHandleRequest request;
+        request.SetHandle(handle1);
+        auto f = shard->DestroyHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(NCloud::E_FS_BADHANDLE, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        TDestroyHandleRequest request;
+        request.SetHandle(handle2);
+        auto f = shard->DestroyHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+}

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_error.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_error.cpp
@@ -1,7 +1,6 @@
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h>
-#include <cloud/filestore/libs/storage/fastshard/testlib/silk_env.h>
 #include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
 
 #include <cloud/storage/core/libs/common/error.h>

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_error.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_error.cpp
@@ -15,19 +15,6 @@ using namespace NFileStore;
 using namespace NFileStore::NProto;
 using namespace NStorage::NFastShard;
 
-////////////////////////////////////////////////////////////////////////////////
-// This is deliberately not a unit test now. This test deliberately bootstraps
-// the whole stack:
-// * several storage nodes on top of files
-// * storage node server
-// * storage node clients
-// * storage group
-// * shard implementation on top of this group
-//
-// This could've been an integration pytest but that would require adding a
-// storage node daemon as well and also it's less convenient to debug pytests
-// than to debug gtests.
-
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ut/ya.make
@@ -4,6 +4,7 @@ SRCS(
     ../persistent_bitmap_ut.cpp
     ../persistent_hash_table_ut.cpp
     ../shard_ut.cpp
+    ../shard_ut_error.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
### Notes
`TFiberShardImpl::CreateHandle()` code incorrectly treated all non-`E_FS_NOENT` codes returned by `Names.Get()` as success. Fixed this and also implemented passing storage group factory into `CreateNaiveMirroredFileSystemShard()` via DI to inject a different implementation in tests. Added a ut with injected errors using this mechanism.

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895