### PR TITLE
[Blockstore] Add discard requests to eternal tests

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/main.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/main.cpp
@@ -18,6 +18,12 @@ int main(int argc, char** argv)
         Cerr << CurrentExceptionMessage() << Endl;
         return 1;
     }
-    return AppMain(options);
+
+    try {
+        return AppMain(options);
+    } catch (...) {
+        Cerr << CurrentExceptionMessage() << Endl;
+        return 1;
+    }
 }
 

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
@@ -208,6 +208,13 @@ void TOptions::Parse(int argc, char** argv)
         .StoreResult(&WriteRate)
         .DefaultValue(0);
 
+    opts.AddLongOption(
+        "zero-rate",
+        "percentage of write requests issued as Zero (discard) instead of Write")
+        .RequiredArgument("NUM")
+        .StoreResult(&ZeroRate)
+        .DefaultValue(0);
+
     opts.AddLongOption("write-parts", "number of parts to split one write")
         .RequiredArgument("NUM")
         .StoreResult(&WriteParts)

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
@@ -210,7 +210,7 @@ void TOptions::Parse(int argc, char** argv)
 
     opts.AddLongOption(
         "zero-rate",
-        "percentage of write requests issued as Zero (discard) instead of Write")
+        "percentage of zero (discard) requests")
         .RequiredArgument("NUM")
         .StoreResult(&ZeroRate)
         .DefaultValue(0);

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.h
@@ -55,6 +55,7 @@ struct TOptions
 
     ui64 BlockSize;
     ui16 WriteRate;
+    ui16 ZeroRate = 0;
     ui64 RequestBlockCount;
     ui16 IoDepth;
     ui64 WriteParts;

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -80,6 +80,7 @@ int TTest::Run()
             Y_ENSURE(Options->FilePath.Defined(), "You need to specify the file path");
             Y_ENSURE(Options->FileSize.Defined(), "You need to specify the file size");
             Y_ENSURE(Options->WriteRate <= 100, "Write rate should be in range [0, 100]");
+            Y_ENSURE(Options->ZeroRate <= 100, "Zero rate should be in range [0, 100]");
 
             ConfigHolder = CreateTestConfig(
                 TCreateTestConfigArguments{
@@ -89,6 +90,7 @@ int TTest::Run()
                     .IoDepth = Options->IoDepth,
                     .BlockSize = Options->BlockSize,
                     .WriteRate = Options->WriteRate,
+                    .ZeroRate = Options->ZeroRate,
                     .RequestBlockCount = Options->RequestBlockCount,
                     .WriteParts = Options->WriteParts,
                     .AlternatingPhase = Options->AlternatingPhase,

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -81,6 +81,12 @@ int TTest::Run()
             Y_ENSURE(Options->FileSize.Defined(), "You need to specify the file size");
             Y_ENSURE(Options->WriteRate <= 100, "Write rate should be in range [0, 100]");
             Y_ENSURE(Options->ZeroRate <= 100, "Zero rate should be in range [0, 100]");
+            Y_ENSURE(
+                Options->WriteRate + Options->ZeroRate <= 100,
+                "Sum of write-rate and zero-rate should be in range [0, 100]");
+            Y_ENSURE(
+                Options->Scenario == EScenario::Aligned || Options->ZeroRate == 0,
+                "zero-rate is only supported for aligned scenario");
 
             ConfigHolder = CreateTestConfig(
                 TCreateTestConfigArguments{
@@ -110,6 +116,15 @@ int TTest::Run()
         case ECommand::ReadConfigCmd:
             Y_ENSURE(Options->RestorePath.Defined(), "You need to specify the restore path");
             ConfigHolder = LoadTestConfig(*Options->RestorePath);
+            Y_ENSURE(
+                ConfigHolder->GetConfig().GetWriteRate() +
+                        ConfigHolder->GetConfig().GetZeroRate() <=
+                    100,
+                "Sum of WriteRate and ZeroRate should be in range [0, 100]");
+            Y_ENSURE(
+                Options->Scenario == EScenario::Aligned ||
+                    ConfigHolder->GetConfig().GetZeroRate() == 0,
+                "zero-rate is only supported for aligned scenario");
             break;
         case ECommand::UnknownCmd:
             STORAGE_ERROR("Unknown command, check avaliable commands in the help");

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
@@ -18,9 +18,12 @@ _BINARY_PATH = 'cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/et
 _MULTIPLE_FILES_TIMEOUT_ENV = 'ETERNAL_LOAD_MULTIPLE_FILES_TIMEOUT'
 _MULTIPLE_FILES_TEST_COUNT_ENV = 'ETERNAL_LOAD_MULTIPLE_FILES_TEST_COUNT'
 
-_SCENARIOS = [
+_ALIGNED_SCENARIOS = [
     ("aligned", "asyncio", True),
     ("aligned", "sync", False),
+]
+
+_SCENARIOS = _ALIGNED_SCENARIOS + [
     ("unaligned", "sync", False)
 ]
 
@@ -29,8 +32,23 @@ _SIMPLE_SCENARIOS = [
     ("random", "sync", False),
 ]
 
+_NON_ALIGNED_SCENARIOS = [
+    ("unaligned", "sync", False),
+    ("sequential", "sync", False),
+    ("random", "sync", False),
+]
 
-def __run_load_test(file_name, scenario="aligned", engine="asyncio", direct=True, timeout=None, test_count=0):
+
+def __run_load_test(
+    file_name,
+    scenario="aligned",
+    engine="asyncio",
+    direct=True,
+    timeout=None,
+    test_count=0,
+    write_rate=70,
+    zero_rate=0,
+):
     eternal_load = yatest_common.binary_path(_BINARY_PATH)
 
     params = [
@@ -43,7 +61,8 @@ def __run_load_test(file_name, scenario="aligned", engine="asyncio", direct=True
         '--file', file_name,
         '--filesize', str(_FILE_SIZE),
         '--iodepth', str(_IO_DEPTH),
-        '--write-rate', '70',
+        '--write-rate', str(write_rate),
+        '--zero-rate', str(zero_rate),
         '--debug',
         '--test-count', str(test_count)
     ]
@@ -86,6 +105,40 @@ def test_load_works(scenario, engine, direct):
         pass
     else:
         pytest.fail(f"Eternal load should not have finished within {timeout} seconds")
+
+
+@pytest.mark.parametrize("scenario,engine,direct", _ALIGNED_SCENARIOS)
+def test_aligned_with_zero_rate(scenario, engine, direct):
+    # Zero/discard requires a block device; on a regular file the aligned
+    # scenario must accept zero-rate and fail when issuing Zero.
+    tmp_file = tempfile.NamedTemporaryFile(suffix=".test")
+    result = __run_load_test(
+        tmp_file.name,
+        scenario=scenario,
+        engine=engine,
+        direct=direct,
+        timeout=30,
+        write_rate=50,
+        zero_rate=20,
+    )
+    assert result.returncode == 1
+    assert "only supported for block devices" in result.stderr
+
+
+@pytest.mark.parametrize("scenario,engine,direct", _NON_ALIGNED_SCENARIOS)
+def test_zero_rate_rejected_for_non_aligned(scenario, engine, direct):
+    tmp_file = tempfile.NamedTemporaryFile(suffix=".test")
+    result = __run_load_test(
+        tmp_file.name,
+        scenario=scenario,
+        engine=engine,
+        direct=direct,
+        timeout=10,
+        write_rate=50,
+        zero_rate=20,
+    )
+    assert result.returncode != 0
+    assert "zero-rate is only supported for aligned scenario" in result.stderr
 
 
 def test_multiple_files():

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests_in_qemu/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests_in_qemu/test.py
@@ -11,6 +11,12 @@ _BLOCKSIZE = 4096  # KB
 _REQUEST_BLOCK_COUNT = 3
 _BINARY_PATH = "cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/eternal-load"
 
+_NON_ALIGNED_SCENARIOS = [
+    ("unaligned", "sync", False),
+    ("sequential", "sync", False),
+    ("random", "sync", False),
+]
+
 
 def __run_load_test(
     file_name,
@@ -19,6 +25,8 @@ def __run_load_test(
     direct=True,
     timeout=60,
     test_count=0,
+    write_rate=70,
+    zero_rate=0,
 ):
     eternal_load = yatest_common.binary_path(_BINARY_PATH)
 
@@ -32,7 +40,8 @@ def __run_load_test(
         "--file", str(file_name),
         "--filesize", str(_FILE_SIZE),
         "--iodepth", str(_IO_DEPTH),
-        "--write-rate", "70",
+        "--write-rate", str(write_rate),
+        "--zero-rate", str(zero_rate),
         "--debug",
         "--test-count", str(test_count),
     ]
@@ -86,7 +95,25 @@ def mount_very_small_ext4(tmp_path):
         subprocess.run(["sudo", "umount", "-l", str(mount_dir)], check=False)
 
 
-def test_load_async_io_fails(very_small_ext4):
+@pytest.fixture(name="loop_device")
+def create_loop_device(tmp_path):
+    image_path = tmp_path / "disk.img"
+    # Sparse 1 GiB image is enough for --filesize 1
+    with open(image_path, "wb") as image:
+        image.truncate(_FILE_SIZE * 1024 ** 3)
+
+    device = subprocess.check_output(
+        ["sudo", "losetup", "-f", "--show", str(image_path)],
+        text=True,
+    ).strip()
+
+    try:
+        yield device
+    finally:
+        subprocess.run(["sudo", "losetup", "-d", device], check=False)
+
+
+def test_aligned_without_zero_rate(very_small_ext4):
     file_path = very_small_ext4 / "load.test"
 
     # Run async-io eternal-load on a small loopback ext4 filesystem to raise ENOSPC.
@@ -96,6 +123,7 @@ def test_load_async_io_fails(very_small_ext4):
         engine="asyncio",
         direct=True,
         timeout=60,
+        zero_rate=0,
     )
 
     assert result.returncode == 1
@@ -105,3 +133,41 @@ def test_load_async_io_fails(very_small_ext4):
         "(No space left on device) async IO operation failed"
     )
     assert msg in result.stderr
+
+
+def test_aligned_with_zero_rate(loop_device):
+    timeout = 30
+    try:
+        result = __run_load_test(
+            loop_device,
+            scenario="aligned",
+            engine="asyncio",
+            direct=True,
+            timeout=timeout,
+            write_rate=50,
+            zero_rate=20,
+        )
+        assert result.returncode == 0
+    except subprocess.TimeoutExpired:
+        pass
+    else:
+        pytest.fail(f"Eternal load should not have finished within {timeout} seconds")
+
+
+@pytest.mark.parametrize("scenario,engine,direct", _NON_ALIGNED_SCENARIOS)
+def test_zero_rate_rejected_for_non_aligned(scenario, engine, direct, tmp_path):
+    file_path = tmp_path / "load.test"
+    file_path.write_bytes(b"")
+
+    result = __run_load_test(
+        file_path,
+        scenario=scenario,
+        engine=engine,
+        direct=direct,
+        timeout=10,
+        write_rate=50,
+        zero_rate=20,
+    )
+
+    assert result.returncode != 0
+    assert "zero-rate is only supported for aligned scenario" in result.stderr

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.cpp
@@ -69,6 +69,10 @@ TConfigHolder::TConfigHolder(const TCreateTestConfigArguments& args)
     Config.SetWriteRate(args.WriteRate);
     Config.SetIoDepth(args.IoDepth);
 
+    if (args.ZeroRate) {
+        Config.SetZeroRate(args.ZeroRate);
+    }
+
     auto& ranges = *Config.MutableRanges();
 
     for (ui16 i = 0; i < args.IoDepth; ++i) {

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h
@@ -32,6 +32,7 @@ struct TCreateTestConfigArguments
     ui16 IoDepth = 0;
     ui64 BlockSize = 0;
     ui16 WriteRate = 0;
+    ui16 ZeroRate = 0;
     ui64 RequestBlockCount = 0;
     ui64 WriteParts = 0;
     TString AlternatingPhase = "";

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
@@ -44,6 +44,6 @@ message TTestConfig {
   // Used in TUnalignedTestScenario
   optional TUnalignedTestConfig UnalignedTest = 12;
   optional uint32 TestCount = 13;
-  // Percentage of write requests that are issued as Zero (discard) instead of Write.
+  // Percentage of Zero (discard) requests among all requests.
   optional uint32 ZeroRate = 14 [default = 0];
 }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
@@ -44,4 +44,6 @@ message TTestConfig {
   // Used in TUnalignedTestScenario
   optional TUnalignedTestConfig UnalignedTest = 12;
   optional uint32 TestCount = 13;
+  // Percentage of write requests that are issued as Zero (discard) instead of Write.
+  optional uint32 ZeroRate = 14 [default = 0];
 }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config_ut.cpp
@@ -155,6 +155,7 @@ Y_UNIT_TEST_SUITE(ConfigTest)
         "BlockSize":4096,
         "FilePath":"/dev/vdb",
         "WriteRate":50,
+        "ZeroRate":10,
         "RangeBlockCount":218453,
         "TestId":13930160852258120406
         }
@@ -176,6 +177,7 @@ Y_UNIT_TEST_SUITE(ConfigTest)
         UNIT_ASSERT_EQUAL(config.GetTestCount(), 13);
         UNIT_ASSERT_EQUAL(config.GetBlockSize(), 4096);
         UNIT_ASSERT_EQUAL(config.GetWriteRate(), 50);
+        UNIT_ASSERT_EQUAL(config.GetZeroRate(), 10);
         UNIT_ASSERT_EQUAL(config.GetRangeBlockCount(), 218453);
         UNIT_ASSERT_EQUAL(config.GetAlternatingPhase(), "");
         UNIT_ASSERT_EQUAL(config.GetTestId(), 13930160852258120406ull);
@@ -205,6 +207,7 @@ Y_UNIT_TEST_SUITE(ConfigTest)
              .IoDepth = 12,
              .BlockSize = 4096,
              .WriteRate = 50,
+             .ZeroRate = 10,
              .RequestBlockCount = 1,
              .WriteParts = 1,
              .AlternatingPhase = "",

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.cpp
@@ -1,0 +1,56 @@
+#include "device_discard.h"
+
+#include <util/string/builder.h>
+
+#include <cerrno>
+#include <cstring>
+
+#if defined(_linux_)
+#   include <linux/fs.h>
+#   include <sys/ioctl.h>
+#   include <sys/stat.h>
+#endif
+
+namespace NCloud::NBlockStore::NTesting {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError DiscardDeviceRange(
+    TFileHandle& file,
+    ui64 offset,
+    ui64 length)
+{
+#if defined(_linux_)
+    struct stat st;
+    if (fstat(FHANDLE(file), &st) != 0) {
+        const int err = errno;
+        return MakeError(
+            E_IO,
+            TStringBuilder() << "fstat failed: " << err << " " << strerror(err));
+    }
+
+    if (!S_ISBLK(st.st_mode)) {
+        return MakeError(
+            E_ARGUMENT,
+            "Discard/Zero is only supported for block devices");
+    }
+
+    ui64 range[2] = {offset, length};
+    if (ioctl(FHANDLE(file), BLKDISCARD, range) == 0) {
+        return {};
+    }
+
+    const int err = errno;
+    return MakeError(
+        E_IO,
+        TStringBuilder() << "BLKDISCARD failed: " << err << " "
+                         << strerror(err));
+#else
+    Y_UNUSED(file);
+    Y_UNUSED(offset);
+    Y_UNUSED(length);
+    return MakeError(E_NOT_IMPLEMENTED, "Discard/Zero is not supported");
+#endif
+}
+
+}   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/system/file.h>
+#include <util/system/types.h>
+
+namespace NCloud::NBlockStore::NTesting {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Issues BLKDISCARD for [offset, offset + length) on a block device.
+// Returns an error if the file handle is not a block device or discard fails.
+NProto::TError DiscardDeviceRange(
+    TFileHandle& file,
+    ui64 offset,
+    ui64 length);
+
+}   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -17,6 +17,17 @@
 #include <util/thread/pool.h>
 
 #include <atomic>
+#include <cerrno>
+#include <cstring>
+
+#if defined(_linux_)
+#   if !defined(FALLOC_FL_ZERO_RANGE)
+#       define FALLOC_FL_ZERO_RANGE 0x10
+#   endif
+#   include <fcntl.h>
+#   include <linux/fs.h>
+#   include <sys/ioctl.h>
+#endif
 
 namespace NCloud::NBlockStore::NTesting {
 
@@ -104,6 +115,11 @@ private:
 
     void Write(
         const void* buffer,
+        ui32 count,
+        ui64 offset,
+        TCallback callback) override;
+
+    void Zero(
         ui32 count,
         ui64 offset,
         TCallback callback) override;
@@ -380,6 +396,66 @@ void TTestExecutor::TWorkerService::Write(
                 Run();
             }
         });
+}
+
+void TTestExecutor::TWorkerService::Zero(
+    ui32 count,
+    ui64 offset,
+    TCallback callback)
+{
+    RequestCount++;
+    PendingRequestCount++;
+
+    auto complete = [this, count, callback = std::move(callback)](
+                        const NProto::TError& error)
+    {
+        if (HasError(error)) {
+            Executor.Fail("Can't zero file range: " + error.GetMessage());
+        } else {
+            Executor.BytesWritten += count;
+            callback();
+        }
+        if (HandleRequest()) {
+            Run();
+        }
+    };
+
+#if defined(_linux_)
+    ui64 range[2] = {offset, count};
+    if (ioctl(FHANDLE(Scenario.File), BLKDISCARD, range) == 0) {
+        complete({});
+        return;
+    }
+
+    const int discardErrno = errno;
+    if (discardErrno != EOPNOTSUPP && discardErrno != ENOTTY) {
+        complete(MakeError(
+            E_IO,
+            TStringBuilder() << "BLKDISCARD failed: " << discardErrno << " "
+                             << strerror(discardErrno)));
+        return;
+    }
+
+    if (fallocate(
+            FHANDLE(Scenario.File),
+            FALLOC_FL_ZERO_RANGE,
+            static_cast<off_t>(offset),
+            static_cast<off_t>(count)) == 0)
+    {
+        complete({});
+        return;
+    }
+
+    const int fallocateErrno = errno;
+    complete(MakeError(
+        E_IO,
+        TStringBuilder() << "Zero failed (BLKDISCARD errno=" << discardErrno
+                         << ", FALLOC_FL_ZERO_RANGE errno=" << fallocateErrno
+                         << " " << strerror(fallocateErrno) << ")"));
+#else
+    Y_UNUSED(offset);
+    complete(MakeError(E_NOT_IMPLEMENTED, "Zero is not supported"));
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -1,5 +1,7 @@
 #include "test_executor.h"
 
+#include "device_discard.h"
+
 #include <cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h>
 
 #include <cloud/storage/core/libs/common/file_io_service.h>
@@ -17,17 +19,6 @@
 #include <util/thread/pool.h>
 
 #include <atomic>
-#include <cerrno>
-#include <cstring>
-
-#if defined(_linux_)
-#   if !defined(FALLOC_FL_ZERO_RANGE)
-#       define FALLOC_FL_ZERO_RANGE 0x10
-#   endif
-#   include <fcntl.h>
-#   include <linux/fs.h>
-#   include <sys/ioctl.h>
-#endif
 
 namespace NCloud::NBlockStore::NTesting {
 
@@ -63,8 +54,10 @@ private:
 
     std::atomic_uint64_t BytesRead = 0;
     std::atomic_uint64_t BytesWritten = 0;
+    std::atomic_uint64_t BytesZeroed = 0;
     ui64 PreviousBytesRead = 0;
     ui64 PreviousBytesWritten = 0;
+    ui64 PreviousBytesZeroed = 0;
     TInstant PreviousStatsTimestamp;
 
     const TLog Log;
@@ -242,18 +235,22 @@ void TTestExecutor::PrintStats()
     auto now = Now();
     auto currentBytesRead = BytesRead.load();
     auto currentBytesWritten = BytesWritten.load();
+    auto currentBytesZeroed = BytesZeroed.load();
 
     auto elapsedSeconds = (now - PreviousStatsTimestamp).SecondsFloat();
     auto bytesRead = currentBytesRead - PreviousBytesRead;
     auto bytesWritten = currentBytesWritten - PreviousBytesWritten;
+    auto bytesZeroed = currentBytesZeroed - PreviousBytesZeroed;
 
     STORAGE_DEBUG(
         "Read: " << bytesRead / elapsedSeconds / 1_MB << " MiB/s, "
-        "Write: " << bytesWritten / elapsedSeconds / 1_MB << " MiB/s");
+        "Write: " << bytesWritten / elapsedSeconds / 1_MB << " MiB/s, "
+        "Zero: " << bytesZeroed / elapsedSeconds / 1_MB << " MiB/s");
 
     PreviousStatsTimestamp = now;
     PreviousBytesRead = currentBytesRead;
     PreviousBytesWritten = currentBytesWritten;
+    PreviousBytesZeroed = currentBytesZeroed;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -406,56 +403,16 @@ void TTestExecutor::TWorkerService::Zero(
     RequestCount++;
     PendingRequestCount++;
 
-    auto complete = [this, count, callback = std::move(callback)](
-                        const NProto::TError& error)
-    {
-        if (HasError(error)) {
-            Executor.Fail("Can't zero file range: " + error.GetMessage());
-        } else {
-            Executor.BytesWritten += count;
-            callback();
-        }
-        if (HandleRequest()) {
-            Run();
-        }
-    };
-
-#if defined(_linux_)
-    ui64 range[2] = {offset, count};
-    if (ioctl(FHANDLE(Scenario.File), BLKDISCARD, range) == 0) {
-        complete({});
-        return;
+    auto error = DiscardDeviceRange(Scenario.File, offset, count);
+    if (HasError(error)) {
+        Executor.Fail("Can't zero device range: " + error.GetMessage());
+    } else {
+        Executor.BytesZeroed += count;
+        callback();
     }
-
-    const int discardErrno = errno;
-    if (discardErrno != EOPNOTSUPP && discardErrno != ENOTTY) {
-        complete(MakeError(
-            E_IO,
-            TStringBuilder() << "BLKDISCARD failed: " << discardErrno << " "
-                             << strerror(discardErrno)));
-        return;
+    if (HandleRequest()) {
+        Run();
     }
-
-    if (fallocate(
-            FHANDLE(Scenario.File),
-            FALLOC_FL_ZERO_RANGE,
-            static_cast<off_t>(offset),
-            static_cast<off_t>(count)) == 0)
-    {
-        complete({});
-        return;
-    }
-
-    const int fallocateErrno = errno;
-    complete(MakeError(
-        E_IO,
-        TStringBuilder() << "Zero failed (BLKDISCARD errno=" << discardErrno
-                         << ", FALLOC_FL_ZERO_RANGE errno=" << fallocateErrno
-                         << " " << strerror(fallocateErrno) << ")"));
-#else
-    Y_UNUSED(offset);
-    complete(MakeError(E_NOT_IMPLEMENTED, "Zero is not supported"));
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
@@ -65,6 +65,14 @@ struct ITestExecutorIOService
         ui64 offset,
         TCallback callback) = 0;
 
+    // Initiates an asynchronous zero (discard) operation and calls the
+    // callback when the operation is completed successfully.
+    // If it fails, the test is stopped and the error is reported.
+    virtual void Zero(
+        ui32 count,
+        ui64 offset,
+        TCallback callback) = 0;
+
     // Gracefully stop the scenario
     virtual void Stop() = 0;
 
@@ -75,7 +83,7 @@ struct ITestExecutorIOService
 ////////////////////////////////////////////////////////////////////////////////
 
 // Workers are run concurrently - Run method and callbacks passed to
-// ITestExecutorIOService::Read and Write can be called from any thread.
+// ITestExecutorIOService::Read, Write and Zero can be called from any thread.
 struct ITestScenarioWorker
 {
     virtual ~ITestScenarioWorker() = default;

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
@@ -9,6 +9,7 @@
 #include <library/cpp/digest/crc32c/crc32c.h>
 
 #include <util/digest/numeric.h>
+#include <util/generic/utility.h>
 #include <util/random/random.h>
 #include <util/string/builder.h>
 #include <util/system/info.h>
@@ -43,9 +44,12 @@ ui64 CalculateInverse(ui64 step, ui64 len)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool IsZeroRequest(ui64 requestNumber, ui32 zeroRate)
+bool IsZeroRequest(ui64 requestNumber, ui32 writeRate, ui32 zeroRate)
 {
-    return IntHash(requestNumber) % 100 < zeroRate;
+    if (zeroRate == 0) {
+        return false;
+    }
+    return IntHash(requestNumber) % (writeRate + zeroRate) < zeroRate;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -208,17 +212,21 @@ void TAlignedTestScenario::DoRequest(
     IService& service)
 {
     const auto writeRate = GetWriteProbabilityPercent(secondsSinceTestStart);
+    const ui32 zeroRate = ConfigHolder->GetConfig().GetZeroRate();
+    const ui32 mutateRate = Min(100u, writeRate + zeroRate);
 
-    if (RandomNumber(100u) >= writeRate) {
+    if (RandomNumber(100u) >= mutateRate) {
         DoReadRequest(rangeIdx, service);
         return;
     }
 
     auto& range = Ranges[rangeIdx];
     auto [blockIdx, iteration] = range.NextWrite();
-    const ui32 zeroRate = ConfigHolder->GetConfig().GetZeroRate();
 
-    if (IsZeroRequest(iteration, zeroRate)) {
+    // Use configured (non-alternating) write rate so the write/zero choice for
+    // a request number stays stable and can be reconstructed on read.
+    const ui32 configuredWriteRate = ConfigHolder->GetConfig().GetWriteRate();
+    if (IsZeroRequest(iteration, configuredWriteRate, zeroRate)) {
         DoZeroRequest(rangeIdx, blockIdx, service);
     } else {
         DoWriteRequest(rangeIdx, blockIdx, iteration, service);
@@ -259,12 +267,13 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
     std::tie(blockIdx, expected) = range.RandomRead();
 
     ui64 blockSize = ConfigHolder->GetConfig().GetBlockSize();
+    const ui32 writeRate = ConfigHolder->GetConfig().GetWriteRate();
     const ui32 zeroRate = ConfigHolder->GetConfig().GetZeroRate();
 
     const auto startTs = Now();
 
     auto readHandler =
-        [this, startTs, blockIdx, rangeIdx, expected, zeroRate, &service]()
+        [this, startTs, blockIdx, rangeIdx, expected, writeRate, zeroRate, &service]()
             mutable
     {
         OnResponse(startTs, rangeIdx, "read", service);
@@ -275,7 +284,7 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
 
         auto& range = Ranges[rangeIdx];
 
-        if (IsZeroRequest(*expected, zeroRate)) {
+        if (IsZeroRequest(*expected, writeRate, zeroRate)) {
             const char* data = range.Data();
             for (ui64 i = 0; i < range.DataSize(); ++i) {
                 if (data[i] != 0) {

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
@@ -8,6 +8,7 @@
 
 #include <library/cpp/digest/crc32c/crc32c.h>
 
+#include <util/digest/numeric.h>
 #include <util/random/random.h>
 #include <util/string/builder.h>
 #include <util/system/info.h>
@@ -38,6 +39,13 @@ ui64 CalculateInverse(ui64 step, ui64 len)
     auto [x, _] = ExtendedEuclideanAlgorithm(step, len);
     x = (x + len) % len;
     return x;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool IsZeroRequest(ui64 requestNumber, ui32 zeroRate)
+{
+    return IntHash(requestNumber) % 100 < zeroRate;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -141,7 +149,12 @@ private:
     void
     DoRequest(ui16 rangeIdx, double secondsSinceTestStart, IService& service);
 
-    void DoWriteRequest(ui16 rangeIdx, IService& service);
+    void DoWriteRequest(
+        ui16 rangeIdx,
+        ui64 blockIdx,
+        ui64 iteration,
+        IService& service);
+    void DoZeroRequest(ui16 rangeIdx, ui64 blockIdx, IService& service);
     void DoReadRequest(ui16 rangeIdx, IService& service);
 
     void OnResponse(
@@ -198,8 +211,17 @@ void TAlignedTestScenario::DoRequest(
 
     if (RandomNumber(100u) >= writeRate) {
         DoReadRequest(rangeIdx, service);
+        return;
+    }
+
+    auto& range = Ranges[rangeIdx];
+    auto [blockIdx, iteration] = range.NextWrite();
+    const ui32 zeroRate = ConfigHolder->GetConfig().GetZeroRate();
+
+    if (IsZeroRequest(iteration, zeroRate)) {
+        DoZeroRequest(rangeIdx, blockIdx, service);
     } else {
-        DoWriteRequest(rangeIdx, service);
+        DoWriteRequest(rangeIdx, blockIdx, iteration, service);
     }
 }
 
@@ -209,7 +231,7 @@ void TAlignedTestScenario::OnResponse(
     TStringBuf reqType,
     IService& service)
 {
-    if (reqType == "write") {
+    if (reqType == "write" || reqType == "zero") {
         const i64 maxRequestCount =
             ConfigHolder->GetConfig().GetMaxWriteRequestCount();
         if (maxRequestCount &&
@@ -237,11 +259,13 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
     std::tie(blockIdx, expected) = range.RandomRead();
 
     ui64 blockSize = ConfigHolder->GetConfig().GetBlockSize();
+    const ui32 zeroRate = ConfigHolder->GetConfig().GetZeroRate();
 
     const auto startTs = Now();
 
     auto readHandler =
-        [this, startTs, blockIdx, rangeIdx, expected, &service]() mutable
+        [this, startTs, blockIdx, rangeIdx, expected, zeroRate, &service]()
+            mutable
     {
         OnResponse(startTs, rangeIdx, "read", service);
 
@@ -250,6 +274,23 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
         }
 
         auto& range = Ranges[rangeIdx];
+
+        if (IsZeroRequest(*expected, zeroRate)) {
+            const char* data = range.Data();
+            for (ui64 i = 0; i < range.DataSize(); ++i) {
+                if (data[i] != 0) {
+                    service.Fail(
+                        TStringBuilder()
+                        << LogTag << "[" << rangeIdx
+                        << "] Wrong data in block " << blockIdx
+                        << " expected zeros after Zero request number "
+                        << expected << " but found non-zero byte at offset "
+                        << i);
+                    return;
+                }
+            }
+            return;
+        }
 
         ui64 partSize = range.DataSize() / range.Config.GetWriteParts();
         for (ui64 part = 0; part < range.Config.GetWriteParts(); ++part) {
@@ -276,12 +317,15 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
         readHandler);
 }
 
-void TAlignedTestScenario::DoWriteRequest(ui16 rangeIdx, IService& service)
+void TAlignedTestScenario::DoWriteRequest(
+    ui16 rangeIdx,
+    ui64 blockIdx,
+    ui64 iteration,
+    IService& service)
 {
     auto& range = Ranges[rangeIdx];
 
     const auto startTs = Now();
-    auto [blockIdx, iteration] = range.NextWrite();
     TBlockData blockData{
         .RequestNumber = iteration,
         .BlockIndex = blockIdx,
@@ -306,6 +350,22 @@ void TAlignedTestScenario::DoWriteRequest(ui16 rangeIdx, IService& service)
             [this, startTs, rangeIdx, &service]() mutable
             { OnResponse(startTs, rangeIdx, "write", service); });
     }
+}
+
+void TAlignedTestScenario::DoZeroRequest(
+    ui16 rangeIdx,
+    ui64 blockIdx,
+    IService& service)
+{
+    auto& range = Ranges[rangeIdx];
+    ui64 blockSize = ConfigHolder->GetConfig().GetBlockSize();
+
+    const auto startTs = Now();
+    service.Zero(
+        range.DataSize(),
+        blockIdx * blockSize,
+        [this, startTs, rangeIdx, &service]() mutable
+        { OnResponse(startTs, rangeIdx, "zero", service); });
 }
 
 }   // namespace

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/ya.make
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     config.cpp
+    device_discard.cpp
     test_executor.cpp
     test_scenarios/aligned_test_scenario.cpp
     test_scenarios/simple_test_scenario.cpp


### PR DESCRIPTION
### Notes

Add the ability to run discard requests alongside read/write requests in eternal tests.

This works only for the aligned test scenario.

### Issue
#4823
