### PR TITLE
Add option for discard requests in eternal tests

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/main.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/main.cpp
@@ -18,6 +18,11 @@ int main(int argc, char** argv)
         Cerr << CurrentExceptionMessage() << Endl;
         return 1;
     }
-    return AppMain(options);
-}
 
+    try {
+        return AppMain(options);
+    } catch (...) {
+        Cerr << CurrentExceptionMessage() << Endl;
+        return 1;
+    }
+}

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
@@ -208,6 +208,13 @@ void TOptions::Parse(int argc, char** argv)
         .StoreResult(&WriteRate)
         .DefaultValue(0);
 
+    opts.AddLongOption(
+        "zero-rate",
+        "percentage of zero (discard) requests; only supported for aligned scenario; only supproted for block devices; moreover, the block device must actually zero-fill the range on discard request")
+        .RequiredArgument("NUM")
+        .StoreResult(&ZeroRate)
+        .DefaultValue(0);
+
     opts.AddLongOption("write-parts", "number of parts to split one write")
         .RequiredArgument("NUM")
         .StoreResult(&WriteParts)

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
@@ -209,8 +209,13 @@ void TOptions::Parse(int argc, char** argv)
         .DefaultValue(0);
 
     opts.AddLongOption(
-        "zero-rate",
-        "percentage of zero (discard) requests; only supported for aligned scenario; only supproted for block devices; moreover, the block device must actually zero-fill the range on discard request")
+            "zero-rate",
+            "percentage of zero (discard) requests;\n"
+            "only supported for sync engine;\n"
+            "only supported for aligned scenario;\n"
+            "only supported for block devices (not supported for regular\n"
+            "files); moreover, the block device must actually zero-fill the \n"
+            "range on discard requests")
         .RequiredArgument("NUM")
         .StoreResult(&ZeroRate)
         .DefaultValue(0);

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.h
@@ -55,6 +55,7 @@ struct TOptions
 
     ui64 BlockSize;
     ui16 WriteRate;
+    ui16 ZeroRate;
     ui64 RequestBlockCount;
     ui16 IoDepth;
     ui64 WriteParts;

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -123,6 +123,10 @@ int TTest::Run()
         Options->Scenario == EScenario::Aligned ||
             ConfigHolder->GetConfig().GetZeroRate() == 0,
         "zero-rate is only supported for aligned scenario");
+    Y_ENSURE(
+        Options->Engine == EIoEngine::Sync ||
+            ConfigHolder->GetConfig().GetZeroRate() == 0,
+        "zero-rate is only supported for sync engine");
 
     return RunTest();
 }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -79,7 +79,6 @@ int TTest::Run()
         case ECommand::GenerateConfigCmd:
             Y_ENSURE(Options->FilePath.Defined(), "You need to specify the file path");
             Y_ENSURE(Options->FileSize.Defined(), "You need to specify the file size");
-            Y_ENSURE(Options->WriteRate <= 100, "Write rate should be in range [0, 100]");
 
             ConfigHolder = CreateTestConfig(
                 TCreateTestConfigArguments{
@@ -89,6 +88,7 @@ int TTest::Run()
                     .IoDepth = Options->IoDepth,
                     .BlockSize = Options->BlockSize,
                     .WriteRate = Options->WriteRate,
+                    .ZeroRate = Options->ZeroRate,
                     .RequestBlockCount = Options->RequestBlockCount,
                     .WriteParts = Options->WriteParts,
                     .AlternatingPhase = Options->AlternatingPhase,
@@ -113,6 +113,16 @@ int TTest::Run()
             STORAGE_ERROR("Unknown command, check avaliable commands in the help");
             return 2;
     }
+
+    Y_ENSURE(
+        ConfigHolder->GetConfig().GetWriteRate() +
+                ConfigHolder->GetConfig().GetZeroRate() <=
+            100,
+        "Sum of WriteRate and ZeroRate should be in range [0, 100]");
+    Y_ENSURE(
+        Options->Scenario == EScenario::Aligned ||
+            ConfigHolder->GetConfig().GetZeroRate() == 0,
+        "zero-rate is only supported for aligned scenario");
 
     return RunTest();
 }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -127,6 +127,10 @@ int TTest::Run()
         Options->Engine == EIoEngine::Sync ||
             ConfigHolder->GetConfig().GetZeroRate() == 0,
         "zero-rate is only supported for sync engine");
+    Y_ENSURE(
+        !ConfigHolder->GetConfig().HasAlternatingPhase() ||
+            ConfigHolder->GetConfig().GetZeroRate() == 0,
+        "zero-rate is not supported for tests with alternating phase");
 
     return RunTest();
 }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
@@ -18,9 +18,12 @@ _BINARY_PATH = 'cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/et
 _MULTIPLE_FILES_TIMEOUT_ENV = 'ETERNAL_LOAD_MULTIPLE_FILES_TIMEOUT'
 _MULTIPLE_FILES_TEST_COUNT_ENV = 'ETERNAL_LOAD_MULTIPLE_FILES_TEST_COUNT'
 
-_SCENARIOS = [
+_ALIGNED_SCENARIOS = [
     ("aligned", "asyncio", True),
     ("aligned", "sync", False),
+]
+
+_SCENARIOS = _ALIGNED_SCENARIOS + [
     ("unaligned", "sync", False)
 ]
 
@@ -29,8 +32,23 @@ _SIMPLE_SCENARIOS = [
     ("random", "sync", False),
 ]
 
+_NON_ALIGNED_SCENARIOS = [
+    ("unaligned", "sync", False),
+    ("sequential", "sync", False),
+    ("random", "sync", False),
+]
 
-def __run_load_test(file_name, scenario="aligned", engine="asyncio", direct=True, timeout=None, test_count=0):
+
+def __run_load_test(
+    file_name,
+    scenario="aligned",
+    engine="asyncio",
+    direct=True,
+    timeout=None,
+    test_count=0,
+    write_rate=70,
+    zero_rate=0,
+):
     eternal_load = yatest_common.binary_path(_BINARY_PATH)
 
     params = [
@@ -43,7 +61,8 @@ def __run_load_test(file_name, scenario="aligned", engine="asyncio", direct=True
         '--file', file_name,
         '--filesize', str(_FILE_SIZE),
         '--iodepth', str(_IO_DEPTH),
-        '--write-rate', '70',
+        '--write-rate', str(write_rate),
+        '--zero-rate', str(zero_rate),
         '--debug',
         '--test-count', str(test_count)
     ]
@@ -86,6 +105,40 @@ def test_load_works(scenario, engine, direct):
         pass
     else:
         pytest.fail(f"Eternal load should not have finished within {timeout} seconds")
+
+
+@pytest.mark.parametrize("scenario,engine,direct", _ALIGNED_SCENARIOS)
+def test_aligned_with_zero_rate(scenario, engine, direct):
+    # Zero/discard requires a block device; on a regular file the aligned
+    # scenario must accept zero-rate and fail when issuing Zero.
+    tmp_file = tempfile.NamedTemporaryFile(suffix=".test")
+    result = __run_load_test(
+        tmp_file.name,
+        scenario=scenario,
+        engine=engine,
+        direct=direct,
+        timeout=30,
+        write_rate=50,
+        zero_rate=20,
+    )
+    assert result.returncode != 0
+    assert "only supported for block devices" in result.stderr
+
+
+@pytest.mark.parametrize("scenario,engine,direct", _NON_ALIGNED_SCENARIOS)
+def test_zero_rate_rejected_for_non_aligned(scenario, engine, direct):
+    tmp_file = tempfile.NamedTemporaryFile(suffix=".test")
+    result = __run_load_test(
+        tmp_file.name,
+        scenario=scenario,
+        engine=engine,
+        direct=direct,
+        timeout=10,
+        write_rate=50,
+        zero_rate=20,
+    )
+    assert result.returncode != 0
+    assert "zero-rate is only supported for aligned scenario" in result.stderr
 
 
 def test_multiple_files():

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests/test.py
@@ -23,6 +23,10 @@ _ALIGNED_SCENARIOS = [
     ("aligned", "sync", False),
 ]
 
+_ALIGNED_ZERO_SCENARIOS = [
+    ("aligned", "sync", False),
+]
+
 _SCENARIOS = _ALIGNED_SCENARIOS + [
     ("unaligned", "sync", False)
 ]
@@ -36,6 +40,11 @@ _NON_ALIGNED_SCENARIOS = [
     ("unaligned", "sync", False),
     ("sequential", "sync", False),
     ("random", "sync", False),
+]
+
+_NON_SYNC_ENGINES = [
+    ("aligned", "asyncio", True),
+    ("aligned", "uring", True),
 ]
 
 
@@ -107,7 +116,7 @@ def test_load_works(scenario, engine, direct):
         pytest.fail(f"Eternal load should not have finished within {timeout} seconds")
 
 
-@pytest.mark.parametrize("scenario,engine,direct", _ALIGNED_SCENARIOS)
+@pytest.mark.parametrize("scenario,engine,direct", _ALIGNED_ZERO_SCENARIOS)
 def test_aligned_with_zero_rate(scenario, engine, direct):
     # Zero/discard requires a block device; on a regular file the aligned
     # scenario must accept zero-rate and fail when issuing Zero.
@@ -139,6 +148,22 @@ def test_zero_rate_rejected_for_non_aligned(scenario, engine, direct):
     )
     assert result.returncode != 0
     assert "zero-rate is only supported for aligned scenario" in result.stderr
+
+
+@pytest.mark.parametrize("scenario,engine,direct", _NON_SYNC_ENGINES)
+def test_zero_rate_rejected_for_non_sync_engine(scenario, engine, direct):
+    tmp_file = tempfile.NamedTemporaryFile(suffix=".test")
+    result = __run_load_test(
+        tmp_file.name,
+        scenario=scenario,
+        engine=engine,
+        direct=direct,
+        timeout=10,
+        write_rate=50,
+        zero_rate=20,
+    )
+    assert result.returncode != 0
+    assert "zero-rate is only supported for sync engine" in result.stderr
 
 
 def test_multiple_files():

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests_in_qemu/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests_in_qemu/test.py
@@ -140,7 +140,7 @@ def test_aligned_with_zero_rate(loop_device):
         result = __run_load_test(
             loop_device,
             scenario="aligned",
-            engine="asyncio",
+            engine="sync",
             direct=True,
             timeout=timeout,
             write_rate=50,

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests_in_qemu/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/tests_in_qemu/test.py
@@ -11,6 +11,12 @@ _BLOCKSIZE = 4096  # KB
 _REQUEST_BLOCK_COUNT = 3
 _BINARY_PATH = "cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/eternal-load"
 
+_NON_ALIGNED_SCENARIOS = [
+    ("unaligned", "sync", False),
+    ("sequential", "sync", False),
+    ("random", "sync", False),
+]
+
 
 def __run_load_test(
     file_name,
@@ -19,6 +25,8 @@ def __run_load_test(
     direct=True,
     timeout=60,
     test_count=0,
+    write_rate=70,
+    zero_rate=0,
 ):
     eternal_load = yatest_common.binary_path(_BINARY_PATH)
 
@@ -32,7 +40,8 @@ def __run_load_test(
         "--file", str(file_name),
         "--filesize", str(_FILE_SIZE),
         "--iodepth", str(_IO_DEPTH),
-        "--write-rate", "70",
+        "--write-rate", str(write_rate),
+        "--zero-rate", str(zero_rate),
         "--debug",
         "--test-count", str(test_count),
     ]
@@ -96,6 +105,7 @@ def test_load_async_io_fails(very_small_ext4):
         engine="asyncio",
         direct=True,
         timeout=60,
+        zero_rate=0,
     )
 
     assert result.returncode == 1
@@ -105,3 +115,39 @@ def test_load_async_io_fails(very_small_ext4):
         "(No space left on device) async IO operation failed"
     )
     assert msg in result.stderr
+
+
+@pytest.fixture(name="loop_device")
+def create_loop_device(tmp_path):
+    image_path = tmp_path / "disk.img"
+    with open(image_path, "wb") as image:
+        image.truncate(_FILE_SIZE * 1024 ** 3)
+
+    device = subprocess.check_output(
+        ["sudo", "losetup", "-f", "--show", str(image_path)],
+        text=True,
+    ).strip()
+
+    try:
+        yield device
+    finally:
+        subprocess.run(["sudo", "losetup", "-d", device], check=False)
+
+
+def test_aligned_with_zero_rate(loop_device):
+    timeout = 30
+    try:
+        result = __run_load_test(
+            loop_device,
+            scenario="aligned",
+            engine="asyncio",
+            direct=True,
+            timeout=timeout,
+            write_rate=50,
+            zero_rate=20,
+        )
+        assert result.returncode == 0
+    except subprocess.TimeoutExpired:
+        pass
+    else:
+        pytest.fail(f"Eternal load should not have finished within {timeout} seconds")

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.cpp
@@ -67,6 +67,7 @@ TConfigHolder::TConfigHolder(const TCreateTestConfigArguments& args)
     Config.SetTestCount(args.TestCount);
     Config.SetBlockSize(args.BlockSize);
     Config.SetWriteRate(args.WriteRate);
+    Config.SetZeroRate(args.ZeroRate);
     Config.SetIoDepth(args.IoDepth);
 
     auto& ranges = *Config.MutableRanges();

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h
@@ -32,6 +32,7 @@ struct TCreateTestConfigArguments
     ui16 IoDepth = 0;
     ui64 BlockSize = 0;
     ui16 WriteRate = 0;
+    ui16 ZeroRate = 0;
     ui64 RequestBlockCount = 0;
     ui64 WriteParts = 0;
     TString AlternatingPhase = "";

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
@@ -44,4 +44,6 @@ message TTestConfig {
   // Used in TUnalignedTestScenario
   optional TUnalignedTestConfig UnalignedTest = 12;
   optional uint32 TestCount = 13;
+  // Percentage of Zero (discard) requests among all requests.
+  optional uint32 ZeroRate = 14 [default = 0];
 }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config_ut.cpp
@@ -155,6 +155,7 @@ Y_UNIT_TEST_SUITE(ConfigTest)
         "BlockSize":4096,
         "FilePath":"/dev/vdb",
         "WriteRate":50,
+        "ZeroRate":10,
         "RangeBlockCount":218453,
         "TestId":13930160852258120406
         }
@@ -176,6 +177,7 @@ Y_UNIT_TEST_SUITE(ConfigTest)
         UNIT_ASSERT_EQUAL(config.GetTestCount(), 13);
         UNIT_ASSERT_EQUAL(config.GetBlockSize(), 4096);
         UNIT_ASSERT_EQUAL(config.GetWriteRate(), 50);
+        UNIT_ASSERT_EQUAL(config.GetZeroRate(), 10);
         UNIT_ASSERT_EQUAL(config.GetRangeBlockCount(), 218453);
         UNIT_ASSERT_EQUAL(config.GetAlternatingPhase(), "");
         UNIT_ASSERT_EQUAL(config.GetTestId(), 13930160852258120406ull);
@@ -205,6 +207,7 @@ Y_UNIT_TEST_SUITE(ConfigTest)
              .IoDepth = 12,
              .BlockSize = 4096,
              .WriteRate = 50,
+             .ZeroRate = 10,
              .RequestBlockCount = 1,
              .WriteParts = 1,
              .AlternatingPhase = "",

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.cpp
@@ -6,19 +6,16 @@
 #include <cstring>
 
 #if defined(_linux_)
-#   include <linux/fs.h>
-#   include <sys/ioctl.h>
-#   include <sys/stat.h>
+#include <linux/fs.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
 #endif
 
 namespace NCloud::NBlockStore::NTesting {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NProto::TError DiscardDeviceRange(
-    TFileHandle& file,
-    ui64 offset,
-    ui64 length)
+NProto::TError DiscardDeviceRange(TFileHandle& file, ui64 offset, ui64 length)
 {
 #if defined(_linux_)
     struct stat st;

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.cpp
@@ -1,0 +1,59 @@
+#include "device_discard.h"
+
+#include <util/string/builder.h>
+
+#include <cerrno>
+#include <cstring>
+
+#if defined(_linux_)
+#   include <linux/fs.h>
+#   include <sys/ioctl.h>
+#   include <sys/stat.h>
+#endif
+
+namespace NCloud::NBlockStore::NTesting {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError DiscardDeviceRange(
+    TFileHandle& file,
+    ui64 offset,
+    ui64 length)
+{
+#if defined(_linux_)
+    struct stat st;
+    if (fstat(FHANDLE(file), &st) != 0) {
+        const int err = errno;
+        char buf[1024]{};
+        return MakeError(
+            E_IO,
+            TStringBuilder() << "fstat failed: " << err << " "
+                             << ::strerror_r(err, buf, sizeof(buf)));
+    }
+
+    if (!S_ISBLK(st.st_mode)) {
+        return MakeError(
+            E_ARGUMENT,
+            "Discard/Zero is only supported for block devices");
+    }
+
+    ui64 range[2] = {offset, length};
+    if (ioctl(FHANDLE(file), BLKDISCARD, range) == 0) {
+        return {};
+    }
+
+    const int err = errno;
+    char buf[1024]{};
+    return MakeError(
+        E_IO,
+        TStringBuilder() << "BLKDISCARD failed: " << err << " "
+                         << ::strerror_r(err, buf, sizeof(buf)));
+#else
+    Y_UNUSED(file);
+    Y_UNUSED(offset);
+    Y_UNUSED(length);
+    return MakeError(E_NOT_IMPLEMENTED, "Discard/Zero is not supported");
+#endif
+}
+
+}   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.h
@@ -1,11 +1,71 @@
 #pragma once
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/file_io_service.h>
 
 #include <util/system/file.h>
 #include <util/system/types.h>
 
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
 namespace NCloud::NBlockStore::NTesting {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IDiscardService
+{
+    virtual ~IDiscardService() = default;
+
+    virtual void AsyncZero(
+        TFileHandle& file,
+        i64 offset,
+        ui32 count,
+        TFileIOCompletion* completion) = 0;
+
+    template <typename F>
+        requires std::is_invocable_v<F, NProto::TError, ui32>
+    void AsyncZero(
+        TFileHandle& file,
+        i64 offset,
+        ui32 count,
+        F&& callback)
+    {
+        auto cb = std::make_unique<TCallbackCompletion<std::decay_t<F>>>(
+            std::forward<F>(callback));
+
+        AsyncZero(file, offset, count, cb.get());
+
+        Y_UNUSED(cb.release());  // ownership transferred
+    }
+
+private:
+    template <typename F>
+    struct TCallbackCompletion
+        : TFileIOCompletion
+    {
+        F Func;
+
+        template <typename T>
+        explicit TCallbackCompletion(T&& func)
+            : TFileIOCompletion{.Func = &TCallbackCompletion::Complete}
+            , Func{std::forward<T>(func)}
+        {}
+
+        static void Complete(
+            TFileIOCompletion* self,
+            const NProto::TError& error,
+            ui32 bytes)
+        {
+            std::unique_ptr<TCallbackCompletion> ptr{
+                static_cast<TCallbackCompletion*>(self)};
+
+            std::invoke(std::move(ptr->Func), error, bytes);
+        }
+    };
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/system/file.h>
+#include <util/system/types.h>
+
+namespace NCloud::NBlockStore::NTesting {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Issues BLKDISCARD for [offset, offset + length) on a block device.
+// Returns an error if the file handle is not a block device or discard fails.
+NProto::TError DiscardDeviceRange(
+    TFileHandle& file,
+    ui64 offset,
+    ui64 length);
+
+}   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/device_discard.h
@@ -27,24 +27,21 @@ struct IDiscardService
 
     template <typename F>
         requires std::is_invocable_v<F, NProto::TError, ui32>
-    void AsyncZero(
-        TFileHandle& file,
-        i64 offset,
-        ui32 count,
-        F&& callback)
+    void AsyncZero(TFileHandle& file, i64 offset, ui32 count, F&& callback)
     {
         auto cb = std::make_unique<TCallbackCompletion<std::decay_t<F>>>(
             std::forward<F>(callback));
 
         AsyncZero(file, offset, count, cb.get());
 
-        Y_UNUSED(cb.release());  // ownership transferred
+        Y_UNUSED(cb.release());   // ownership transferred
     }
 
 private:
+    // TODO: deduplicate with TFileIOCompletion in file_io_service.h:
+    // https://github.com/ydb-platform/nbs/blob/main/cloud/storage/core/libs/common/file_io_service.h
     template <typename F>
-    struct TCallbackCompletion
-        : TFileIOCompletion
+    struct TCallbackCompletion: TFileIOCompletion
     {
         F Func;
 
@@ -71,9 +68,6 @@ private:
 
 // Issues BLKDISCARD for [offset, offset + length) on a block device.
 // Returns an error if the file handle is not a block device or discard fails.
-NProto::TError DiscardDeviceRange(
-    TFileHandle& file,
-    ui64 offset,
-    ui64 length);
+NProto::TError DiscardDeviceRange(TFileHandle& file, ui64 offset, ui64 length);
 
 }   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -1,5 +1,7 @@
 #include "test_executor.h"
 
+#include "device_discard.h"
+
 #include <cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h>
 
 #include <cloud/storage/core/libs/common/file_io_service.h>
@@ -52,8 +54,10 @@ private:
 
     std::atomic_uint64_t BytesRead = 0;
     std::atomic_uint64_t BytesWritten = 0;
+    std::atomic_uint64_t BytesZeroed = 0;
     ui64 PreviousBytesRead = 0;
     ui64 PreviousBytesWritten = 0;
+    ui64 PreviousBytesZeroed = 0;
     TInstant PreviousStatsTimestamp;
 
     const TLog Log;
@@ -104,6 +108,11 @@ private:
 
     void Write(
         const void* buffer,
+        ui32 count,
+        ui64 offset,
+        TCallback callback) override;
+
+    void Zero(
         ui32 count,
         ui64 offset,
         TCallback callback) override;
@@ -226,18 +235,22 @@ void TTestExecutor::PrintStats()
     auto now = Now();
     auto currentBytesRead = BytesRead.load();
     auto currentBytesWritten = BytesWritten.load();
+    auto currentBytesZeroed = BytesZeroed.load();
 
     auto elapsedSeconds = (now - PreviousStatsTimestamp).SecondsFloat();
     auto bytesRead = currentBytesRead - PreviousBytesRead;
     auto bytesWritten = currentBytesWritten - PreviousBytesWritten;
+    auto bytesZeroed = currentBytesZeroed - PreviousBytesZeroed;
 
     STORAGE_DEBUG(
         "Read: " << bytesRead / elapsedSeconds / 1_MB << " MiB/s, "
-        "Write: " << bytesWritten / elapsedSeconds / 1_MB << " MiB/s");
+        "Write: " << bytesWritten / elapsedSeconds / 1_MB << " MiB/s, "
+        "Zero: " << bytesZeroed / elapsedSeconds / 1_MB << " MiB/s");
 
     PreviousStatsTimestamp = now;
     PreviousBytesRead = currentBytesRead;
     PreviousBytesWritten = currentBytesWritten;
+    PreviousBytesZeroed = currentBytesZeroed;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -380,6 +393,26 @@ void TTestExecutor::TWorkerService::Write(
                 Run();
             }
         });
+}
+
+void TTestExecutor::TWorkerService::Zero(
+    ui32 count,
+    ui64 offset,
+    TCallback callback)
+{
+    RequestCount++;
+    PendingRequestCount++;
+
+    auto error = DiscardDeviceRange(Scenario.File, offset, count);
+    if (HasError(error)) {
+        Executor.Fail("Can't zero device range: " + error.GetMessage());
+    } else {
+        Executor.BytesZeroed += count;
+        callback();
+    }
+    if (HandleRequest()) {
+        Run();
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -43,7 +43,7 @@ private:
 
     const TInstant TestStartTimestamp;
     TVector<std::unique_ptr<TTestScenario>> TestScenarios;
-    IFileIOServicePtr FileService;
+    ITestFileIOServicePtr FileService;
 
     std::atomic_bool ShouldStop = false;
     std::atomic_bool Failed = false;
@@ -67,7 +67,7 @@ private:
     static constexpr TDuration PrintStatsInterval = TDuration::Seconds(5);
 
 public:
-    TTestExecutor(TTestExecutorSettings settings, IFileIOServicePtr service);
+    TTestExecutor(TTestExecutorSettings settings, ITestFileIOServicePtr service);
     bool Run() override;
     void Stop() override;
     void Fail(const TString& message);
@@ -135,7 +135,7 @@ EOpenMode GetFileOpenMode(bool noDirect)
 
 TTestExecutor::TTestExecutor(
         TTestExecutorSettings settings,
-        IFileIOServicePtr service)
+        ITestFileIOServicePtr service)
     : TestStartTimestamp(Now())
     , FileService(std::move(service))
     , PreviousStatsTimestamp(TestStartTimestamp)
@@ -403,22 +403,35 @@ void TTestExecutor::TWorkerService::Zero(
     RequestCount++;
     PendingRequestCount++;
 
-    auto error = DiscardDeviceRange(Scenario.File, offset, count);
-    if (HasError(error)) {
-        Executor.Fail("Can't zero device range: " + error.GetMessage());
-    } else {
-        Executor.BytesZeroed += count;
-        callback();
-    }
-    if (HandleRequest()) {
-        Run();
-    }
+    Executor.FileService->AsyncZero(
+        Scenario.File,
+        static_cast<i64>(offset),
+        count,
+        [this, count, callback = std::move(callback)](
+            const NProto::TError& error,
+            ui32 value)
+        {
+            if (HasError(error)) {
+                Executor.Fail(
+                    "Can't zero device range: " + error.GetMessage());
+            } else if (value < count) {
+                Executor.Fail(
+                    TStringBuilder() << "Zeroed less than expected: " << value
+                                     << " < " << count);
+            } else {
+                Executor.BytesZeroed += count;
+                callback();
+            }
+            if (HandleRequest()) {
+                Run();
+            }
+        });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 class TAsyncIoFileService
-    : public IFileIOService
+    : public ITestFileIOService
     , private NAsyncIO::TAsyncIOService
 {
 public:
@@ -498,6 +511,19 @@ public:
         Y_ABORT("Not used");
     }
 
+    void AsyncZero(
+        TFileHandle& file,
+        i64 offset,
+        ui32 count,
+        TFileIOCompletion* completion) override
+    {
+        Y_UNUSED(file);
+        Y_UNUSED(offset);
+        Y_UNUSED(count);
+        Y_UNUSED(completion);
+        Y_ABORT("Not supported");
+    }
+
     static void RunCompletion(
         const NThreading::TFuture<ui32>& future,
         TFileIOCompletion* completion)
@@ -516,7 +542,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TThreadPoolFileService: public IFileIOService
+class TThreadPoolFileService: public ITestFileIOService
 {
 private:
     TThreadPool ThreadPool;
@@ -607,6 +633,29 @@ public:
         Y_ABORT("Not supported");
     }
 
+    void AsyncZero(
+        TFileHandle& file,
+        i64 offset,
+        ui32 count,
+        TFileIOCompletion* completion) override
+    {
+        auto added = ThreadPool.AddFunc(
+            [&file, offset, count, completion]()
+            {
+                auto error = DiscardDeviceRange(
+                    file,
+                    static_cast<ui64>(offset),
+                    count);
+                if (HasError(error)) {
+                    completion->Func(completion, error, 0);
+                } else {
+                    completion->Func(completion, {}, count);
+                }
+            });
+
+        Y_ABORT_UNLESS(added, "Cannot add function to a thread pool");
+    }
+
     static void RunCompletion(i32 value, TFileIOCompletion* completion)
     {
         if (value >= 0) {
@@ -619,7 +668,81 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IFileIOServicePtr CreateUringFileService()
+class TIoUringTestFileService: public ITestFileIOService
+{
+private:
+    IFileIOServicePtr Impl;
+
+public:
+    explicit TIoUringTestFileService(IFileIOServicePtr impl)
+        : Impl(std::move(impl))
+    {}
+
+    void Start() override
+    {
+        Impl->Start();
+    }
+
+    void Stop() override
+    {
+        Impl->Stop();
+    }
+
+    void AsyncRead(
+        TFileHandle& file,
+        i64 offset,
+        TArrayRef<char> buffer,
+        TFileIOCompletion* completion) override
+    {
+        Impl->AsyncRead(file, offset, buffer, completion);
+    }
+
+    void AsyncReadV(
+        TFileHandle& file,
+        i64 offset,
+        const TVector<TArrayRef<char>>& buffers,
+        TFileIOCompletion* completion) override
+    {
+        Impl->AsyncReadV(file, offset, buffers, completion);
+    }
+
+    void AsyncWrite(
+        TFileHandle& file,
+        i64 offset,
+        TArrayRef<const char> buffer,
+        TFileIOCompletion* completion,
+        ui32 flags) override
+    {
+        Impl->AsyncWrite(file, offset, buffer, completion, flags);
+    }
+
+    void AsyncWriteV(
+        TFileHandle& file,
+        i64 offset,
+        const TVector<TArrayRef<const char>>& buffers,
+        TFileIOCompletion* completion,
+        ui32 flags) override
+    {
+        Impl->AsyncWriteV(file, offset, buffers, completion, flags);
+    }
+
+    void AsyncZero(
+        TFileHandle& file,
+        i64 offset,
+        ui32 count,
+        TFileIOCompletion* completion) override
+    {
+        Y_UNUSED(file);
+        Y_UNUSED(offset);
+        Y_UNUSED(count);
+        Y_UNUSED(completion);
+        Y_ABORT("Not supported");
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITestFileIOServicePtr CreateUringFileService()
 {
     auto factory = CreateIoUringServiceFactory({
         .SubmissionQueueEntries = 1024,
@@ -629,10 +752,11 @@ IFileIOServicePtr CreateUringFileService()
         .SQKernelPollingEnabled = true,
     });
 
-    return factory->CreateFileIOService();
+    return std::make_shared<TIoUringTestFileService>(
+        factory->CreateFileIOService());
 }
 
-IFileIOServicePtr CreateFileService(
+ITestFileIOServicePtr CreateFileService(
     ETestExecutorFileService fileService,
     ui32 threadCount)
 {

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.cpp
@@ -412,8 +412,7 @@ void TTestExecutor::TWorkerService::Zero(
             ui32 value)
         {
             if (HasError(error)) {
-                Executor.Fail(
-                    "Can't zero device range: " + error.GetMessage());
+                Executor.Fail("Can't zero device range: " + error.GetMessage());
             } else if (value < count) {
                 Executor.Fail(
                     TStringBuilder() << "Zeroed less than expected: " << value
@@ -642,10 +641,8 @@ public:
         auto added = ThreadPool.AddFunc(
             [&file, offset, count, completion]()
             {
-                auto error = DiscardDeviceRange(
-                    file,
-                    static_cast<ui64>(offset),
-                    count);
+                auto error =
+                    DiscardDeviceRange(file, static_cast<ui64>(offset), count);
                 if (HasError(error)) {
                     completion->Func(completion, error, 0);
                 } else {

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
@@ -65,6 +65,14 @@ struct ITestExecutorIOService
         ui64 offset,
         TCallback callback) = 0;
 
+    // Initiates a discard operation and calls the callback when the operation
+    // is completed successfully. Note that discard is called synchronously.
+    // If it fails, the test is stopped and the error is reported.
+    virtual void Zero(
+        ui32 count,
+        ui64 offset,
+        TCallback callback) = 0;
+
     // Gracefully stop the scenario
     virtual void Stop() = 0;
 
@@ -75,7 +83,7 @@ struct ITestExecutorIOService
 ////////////////////////////////////////////////////////////////////////////////
 
 // Workers are run concurrently - Run method and callbacks passed to
-// ITestExecutorIOService::Read and Write can be called from any thread.
+// ITestExecutorIOService::Read, Write and Zero can be called from any thread.
 struct ITestScenarioWorker
 {
     virtual ~ITestScenarioWorker() = default;

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_executor.h
@@ -2,6 +2,10 @@
 
 #include "public.h"
 
+#include "device_discard.h"
+
+#include <cloud/storage/core/libs/common/file_io_service.h>
+
 #include <library/cpp/logger/log.h>
 
 #include <util/generic/string.h>
@@ -41,6 +45,16 @@ using ITestExecutorPtr = std::shared_ptr<ITestExecutor>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct ITestFileIOService
+    : public IFileIOService
+    , public IDiscardService
+{
+};
+
+using ITestFileIOServicePtr = std::shared_ptr<ITestFileIOService>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct ITestExecutorIOService
 {
     using TCallback = std::function<void()>;
@@ -65,8 +79,8 @@ struct ITestExecutorIOService
         ui64 offset,
         TCallback callback) = 0;
 
-    // Initiates a discard operation and calls the callback when the operation
-    // is completed successfully. Note that discard is called synchronously.
+    // Initiates an asynchronous zero (discard) operation and calls the
+    // callback when the operation is completed successfully.
     // If it fails, the test is stopped and the error is reported.
     virtual void Zero(
         ui32 count,

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
@@ -8,6 +8,8 @@
 
 #include <library/cpp/digest/crc32c/crc32c.h>
 
+#include <util/digest/numeric.h>
+#include <util/generic/utility.h>
 #include <util/random/random.h>
 #include <util/string/builder.h>
 #include <util/system/info.h>
@@ -38,6 +40,16 @@ ui64 CalculateInverse(ui64 step, ui64 len)
     auto [x, _] = ExtendedEuclideanAlgorithm(step, len);
     x = (x + len) % len;
     return x;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool IsZeroRequest(ui64 requestNumber, ui32 writeRate, ui32 zeroRate)
+{
+    if (zeroRate == 0) {
+        return false;
+    }
+    return IntHash(requestNumber) % (writeRate + zeroRate) < zeroRate;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -141,7 +153,12 @@ private:
     void
     DoRequest(ui16 rangeIdx, double secondsSinceTestStart, IService& service);
 
-    void DoWriteRequest(ui16 rangeIdx, IService& service);
+    void DoWriteRequest(
+        ui16 rangeIdx,
+        ui64 blockIdx,
+        ui64 iteration,
+        IService& service);
+    void DoZeroRequest(ui16 rangeIdx, ui64 blockIdx, IService& service);
     void DoReadRequest(ui16 rangeIdx, IService& service);
 
     void OnResponse(
@@ -195,11 +212,22 @@ void TAlignedTestScenario::DoRequest(
     IService& service)
 {
     const auto writeRate = GetWriteProbabilityPercent(secondsSinceTestStart);
+    const ui32 zeroRate = ConfigHolder->GetConfig().GetZeroRate();
+    const ui32 mutateRate = Min(100u, writeRate + zeroRate);
 
-    if (RandomNumber(100u) >= writeRate) {
+    if (RandomNumber(100u) >= mutateRate) {
         DoReadRequest(rangeIdx, service);
+        return;
+    }
+
+    auto& range = Ranges[rangeIdx];
+    auto [blockIdx, iteration] = range.NextWrite();
+
+    const ui32 configuredWriteRate = ConfigHolder->GetConfig().GetWriteRate();
+    if (IsZeroRequest(iteration, configuredWriteRate, zeroRate)) {
+        DoZeroRequest(rangeIdx, blockIdx, service);
     } else {
-        DoWriteRequest(rangeIdx, service);
+        DoWriteRequest(rangeIdx, blockIdx, iteration, service);
     }
 }
 
@@ -209,7 +237,7 @@ void TAlignedTestScenario::OnResponse(
     TStringBuf reqType,
     IService& service)
 {
-    if (reqType == "write") {
+    if (reqType == "write" || reqType == "zero") {
         const i64 maxRequestCount =
             ConfigHolder->GetConfig().GetMaxWriteRequestCount();
         if (maxRequestCount &&
@@ -237,11 +265,14 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
     std::tie(blockIdx, expected) = range.RandomRead();
 
     ui64 blockSize = ConfigHolder->GetConfig().GetBlockSize();
+    const ui32 writeRate = ConfigHolder->GetConfig().GetWriteRate();
+    const ui32 zeroRate = ConfigHolder->GetConfig().GetZeroRate();
 
     const auto startTs = Now();
 
     auto readHandler =
-        [this, startTs, blockIdx, rangeIdx, expected, &service]() mutable
+        [this, startTs, blockIdx, rangeIdx, expected, writeRate, zeroRate, &service]()
+            mutable
     {
         OnResponse(startTs, rangeIdx, "read", service);
 
@@ -250,6 +281,23 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
         }
 
         auto& range = Ranges[rangeIdx];
+
+        if (IsZeroRequest(*expected, writeRate, zeroRate)) {
+            const char* data = range.Data();
+            for (ui64 i = 0; i < range.DataSize(); ++i) {
+                if (data[i] != 0) {
+                    service.Fail(
+                        TStringBuilder()
+                        << LogTag << "[" << rangeIdx
+                        << "] Wrong data in block " << blockIdx
+                        << " expected zeros after Zero request number "
+                        << expected << " but found non-zero byte at offset "
+                        << i);
+                    return;
+                }
+            }
+            return;
+        }
 
         ui64 partSize = range.DataSize() / range.Config.GetWriteParts();
         for (ui64 part = 0; part < range.Config.GetWriteParts(); ++part) {
@@ -276,12 +324,15 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
         readHandler);
 }
 
-void TAlignedTestScenario::DoWriteRequest(ui16 rangeIdx, IService& service)
+void TAlignedTestScenario::DoWriteRequest(
+    ui16 rangeIdx,
+    ui64 blockIdx,
+    ui64 iteration,
+    IService& service)
 {
     auto& range = Ranges[rangeIdx];
 
     const auto startTs = Now();
-    auto [blockIdx, iteration] = range.NextWrite();
     TBlockData blockData{
         .RequestNumber = iteration,
         .BlockIndex = blockIdx,
@@ -306,6 +357,25 @@ void TAlignedTestScenario::DoWriteRequest(ui16 rangeIdx, IService& service)
             [this, startTs, rangeIdx, &service]() mutable
             { OnResponse(startTs, rangeIdx, "write", service); });
     }
+}
+
+// The underlying block device must actually zero-fill the range on discard
+// request. Otherwise the test will fail during data validation on read
+// requests.
+void TAlignedTestScenario::DoZeroRequest(
+    ui16 rangeIdx,
+    ui64 blockIdx,
+    IService& service)
+{
+    auto& range = Ranges[rangeIdx];
+    ui64 blockSize = ConfigHolder->GetConfig().GetBlockSize();
+
+    const auto startTs = Now();
+    service.Zero(
+        range.DataSize(),
+        blockIdx * blockSize,
+        [this, startTs, rangeIdx, &service]() mutable
+        { OnResponse(startTs, rangeIdx, "zero", service); });
 }
 
 }   // namespace

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
@@ -288,8 +288,8 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
                 if (data[i] != 0) {
                     service.Fail(
                         TStringBuilder()
-                        << LogTag << "[" << rangeIdx
-                        << "] Wrong data in block " << blockIdx
+                        << LogTag << "[" << rangeIdx << "] Wrong data in block "
+                        << blockIdx
                         << " expected zeros after Zero request number "
                         << expected << " but found non-zero byte at offset "
                         << i);
@@ -359,9 +359,6 @@ void TAlignedTestScenario::DoWriteRequest(
     }
 }
 
-// The underlying block device must actually zero-fill the range on discard
-// request. Otherwise the test will fail during data validation on read
-// requests.
 void TAlignedTestScenario::DoZeroRequest(
     ui16 rangeIdx,
     ui64 blockIdx,

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.cpp
@@ -36,6 +36,10 @@ TTestScenarioBase::TTestScenarioBase(
     auto& config = ConfigHolder->GetConfig();
 
     if (config.HasAlternatingPhase()) {
+        Y_ENSURE(
+            config.GetZeroRate() == 0,
+            "Alternating phase is not supported for tests with discard requests"
+            " (zero-rate is " << config.GetZeroRate() << ")");
         PhaseDuration =
             TDuration::Parse(config.GetAlternatingPhase()).SecondsFloat();
     }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.cpp
@@ -36,10 +36,6 @@ TTestScenarioBase::TTestScenarioBase(
     auto& config = ConfigHolder->GetConfig();
 
     if (config.HasAlternatingPhase()) {
-        Y_ENSURE(
-            config.GetZeroRate() == 0,
-            "Alternating phase is not supported for tests with discard requests"
-            " (zero-rate is " << config.GetZeroRate() << ")");
         PhaseDuration =
             TDuration::Parse(config.GetAlternatingPhase()).SecondsFloat();
     }

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/ya.make
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     config.cpp
+    device_discard.cpp
     test_executor.cpp
     test_scenarios/aligned_test_scenario.cpp
     test_scenarios/simple_test_scenario.cpp

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/configs/config.json
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/configs/config.json
@@ -2,6 +2,7 @@
   "IoDepth":$ioDepth,
   "FileSize":$fileSize,
   "WriteRate":$writeRate,
+  "ZeroRate":$zeroRate,
   "BlockSize":$blockSize,
   "FilePath":"$filePath",
   "Ranges":

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/main.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/main.py
@@ -38,6 +38,7 @@ def get_generate_load_command(load_config: LoadConfig) -> str:
         io_depth=load_config.io_depth,
         write_rate=load_config.write_rate,
         write_parts=load_config.write_parts,
+        zero_rate=load_config.zero_rate,
     )
 
 
@@ -46,6 +47,7 @@ def render_load_config(load_config: LoadConfig):
         ioDepth=load_config.io_depth,
         fileSize=load_config.size * 1024**3,
         writeRate=load_config.write_rate,
+        zeroRate=load_config.zero_rate,
         blockSize=load_config.bs,
         filePath=load_config.test_file,
     )
@@ -79,6 +81,7 @@ class EternalTestHelper:
                        '--dump-config-path {dump_config_path} '
                        '--write-rate {write_rate} '
                        '--write-parts {write_parts} '
+                       '--zero-rate {zero_rate} '
                        '>> {log_path} 2>&1')
 
     _START_LOAD_WITH_CONFIG_CMD = ('/usr/bin/eternal-load --config-type file '

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/main.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/main.py
@@ -25,6 +25,7 @@ def get_restore_load_command(load_config: LoadConfig) -> str:
         file=load_config.test_file,
         config_path=load_config.config_path,
         log_path=load_config.log_path,
+        engine=load_config.engine,
     )
 
 
@@ -39,6 +40,7 @@ def get_generate_load_command(load_config: LoadConfig) -> str:
         write_rate=load_config.write_rate,
         write_parts=load_config.write_parts,
         zero_rate=load_config.zero_rate,
+        engine=load_config.engine,
     )
 
 
@@ -82,12 +84,14 @@ class EternalTestHelper:
                        '--write-rate {write_rate} '
                        '--write-parts {write_parts} '
                        '--zero-rate {zero_rate} '
+                       '--engine {engine} '
                        '>> {log_path} 2>&1')
 
     _START_LOAD_WITH_CONFIG_CMD = ('/usr/bin/eternal-load --config-type file '
                                    '--restore-config-path {config_path} '
                                    '--file {file} '
                                    '--dump-config-path {config_path}  '
+                                   '--engine {engine} '
                                    '>> {log_path} 2>&1')
 
     _FIO_CMD_TO_FILL_DISK = ('fio --name fill-secondary-disk --filename {filename} --rw write --bs 4M --iodepth 128'

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/test_configs.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/test_configs.py
@@ -93,6 +93,7 @@ class LoadConfig(ITestCreateConfig):
     zero_rate: int
     write_parts: int
     run_in_systemd: bool
+    engine: str
     test_file: str
     config_dir: str
     config_name: str
@@ -108,7 +109,8 @@ class LoadConfig(ITestCreateConfig):
             bs,
             write_parts=1,
             run_in_systemd=False,
-            zero_rate=0):
+            zero_rate=0,
+            engine='asyncio'):
         self.use_requests_with_different_sizes = use_requests_with_different_sizes
         self.need_filling = need_filling
         self.io_depth = io_depth
@@ -118,6 +120,7 @@ class LoadConfig(ITestCreateConfig):
         self.bs = bs
         self.write_parts = write_parts
         self.run_in_systemd = run_in_systemd
+        self.engine = engine
         self.test_file = None
         self.config_dir = self.DEFAULT_CONFIG_DIR
         self.config_name = self.DEFAULT_CONFIG_NAME
@@ -331,12 +334,14 @@ _FS_CONFIGS = {
 _LOAD_CONFIGS = {
     'eternal-640gb-verify-checkpoint': LoadConfig(False, True, 32, 50, 640, 4096),
     'eternal-320gb': LoadConfig(False, True, 32, 50, 320, 4096),
-    'eternal-320gb-with-zero': LoadConfig(False, True, 32, 50, 320, 4096, zero_rate=10),
+    'eternal-320gb-with-zero': LoadConfig(
+        False, True, 32, 50, 320, 4096, zero_rate=10, engine='sync'),
     'eternal-4tb': LoadConfig(False, True, 32, 50, 4096, 4096),
     'eternal-4tb-one-partition': LoadConfig(False, True, 32, 50, 4096, 4096),
     'eternal-320gb-mirror-3of4-no-throttling': LoadConfig(False, True, 32, 50, 320, 4096),
     'eternal-1024gb-hdd-no-throttling': LoadConfig(False, True, 8, 50, 1024, 4096),
-    'eternal-1024gb-hdd-no-throttling-with-zero': LoadConfig(False, True, 8, 50, 1024, 4096, zero_rate=10),
+    'eternal-1024gb-hdd-no-throttling-with-zero': LoadConfig(
+        False, True, 8, 50, 1024, 4096, zero_rate=10, engine='sync'),
     'eternal-1024gb-mirror-3of4-hdd-no-throttling': LoadConfig(False, True, 8, 50, 1024, 4096),
     'eternal-1023gb-nonrepl': LoadConfig(False, False, 32, 50, 1023, 4096),
     'eternal-1023gb-nonrepl-vhost': LoadConfig(False, False, 32, 50, 1023, 4096),
@@ -353,9 +358,10 @@ _LOAD_CONFIGS = {
 
     'eternal-512gb-different-size-requests': LoadConfig(True, True, 32, 50, 512, 4096),
     'eternal-512gb-different-size-requests-with-zero': LoadConfig(
-        True, True, 32, 50, 512, 4096, zero_rate=10),
+        True, True, 32, 50, 512, 4096, zero_rate=10, engine='sync'),
     'eternal-1tb-different-size-requests': LoadConfig(True, True, 32, 50, 1024, 4096),
-    'eternal-1tb-different-size-requests-with-zero': LoadConfig(True, True, 32, 50, 1024, 4096, zero_rate=10),
+    'eternal-1tb-different-size-requests-with-zero': LoadConfig(
+        True, True, 32, 50, 1024, 4096, zero_rate=10, engine='sync'),
 
     'eternal-320gb-overlay': LoadConfig(True, False, 32, 25, 320, 4096),
 

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/test_configs.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/test_configs.py
@@ -173,6 +173,7 @@ _DISK_CONFIGS = {
     'eternal-320gb-mirror-3of4-no-throttling':
         DiskCreateConfig(320, 4096, 'network-ssd'),
     'eternal-1024gb-hdd-no-throttling': DiskCreateConfig(1024, 4096, 'network-hdd'),
+    'eternal-1024gb-hdd-no-throttling-with-zero': DiskCreateConfig(1024, 4096, 'network-hdd'),
     'eternal-1024gb-mirror-3of4-hdd-no-throttling':
         DiskCreateConfig(1024, 4096, 'network-hdd'),
     'eternal-1023gb-nonrepl':
@@ -242,6 +243,7 @@ _DISK_CONFIGS = {
     'eternal-512gb-different-size-requests': DiskCreateConfig(512, 4096, 'network-ssd'),
     'eternal-512gb-different-size-requests-with-zero': DiskCreateConfig(512, 4096, 'network-ssd'),
     'eternal-1tb-different-size-requests': DiskCreateConfig(1024, 4096, 'network-ssd'),
+    'eternal-1tb-different-size-requests-with-zero': DiskCreateConfig(1024, 4096, 'network-ssd'),
 
     'eternal-1tb-mysql': DiskCreateConfig(1024, 4096, 'network-ssd'),
     'eternal-1tb-postgresql': DiskCreateConfig(1024, 4096, 'network-ssd'),
@@ -334,6 +336,7 @@ _LOAD_CONFIGS = {
     'eternal-4tb-one-partition': LoadConfig(False, True, 32, 50, 4096, 4096),
     'eternal-320gb-mirror-3of4-no-throttling': LoadConfig(False, True, 32, 50, 320, 4096),
     'eternal-1024gb-hdd-no-throttling': LoadConfig(False, True, 8, 50, 1024, 4096),
+    'eternal-1024gb-hdd-no-throttling-with-zero': LoadConfig(False, True, 8, 50, 1024, 4096, zero_rate=10),
     'eternal-1024gb-mirror-3of4-hdd-no-throttling': LoadConfig(False, True, 8, 50, 1024, 4096),
     'eternal-1023gb-nonrepl': LoadConfig(False, False, 32, 50, 1023, 4096),
     'eternal-1023gb-nonrepl-vhost': LoadConfig(False, False, 32, 50, 1023, 4096),
@@ -352,6 +355,7 @@ _LOAD_CONFIGS = {
     'eternal-512gb-different-size-requests-with-zero': LoadConfig(
         True, True, 32, 50, 512, 4096, zero_rate=10),
     'eternal-1tb-different-size-requests': LoadConfig(True, True, 32, 50, 1024, 4096),
+    'eternal-1tb-different-size-requests-with-zero': LoadConfig(True, True, 32, 50, 1024, 4096, zero_rate=10),
 
     'eternal-320gb-overlay': LoadConfig(True, False, 32, 25, 320, 4096),
 

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/test_configs.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/lib/test_configs.py
@@ -90,6 +90,7 @@ class LoadConfig(ITestCreateConfig):
     need_filling: bool
     io_depth: int
     write_rate: int
+    zero_rate: int
     write_parts: int
     run_in_systemd: bool
     test_file: str
@@ -106,11 +107,13 @@ class LoadConfig(ITestCreateConfig):
             size,
             bs,
             write_parts=1,
-            run_in_systemd=False):
+            run_in_systemd=False,
+            zero_rate=0):
         self.use_requests_with_different_sizes = use_requests_with_different_sizes
         self.need_filling = need_filling
         self.io_depth = io_depth
         self.write_rate = write_rate
+        self.zero_rate = zero_rate
         self.size = size
         self.bs = bs
         self.write_parts = write_parts
@@ -164,6 +167,7 @@ class FioSequentialConfig:
 _DISK_CONFIGS = {
     'eternal-640gb-verify-checkpoint': DiskCreateConfig(640, 4096, 'network-ssd'),
     'eternal-320gb': DiskCreateConfig(320, 4096, 'network-ssd'),
+    'eternal-320gb-with-zero': DiskCreateConfig(320, 4096, 'network-ssd'),
     'eternal-4tb': DiskCreateConfig(4096, 4096, 'network-ssd'),
     'eternal-4tb-one-partition': DiskCreateConfig(4096, 4096, 'network-ssd', initial_size=1),
     'eternal-320gb-mirror-3of4-no-throttling':
@@ -236,6 +240,7 @@ _DISK_CONFIGS = {
             type='network-ssd-io-m3'),
 
     'eternal-512gb-different-size-requests': DiskCreateConfig(512, 4096, 'network-ssd'),
+    'eternal-512gb-different-size-requests-with-zero': DiskCreateConfig(512, 4096, 'network-ssd'),
     'eternal-1tb-different-size-requests': DiskCreateConfig(1024, 4096, 'network-ssd'),
 
     'eternal-1tb-mysql': DiskCreateConfig(1024, 4096, 'network-ssd'),
@@ -324,6 +329,7 @@ _FS_CONFIGS = {
 _LOAD_CONFIGS = {
     'eternal-640gb-verify-checkpoint': LoadConfig(False, True, 32, 50, 640, 4096),
     'eternal-320gb': LoadConfig(False, True, 32, 50, 320, 4096),
+    'eternal-320gb-with-zero': LoadConfig(False, True, 32, 50, 320, 4096, zero_rate=10),
     'eternal-4tb': LoadConfig(False, True, 32, 50, 4096, 4096),
     'eternal-4tb-one-partition': LoadConfig(False, True, 32, 50, 4096, 4096),
     'eternal-320gb-mirror-3of4-no-throttling': LoadConfig(False, True, 32, 50, 320, 4096),
@@ -343,6 +349,8 @@ _LOAD_CONFIGS = {
     'eternal-1023gb-mirror3-rdma': LoadConfig(False, False, 32, 50, 1023, 4096),
 
     'eternal-512gb-different-size-requests': LoadConfig(True, True, 32, 50, 512, 4096),
+    'eternal-512gb-different-size-requests-with-zero': LoadConfig(
+        True, True, 32, 50, 512, 4096, zero_rate=10),
     'eternal-1tb-different-size-requests': LoadConfig(True, True, 32, 50, 1024, 4096),
 
     'eternal-320gb-overlay': LoadConfig(True, False, 32, 25, 320, 4096),

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/result.json
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/result.json
@@ -17,6 +17,9 @@
     "test.test_eternal_load_test[add-auto-run-eternal-4tb-cluster1]": {
         "uri": "file://test.test_eternal_load_test_add-auto-run-eternal-4tb-cluster1_/testing_out_stuff_results.txt"
     },
+    "test.test_eternal_load_test[add-auto-run-eternal-512gb-different-size-requests-with-zero-cluster1]": {
+        "uri": "file://test.test_eternal_load_test_add-auto-run-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt"
+    },
     "test.test_eternal_load_test[add-auto-run-eternal-640gb-verify-checkpoint-cluster1]": {
         "uri": "file://test.test_eternal_load_test_add-auto-run-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt"
     },
@@ -31,6 +34,9 @@
     },
     "test.test_eternal_load_test[continue-load-eternal-4tb-cluster1]": {
         "uri": "file://test.test_eternal_load_test_continue-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt"
+    },
+    "test.test_eternal_load_test[continue-load-eternal-512gb-different-size-requests-with-zero-cluster1]": {
+        "uri": "file://test.test_eternal_load_test_continue-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt"
     },
     "test.test_eternal_load_test[continue-load-eternal-640gb-verify-checkpoint-cluster1]": {
         "uri": "file://test.test_eternal_load_test_continue-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt"
@@ -47,6 +53,9 @@
     "test.test_eternal_load_test[delete-test-eternal-4tb-cluster1]": {
         "uri": "file://test.test_eternal_load_test_delete-test-eternal-4tb-cluster1_/testing_out_stuff_results.txt"
     },
+    "test.test_eternal_load_test[delete-test-eternal-512gb-different-size-requests-with-zero-cluster1]": {
+        "uri": "file://test.test_eternal_load_test_delete-test-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt"
+    },
     "test.test_eternal_load_test[delete-test-eternal-640gb-verify-checkpoint-cluster1]": {
         "uri": "file://test.test_eternal_load_test_delete-test-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt"
     },
@@ -61,6 +70,9 @@
     },
     "test.test_eternal_load_test[rerun-load-eternal-4tb-cluster1]": {
         "uri": "file://test.test_eternal_load_test_rerun-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt"
+    },
+    "test.test_eternal_load_test[rerun-load-eternal-512gb-different-size-requests-with-zero-cluster1]": {
+        "uri": "file://test.test_eternal_load_test_rerun-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt"
     },
     "test.test_eternal_load_test[rerun-load-eternal-640gb-verify-checkpoint-cluster1]": {
         "uri": "file://test.test_eternal_load_test_rerun-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt"
@@ -77,6 +89,9 @@
     "test.test_eternal_load_test[setup-test-eternal-4tb-cluster1]": {
         "uri": "file://test.test_eternal_load_test_setup-test-eternal-4tb-cluster1_/testing_out_stuff_results.txt"
     },
+    "test.test_eternal_load_test[setup-test-eternal-512gb-different-size-requests-with-zero-cluster1]": {
+        "uri": "file://test.test_eternal_load_test_setup-test-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt"
+    },
     "test.test_eternal_load_test[setup-test-eternal-640gb-verify-checkpoint-cluster1]": {
         "uri": "file://test.test_eternal_load_test_setup-test-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt"
     },
@@ -91,6 +106,9 @@
     },
     "test.test_eternal_load_test[stop-load-eternal-4tb-cluster1]": {
         "uri": "file://test.test_eternal_load_test_stop-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt"
+    },
+    "test.test_eternal_load_test[stop-load-eternal-512gb-different-size-requests-with-zero-cluster1]": {
+        "uri": "file://test.test_eternal_load_test_stop-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt"
     },
     "test.test_eternal_load_test[stop-load-eternal-640gb-verify-checkpoint-cluster1]": {
         "uri": "file://test.test_eternal_load_test_stop-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt"

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
@@ -1,3 +1,3 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
-SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1") | crontab -
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
@@ -1,3 +1,3 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
-SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1") | crontab -
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-4tb-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-4tb-cluster1_/testing_out_stuff_results.txt
@@ -1,3 +1,3 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
-SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1") | crontab -
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-4tb-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-4tb-cluster1_/testing_out_stuff_results.txt
@@ -1,3 +1,3 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
-SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1") | crontab -
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -1,3 +1,3 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
-SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1") | crontab -
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine sync >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -1,0 +1,3 @@
+Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
@@ -1,3 +1,3 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
-SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1") | crontab -
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
@@ -1,3 +1,3 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
-SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1") | crontab -
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-big-hdd-nonrepl-diff-size-reqs-1-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_add-auto-run-eternal-big-hdd-nonrepl-diff-size-reqs-1-cluster1_/testing_out_stuff_results.txt
@@ -1,3 +1,3 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
-SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1") | crontab -
+SSH 1:1:1:1:1:1:1:1: (crontab -l 2>/dev/null; echo "@reboot /usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1") | crontab -

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_case_all_ok_rerun-load-all-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_case_all_ok_rerun-load-all-cluster1_/testing_out_stuff_results.txt
@@ -1,34 +1,41 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 10 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
@@ -39,21 +46,21 @@ SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
 SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
 SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
@@ -68,66 +75,37 @@ SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
 SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/disk/by-id/virtio-nvme-disk-0 --filesize 186 --iodepth 128 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/disk/by-id/virtio-nvme-disk-0 --filesize 186 --iodepth 128 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
 SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/disk/by-id/virtio-nvme-disk-0 --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/disk/by-id/virtio-nvme-disk-0 --filesize 366 --iodepth 128 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/disk/by-id/virtio-nvme-disk-0 --filesize 366 --iodepth 128 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
 SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/disk/by-id/virtio-nvme-disk-0 --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 Execute command nohup sh -c "rm /root/load-config.json" &>/dev/null &Execute command nohup sh -c "systemctl start eternalload_vdb.service" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 32768 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 32768 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 32768 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 32768 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 100 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 100 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
@@ -136,8 +114,27 @@ SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command no
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
@@ -161,16 +158,26 @@ SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command no
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 1 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /test/test.txt --filesize 256 --iodepth 1 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 1 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /test/test.txt --filesize 256 --iodepth 1 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_case_all_ok_rerun-load-all-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_case_all_ok_rerun-load-all-cluster1_/testing_out_stuff_results.txt
@@ -22,6 +22,9 @@ SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 10 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
@@ -57,6 +60,10 @@ Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blo
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_case_all_ok_rerun-load-all-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_case_all_ok_rerun-load-all-cluster1_/testing_out_stuff_results.txt
@@ -1,190 +1,190 @@
 Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 10 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 10 --engine sync >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 10 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 10 --engine sync >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1024 --iodepth 8 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine sync >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine sync >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/disk/by-id/virtio-nvme-disk-0 --filesize 186 --iodepth 128 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
-SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/disk/by-id/virtio-nvme-disk-0 --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/disk/by-id/virtio-nvme-disk-0 --filesize 366 --iodepth 128 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/disk/by-id/virtio-nvme-disk-0 --filesize 186 --iodepth 128 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id nbs.tests.folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/disk/by-id/virtio-nvme-disk-0 --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/disk/by-id/virtio-nvme-disk-0 --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/disk/by-id/virtio-nvme-disk-0 --filesize 366 --iodepth 128 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*virtio-nvme-disk-0"
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/disk/by-id/virtio-nvme-disk-0 --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 Execute command nohup sh -c "rm /root/load-config.json" &>/dev/null &Execute command nohup sh -c "systemctl start eternalload_vdb.service" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 32768 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 32768 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 32768 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 32768 --file /dev/vdb --filesize 320 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 100 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
-Input=
-SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
-SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 100 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 512 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 25 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /test/test.txt --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 1 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 1048576 --file /test/test.txt --filesize 256 --iodepth 1 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
 Input=
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
 SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /test/test.txt --filesize 256 --iodepth 1 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /test/test.txt --filesize 256 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*test.txt"
+SSH 1:1:1:1:1:1:1:1: mkdir -p /test && { sudo umount /test || true; } && mount -t virtiofs nfs /test && touch /test/test.txt
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /test/test.txt --filesize 256 --iodepth 1 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine sync >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -1,0 +1,5 @@
+Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
+SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-big-hdd-nonrepl-diff-size-reqs-1-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_continue-load-eternal-big-hdd-nonrepl-diff-size-reqs-1-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_delete-test-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_delete-test-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -1,0 +1,4 @@
+Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+Command=ycp --format json --profile cluster1 compute instance delete --request -
+Input=

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-4tb-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -3,4 +3,4 @@ Input=
 SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine sync >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -1,0 +1,6 @@
+Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
@@ -2,4 +2,4 @@ Command=ycp --format json --profile cluster1 compute instance list --folder-id f
 Input=
 SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-big-hdd-nonrepl-diff-size-reqs-1-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_rerun-load-eternal-big-hdd-nonrepl-diff-size-reqs-1-cluster1_/testing_out_stuff_results.txt
@@ -3,4 +3,4 @@ Input=
 SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
 SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
@@ -19,4 +19,4 @@ Command=ycp --format json --profile cluster1 compute instance attach-disk --requ
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-1023gb-nonrepl-cluster1_/testing_out_stuff_results.txt
@@ -19,4 +19,4 @@ Command=ycp --format json --profile cluster1 compute instance attach-disk --requ
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "/usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 1023 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-4tb-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-4tb-cluster1_/testing_out_stuff_results.txt
@@ -15,4 +15,4 @@ Command=ycp --format json --profile cluster1 compute instance attach-disk --requ
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -15,4 +15,5 @@ Command=ycp --format json --profile cluster1 compute instance attach-disk --requ
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 4096 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -16,4 +16,4 @@ Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine sync >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
@@ -15,4 +15,4 @@ Command=ycp --format json --profile cluster1 compute instance attach-disk --requ
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-640gb-verify-checkpoint-cluster1_/testing_out_stuff_results.txt
@@ -15,4 +15,4 @@ Command=ycp --format json --profile cluster1 compute instance attach-disk --requ
 Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
-Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+Execute command nohup sh -c "fio --name fill-secondary-disk --filename /dev/vdb --rw write --bs 4M --iodepth 128 --direct 1 --sync 1 --ioengine libaio --size 100%  >> /tmp/eternal-load.log 2>&1 && /usr/bin/eternal-load --config-type generated --blocksize 4096 --file /dev/vdb --filesize 640 --iodepth 32 --dump-config-path /tmp/load-config.json --write-rate 50 --write-parts 1 --zero-rate 0 >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-big-hdd-nonrepl-diff-size-reqs-1-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_setup-test-eternal-big-hdd-nonrepl-diff-size-reqs-1-cluster1_/testing_out_stuff_results.txt
@@ -20,4 +20,4 @@ Input=
 SFTP PUT 1:1:1:1:1:1:1:1/../eternal-load/bin/eternal-load -> /usr/bin/eternal-load
 SFTP CHMOD 1:1:1:1:1:1:1:1//usr/bin/eternal-load f=493
 SFTP FILE 1:1:1:1:1:1:1:1//tmp/load-config.json f=w
-SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  >> /tmp/eternal-load.log 2>&1" &>/dev/null &
+SFTP WRITE FILE 1:1:1:1:1:1:1:1SFTP FLUSH FILE 1:1:1:1:1:1:1:1Execute command nohup sh -c "/usr/bin/eternal-load --config-type file --restore-config-path /tmp/load-config.json --file /dev/vdb --dump-config-path /tmp/load-config.json  --engine asyncio >> /tmp/eternal-load.log 2>&1" &>/dev/null &

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_stop-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/canondata/test.test_eternal_load_test_stop-load-eternal-512gb-different-size-requests-with-zero-cluster1_/testing_out_stuff_results.txt
@@ -1,0 +1,4 @@
+Command=ycp --format json --profile cluster1 compute instance list --folder-id fake-folder
+Input=
+SSH 1:1:1:1:1:1:1:1: pkill -f "^/usr/bin/eternal-load.*vdb"
+SSH 1:1:1:1:1:1:1:1: pgrep -f "^/usr/bin/eternal-load.*vdb"

--- a/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/test.py
+++ b/cloud/blockstore/tools/testing/eternal_tests/test_runner/tests/test.py
@@ -44,7 +44,8 @@ def run_test(cluster, test_case, command, expected_result):
     'eternal-relocation-network-ssd',
     'eternal-1023gb-nonrepl',
     'eternal-big-hdd-nonrepl-diff-size-reqs-1',
-    'eternal-640gb-verify-checkpoint'])
+    'eternal-640gb-verify-checkpoint',
+    'eternal-512gb-different-size-requests-with-zero'])
 @pytest.mark.parametrize('command', [
     'setup-test',
     'stop-load',


### PR DESCRIPTION
### Notes

Add the ability to run discard requests alongside read/write requests in eternal tests.

The new functionality has the following restrictions:
1. Discards are allowed only for the `aligned` test scenario.
2. Discards are allowed only for `sync` engine, but not for `asyncio` and `uring`.

### Issue
[#4823](https://github.com/ydb-platform/nbs/issues/4823)
