### PR TITLE
[NBS] cancel stuck follower requests during shutdown, add UTs

### DIFF
--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
@@ -101,7 +101,8 @@ void TFollowerDiskActor::OnBootstrap(const NActors::TActorContext& ctx)
         ctx,
         LogTitle,
         LeaderBlockSize,
-        FollowerDiskInfo.Link.FollowerDiskId);
+        FollowerDiskInfo.Link.FollowerDiskId,
+        GetConfig()->GetDestroyVolumeTimeout());
 
     InitWork(
         ctx,

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
@@ -13,6 +13,8 @@
 #include <contrib/ydb/library/actors/core/hfunc.h>
 #include <contrib/ydb/library/actors/core/log.h>
 
+#include <util/generic/vector.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -22,10 +24,12 @@ using namespace NActors;
 TVolumeAsPartitionActor::TVolumeAsPartitionActor(
         TChildLogTitle logTitle,
         ui32 originalBlockSize,
-        TString diskId)
+        TString diskId,
+        TDuration shutdownTimeout)
     : LogTitle(std::move(logTitle))
     , OriginalBlockSize(originalBlockSize)
     , DiskId(std::move(diskId))
+    , ShutdownTimeout(shutdownTimeout)
 {}
 
 TVolumeAsPartitionActor::~TVolumeAsPartitionActor() = default;
@@ -55,7 +59,8 @@ template <typename TEvent>
 void TVolumeAsPartitionActor::ForwardRequestToFollower(
     const TEvent& ev,
     const TActorContext& ctx,
-    EReplyType replyType)
+    EReplyType replyType,
+    ERequestType requestType)
 {
     auto* msg = ev->Get();
     msg->Record.MutableHeaders()->SetExactDiskIdMatch(true);
@@ -65,7 +70,8 @@ void TVolumeAsPartitionActor::ForwardRequestToFollower(
         TRequestCtx{
             .OriginalSender = ev->Sender,
             .OriginalCookie = ev->Cookie,
-            .ReplyType = replyType});
+            .ReplyType = replyType,
+            .RequestType = requestType});
 
     NActors::TActorId nondeliveryActor = SelfId();
     auto message = std::make_unique<NActors::IEventHandle>(
@@ -300,7 +306,7 @@ void TVolumeAsPartitionActor::DoWriteBlocks(
     msg->Record.SetDiskId(DiskId);
     msg->Record.MutableHeaders()->SetClientId(TString(CopyVolumeClientId));
 
-    ForwardRequestToFollower(ev, ctx, replyType);
+    ForwardRequestToFollower(ev, ctx, replyType, ERequestType::WriteBlocks);
 }
 
 void TVolumeAsPartitionActor::ReplyAndDie(const NActors::TActorContext& ctx)
@@ -502,7 +508,11 @@ void TVolumeAsPartitionActor::HandleZeroBlocks(
     msg->Record.SetDiskId(DiskId);
     msg->Record.MutableHeaders()->SetClientId(TString(CopyVolumeClientId));
 
-    ForwardRequestToFollower(ev, ctx, EReplyType::Ordinary);
+    ForwardRequestToFollower(
+        ev,
+        ctx,
+        EReplyType::Ordinary,
+        ERequestType::ZeroBlocks);
 }
 
 void TVolumeAsPartitionActor::HandlePoisonPill(
@@ -517,9 +527,84 @@ void TVolumeAsPartitionActor::HandlePoisonPill(
         MakeIntrusive<TCallContext>());
 
     if (!RequestsInProgress.Empty()) {
+        ctx.Schedule(ShutdownTimeout, new TEvents::TEvWakeup());
         return;
     }
 
+    ReplyAndDie(ctx);
+}
+
+void TVolumeAsPartitionActor::CancelRequests(const TActorContext& ctx)
+{
+    TVector<ui64> requestIds;
+    requestIds.reserve(RequestsInProgress.GetRequestCount());
+    RequestsInProgress.EnumerateRequests(
+        [&](ui64 requestId,
+            bool write,
+            TBlockRange64 range,
+            const TRequestCtx& requestCtx)
+        {
+            Y_UNUSED(write);
+            Y_UNUSED(range);
+            Y_UNUSED(requestCtx);
+            requestIds.push_back(requestId);
+        });
+
+    for (const ui64 requestId: requestIds) {
+        auto request = RequestsInProgress.ExtractRequest(requestId);
+        Y_DEBUG_ABORT_UNLESS(request);
+        if (!request) {
+            continue;
+        }
+
+        const auto& requestCtx = request->Value;
+        auto error = MakeError(
+            E_CANCELLED,
+            "Follower request timed out during shutdown");
+
+        if (requestCtx.RequestType == ERequestType::ZeroBlocks) {
+            ctx.Send(
+                requestCtx.OriginalSender,
+                std::make_unique<TEvService::TEvZeroBlocksResponse>(
+                    std::move(error)),
+                0,   // flags
+                requestCtx.OriginalCookie);
+        } else if (requestCtx.ReplyType == EReplyType::Local) {
+            ctx.Send(
+                requestCtx.OriginalSender,
+                std::make_unique<TEvService::TEvWriteBlocksLocalResponse>(
+                    std::move(error)),
+                0,   // flags
+                requestCtx.OriginalCookie);
+        } else {
+            ctx.Send(
+                requestCtx.OriginalSender,
+                std::make_unique<TEvService::TEvWriteBlocksResponse>(
+                    std::move(error)),
+                0,   // flags
+                requestCtx.OriginalCookie);
+        }
+    }
+}
+
+void TVolumeAsPartitionActor::HandleShutdownTimeout(
+    const TEvents::TEvWakeup::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    if (State != EState::Zombie || !Poisoner) {
+        return;
+    }
+
+    LOG_WARN(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Cancelling %lu follower requests during shutdown",
+        LogTitle.GetWithTime().c_str(),
+        RequestsInProgress.GetRequestCount());
+
+    CancelRequests(ctx);
     ReplyAndDie(ctx);
 }
 
@@ -545,6 +630,7 @@ STFUNC(TVolumeAsPartitionActor::StateWork)
             ForwardResponse<TEvService::TZeroBlocksMethod>);
 
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(TEvents::TEvWakeup, HandleShutdownTimeout);
 
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.h
@@ -12,6 +12,8 @@
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
+#include <util/datetime/base.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -36,17 +38,25 @@ public:
         Local,
     };
 
+    enum class ERequestType
+    {
+        WriteBlocks,
+        ZeroBlocks,
+    };
+
 private:
     struct TRequestCtx
     {
         const NActors::TActorId OriginalSender;
         const ui64 OriginalCookie = 0;
         const EReplyType ReplyType = EReplyType::Ordinary;
+        const ERequestType RequestType = ERequestType::WriteBlocks;
     };
 
     const TChildLogTitle LogTitle;
     const ui32 OriginalBlockSize;
     const TString DiskId;
+    const TDuration ShutdownTimeout;
 
     EState State = EState::Describing;
     ui64 BlockCount = 0;
@@ -62,7 +72,8 @@ public:
     TVolumeAsPartitionActor(
         TChildLogTitle logTitle,
         ui32 originalBlockSize,
-        TString diskId);
+        TString diskId,
+        TDuration shutdownTimeout);
 
     ~TVolumeAsPartitionActor() override;
 
@@ -75,7 +86,8 @@ private:
     void ForwardRequestToFollower(
         const TEvent& ev,
         const NActors::TActorContext& ctx,
-        EReplyType replyType);
+        EReplyType replyType,
+        ERequestType requestType);
 
     template <typename TMethod>
     void ForwardResponse(
@@ -102,6 +114,7 @@ private:
         EReplyType replyType);
 
     void ReplyAndDie(const NActors::TActorContext& ctx);
+    void CancelRequests(const NActors::TActorContext& ctx);
 
     void HandleDescribeVolumeResponse(
         const TEvSSProxy::TEvDescribeVolumeResponse::TPtr& ev,
@@ -119,6 +132,9 @@ private:
 
     void HandlePoisonPill(
         const NActors::TEvents::TEvPoisonPill::TPtr& ev,
+        const NActors::TActorContext& ctx);
+    void HandleShutdownTimeout(
+        const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);
 
 private:

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor_ut.cpp
@@ -149,7 +149,8 @@ Y_UNIT_TEST_SUITE(TVolumeAsPartitionActorTests)
                 ActorSystem.Register(new TVolumeAsPartitionActor{
                     LogTitle.GetChild(GetCycleCount()),
                     LeaderBlockSize,
-                    FollowerDiskId});
+                    FollowerDiskId,
+                    TDuration::Seconds(30)});
         }
 
         template <typename TEvent>

--- a/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
@@ -1971,6 +1971,216 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             }
         }
     }
+
+    Y_UNIT_TEST_F(
+        ShouldCompleteGracefulShutdownDuringFollowerMigration,
+        TFixture)
+    {
+        TActorId latestSourcePartitionActor;
+        TActorId migrationSourcePartitionActor;
+        TActorId followerDiskActor;
+        TActorId followerPartitionActor;
+
+        auto prevRegistrationObserver =
+            Runtime->SetRegistrationObserverFunc({});
+        Runtime->SetRegistrationObserverFunc(
+            [&](TTestActorRuntimeBase& runtime,
+                const TActorId& parentId,
+                const TActorId& actorId)
+            {
+                if (prevRegistrationObserver) {
+                    prevRegistrationObserver(runtime, parentId, actorId);
+                }
+
+                auto* actor = runtime.FindActor(actorId);
+                if (!followerDiskActor &&
+                    (dynamic_cast<TNonreplicatedPartitionActor*>(actor) ||
+                     dynamic_cast<TMirrorPartitionActor*>(actor)))
+                {
+                    latestSourcePartitionActor = actorId;
+                } else if (
+                    !followerDiskActor &&
+                    dynamic_cast<TFollowerDiskActor*>(actor))
+                {
+                    followerDiskActor = actorId;
+                    migrationSourcePartitionActor = latestSourcePartitionActor;
+                } else if (
+                    followerDiskActor && !followerPartitionActor &&
+                    parentId == followerDiskActor)
+                {
+                    followerPartitionActor = actorId;
+                }
+            });
+
+        TTestActorRuntimeBase::TEventFilter prevEventFilter;
+        TTestActorRuntimeBase::TScheduledEventFilter prevScheduledEventFilter;
+        std::optional<TFollowerDiskInfo::EState> followerState;
+        bool followerResponseDropped = false;
+        bool shutdownTimeoutScheduled = false;
+        auto scheduledEventFilter =
+            [&](TTestActorRuntimeBase& runtime,
+                TAutoPtr<IEventHandle>& event,
+                TDuration delay,
+                TInstant& deadline)
+        {
+            if (event->GetTypeRewrite() == TEvents::TEvWakeup::EventType &&
+                event->Recipient == followerPartitionActor)
+            {
+                shutdownTimeoutScheduled = true;
+            }
+
+            return prevScheduledEventFilter
+                       ? prevScheduledEventFilter(
+                             runtime,
+                             event,
+                             delay,
+                             deadline)
+                       : false;
+        };
+        prevScheduledEventFilter =
+            Runtime->SetScheduledEventFilter(scheduledEventFilter);
+
+        auto eventFilter =
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            if (event->GetTypeRewrite() ==
+                TEvVolumePrivate::EvUpdateFollowerStateResponse)
+            {
+                const auto* msg = event->Get<
+                    TEvVolumePrivate::TEvUpdateFollowerStateResponse>();
+                followerState = msg->Follower.State;
+            }
+
+            const bool isFollowerWriteResponse =
+                event->GetTypeRewrite() == TEvService::EvWriteBlocksResponse ||
+                event->GetTypeRewrite() == TEvService::EvZeroBlocksResponse;
+            if (!followerResponseDropped && followerPartitionActor &&
+                event->Recipient == followerPartitionActor &&
+                isFollowerWriteResponse)
+            {
+                followerResponseDropped = true;
+                return true;
+            }
+
+            return prevEventFilter ? prevEventFilter(runtime, event) : false;
+        };
+        prevEventFilter = Runtime->SetEventFilter(eventFilter);
+
+        TVolumeClient volume1(*Runtime, 0, TestVolumeTablets[0]);
+        volume1.CreateVolume(volume1.CreateUpdateVolumeConfigRequest(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            VolumeBlockCount,
+            "vol1"));
+        volume1.WaitReady();
+
+        auto clientInfo1 = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume1.AddClient(clientInfo1);
+        Volumes["vol1"] = {
+            .VolumeClient = &volume1,
+            .VolumeClientInfo = &clientInfo1};
+
+        TVolumeClient volume2(*Runtime, 0, TestVolumeTablets[1]);
+        volume2.CreateVolume(volume2.CreateUpdateVolumeConfigRequest(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NProto::STORAGE_MEDIA_SSD,
+            VolumeBlockCount,
+            "vol2"));
+        volume2.WaitReady();
+        Volumes["vol2"] = {
+            .VolumeClient = &volume2,
+            .VolumeClientInfo = nullptr};
+
+        volume1.WriteBlocks(
+            TBlockRange64::MakeOneBlock(0),
+            clientInfo1.GetClientId(),
+            'a');
+
+        TLeaderFollowerLink link{
+            .LinkUUID = "",
+            .LeaderDiskId = "vol1",
+            .LeaderShardId = "su1",
+            .FollowerDiskId = "vol2",
+            .FollowerShardId = "su2"};
+        auto linkResponse = volume1.LinkLeaderVolumeToFollower(link);
+        link.LinkUUID = linkResponse->Record.GetLinkUUID();
+
+        volume1.ReconnectPipe();
+        volume1.AddClient(clientInfo1);
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return followerResponseDropped;
+        };
+        Runtime->DispatchEvents(options, TDuration::Seconds(10));
+
+        UNIT_ASSERT_C(followerState, "Follower state was not observed");
+        UNIT_ASSERT_VALUES_EQUAL(
+            TFollowerDiskInfo::EState::Preparing,
+            *followerState);
+        UNIT_ASSERT_C(
+            migrationSourcePartitionActor && followerDiskActor &&
+                followerPartitionActor,
+            "Failed to capture the follower migration actor tree");
+        UNIT_ASSERT_C(
+            followerResponseDropped,
+            "Failed to leave a follower request in flight");
+
+        volume1.SendGracefulShutdownRequest();
+        options.CustomFinalCondition = [&]
+        {
+            return shutdownTimeoutScheduled;
+        };
+        Runtime->DispatchEvents(options, TDuration::Seconds(10));
+        UNIT_ASSERT_C(
+            shutdownTimeoutScheduled,
+            "Follower partition did not schedule its shutdown timeout");
+
+        Runtime->AdvanceCurrentTime(TDuration::Minutes(1));
+        auto shutdownResponse =
+            volume1.RecvGracefulShutdownResponse(TDuration::Seconds(1));
+
+        const bool sourcePartitionStopped =
+            !Runtime->FindActor(migrationSourcePartitionActor);
+        const bool followerDiskStopped = !Runtime->FindActor(followerDiskActor);
+        const bool followerPartitionStopped =
+            !Runtime->FindActor(followerPartitionActor);
+
+        Runtime->SetEventFilter(std::move(prevEventFilter));
+        Runtime->SetScheduledEventFilter(
+            std::move(prevScheduledEventFilter));
+        Runtime->SetRegistrationObserverFunc(
+            std::move(prevRegistrationObserver));
+
+        UNIT_ASSERT_C(
+            shutdownResponse,
+            "Graceful shutdown did not complete after a stuck follower "
+            "request");
+        UNIT_ASSERT_C(
+            sourcePartitionStopped,
+            "Source partition is still alive after graceful shutdown");
+        UNIT_ASSERT_C(
+            followerDiskStopped,
+            "Follower disk actor is still alive after graceful shutdown");
+        UNIT_ASSERT_C(
+            followerPartitionStopped,
+            "Follower partition adapter is still alive after graceful "
+            "shutdown");
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
### Notes
During disk migration shutdown, TVolumeAsPartitionActor could wait indefinitely for an in-flight follower request whose response never arrived. This prevents PoisonTaken propagation and blocks graceful shutdown of the leader volume.

The change bounds request draining by DestroyVolumeTimeout, cancels stuck requests, and allows the migration actor tree to terminate.