### PR TITLE
[NBS] Persist flush commit ID in partition metadata

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -170,7 +170,7 @@ public:
         if (UseFlushCommitIdAsTrimFreshLogToCommitId &&
             Args.Mode == ADD_FLUSH_RESULT)
         {
-            const auto trimFreshLogToCommitId =
+            const ui64 trimFreshLogToCommitId =
                 Max(State.GetTrimFreshLogToCommitId(), Args.CommitId);
             State.AccessMeta().SetTrimFreshLogToCommitId(
                 trimFreshLogToCommitId);

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -83,7 +83,7 @@ public:
             TString diskId,
             ui64 deletionCommitId,
             ui32 maxBlocksInBlob,
-            const bool useFlushCommitIdAsTrimFreshLogToCommitId,
+            bool useFlushCommitIdAsTrimFreshLogToCommitId,
             TChildLogTitle logTitle)
         : State(state)
         , Args(args)
@@ -170,6 +170,12 @@ public:
         if (UseFlushCommitIdAsTrimFreshLogToCommitId &&
             Args.Mode == ADD_FLUSH_RESULT)
         {
+            // Persist the flush commit id to avoid reloading and flushing the
+            // same fresh blobs again after a restart (see
+            // ShouldNotReloadFlushedFreshBlobsAfterRestartBeforeTrim). Trim
+            // barriers are released later, after this transaction commits:
+            // trimming before AddBlobs commits could cause data loss if the
+            // transaction fails.
             const ui64 trimFreshLogToCommitId =
                 Max(State.GetTrimFreshLogToCommitId(), Args.CommitId);
             State.AccessMeta().SetTrimFreshLogToCommitId(

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -61,6 +61,7 @@ private:
     const TString DiskId;
     const ui64 DeletionCommitId;
     const ui32 MaxBlocksInBlob;
+    const bool UseFlushCommitIdAsTrimFreshLogToCommitId;
     TChildLogTitle LogTitle;
 
     struct TRangeInfo
@@ -82,6 +83,7 @@ public:
             TString diskId,
             ui64 deletionCommitId,
             ui32 maxBlocksInBlob,
+            const bool useFlushCommitIdAsTrimFreshLogToCommitId,
             TChildLogTitle logTitle)
         : State(state)
         , Args(args)
@@ -89,6 +91,8 @@ public:
         , DiskId(std::move(diskId))
         , DeletionCommitId(deletionCommitId)
         , MaxBlocksInBlob(maxBlocksInBlob)
+        , UseFlushCommitIdAsTrimFreshLogToCommitId(
+              useFlushCommitIdAsTrimFreshLogToCommitId)
         , LogTitle(std::move(logTitle))
     {}
 
@@ -162,7 +166,17 @@ public:
         }
 
         UpdateCompactionMap(db);
-        State.UpdateTrimFreshLogToCommitIdInMeta();
+
+        if (UseFlushCommitIdAsTrimFreshLogToCommitId &&
+            Args.Mode == ADD_FLUSH_RESULT)
+        {
+            const auto trimFreshLogToCommitId =
+                Max(State.GetTrimFreshLogToCommitId(), Args.CommitId);
+            State.AccessMeta().SetTrimFreshLogToCommitId(
+                trimFreshLogToCommitId);
+        } else {
+            State.UpdateTrimFreshLogToCommitIdInMeta();
+        }
 
         db.WriteMeta(State.GetMeta());
     }
@@ -780,8 +794,9 @@ void TPartitionActor::ExecuteAddBlobs(
         PartitionConfig.GetDiskId(),
         args.DeletionCommitId,
         State->GetMaxBlocksInBlob(),
-        LogTitle.GetChild(GetCycleCount())
-    );
+        Config
+            ->GetWaitForFreshWritesBeforeFlushEnabled(),   // useFlushCommitIdAsTrimFreshLogToCommitId
+        LogTitle.GetChild(GetCycleCount()));
     executor.Execute(ctx, db);
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -348,6 +348,11 @@ public:
         return Meta;
     }
 
+    NProto::TPartitionMeta& AccessMeta()
+    {
+        return Meta;
+    }
+
     const NProto::TPartitionConfig& GetConfig() const
     {
         return Config;
@@ -1085,10 +1090,11 @@ public:
     //
 
 public:
-
     void UpdateTrimFreshLogToCommitIdInMeta()
     {
-        Meta.SetTrimFreshLogToCommitId(GetTrimFreshLogToCommitId());
+        auto commitId =
+            Max(GetTrimFreshLogToCommitId(), Meta.GetTrimFreshLogToCommitId());
+        Meta.SetTrimFreshLogToCommitId(commitId);
     }
 
     //

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -1092,7 +1092,7 @@ public:
 public:
     void UpdateTrimFreshLogToCommitIdInMeta()
     {
-        auto commitId =
+        ui64 commitId =
             Max(GetTrimFreshLogToCommitId(), Meta.GetTrimFreshLogToCommitId());
         Meta.SetTrimFreshLogToCommitId(commitId);
     }

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -2204,6 +2204,95 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(true, trimCompletedSeen);
     }
 
+    Y_UNIT_TEST(ShouldNotReloadFlushedFreshBlobsAfterRestartBeforeTrim)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetWaitForFreshWritesBeforeFlushEnabled(true);
+        config.SetMaxCompactionRangesLoadingPerTx(1);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        TAutoPtr<IEventHandle> trimFreshLogRequest;
+        bool interceptTrimFreshLogRequest = true;
+        bool trimFreshLogCompleted = false;
+        THashMap<ui32, ui32> flushCountByBlock;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvAddBlobsRequest)
+                {
+                    auto* msg = event->Get<
+                        TEvPartitionPrivate::TEvAddBlobsRequest>();
+                    if (msg->Mode == EAddBlobMode::ADD_FLUSH_RESULT) {
+                        for (const auto& blob: msg->FreshBlobs) {
+                            for (const auto& block: blob.Blocks) {
+                                ++flushCountByBlock[block.BlockIndex];
+                            }
+                        }
+                    }
+                }
+
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::EvTrimFreshLogRequest &&
+                    interceptTrimFreshLogRequest)
+                {
+                    trimFreshLogRequest = event.Release();
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                trimFreshLogCompleted |=
+                    event->GetTypeRewrite() ==
+                    TEvPartitionCommonPrivate::EvTrimFreshLogCompleted;
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Flush();
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return !!trimFreshLogRequest;
+        };
+        runtime->DispatchEvents(options);
+
+        UNIT_ASSERT(trimFreshLogRequest);
+        UNIT_ASSERT(!trimFreshLogCompleted);
+        interceptTrimFreshLogRequest = false;
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        auto flushResponse = partition.Flush();
+        UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, flushResponse->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(3, flushCountByBlock.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, flushCountByBlock[1]);
+        UNIT_ASSERT_VALUES_EQUAL(1, flushCountByBlock[2]);
+        UNIT_ASSERT_VALUES_EQUAL(1, flushCountByBlock[3]);
+
+        // wait for compaction map loading to complete
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.Compaction(0);
+        partition.Cleanup();
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+    }
+
     Y_UNIT_TEST(ShouldAutomaticallyTrimFreshBlobsFromPreviousGeneration)
     {
         auto config = DefaultConfig();

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -197,6 +197,7 @@ def storage_config_with_new_features_enabled():
     storage.FreshBlocksWriterEnabled = True
     storage.IgnoringZeroedCompactionEnabled = True
     storage.MixedBlocksFilterEnabled = True
+    storage.WaitForFreshWritesBeforeFlushEnabled = True
 
     return storage
 
@@ -392,6 +393,14 @@ TESTS = [
         "cloud/blockstore/tests/loadtest/local-newfeatures/local-tablet-version-1-multiple-ranges.txt",
         [
             storage_config_with_mixed_blocks_filter_enabled(),
+        ],
+        None,
+    ),
+    TestCase(
+        "version1-with-new-features",
+        "cloud/blockstore/tests/loadtest/local-newfeatures/local-tablet-version-1-multiple-ranges.txt",
+        [
+            storage_config_with_new_features_enabled(),
         ],
         None,
     ),


### PR DESCRIPTION
### Notes
Persist flush commit id in partition metadata to avoid flushing the same block twice and blob leakage 
### Issue
#6628 