### PR TITLE
[NBS] take ownership of source partition during disk migration, add UTs

### DIFF
--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
@@ -100,7 +100,8 @@ void TFollowerDiskActor::OnBootstrap(const NActors::TActorContext& ctx)
         ctx,
         LogTitle,
         LeaderBlockSize,
-        FollowerDiskInfo.Link.FollowerDiskId);
+        FollowerDiskInfo.Link.FollowerDiskId,
+        GetConfig()->GetDestroyVolumeTimeout());
 
     InitWork(
         ctx,

--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
@@ -73,7 +73,6 @@ TFollowerDiskActor::TFollowerDiskActor(
     , LeaderBlockSize(params.LeaderBlockSize)
     , LeaderVolumeActorId(params.LeaderVolumeActorId)
     , LeaderPartitionActorId(params.LeaderPartitionActorId)
-    , TakePartitionOwnership(params.TakePartitionOwnership)
     , ClientId(params.ClientId)
     , FollowerDiskInfo(params.FollowerDiskInfo)
 {
@@ -109,7 +108,7 @@ void TFollowerDiskActor::OnBootstrap(const NActors::TActorContext& ctx)
             .MigrationSrcActorId = LeaderPartitionActorId,
             .SrcActorId = LeaderPartitionActorId,
             .DstActorId = FollowerPartitionActorId,
-            .TakeOwnershipOverSrcActor = TakePartitionOwnership,
+            .TakeOwnershipOverSrcActor = true,
             .TakeOwnershipOverDstActor = true,
             .SendWritesToSrc = true,
             .TimeoutCalculator = std::make_unique<TMigrationTimeoutCalculator>(

--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.h
@@ -20,7 +20,6 @@ struct TFollowerDiskActorParams
 
     NActors::TActorId LeaderVolumeActorId;
     NActors::TActorId LeaderPartitionActorId;
-    bool TakePartitionOwnership = false;
     TString ClientId;
 
     TFollowerDiskInfo FollowerDiskInfo;
@@ -72,7 +71,6 @@ private:
     const ui32 LeaderBlockSize = 0;
     const NActors::TActorId LeaderVolumeActorId;
     const NActors::TActorId LeaderPartitionActorId;
-    const bool TakePartitionOwnership = false;
 
     TString ClientId;
 

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
@@ -556,7 +556,7 @@ void TVolumeAsPartitionActor::CancelRequests(const TActorContext& ctx)
 
         const auto& requestCtx = request->Value;
         auto error = MakeError(
-            E_CANCELLED,
+            E_REJECTED,
             "Follower request timed out during shutdown");
 
         switch (requestCtx.RequestType) {

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
@@ -13,6 +13,8 @@
 #include <contrib/ydb/library/actors/core/hfunc.h>
 #include <contrib/ydb/library/actors/core/log.h>
 
+#include <util/generic/vector.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -22,10 +24,12 @@ using namespace NActors;
 TVolumeAsPartitionActor::TVolumeAsPartitionActor(
         TChildLogTitle logTitle,
         ui32 originalBlockSize,
-        TString diskId)
+        TString diskId,
+        TDuration shutdownTimeout)
     : LogTitle(std::move(logTitle))
     , OriginalBlockSize(originalBlockSize)
     , DiskId(std::move(diskId))
+    , ShutdownTimeout(shutdownTimeout)
 {}
 
 TVolumeAsPartitionActor::~TVolumeAsPartitionActor() = default;
@@ -55,7 +59,7 @@ template <typename TEvent>
 void TVolumeAsPartitionActor::ForwardRequestToFollower(
     const TEvent& ev,
     const TActorContext& ctx,
-    EReplyType replyType)
+    ERequestType requestType)
 {
     auto* msg = ev->Get();
     msg->Record.MutableHeaders()->SetExactDiskIdMatch(true);
@@ -65,7 +69,7 @@ void TVolumeAsPartitionActor::ForwardRequestToFollower(
         TRequestCtx{
             .OriginalSender = ev->Sender,
             .OriginalCookie = ev->Cookie,
-            .ReplyType = replyType});
+            .RequestType = requestType});
 
     NActors::TActorId nondeliveryActor = SelfId();
     auto message = std::make_unique<NActors::IEventHandle>(
@@ -86,7 +90,7 @@ void TVolumeAsPartitionActor::ForwardResponse(
     auto* msg = ev->Get();
 
     if (auto requestCtx = RequestsInProgress.ExtractRequest(ev->Cookie)) {
-        if (requestCtx->Value.ReplyType == EReplyType::Local) {
+        if (requestCtx->Value.RequestType == ERequestType::WriteBlocksLocal) {
             ctx.Send(
                 requestCtx->Value.OriginalSender,
                 new TEvService::TEvWriteBlocksLocalResponse(
@@ -131,7 +135,7 @@ void TVolumeAsPartitionActor::ReplyUndelivery(
             LogTitle.GetWithTime().c_str(),
             message.c_str());
 
-        if (requestCtx->Value.ReplyType == EReplyType::Local) {
+        if (requestCtx->Value.RequestType == ERequestType::WriteBlocksLocal) {
             ctx.Send(
                 requestCtx->Value.OriginalSender,
                 std::make_unique<
@@ -191,7 +195,7 @@ template <typename TMethod>
 void TVolumeAsPartitionActor::ReplyInvalidRange(
     const typename TMethod::TRequest::TPtr& ev,
     const TActorContext& ctx,
-    EReplyType replyType)
+    ERequestType requestType)
 {
     auto message =
         TStringBuilder()
@@ -205,7 +209,7 @@ void TVolumeAsPartitionActor::ReplyInvalidRange(
         LogTitle.GetWithTime().c_str(),
         message.c_str());
 
-    if (replyType == EReplyType::Local) {
+    if (requestType == ERequestType::WriteBlocksLocal) {
         NCloud::Reply(
             ctx,
             *ev,
@@ -223,7 +227,7 @@ void TVolumeAsPartitionActor::ReplyInvalidRange(
 void TVolumeAsPartitionActor::DoWriteBlocks(
     const TEvService::TEvWriteBlocksRequest::TPtr& ev,
     const TActorContext& ctx,
-    EReplyType replyType)
+    ERequestType requestType)
 {
     auto* msg = ev->Get();
 
@@ -245,7 +249,7 @@ void TVolumeAsPartitionActor::DoWriteBlocks(
             LogTitle.GetWithTime().c_str(),
             message.c_str());
 
-        if (replyType == EReplyType::Local) {
+        if (requestType == ERequestType::WriteBlocksLocal) {
             ctx.Send(
                 ev->Sender,
                 std::make_unique<TEvService::TEvWriteBlocksLocalResponse>(
@@ -279,7 +283,7 @@ void TVolumeAsPartitionActor::DoWriteBlocks(
         needReadModifyWrite ? " with RMW" : "");
 
     if (!CheckRange(destRange)) {
-        ReplyInvalidRange<TEvService::TWriteBlocksMethod>(ev, ctx, replyType);
+        ReplyInvalidRange<TEvService::TWriteBlocksMethod>(ev, ctx, requestType);
         return;
     }
 
@@ -300,7 +304,7 @@ void TVolumeAsPartitionActor::DoWriteBlocks(
     msg->Record.SetDiskId(DiskId);
     msg->Record.MutableHeaders()->SetClientId(TString(CopyVolumeClientId));
 
-    ForwardRequestToFollower(ev, ctx, replyType);
+    ForwardRequestToFollower(ev, ctx, requestType);
 }
 
 void TVolumeAsPartitionActor::ReplyAndDie(const NActors::TActorContext& ctx)
@@ -370,7 +374,7 @@ void TVolumeAsPartitionActor::HandleWriteBlocks(
         return;
     }
 
-    DoWriteBlocks(ev, ctx, EReplyType::Ordinary);
+    DoWriteBlocks(ev, ctx, ERequestType::WriteBlocks);
 }
 
 void TVolumeAsPartitionActor::HandleWriteBlocksLocal(
@@ -428,7 +432,7 @@ void TVolumeAsPartitionActor::HandleWriteBlocksLocal(
         IEventHandle::Downcast<TEvService::TEvWriteBlocksRequest>(
             std::move(newEv)),
         ctx,
-        EReplyType::Local);
+        ERequestType::WriteBlocksLocal);
 }
 
 void TVolumeAsPartitionActor::HandleZeroBlocks(
@@ -490,7 +494,7 @@ void TVolumeAsPartitionActor::HandleZeroBlocks(
         ReplyInvalidRange<TEvService::TZeroBlocksMethod>(
             ev,
             ctx,
-            EReplyType::Ordinary);
+            ERequestType::ZeroBlocks);
         return;
     }
 
@@ -502,7 +506,10 @@ void TVolumeAsPartitionActor::HandleZeroBlocks(
     msg->Record.SetDiskId(DiskId);
     msg->Record.MutableHeaders()->SetClientId(TString(CopyVolumeClientId));
 
-    ForwardRequestToFollower(ev, ctx, EReplyType::Ordinary);
+    ForwardRequestToFollower(
+        ev,
+        ctx,
+        ERequestType::ZeroBlocks);
 }
 
 void TVolumeAsPartitionActor::HandlePoisonPill(
@@ -517,9 +524,88 @@ void TVolumeAsPartitionActor::HandlePoisonPill(
         MakeIntrusive<TCallContext>());
 
     if (!RequestsInProgress.Empty()) {
+        ctx.Schedule(ShutdownTimeout, new TEvents::TEvWakeup());
         return;
     }
 
+    ReplyAndDie(ctx);
+}
+
+void TVolumeAsPartitionActor::CancelRequests(const TActorContext& ctx)
+{
+    TVector<ui64> requestIds;
+    requestIds.reserve(RequestsInProgress.GetRequestCount());
+    RequestsInProgress.EnumerateRequests(
+        [&](ui64 requestId,
+            bool write,
+            TBlockRange64 range,
+            const TRequestCtx& requestCtx)
+        {
+            Y_UNUSED(write);
+            Y_UNUSED(range);
+            Y_UNUSED(requestCtx);
+            requestIds.push_back(requestId);
+        });
+
+    for (const ui64 requestId: requestIds) {
+        auto request = RequestsInProgress.ExtractRequest(requestId);
+        Y_DEBUG_ABORT_UNLESS(request);
+        if (!request) {
+            continue;
+        }
+
+        const auto& requestCtx = request->Value;
+        auto error = MakeError(
+            E_CANCELLED,
+            "Follower request timed out during shutdown");
+
+        switch (requestCtx.RequestType) {
+            case ERequestType::WriteBlocks:
+                ctx.Send(
+                    requestCtx.OriginalSender,
+                    std::make_unique<TEvService::TEvWriteBlocksResponse>(
+                        std::move(error)),
+                    0,   // flags
+                    requestCtx.OriginalCookie);
+                break;
+            case ERequestType::WriteBlocksLocal:
+                ctx.Send(
+                    requestCtx.OriginalSender,
+                    std::make_unique<TEvService::TEvWriteBlocksLocalResponse>(
+                        std::move(error)),
+                    0,   // flags
+                    requestCtx.OriginalCookie);
+                break;
+            case ERequestType::ZeroBlocks:
+                ctx.Send(
+                    requestCtx.OriginalSender,
+                    std::make_unique<TEvService::TEvZeroBlocksResponse>(
+                        std::move(error)),
+                    0,   // flags
+                    requestCtx.OriginalCookie);
+                break;
+        }
+    }
+}
+
+void TVolumeAsPartitionActor::HandleShutdownTimeout(
+    const TEvents::TEvWakeup::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    if (State != EState::Zombie || !Poisoner) {
+        return;
+    }
+
+    LOG_WARN(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "%s Cancelling %lu follower requests during shutdown",
+        LogTitle.GetWithTime().c_str(),
+        RequestsInProgress.GetRequestCount());
+
+    CancelRequests(ctx);
     ReplyAndDie(ctx);
 }
 
@@ -545,6 +631,7 @@ STFUNC(TVolumeAsPartitionActor::StateWork)
             ForwardResponse<TEvService::TZeroBlocksMethod>);
 
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(TEvents::TEvWakeup, HandleShutdownTimeout);
 
         HFunc(
             TEvNonreplPartitionPrivate::TEvGetDeviceForRangeRequest,

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.h
@@ -12,6 +12,8 @@
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
+#include <util/datetime/base.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,10 +32,11 @@ public:
         Zombie,
     };
 
-    enum class EReplyType
+    enum class ERequestType
     {
-        Ordinary,
-        Local,
+        WriteBlocks,
+        WriteBlocksLocal,
+        ZeroBlocks,
     };
 
 private:
@@ -41,12 +44,13 @@ private:
     {
         const NActors::TActorId OriginalSender;
         const ui64 OriginalCookie = 0;
-        const EReplyType ReplyType = EReplyType::Ordinary;
+        const ERequestType RequestType = ERequestType::WriteBlocks;
     };
 
     const TChildLogTitle LogTitle;
     const ui32 OriginalBlockSize;
     const TString DiskId;
+    const TDuration ShutdownTimeout;
 
     EState State = EState::Describing;
     ui64 BlockCount = 0;
@@ -62,7 +66,8 @@ public:
     TVolumeAsPartitionActor(
         TChildLogTitle logTitle,
         ui32 originalBlockSize,
-        TString diskId);
+        TString diskId,
+        TDuration shutdownTimeout);
 
     ~TVolumeAsPartitionActor() override;
 
@@ -75,7 +80,7 @@ private:
     void ForwardRequestToFollower(
         const TEvent& ev,
         const NActors::TActorContext& ctx,
-        EReplyType replyType);
+        ERequestType requestType);
 
     template <typename TMethod>
     void ForwardResponse(
@@ -94,14 +99,15 @@ private:
     void ReplyInvalidRange(
         const typename TMethod::TRequest::TPtr& ev,
         const NActors::TActorContext& ctx,
-        EReplyType replyType);
+        ERequestType requestType);
 
     void DoWriteBlocks(
         const TEvService::TEvWriteBlocksRequest::TPtr& ev,
         const NActors::TActorContext& ctx,
-        EReplyType replyType);
+        ERequestType requestType);
 
     void ReplyAndDie(const NActors::TActorContext& ctx);
+    void CancelRequests(const NActors::TActorContext& ctx);
 
     void HandleDescribeVolumeResponse(
         const TEvSSProxy::TEvDescribeVolumeResponse::TPtr& ev,
@@ -119,6 +125,9 @@ private:
 
     void HandlePoisonPill(
         const NActors::TEvents::TEvPoisonPill::TPtr& ev,
+        const NActors::TActorContext& ctx);
+    void HandleShutdownTimeout(
+        const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);
 
 private:

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor_ut.cpp
@@ -149,7 +149,8 @@ Y_UNIT_TEST_SUITE(TVolumeAsPartitionActorTests)
                 ActorSystem.Register(new TVolumeAsPartitionActor{
                     LogTitle.GetChild(GetCycleCount()),
                     LeaderBlockSize,
-                    FollowerDiskId});
+                    FollowerDiskId,
+                    TDuration::Seconds(30)});
         }
 
         template <typename TEvent>

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -1331,8 +1331,7 @@ private:
 
     TActorsStack WrapWithFollowerActorIfNeeded(
         const NActors::TActorContext& ctx,
-        TActorsStack actors,
-        bool takePartitionOwnership);
+        TActorsStack actors);
 
     void HandleCreateLinkFinished(
         const TEvVolumePrivate::TEvCreateLinkFinished::TPtr& ev,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -165,7 +165,7 @@ void TVolumeActor::OnPartitionStateChanged(
                 TActorsStack::EActorPurpose::MultiPartitionWrapper);
 
             actorStack =
-                WrapWithFollowerActorIfNeeded(ctx, std::move(actorStack), true);
+                WrapWithFollowerActorIfNeeded(ctx, std::move(actorStack));
 
             State->SetMultiPartitionWrapperActor(std::move(actorStack));
         }
@@ -355,7 +355,7 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
         ctx,
         std::move(actorStack),
         nonreplicatedConfig);
-    actorStack = WrapWithFollowerActorIfNeeded(ctx, std::move(actorStack), false);
+    actorStack = WrapWithFollowerActorIfNeeded(ctx, std::move(actorStack));
 
     State->SetDiskRegistryBasedPartitionActor(
         std::move(actorStack),
@@ -403,8 +403,7 @@ TActorsStack TVolumeActor::WrapWithShadowDiskActorIfNeeded(
 
 TActorsStack TVolumeActor::WrapWithFollowerActorIfNeeded(
     const TActorContext& ctx,
-    TActorsStack actors,
-    bool takePartitionOwnership)
+    TActorsStack actors)
 {
     for (const auto& follower: State->GetAllFollowers()) {
         switch (follower.State) {
@@ -445,7 +444,6 @@ TActorsStack TVolumeActor::WrapWithFollowerActorIfNeeded(
                         .LeaderBlockSize = State->GetBlockSize(),
                         .LeaderVolumeActorId = SelfId(),
                         .LeaderPartitionActorId = actors.GetTop(),
-                        .TakePartitionOwnership = takePartitionOwnership,
                         .ClientId = State->GetReadWriteAccessClientId(),
                         .FollowerDiskInfo = follower});
                 actors.Push(
@@ -944,10 +942,8 @@ void TVolumeActor::HandleTabletStatus(
             }
 
             if (State->GetPartitions().size() == 1) {
-                actorStack = WrapWithFollowerActorIfNeeded(
-                    ctx,
-                    std::move(actorStack),
-                    true);
+                actorStack =
+                    WrapWithFollowerActorIfNeeded(ctx, std::move(actorStack));
             }
             partition->SetStarted(std::move(actorStack));
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
@@ -2,6 +2,8 @@
 #include <cloud/blockstore/libs/storage/core/volume_model.h>
 #include <cloud/blockstore/libs/storage/model/composite_id.h>
 #include <cloud/blockstore/libs/storage/partition_common/events_private.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h>
@@ -2046,6 +2048,216 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
                 checkZero(volume2, clientInfo1.GetClientId(), S_OK);
             }
         }
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldCompleteGracefulShutdownDuringFollowerMigration,
+        TFixture)
+    {
+        TActorId latestSourcePartitionActor;
+        TActorId migrationSourcePartitionActor;
+        TActorId followerDiskActor;
+        TActorId followerPartitionActor;
+
+        auto prevRegistrationObserver =
+            Runtime->SetRegistrationObserverFunc({});
+        Runtime->SetRegistrationObserverFunc(
+            [&](TTestActorRuntimeBase& runtime,
+                const TActorId& parentId,
+                const TActorId& actorId)
+            {
+                if (prevRegistrationObserver) {
+                    prevRegistrationObserver(runtime, parentId, actorId);
+                }
+
+                auto* actor = runtime.FindActor(actorId);
+                if (!followerDiskActor &&
+                    (dynamic_cast<TNonreplicatedPartitionActor*>(actor) ||
+                     dynamic_cast<TMirrorPartitionActor*>(actor)))
+                {
+                    latestSourcePartitionActor = actorId;
+                } else if (
+                    !followerDiskActor &&
+                    dynamic_cast<TFollowerDiskActor*>(actor))
+                {
+                    followerDiskActor = actorId;
+                    migrationSourcePartitionActor = latestSourcePartitionActor;
+                } else if (
+                    followerDiskActor && !followerPartitionActor &&
+                    parentId == followerDiskActor)
+                {
+                    followerPartitionActor = actorId;
+                }
+            });
+
+        TTestActorRuntimeBase::TEventFilter prevEventFilter;
+        TTestActorRuntimeBase::TScheduledEventFilter prevScheduledEventFilter;
+        std::optional<TFollowerDiskInfo::EState> followerState;
+        bool followerResponseDropped = false;
+        bool shutdownTimeoutScheduled = false;
+        auto scheduledEventFilter =
+            [&](TTestActorRuntimeBase& runtime,
+                TAutoPtr<IEventHandle>& event,
+                TDuration delay,
+                TInstant& deadline)
+        {
+            if (event->GetTypeRewrite() == TEvents::TEvWakeup::EventType &&
+                event->Recipient == followerPartitionActor)
+            {
+                shutdownTimeoutScheduled = true;
+            }
+
+            return prevScheduledEventFilter
+                       ? prevScheduledEventFilter(
+                             runtime,
+                             event,
+                             delay,
+                             deadline)
+                       : false;
+        };
+        prevScheduledEventFilter =
+            Runtime->SetScheduledEventFilter(scheduledEventFilter);
+
+        auto eventFilter =
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            if (event->GetTypeRewrite() ==
+                TEvVolumePrivate::EvUpdateFollowerStateResponse)
+            {
+                const auto* msg = event->Get<
+                    TEvVolumePrivate::TEvUpdateFollowerStateResponse>();
+                followerState = msg->Follower.State;
+            }
+
+            const bool isFollowerWriteResponse =
+                event->GetTypeRewrite() == TEvService::EvWriteBlocksResponse ||
+                event->GetTypeRewrite() == TEvService::EvZeroBlocksResponse;
+            if (!followerResponseDropped && followerPartitionActor &&
+                event->Recipient == followerPartitionActor &&
+                isFollowerWriteResponse)
+            {
+                followerResponseDropped = true;
+                return true;
+            }
+
+            return prevEventFilter ? prevEventFilter(runtime, event) : false;
+        };
+        prevEventFilter = Runtime->SetEventFilter(eventFilter);
+
+        TVolumeClient volume1(*Runtime, 0, TestVolumeTablets[0]);
+        volume1.CreateVolume(volume1.CreateUpdateVolumeConfigRequest(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            VolumeBlockCount,
+            "vol1"));
+        volume1.WaitReady();
+
+        auto clientInfo1 = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume1.AddClient(clientInfo1);
+        Volumes["vol1"] = {
+            .VolumeClient = &volume1,
+            .VolumeClientInfo = &clientInfo1};
+
+        TVolumeClient volume2(*Runtime, 0, TestVolumeTablets[1]);
+        volume2.CreateVolume(volume2.CreateUpdateVolumeConfigRequest(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NProto::STORAGE_MEDIA_SSD,
+            VolumeBlockCount,
+            "vol2"));
+        volume2.WaitReady();
+        Volumes["vol2"] = {
+            .VolumeClient = &volume2,
+            .VolumeClientInfo = nullptr};
+
+        volume1.WriteBlocks(
+            TBlockRange64::MakeOneBlock(0),
+            clientInfo1.GetClientId(),
+            'a');
+
+        TLeaderFollowerLink link{
+            .LinkUUID = "",
+            .LeaderDiskId = "vol1",
+            .LeaderShardId = "su1",
+            .FollowerDiskId = "vol2",
+            .FollowerShardId = "su2"};
+        auto linkResponse = volume1.LinkLeaderVolumeToFollower(link);
+        link.LinkUUID = linkResponse->Record.GetLinkUUID();
+
+        volume1.ReconnectPipe();
+        volume1.AddClient(clientInfo1);
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return followerResponseDropped;
+        };
+        Runtime->DispatchEvents(options, TDuration::Seconds(10));
+
+        UNIT_ASSERT_C(followerState, "Follower state was not observed");
+        UNIT_ASSERT_VALUES_EQUAL(
+            TFollowerDiskInfo::EState::Preparing,
+            *followerState);
+        UNIT_ASSERT_C(
+            migrationSourcePartitionActor && followerDiskActor &&
+                followerPartitionActor,
+            "Failed to capture the follower migration actor tree");
+        UNIT_ASSERT_C(
+            followerResponseDropped,
+            "Failed to leave a follower request in flight");
+
+        volume1.SendGracefulShutdownRequest();
+        options.CustomFinalCondition = [&]
+        {
+            return shutdownTimeoutScheduled;
+        };
+        Runtime->DispatchEvents(options, TDuration::Seconds(10));
+        UNIT_ASSERT_C(
+            shutdownTimeoutScheduled,
+            "Follower partition did not schedule its shutdown timeout");
+
+        Runtime->AdvanceCurrentTime(TDuration::Minutes(1));
+        auto shutdownResponse =
+            volume1.RecvGracefulShutdownResponse(TDuration::Seconds(1));
+
+        const bool sourcePartitionStopped =
+            !Runtime->FindActor(migrationSourcePartitionActor);
+        const bool followerDiskStopped = !Runtime->FindActor(followerDiskActor);
+        const bool followerPartitionStopped =
+            !Runtime->FindActor(followerPartitionActor);
+
+        Runtime->SetEventFilter(std::move(prevEventFilter));
+        Runtime->SetScheduledEventFilter(
+            std::move(prevScheduledEventFilter));
+        Runtime->SetRegistrationObserverFunc(
+            std::move(prevRegistrationObserver));
+
+        UNIT_ASSERT_C(
+            shutdownResponse,
+            "Graceful shutdown did not complete after a stuck follower "
+            "request");
+        UNIT_ASSERT_C(
+            sourcePartitionStopped,
+            "Source partition is still alive after graceful shutdown");
+        UNIT_ASSERT_C(
+            followerDiskStopped,
+            "Follower disk actor is still alive after graceful shutdown");
+        UNIT_ASSERT_C(
+            followerPartitionStopped,
+            "Follower partition adapter is still alive after graceful "
+            "shutdown");
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
@@ -3,7 +3,10 @@
 #include <cloud/blockstore/libs/storage/model/composite_id.h>
 #include <cloud/blockstore/libs/storage/partition_common/events_private.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/model/processing_blocks.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h>
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h>
 #include <cloud/blockstore/libs/storage/stats_service/stats_service_events_private.h>
+#include <cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.h>
 #include <cloud/blockstore/libs/storage/volume/testlib/test_env.h>
 
 #include <cloud/storage/core/libs/common/media.h>
@@ -694,8 +697,39 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
         NProto::EStorageMediaKind leaderMediaType,
         NProto::EStorageMediaKind followerMediaType,
         ECheckpointBehaviour checkpoint,
-        bool isMultipartition = false)
+        bool isMultipartition = false,
+        bool verifySourcePartitionStopped = false)
     {
+        TActorId latestSourcePartitionActor;
+        TActorId migrationSourcePartitionActor;
+        TTestActorRuntimeBase::TRegistrationObserver prevRegistrationObserver;
+
+        if (verifySourcePartitionStopped) {
+            prevRegistrationObserver =
+                fixture.Runtime->SetRegistrationObserverFunc({});
+            fixture.Runtime->SetRegistrationObserverFunc(
+                [&](TTestActorRuntimeBase& runtime,
+                    const TActorId& parentId,
+                    const TActorId& actorId)
+                {
+                    if (prevRegistrationObserver) {
+                        prevRegistrationObserver(runtime, parentId, actorId);
+                    }
+                    if (migrationSourcePartitionActor) {
+                        return;
+                    }
+                    auto* actor = runtime.FindActor(actorId);
+                    if (dynamic_cast<TNonreplicatedPartitionActor*>(actor) ||
+                        dynamic_cast<TMirrorPartitionActor*>(actor))
+                    {
+                        latestSourcePartitionActor = actorId;
+                    } else if (dynamic_cast<TFollowerDiskActor*>(actor)) {
+                        migrationSourcePartitionActor =
+                            latestSourcePartitionActor;
+                    }
+                });
+        }
+
         const ui32 leaderPartitionCount =
             isMultipartition && leaderMediaType == NProto::STORAGE_MEDIA_SSD
                 ? 2
@@ -858,6 +892,24 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
         // Check volumes content match.
         volume1.UnlinkLeaderVolumeFromFollower(link);
         fixture.CheckVolumesDataMatch();
+
+        if (verifySourcePartitionStopped) {
+            const bool sourcePartitionStopped =
+                migrationSourcePartitionActor &&
+                !fixture.Runtime->FindActor(migrationSourcePartitionActor);
+
+            fixture.Runtime->SetRegistrationObserverFunc(
+                std::move(prevRegistrationObserver));
+
+            UNIT_ASSERT_C(
+                migrationSourcePartitionActor,
+                "Failed to capture the source partition used by migration");
+            UNIT_ASSERT_C(
+                sourcePartitionStopped,
+                TStringBuilder()
+                    << "Source partition " << migrationSourcePartitionActor
+                    << " is still alive after leader cutover");
+        }
     }
 
     Y_UNIT_TEST_F(ShouldPrepareFollowerVolume_NRD_SSD, TFixture)
@@ -1232,6 +1284,30 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             NProto::STORAGE_MEDIA_SSD,
             true);
+    }
+
+    Y_UNIT_TEST_F(ShouldStopSourcePartitionAfterMigration_NRD, TFixture)
+    {
+        DoShouldPrepareFollowerVolume(
+            *this,
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            NProto::STORAGE_MEDIA_SSD,
+            ECheckpointBehaviour::None,
+            false,   // isMultipartition
+            true     // verifySourcePartitionStopped
+        );
+    }
+
+    Y_UNIT_TEST_F(ShouldStopSourcePartitionAfterMigration_MIRROR, TFixture)
+    {
+        DoShouldPrepareFollowerVolume(
+            *this,
+            NProto::STORAGE_MEDIA_SSD_MIRROR3,
+            NProto::STORAGE_MEDIA_SSD,
+            ECheckpointBehaviour::None,
+            false,   // isMultipartition
+            true     // verifySourcePartitionStopped
+        );
     }
 
     Y_UNIT_TEST_F(


### PR DESCRIPTION
### Notes
Two scenarios:
1. during disk migration, the old leader volume could terminate while its source partition actor remained alive because the follower wrapper did not own it. This could leave a stale partition serving I/O after cutover;
2. during disk migration shutdown, TVolumeAsPartitionActor could wait indefinitely for an in-flight follower request whose response never arrived. This prevents PoisonTaken propagation and blocks graceful shutdown of the leader volume.

The change in commit 1 transfers source partition ownership to the follower wrapper, ensuring the entire actor tree is stopped.
The change in commit 2 bounds request draining by DestroyVolumeTimeout, cancels stuck requests, and allows the migration actor tree to terminate.
