### PR TITLE
Switch subset of per-host AppCriticalEvents to new per-disk VolumeCriticalEvents

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -360,16 +360,20 @@ void ResetVolumeCriticalEventsCounter()
             const TCritEventParams& keyValues)                                 \
         {                                                                      \
             TString retMessage;                                                \
-            TString submsg =                                                   \
-                ComposeMessageWithSuffix(message, PrintParams(keyValues));     \
                                                                                \
-            /* Keep legacy AppCriticalEvents/ metrics alive */                 \
+            /* Keep per-host AppCriticalEvents/ metrics alive */               \
             if (VolumeCriticalEventsReportingMode !=                           \
                 NProto::EVolumeCriticalEventsReportingMode::VOLUME_ONLY)       \
             {                                                                  \
+                TString params =                                               \
+                    diskId.empty()                                             \
+                        ? PrintParams(keyValues)                               \
+                        : PrintParams(TCritEventParams{{"disk", diskId}}) +    \
+                              " " + PrintParams(keyValues);                    \
+                                                                               \
                 retMessage = ReportCriticalEvent(                              \
                     GetAppCriticalEventFor##name(),                            \
-                    submsg,                                                    \
+                    ComposeMessageWithSuffix(message, params),                 \
                     /*verifyDebug=*/false);                                    \
             }                                                                  \
                                                                                \
@@ -379,20 +383,28 @@ void ResetVolumeCriticalEventsCounter()
                 return retMessage;                                             \
             }                                                                  \
                                                                                \
+            TString msg =                                                      \
+                ComposeMessageWithSuffix(message, PrintParams(keyValues));     \
+                                                                               \
             auto prefix = TCritEventParams{                                    \
                 {"disk", diskId.empty() ? "<empty>" : diskId},                 \
                 {"cloud", cloudId.empty() ? "<empty>" : cloudId},              \
                 {"folder", folderId.empty() ? "<empty>" : folderId}};          \
                                                                                \
             TString logMessage =                                               \
-                !submsg.empty()                                                \
-                    ? ComposeMessageWithSuffix(PrintParams(prefix), submsg)    \
+                !msg.empty()                                                   \
+                    ? ComposeMessageWithSuffix(PrintParams(prefix), msg)       \
                     : PrintParams(prefix);                                     \
                                                                                \
             /* Log immediately */                                              \
             retMessage = LogCriticalEvent(                                     \
                 GetVolumeCriticalEventFor##name(),                             \
                 logMessage);                                                   \
+                                                                               \
+            if (diskId.empty()) {                                              \
+                /* No metric creation for empty disk id */                     \
+                return retMessage;                                             \
+            }                                                                  \
                                                                                \
             auto key = TVolumeCriticalEventKey{                                \
                 .Event = GetVolumeCriticalEventFor##name(),                    \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -401,8 +401,18 @@ void ResetVolumeCriticalEventsCounter()
                 GetVolumeCriticalEventFor##name(),                             \
                 logMessage);                                                   \
                                                                                \
-            if (diskId.empty()) {                                              \
-                /* No metric creation for empty disk id */                     \
+            if (diskId.empty() || diskId == "<nullptr>") {                     \
+                if (diskId.empty()) {                                          \
+                    REPORT_BUG(Sprintf(                                        \
+                        "empty diskId provided for %s report, "                \
+                        "monitoring metrics will not be updated",              \
+                        GetVolumeCriticalEventFor##name().c_str()));           \
+                }                                                              \
+                /* else - bug was reported earlier in                          \
+                   Report##name(TVolumeLabelsConstPtr) caller overload */      \
+                                                                               \
+                /* No metric with an empty 'volume=""' label is created for    \
+                   empty disk id */                                            \
                 return retMessage;                                             \
             }                                                                  \
                                                                                \

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -9,7 +9,6 @@
 #include <util/string/printf.h>
 #include <util/system/src_location.h>
 
-#include <source_location>
 #include <utility>
 
 namespace NCloud::NBlockStore {
@@ -114,9 +113,8 @@ using TCritEventParams =
 /* Report AppImpossibeEvent/Bug with source location log */
 #define REPORT_BUG(message, ...)                                               \
     ::NCloud::NBlockStore::ReportBug(                                          \
-        (TStringBuilder() << __LOCATION__ << ":'"                              \
-                          << std::source_location::current().function_name()   \
-                          << "': " << (message)) __VA_OPT__(, ) __VA_ARGS__)
+        (TStringBuilder() << __LOCATION__ << ": " << (message)) __VA_OPT__(, ) \
+            __VA_ARGS__)
 
 #define BLOCKSTORE_VOLUME_CRITICAL_EVENTS(xxx)                                 \
     xxx(InvalidTabletConfig)                                                   \
@@ -226,15 +224,14 @@ BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)
         TArgs&&... args)                                                       \
     {                                                                          \
         if (!volumeLabels) {                                                   \
-            REPORT_BUG(                                                        \
-                Sprintf(                                                       \
-                    "volumeLabels = nullptr for %s report, "                   \
-                    "corresponding metric was not updated",                    \
-                    GetVolumeCriticalEventFor##name().c_str()),                \
-                /*keyValues=*/{} /* - use non-aborting overload for tests */); \
+            REPORT_BUG(Sprintf(                                                \
+                "volumeLabels = nullptr provided for %s report, "              \
+                "monitoring metrics will not be updated",                      \
+                GetVolumeCriticalEventFor##name().c_str()));                   \
         }                                                                      \
-        const auto& labels =                                                   \
-            volumeLabels ? volumeLabels : MakeVolumeLabels("", "", "");        \
+        const auto& labels = volumeLabels                                      \
+                                 ? volumeLabels                                \
+                                 : MakeVolumeLabels("<nullptr>", "", "");      \
         return Report##name(*labels, std::forward<TArgs>(args)...);            \
     }                                                                          \
     // BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/common/printable_params.h>
 #include <cloud/blockstore/libs/common/volume_labels.h>
 
+#include <util/string/printf.h>
 #include <util/system/src_location.h>
 
 #include <source_location>
@@ -111,13 +112,7 @@ using TCritEventParams =
     // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
 /* Report AppImpossibeEvent/Bug with source location log */
-#define REPORT_BUG()                                                           \
-    ::NCloud::NBlockStore::ReportBug(                                          \
-        (TStringBuilder() << __LOCATION__ << ":'"                              \
-                          << std::source_location::current().function_name()   \
-                          << "'"))
-
-#define REPORT_BUG_DESCR(message, ...)                                         \
+#define REPORT_BUG(message, ...)                                               \
     ::NCloud::NBlockStore::ReportBug(                                          \
         (TStringBuilder() << __LOCATION__ << ":'"                              \
                           << std::source_location::current().function_name()   \
@@ -198,6 +193,8 @@ BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)
 #undef BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
 
 #define BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE(name)                 \
+    const TString GetVolumeCriticalEventFor##name();                           \
+    const TString GetAppCriticalEventFor##name();                              \
     TString Report##name(                                                      \
         const TString& diskId,                                                 \
         const TString& cloudId,                                                \
@@ -229,16 +226,17 @@ BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)
         TArgs&&... args)                                                       \
     {                                                                          \
         if (!volumeLabels) {                                                   \
-            REPORT_BUG_DESCR(                                                  \
-                "volumeLabels = nullptr for VolumeCriticalEvent "              \
-                "report",                                                      \
+            REPORT_BUG(                                                        \
+                Sprintf(                                                       \
+                    "volumeLabels = nullptr for %s report, "                   \
+                    "corresponding metric was not updated",                    \
+                    GetVolumeCriticalEventFor##name().c_str()),                \
                 /*keyValues=*/{} /* - use non-aborting overload for tests */); \
         }                                                                      \
-        const auto& labels = volumeLabels ?: MakeVolumeLabels("", "", "");     \
+        const auto& labels =                                                   \
+            volumeLabels ? volumeLabels : MakeVolumeLabels("", "", "");        \
         return Report##name(*labels, std::forward<TArgs>(args)...);            \
     }                                                                          \
-    const TString GetVolumeCriticalEventFor##name();                           \
-    const TString GetAppCriticalEventFor##name();                              \
     // BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
 
 BLOCKSTORE_VOLUME_CRITICAL_EVENTS(

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -16,69 +16,35 @@ using TCritEventParams =
 ////////////////////////////////////////////////////////////////////////////////
 
 #define BLOCKSTORE_CRITICAL_EVENTS(xxx)                                        \
-    xxx(InvalidTabletConfig)                                                   \
-    xxx(ReassignTablet)                                                        \
-    xxx(TabletBSFailure)                                                       \
-    xxx(DiskAllocationFailure)                                                 \
-    xxx(CollectGarbageError)                                                   \
     xxx(VhostQueueRunningError)                                                \
-    xxx(MigrationFailed)                                                       \
-    xxx(BadMigrationConfig)                                                    \
-    xxx(InitFreshBlocksError)                                                  \
-    xxx(TrimFreshLogError)                                                     \
-    xxx(NrdDestructionError)                                                   \
-    xxx(FailedToStartVolumeLocally)                                            \
     xxx(PublishDiskStateError)                                                 \
     xxx(EndpointRestoringError)                                                \
     xxx(HangingYdbStatsRequest)                                                \
     xxx(UserNotificationError)                                                 \
     xxx(BackupPathDescriptionsFailure)                                         \
     xxx(RdmaError)                                                             \
-    xxx(MirroredDiskAllocationCleanupFailure)                                  \
-    xxx(MirroredDiskAllocationPlacementGroupCleanupFailure)                    \
-    xxx(MirroredDiskDeviceReplacementForbidden)                                \
-    xxx(MirroredDiskDeviceReplacementFailure)                                  \
-    xxx(MirroredDiskDeviceReplacementRateLimitExceeded)                        \
-    xxx(MirroredDiskMinorityChecksumMismatch)                                  \
-    xxx(MirroredDiskMajorityChecksumMismatch)                                  \
-    xxx(MirroredDiskChecksumMismatchUponRead)                                  \
-    xxx(MirroredDiskAddTagFailed)                                              \
     xxx(CounterUpdateRace)                                                     \
     xxx(EndpointStartingError)                                                 \
-    xxx(ResyncFailed)                                                          \
     xxx(DiskRegistryBackupFailed)                                              \
     xxx(RegisterAgentWithEmptyRackName)                                        \
-    xxx(AddConfirmedBlobsError)                                                \
-    xxx(ConfirmBlobsError)                                                     \
     xxx(ManuallyPreemptedVolumesFileError)                                     \
     xxx(ServiceProxyWakeupTimerHit)                                            \
     xxx(ReceivedUnknownTaskId)                                                 \
-    xxx(MigrationSourceNotFound)                                               \
     xxx(UnexpectedBatchMigration)                                              \
     xxx(FreshDeviceNotFoundInConfig)                                           \
     xxx(DiskRegistryDeviceNotFoundSoft)                                        \
     xxx(DiskRegistrySourceDiskNotFound)                                        \
     xxx(EndpointSwitchFailure)                                                 \
     xxx(ExternalEndpointUnexpectedExit)                                        \
-    xxx(BlockDigestMismatchInBlob)                                             \
     xxx(DiskRegistryResumeDeviceFailed)                                        \
     xxx(DiskRegistryAgentDevicePoolConfigMismatch)                             \
     xxx(DiskRegistryPurgeHostError)                                            \
     xxx(DiskRegistryOccupiedDeviceConfigurationHasChanged)                     \
     xxx(DiskRegistryWrongMigratedDeviceOwnership)                              \
     xxx(DiskRegistryInitialAgentRejectionThresholdExceeded)                    \
-    xxx(ErrorWasSentToTheGuestForReliableDisk)                                 \
-    xxx(ErrorWasSentToTheGuestForNonReliableDisk)                              \
-    xxx(MirroredDiskResyncChecksumMismatch)                                    \
     xxx(DiskAgentInconsistentMultiWriteResponse)                               \
-    xxx(ReleaseShadowDiskError)                                                \
-    xxx(WrongCellIdInDescribeVolume)                                           \
-    xxx(TrimFreshLogTimeout)                                                   \
     xxx(DiskRegistryStateIntegrityBroken)                                      \
-    xxx(AddFreshBlocksResultedInError)                                         \
-    xxx(OverlappingRequestsDetected)                                           \
-    xxx(CrossPartitionRequestDetected)                                         \
-// BLOCKSTORE_CRITICAL_EVENTS
+    // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(xxx)                             \
     xxx(AcquiredDiskEraseAttempt)                                              \
@@ -162,6 +128,7 @@ using TCritEventParams =
     xxx(ResyncFailed)                                                          \
     xxx(AddConfirmedBlobsError)                                                \
     xxx(ConfirmBlobsError)                                                     \
+    xxx(MigrationSourceNotFound)                                               \
     xxx(BlockDigestMismatchInBlob)                                             \
     xxx(ErrorWasSentToTheGuestForReliableDisk)                                 \
     xxx(ErrorWasSentToTheGuestForNonReliableDisk)                              \

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -6,6 +6,9 @@
 #include <cloud/blockstore/libs/common/printable_params.h>
 #include <cloud/blockstore/libs/common/volume_labels.h>
 
+#include <util/system/src_location.h>
+
+#include <source_location>
 #include <utility>
 
 namespace NCloud::NBlockStore {
@@ -43,6 +46,7 @@ using TCritEventParams =
     xxx(DiskRegistryWrongMigratedDeviceOwnership)                              \
     xxx(DiskRegistryInitialAgentRejectionThresholdExceeded)                    \
     xxx(DiskAgentInconsistentMultiWriteResponse)                               \
+    xxx(WrongCellIdInDescribeVolume)                                           \
     xxx(DiskRegistryStateIntegrityBroken)                                      \
     // BLOCKSTORE_CRITICAL_EVENTS
 
@@ -102,7 +106,22 @@ using TCritEventParams =
     xxx(RdmaMessageTypeMismatch)                                               \
     xxx(BlockChecksumAbsent)                                                   \
     xxx(CleanupBlobMetaBlocksMismatch)                                         \
-// BLOCKSTORE_IMPOSSIBLE_EVENTS
+    xxx(Bug) /* General software bug event.                                    \
+                Used for non-specialized or unclassified errors. */            \
+    // BLOCKSTORE_IMPOSSIBLE_EVENTS
+
+/* Report AppImpossibeEvent/Bug with source location log */
+#define REPORT_BUG()                                                           \
+    ::NCloud::NBlockStore::ReportBug(                                          \
+        (TStringBuilder() << __LOCATION__ << ":'"                              \
+                          << std::source_location::current().function_name()   \
+                          << "'"))
+
+#define REPORT_BUG_DESCR(message, ...)                                         \
+    ::NCloud::NBlockStore::ReportBug(                                          \
+        (TStringBuilder() << __LOCATION__ << ":'"                              \
+                          << std::source_location::current().function_name()   \
+                          << "': " << (message)) __VA_OPT__(, ) __VA_ARGS__)
 
 #define BLOCKSTORE_VOLUME_CRITICAL_EVENTS(xxx)                                 \
     xxx(InvalidTabletConfig)                                                   \
@@ -134,7 +153,6 @@ using TCritEventParams =
     xxx(ErrorWasSentToTheGuestForNonReliableDisk)                              \
     xxx(MirroredDiskResyncChecksumMismatch)                                    \
     xxx(ReleaseShadowDiskError)                                                \
-    xxx(WrongCellIdInDescribeVolume)                                           \
     xxx(TrimFreshLogTimeout)                                                   \
     xxx(AddFreshBlocksResultedInError)                                         \
     xxx(OverlappingRequestsDetected)                                           \
@@ -148,12 +166,11 @@ using TCritEventParams =
     TString Report##name(                                                      \
         const TString& message,                                                \
         const TCritEventParams& keyValues);                                    \
-    TString Report##name(                                                      \
-        const TCritEventParams& keyValues);                                    \
+    TString Report##name(const TCritEventParams& keyValues);                   \
     const TString GetCriticalEventFor##name();                                 \
-// BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE
+    // BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE
 
-    BLOCKSTORE_CRITICAL_EVENTS(BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE)
+BLOCKSTORE_CRITICAL_EVENTS(BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE)
 #undef BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE
 
 #define BLOCKSTORE_DECLARE_DISK_AGENT_CRITICAL_EVENT_ROUTINE(name)             \
@@ -161,13 +178,12 @@ using TCritEventParams =
     TString Report##name(                                                      \
         const TString& message,                                                \
         const TCritEventParams& keyValues);                                    \
-    TString Report##name(                                                      \
-        const TCritEventParams& keyValues);                                    \
+    TString Report##name(const TCritEventParams& keyValues);                   \
     const TString GetCriticalEventFor##name();                                 \
-// BLOCKSTORE_DECLARE_DISK_AGENT_CRITICAL_EVENT_ROUTINE
+    // BLOCKSTORE_DECLARE_DISK_AGENT_CRITICAL_EVENT_ROUTINE
 
-    BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(
-        BLOCKSTORE_DECLARE_DISK_AGENT_CRITICAL_EVENT_ROUTINE)
+BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(
+    BLOCKSTORE_DECLARE_DISK_AGENT_CRITICAL_EVENT_ROUTINE)
 #undef BLOCKSTORE_DECLARE_DISK_AGENT_CRITICAL_EVENT_ROUTINE
 
 #define BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE(name)                      \
@@ -175,55 +191,58 @@ using TCritEventParams =
     TString Report##name(                                                      \
         const TString& message,                                                \
         const TCritEventParams& keyValues);                                    \
-    TString Report##name(                                                      \
-        const TCritEventParams& keyValues);                                    \
+    TString Report##name(const TCritEventParams& keyValues);                   \
     const TString GetCriticalEventFor##name();                                 \
-// BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
-    BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)
+    // BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
+BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)
 #undef BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
 
-#define BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE(name)             \
-        TString Report##name(                                                  \
-            const TString& diskId,                                             \
-            const TString& cloudId,                                            \
-            const TString& folderId,                                           \
-            const TString& message = "");                                      \
-        TString Report##name(                                                  \
-            const TString& diskId,                                             \
-            const TString& cloudId,                                            \
-            const TString& folderId,                                           \
-            const TString& message,                                            \
-            const TCritEventParams& keyValues);                                \
-        TString Report##name(                                                  \
-            const TString& diskId,                                             \
-            const TString& cloudId,                                            \
-            const TString& folderId,                                           \
-            const TCritEventParams& keyValues);                                \
-        template <typename... TArgs>                                           \
-        TString Report##name(                                                  \
-            const TVolumeLabels& volumeLabels,                                 \
-            TArgs&&... args)                                                   \
-        {                                                                      \
-            return Report##name(                                               \
-                volumeLabels.DiskId,                                           \
-                volumeLabels.CloudId,                                          \
-                volumeLabels.FolderId,                                         \
-                std::forward<TArgs>(args)...);                                 \
+#define BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE(name)                 \
+    TString Report##name(                                                      \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TString& message = "");                                          \
+    TString Report##name(                                                      \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TString& message,                                                \
+        const TCritEventParams& keyValues);                                    \
+    TString Report##name(                                                      \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TCritEventParams& keyValues);                                    \
+    template <typename... TArgs>                                               \
+    TString Report##name(const TVolumeLabels& volumeLabels, TArgs&&... args)   \
+    {                                                                          \
+        return Report##name(                                                   \
+            volumeLabels.DiskId,                                               \
+            volumeLabels.CloudId,                                              \
+            volumeLabels.FolderId,                                             \
+            std::forward<TArgs>(args)...);                                     \
+    }                                                                          \
+    template <typename... TArgs>                                               \
+    TString Report##name(                                                      \
+        const TVolumeLabelsConstPtr& volumeLabels,                             \
+        TArgs&&... args)                                                       \
+    {                                                                          \
+        if (!volumeLabels) {                                                   \
+            REPORT_BUG_DESCR(                                                  \
+                "volumeLabels = nullptr for VolumeCriticalEvent "              \
+                "report",                                                      \
+                /*keyValues=*/{} /* - use non-aborting overload for tests */); \
         }                                                                      \
-        template <typename... TArgs>                                           \
-        TString Report##name(                                                  \
-            const TVolumeLabelsConstPtr& volumeLabels,                         \
-            TArgs&&... args)                                                   \
-        {                                                                      \
-            Y_ABORT_UNLESS(volumeLabels);                                      \
-            return Report##name(*volumeLabels, std::forward<TArgs>(args)...);  \
-        }                                                                      \
-        const TString GetVolumeCriticalEventFor##name();                       \
-        const TString GetAppCriticalEventFor##name();                          \
-        // BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
+        const auto& labels = volumeLabels ?: MakeVolumeLabels("", "", "");     \
+        return Report##name(*labels, std::forward<TArgs>(args)...);            \
+    }                                                                          \
+    const TString GetVolumeCriticalEventFor##name();                           \
+    const TString GetAppCriticalEventFor##name();                              \
+    // BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
 
-    BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
-        BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE)
+BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
+    BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE)
 #undef BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -32,13 +32,13 @@ TIntrusivePtr<TDynamicCounters> FindNestedGroup(
     return group;
 }
 
-// Resolves the per-disk counter group under component=service_volume.
+// Resolves the per-disk counter group under component=critical_events.
 TIntrusivePtr<TDynamicCounters> FindVolumeGroup(
-    TDynamicCountersPtr serviceVolumeGroup,
+    TDynamicCountersPtr volumeCriticalEventsGroup,
     const TVolumeLabels& v)
 {
     return FindNestedGroup(
-        serviceVolumeGroup,
+        volumeCriticalEventsGroup,
         {{"volume", v.DiskId}, {"cloud", v.CloudId}, {"folder", v.FolderId}});
 }
 
@@ -533,6 +533,49 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         ReportBlockDigestMismatchInBlob(v, "some msg");
         handler->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(1, volumeCounter->Val());
+    }
+
+    // A null labels pointer should report the bug and preserve the original
+    // critical event.
+    Y_UNIT_TEST(ShouldGracefullyReportNullVolumeLabels)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
+
+        InitVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumeLabelsConstPtr volumeLabels;
+        const auto logMessage =
+            ReportBlockDigestMismatchInBlob(volumeLabels, "some msg");
+
+        auto bugCounter =
+            criticalEventsGroup->FindCounter(GetCriticalEventForBug());
+        UNIT_ASSERT(bugCounter);
+        UNIT_ASSERT_VALUES_EQUAL(1, bugCounter->Val());
+
+        auto appCounter = criticalEventsGroup->FindCounter(GetAppSensorName());
+        UNIT_ASSERT(appCounter);
+        UNIT_ASSERT_VALUES_EQUAL(1, appCounter->Val());
+
+        UNIT_ASSERT_STRING_CONTAINS(logMessage, "disk:<empty>");
+        UNIT_ASSERT_STRING_CONTAINS(logMessage, "cloud:<empty>");
+        UNIT_ASSERT_STRING_CONTAINS(logMessage, "folder:<empty>");
+
+        handler->UpdateStats(true);
+
+        // No metrics must be created for empty diskId
+        UNIT_ASSERT(volumeCriticalEventsGroup->ReadSnapshot().empty());
     }
 
     // All Report...() overloads works

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -135,11 +135,6 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto assertInitialized = [&](const TString& sensorName)
         {
-            // TODO: fails until all per-disk critical events are removed from
-            // AppCriticalEvents API (now are duplicated in VolumeCriticalEvents
-            // API)
-            return;
-
             auto msg = Sprintf(
                 "reportingMode=%s, sensor=%s",
                 NProto::EVolumeCriticalEventsReportingMode_Name(reportingMode)
@@ -220,15 +215,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
             UNIT_ASSERT_C(appCounter, msg);
             UNIT_ASSERT_VALUES_EQUAL_C(1, appCounter->Val(), msg);
         } else {
-            // TODO: fails until all per-disk critical events are removed from
-            // AppCriticalEvents API (now are duplicated in VolumeCriticalEvents
-            // API)
-
-            // Restore after removed
-            // UNIT_ASSERT_C(!appCounter, msg);
-
-            // Remove after removed
-            UNIT_ASSERT_VALUES_EQUAL_C(0, appCounter->Val(), msg);
+            UNIT_ASSERT_C(!appCounter, msg);
         }
 
         handler->UpdateStats(true);

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -535,6 +535,10 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         UNIT_ASSERT_VALUES_EQUAL(1, volumeCounter->Val());
     }
 
+    // The next two tests report AppImpossibleEvents, which causes crash in
+    // debug builds ('debug', 'relwithdebinfo'), but they shall be executed
+    // within sanitizer builds (which are 'release' builds)
+#ifdef NDEBUG
     // A null labels pointer should report the bug and preserve the original
     // critical event.
     Y_UNIT_TEST(ShouldGracefullyReportNullVolumeLabels)
@@ -555,13 +559,62 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
+        auto bugCounter =
+            criticalEventsGroup->FindCounter(GetCriticalEventForBug());
+        UNIT_ASSERT(bugCounter);
+        bugCounter->Set(0);
+        UNIT_ASSERT_VALUES_EQUAL(0, bugCounter->Val());
+
         const TVolumeLabelsConstPtr volumeLabels;
         const auto logMessage =
             ReportBlockDigestMismatchInBlob(volumeLabels, "some msg");
 
+        UNIT_ASSERT_VALUES_EQUAL(1, bugCounter->Val());
+
+        auto appCounter = criticalEventsGroup->FindCounter(GetAppSensorName());
+        UNIT_ASSERT(appCounter);
+        UNIT_ASSERT_VALUES_EQUAL(1, appCounter->Val());
+
+        UNIT_ASSERT_STRING_CONTAINS(logMessage, "disk:<nullptr>");
+        UNIT_ASSERT_STRING_CONTAINS(logMessage, "cloud:<empty>");
+        UNIT_ASSERT_STRING_CONTAINS(logMessage, "folder:<empty>");
+
+        handler->UpdateStats(true);
+
+        // No metrics must be created for empty diskId
+        UNIT_ASSERT(volumeCriticalEventsGroup->ReadSnapshot().empty());
+    }
+
+    // An empty diskId should report the bug and preserve the original critical
+    // event.
+    Y_UNIT_TEST(ShouldGracefullyReportEmptyDiskId)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto criticalEventsGroup =
+            root->GetSubgroup("component", AppCriticalEventsComponent.data());
+        auto volumeCriticalEventsGroup = root->GetSubgroup(
+            "component",
+            VolumeCriticalEventsComponent.data());
+
+        InitVolumeCriticalEventsReportingMode(
+            NProto::EVolumeCriticalEventsReportingMode::ALL);
+        InitCriticalEventsCounter(criticalEventsGroup);
+        InitVolumeCriticalEventsCounter(volumeCriticalEventsGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
         auto bugCounter =
             criticalEventsGroup->FindCounter(GetCriticalEventForBug());
         UNIT_ASSERT(bugCounter);
+        bugCounter->Set(0);
+        UNIT_ASSERT_VALUES_EQUAL(0, bugCounter->Val());
+
+        const TVolumeLabels volumeLabels;
+        const auto logMessage =
+            ReportBlockDigestMismatchInBlob(volumeLabels, "some msg");
+
         UNIT_ASSERT_VALUES_EQUAL(1, bugCounter->Val());
 
         auto appCounter = criticalEventsGroup->FindCounter(GetAppSensorName());
@@ -577,6 +630,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         // No metrics must be created for empty diskId
         UNIT_ASSERT(volumeCriticalEventsGroup->ReadSnapshot().empty());
     }
+#endif   // NDEBUG
 
     // All Report...() overloads works
     Y_UNIT_TEST(ShouldProperlyImplementAllReportOverloads)

--- a/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
+++ b/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
@@ -54,6 +54,8 @@ public:
     {
         NBD::TStorageOptions options;
         options.DiskId = request.GetDiskId();
+        options.CloudId = volume.GetCloudId();
+        options.FolderId = volume.GetFolderId();
         options.ClientId = request.GetClientId();
         options.BlockSize = volume.GetBlockSize();
         options.BlocksCount = volume.GetBlocksCount();

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -53,6 +53,8 @@ public:
         NVhost::TStorageOptions options;
         options.DeviceName = request.GetDeviceName();
         options.DiskId = request.GetDiskId();
+        options.CloudId = volume.GetCloudId();
+        options.FolderId = volume.GetFolderId();
         options.ClientId = request.GetClientId();
         options.BlockSize = volume.GetBlockSize();
         options.BlocksCount = volume.GetBlocksCount();

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -952,6 +952,8 @@ IServerHandlerFactoryPtr CreateServerHandlerFactory(
     TDeviceHandlerParams params{
         .Storage = std::move(storage),
         .DiskId = options.DiskId,
+        .CloudId = options.CloudId,
+        .FolderId = options.FolderId,
         .ClientId = options.ClientId,
         .BlockSize = options.BlockSize,
         .MaxZeroBlocksSubRequestSize = options.MaxZeroBlocksSubRequestSize,

--- a/cloud/blockstore/libs/nbd/server_handler.h
+++ b/cloud/blockstore/libs/nbd/server_handler.h
@@ -120,6 +120,8 @@ struct IServerHandlerFactory
 struct TStorageOptions
 {
     TString DiskId;
+    TString CloudId;
+    TString FolderId;
     TString ClientId;
     ui32 BlockSize = 0;
     ui64 BlocksCount = 0;

--- a/cloud/blockstore/libs/server/server.cpp
+++ b/cloud/blockstore/libs/server/server.cpp
@@ -739,11 +739,10 @@ private:
             if (cellId && cellId != AppCtx.CellId) {
                 const auto* msg = "DescribeVolume response cell id mismatch";
                 ReportWrongCellIdInDescribeVolume(
-                    Request->GetDiskId(),
-                    "",   // cloudId — not available at this point
-                    "",   // folderId — not available at this point
                     msg,
-                    {{"expected", AppCtx.CellId}, {"actual", cellId}});
+                    {{"disk", Request->GetDiskId()},
+                     {"expected", AppCtx.CellId},
+                     {"actual", cellId}});
 
                 STORAGE_THROW_SERVICE_ERROR(E_REJECTED) << msg;
             }

--- a/cloud/blockstore/libs/server/server.cpp
+++ b/cloud/blockstore/libs/server/server.cpp
@@ -739,6 +739,9 @@ private:
             if (cellId && cellId != AppCtx.CellId) {
                 const auto* msg = "DescribeVolume response cell id mismatch";
                 ReportWrongCellIdInDescribeVolume(
+                    Request->GetDiskId(),
+                    "",   // cloudId — not available at this point
+                    "",   // folderId — not available at this point
                     msg,
                     {{"expected", AppCtx.CellId}, {"actual", cellId}});
 

--- a/cloud/blockstore/libs/service/aligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/aligned_device_handler.cpp
@@ -95,6 +95,8 @@ TAlignedDeviceHandler::TAlignedDeviceHandler(
         ui32 maxSubRequestSize)
     : Storage(std::move(params.Storage))
     , DiskId(std::move(params.DiskId))
+    , CloudId(std::move(params.CloudId))
+    , FolderId(std::move(params.FolderId))
     , ClientId(std::move(params.ClientId))
     , BlockSize(params.BlockSize)
     , MaxBlockCount(maxSubRequestSize / BlockSize)
@@ -467,12 +469,20 @@ void TAlignedDeviceHandler::ReportCriticalError(
     }
 
     auto message = TStringBuilder()
-                   << "disk: " << DiskId.Quote() << ", op: " << operation
+                   << "op: " << operation
                    << ", range: " << range << ", error: " << FormatError(error);
     if (IsReliableMediaKind(StorageMediaKind)) {
-        ReportErrorWasSentToTheGuestForReliableDisk(message);
+        ReportErrorWasSentToTheGuestForReliableDisk(
+            DiskId,
+            CloudId,
+            FolderId,
+            message);
     } else {
-        ReportErrorWasSentToTheGuestForNonReliableDisk(message);
+        ReportErrorWasSentToTheGuestForNonReliableDisk(
+            DiskId,
+            CloudId,
+            FolderId,
+            message);
     }
 }
 

--- a/cloud/blockstore/libs/service/aligned_device_handler.h
+++ b/cloud/blockstore/libs/service/aligned_device_handler.h
@@ -19,6 +19,8 @@ class TAlignedDeviceHandler final
 private:
     const IStoragePtr Storage;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TString ClientId;
     const ui32 BlockSize;
     const ui32 MaxBlockCount;

--- a/cloud/blockstore/libs/service/device_handler.h
+++ b/cloud/blockstore/libs/service/device_handler.h
@@ -41,6 +41,8 @@ struct TDeviceHandlerParams
 {
     IStoragePtr Storage;
     TString DiskId;
+    TString CloudId;
+    TString FolderId;
     TString ClientId;
     ui32 BlockSize = 0;
     ui32 MaxZeroBlocksSubRequestSize = 0;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1387,6 +1387,23 @@ NProto::TError TDiskRegistryState::ReplaceDevice(
     return {};
 }
 
+const TDiskRegistryState::TDiskState&
+TDiskRegistryState::GetMirroredDiskLabelsSource(
+    const TDiskId& masterDiskId,
+    const TDiskId& replicaDiskId) const
+{
+    if (const auto* masterDisk = Disks.FindPtr(masterDiskId)) {
+        return *masterDisk;
+    }
+
+    if (const auto* replicaDisk = Disks.FindPtr(replicaDiskId)) {
+        return *replicaDisk;
+    }
+
+    static const TDiskState emptyDisk;
+    return emptyDisk;
+}
+
 void TDiskRegistryState::TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
     TDiskRegistryDatabase& db,
     TDiskState& disk,
@@ -1417,10 +1434,12 @@ void TDiskRegistryState::TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
         false);   // manual
 
     if (HasError(error)) {
+        const auto& labelsSource =
+            GetMirroredDiskLabelsSource(disk.MasterDiskId, diskId);
         ReportMirroredDiskDeviceReplacementFailure(
             disk.MasterDiskId ? disk.MasterDiskId : diskId,
-            disk.CloudId,
-            disk.FolderId,
+            labelsSource.CloudId,
+            labelsSource.FolderId,
             FormatError(error),
             {{"replica", diskId}, {"device", deviceId}});
     }
@@ -7981,13 +8000,12 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
         StorageConfig->GetMaxAutomaticDeviceReplacementsPerHour();
 
     if (rateLimit && rateLimit <= AutomaticReplacementTimestamps.size()) {
-        const auto* masterDisk = Disks.FindPtr(masterDiskId);
-        const TString& cloudId = masterDisk ? masterDisk->CloudId : TString();
-        const TString& folderId = masterDisk ? masterDisk->FolderId : TString();
+        const auto& labelsSource =
+            GetMirroredDiskLabelsSource(masterDiskId, replicaDiskId);
         ReportMirroredDiskDeviceReplacementRateLimitExceeded(
             masterDiskId,
-            cloudId,
-            folderId,
+            labelsSource.CloudId,
+            labelsSource.FolderId,
             {{"replica", replicaDiskId}, {"device", deviceId}});
         return false;
     }
@@ -7997,13 +8015,12 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
         deviceId);
 
     if (!canReplaceDevice) {
-        const auto* masterDisk = Disks.FindPtr(masterDiskId);
-        const TString& cloudId = masterDisk ? masterDisk->CloudId : TString();
-        const TString& folderId = masterDisk ? masterDisk->FolderId : TString();
+        const auto& labelsSource =
+            GetMirroredDiskLabelsSource(masterDiskId, replicaDiskId);
         ReportMirroredDiskDeviceReplacementForbidden(
             masterDiskId,
-            cloudId,
-            folderId,
+            labelsSource.CloudId,
+            labelsSource.FolderId,
             {{"replica", replicaDiskId}, {"device", deviceId}});
         return false;
     }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1398,6 +1398,7 @@ void TDiskRegistryState::TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
     if (!CheckIfDeviceReplacementIsAllowed(
             timestamp,
             disk.MasterDiskId,
+            diskId,
             deviceId))
     {
         return;
@@ -1416,7 +1417,12 @@ void TDiskRegistryState::TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
         false);   // manual
 
     if (HasError(error)) {
-        ReportMirroredDiskDeviceReplacementFailure(FormatError(error));
+        ReportMirroredDiskDeviceReplacementFailure(
+            disk.MasterDiskId ? disk.MasterDiskId : diskId,
+            disk.CloudId,
+            disk.FolderId,
+            FormatError(error),
+            {{"replica", diskId}, {"device", deviceId}});
     }
 }
 
@@ -2620,7 +2626,9 @@ void TDiskRegistryState::CleanupMirroredDisk(
 
     if (affectedDisks.size()) {
         ReportMirroredDiskAllocationPlacementGroupCleanupFailure(
-            {{"disk", diskId}});
+            diskId,
+            params.CloudId,
+            params.FolderId);
     }
 
     AddToBrokenDisks(now, db, diskId);
@@ -2745,7 +2753,9 @@ NProto::TError TDiskRegistryState::AllocateMirroredDisk(
             // TODO (NBS-3419):
             // support automatic cleanup after a failed resize
             ReportMirroredDiskAllocationCleanupFailure(
-                {{"disk", params.DiskId}});
+                params.DiskId,
+                params.CloudId,
+                params.FolderId);
         }
 
         onError();
@@ -3072,7 +3082,10 @@ NProto::TError TDiskRegistryState::DeallocateDisk(
     }
 
     if (!IsReadyForCleanup(diskId)) {
-        auto message = ReportNrdDestructionError({{"disk", diskId}});
+        auto message = ReportNrdDestructionError(
+            diskId,
+            disk->CloudId,
+            disk->FolderId);
 
         return MakeError(E_INVALID_STATE, std::move(message));
     }
@@ -7951,6 +7964,7 @@ void TDiskRegistryState::DeleteAutomaticallyReplacedDevice(
 bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
     TInstant now,
     const TDiskId& masterDiskId,
+    const TDiskId& replicaDiskId,
     const TDeviceId& deviceId)
 {
     while (AutomaticReplacementTimestamps) {
@@ -7965,10 +7979,16 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
 
     const auto rateLimit =
         StorageConfig->GetMaxAutomaticDeviceReplacementsPerHour();
-    if (rateLimit
-            && rateLimit <= AutomaticReplacementTimestamps.size()) {
+
+    if (rateLimit && rateLimit <= AutomaticReplacementTimestamps.size()) {
+        const auto* masterDisk = Disks.FindPtr(masterDiskId);
+        const TString& cloudId = masterDisk ? masterDisk->CloudId : TString();
+        const TString& folderId = masterDisk ? masterDisk->FolderId : TString();
         ReportMirroredDiskDeviceReplacementRateLimitExceeded(
-            {{"disk", masterDiskId}, {"device", deviceId}});
+            masterDiskId,
+            cloudId,
+            folderId,
+            {{"replica", replicaDiskId}, {"device", deviceId}});
         return false;
     }
 
@@ -7977,8 +7997,14 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
         deviceId);
 
     if (!canReplaceDevice) {
+        const auto* masterDisk = Disks.FindPtr(masterDiskId);
+        const TString& cloudId = masterDisk ? masterDisk->CloudId : TString();
+        const TString& folderId = masterDisk ? masterDisk->FolderId : TString();
         ReportMirroredDiskDeviceReplacementForbidden(
-            {{"disk", masterDiskId}, {"device", deviceId}});
+            masterDiskId,
+            cloudId,
+            folderId,
+            {{"replica", replicaDiskId}, {"device", deviceId}});
         return false;
     }
 
@@ -7986,10 +8012,11 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
         ReplicaTable.IsRecentlyReplacedDevice(masterDiskId, deviceId))
     {
         STORAGE_WARN(
-            "DiskId=%s, DeviceId=%s, automatic device replacement is postponed "
+            "DiskId=%s, ReplicaId=%s, DeviceId=%s, automatic device replacement is postponed "
             "due to replacements in "
             "other replicas.",
             masterDiskId.c_str(),
+            replicaDiskId.c_str(),
             deviceId.c_str());
         return false;
     }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -857,6 +857,7 @@ public:
     bool CheckIfDeviceReplacementIsAllowed(
         TInstant now,
         const TDiskId& masterDiskId,
+        const TDiskId& replicaDiskId,
         const TDeviceId& deviceId);
 
     NProto::TError CreateDiskFromDevices(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1418,6 +1418,10 @@ private:
         TString message,
         bool manual);
 
+    const TDiskState& GetMirroredDiskLabelsSource(
+        const TDiskId& masterDiskId,
+        const TDiskId& replicaDiskId) const;
+
     void TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
         TDiskRegistryDatabase& db,
         TDiskState& disk,

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
@@ -78,6 +78,10 @@ TFreshBlocksWriterActor::TFreshBlocksWriterActor(
         IProfileLogPtr profileLog)
     : Config(std::move(config))
     , PartitionConfig(std::move(partitionConfig))
+    , VolumeLabels(MakeVolumeLabels(
+          PartitionConfig.GetDiskId(),
+          PartitionConfig.GetCloudId(),
+          PartitionConfig.GetFolderId()))
     , StorageAccessMode(storageAccessMode)
     , PartitionTabletID(partitionTabletId)
     , PartitionActorId(partitionActorId)

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/storage/api/fresh_blocks_writer.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
@@ -36,6 +37,7 @@ class TFreshBlocksWriterActor final
 private:
     const TStorageConfigPtr Config;
     const NProto::TPartitionConfig PartitionConfig;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const EStorageAccessMode StorageAccessMode;
     const ui64 PartitionTabletID;
     const NActors::TActorId PartitionActorId;

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/common/volume_labels.h>
+#include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/api/fresh_blocks_writer.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
@@ -133,6 +133,7 @@ void TFreshBlocksWriterActor::WriteFreshBlocks(
         BlockDigestGenerator,
         false,   // waitForAddFreshBlocksResponseBeforeResponse
         PartitionTabletID,
+        VolumeLabels,
         SharedState);
 
     Actors.Insert(actor);
@@ -219,6 +220,7 @@ void TFreshBlocksWriterActor::ZeroFreshBlocks(
         BlockDigestGenerator,
         false,   // waitForAddFreshBlocksResponseBeforeResponse
         PartitionTabletID,
+        VolumeLabels,
         SharedState);
 
     Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -345,11 +345,9 @@ void TPartitionActor::ReassignChannelsIfNeeded(const NActors::TActorContext& ctx
         std::move(channels));
 
     ReportReassignTablet(
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
-        {{"tablet_id", TabletID()},
-         {"channels", sb}});
+        VolumeLabels,
+        "Reassign request sent",
+        TCritEventParams{{"tablet_id", TabletID()}, {"channels", sb}});
     ReassignRequestSentTs = ctx.Now();
 }
 
@@ -1454,6 +1452,25 @@ NProto::TError VerifyBlockChecksum(
     }
 
     return {};
+}
+
+NProto::TError VerifyBlockChecksum(
+    const ui32 actualChecksum,
+    const NKikimr::TLogoBlobID& blobID,
+    const ui64 blockIndex,
+    const ui16 blobOffset,
+    const ui32 expectedChecksum,
+    const TVolumeLabelsConstPtr& volumeLabels)
+{
+    return VerifyBlockChecksum(
+        actualChecksum,
+        blobID,
+        blockIndex,
+        blobOffset,
+        expectedChecksum,
+        volumeLabels->DiskId,
+        volumeLabels->CloudId,
+        volumeLabels->FolderId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -69,6 +69,10 @@ TPartitionActor::TPartitionActor(
     , TTabletBase(owner, std::move(storage), &TransactionTimeTracker)
     , Config(std::move(config))
     , PartitionConfig(std::move(partitionConfig))
+    , VolumeLabels(MakeVolumeLabels(
+          PartitionConfig.GetDiskId(),
+          PartitionConfig.GetCloudId(),
+          PartitionConfig.GetFolderId()))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , BlockDigestGenerator(std::move(blockDigestGenerator))
@@ -341,8 +345,10 @@ void TPartitionActor::ReassignChannelsIfNeeded(const NActors::TActorContext& ctx
         std::move(channels));
 
     ReportReassignTablet(
-        {{"disk", PartitionConfig.GetDiskId()},
-         {"tablet_id", TabletID()},
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
+        {{"tablet_id", TabletID()},
          {"channels", sb}});
     ReassignRequestSentTs = ctx.Now();
 }
@@ -1415,7 +1421,9 @@ NProto::TError VerifyBlockChecksum(
     const ui64 blockIndex,
     const ui16 blobOffset,
     const ui32 expectedChecksum,
-    const TString& diskId)
+    const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId)
 {
     if (expectedChecksum == 0) {
         // 0 is a special case - block digest calculation can be
@@ -1429,8 +1437,10 @@ NProto::TError VerifyBlockChecksum(
 
     if (actualChecksum != expectedChecksum) {
         ReportBlockDigestMismatchInBlob(
-            {{"disk", diskId},
-             {"BlockIndex", blockIndex},
+            diskId,
+            cloudId,
+            folderId,
+            {{"BlockIndex", blockIndex},
              {"blobOffset", blobOffset},
              {"blob", blobID.ToString()}});
         // we might read proper data upon retry - let's give it a chance

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -7,9 +7,9 @@
 #include "part_state.h"
 #include "part_tx.h"
 
+#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
-#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
@@ -853,5 +853,13 @@ NProto::TError VerifyBlockChecksum(
     const TString& diskId,
     const TString& cloudId,
     const TString& folderId);
+
+NProto::TError VerifyBlockChecksum(
+    const ui32 actualChecksum,
+    const NKikimr::TLogoBlobID& blobID,
+    const ui64 blockIndex,
+    const ui16 blobOffset,
+    const ui32 expectedChecksum,
+    const TVolumeLabelsConstPtr& volumeLabels);
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -9,6 +9,7 @@
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
@@ -121,6 +122,7 @@ private:
     const ui64 StartTime = GetCycleCount();
     const TStorageConfigPtr Config;
     const NProto::TPartitionConfig PartitionConfig;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
@@ -848,6 +850,8 @@ NProto::TError VerifyBlockChecksum(
     const ui64 blockIndex,
     const ui16 blobOffset,
     const ui32 expectedChecksum,
-    const TString& diskId);
+    const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId);
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
@@ -345,8 +345,10 @@ void TPartitionActor::HandleAddConfirmedBlobsCompleted(
             FormatError(msg->GetError()).c_str());
 
         ReportAddConfirmedBlobsError(
-            FormatError(msg->GetError()),
-            {{"disk", PartitionConfig.GetDiskId()}});
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
+            FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
@@ -37,7 +37,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
-    const TString DiskId;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 LastGCCommitId;
     const ui64 CollectCommitId;
@@ -62,7 +62,7 @@ public:
     TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -107,7 +107,7 @@ private:
 TCollectGarbageActor::TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -122,7 +122,7 @@ TCollectGarbageActor::TCollectGarbageActor(
         bool passTraceIdToBlobstorage)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
-    , DiskId(std::move(diskId))
+    , VolumeLabels(std::move(volumeLabels))
     , TabletInfo(std::move(tabletInfo))
     , LastGCCommitId(lastGCCommitId)
     , CollectCommitId(collectCommitId)
@@ -248,9 +248,9 @@ void TCollectGarbageActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
+            VolumeLabels,
             TStringBuilder()
-                << "Garbage collection error: " << FormatError(error),
-            {{"disk", DiskId}});
+                << "Garbage collection error: " << FormatError(error));
 
         Error = std::move(error);
     }
@@ -345,7 +345,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
-    const TString DiskId;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 CollectCommitId;
     const ui32 RecordGeneration;
@@ -364,7 +364,7 @@ public:
     TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -401,7 +401,7 @@ private:
 TCollectGarbageHardActor::TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -412,7 +412,7 @@ TCollectGarbageHardActor::TCollectGarbageHardActor(
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
-    , DiskId(std::move(diskId))
+    , VolumeLabels(std::move(volumeLabels))
     , TabletInfo(std::move(tabletInfo))
     , CollectCommitId(collectCommitId)
     , RecordGeneration(recordGeneration)
@@ -499,9 +499,9 @@ void TCollectGarbageHardActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
+            VolumeLabels,
             TStringBuilder()
-                << "Hard garbage collection error: " << FormatError(error),
-            {{"disk", DiskId}});
+                << "Hard garbage collection error: " << FormatError(error));
         Error = std::move(error);
     }
 }
@@ -735,7 +735,7 @@ void TPartitionActor::HandleCollectGarbage(
         ctx,
         requestInfo,
         SelfId(),
-        PartitionConfig.GetDiskId(),
+        VolumeLabels,
         Info(),
         State->GetLastCollectCommitId(),
         commitId,
@@ -852,7 +852,7 @@ void TPartitionActor::CompleteCollectGarbage(
         ctx,
         args.RequestInfo,
         SelfId(),
-        PartitionConfig.GetDiskId(),
+        VolumeLabels,
         Info(),
         args.CollectCommitId,
         Executor()->Generation(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -384,9 +384,7 @@ NProto::TError TCompactionActor::VerifyBlockChecksums()
                 r->BlockIndex,
                 r->BlobOffset,
                 expectedChecksum,
-                VolumeLabels->DiskId,
-                VolumeLabels->CloudId,
-                VolumeLabels->FolderId);
+                VolumeLabels);
 
             if (HasError(error)) {
                 return error;

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -143,7 +143,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const ui64 TabletId;
-    const TString DiskId;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const TActorId Tablet;
     const ui32 BlockSize;
     const ui32 MaxAffectedBlocksPerCompaction;
@@ -199,7 +199,7 @@ public:
     TCompactionActor(
         TRequestInfoPtr requestInfo,
         ui64 tabletId,
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         const TActorId& tablet,
         ui32 blockSize,
         ui32 maxAffectedBlocksPerCompaction,
@@ -275,7 +275,7 @@ private:
 TCompactionActor::TCompactionActor(
         TRequestInfoPtr requestInfo,
         ui64 tabletId,
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         const TActorId& tablet,
         ui32 blockSize,
         ui32 maxAffectedBlocksPerCompaction,
@@ -293,7 +293,7 @@ TCompactionActor::TCompactionActor(
         TVector<TPartialBlobId> blobsToReadBlobMetas)
     : RequestInfo(std::move(requestInfo))
     , TabletId(tabletId)
-    , DiskId(std::move(diskId))
+    , VolumeLabels(std::move(volumeLabels))
     , Tablet(tablet)
     , BlockSize(blockSize)
     , MaxAffectedBlocksPerCompaction(maxAffectedBlocksPerCompaction)
@@ -384,7 +384,9 @@ NProto::TError TCompactionActor::VerifyBlockChecksums()
                 r->BlockIndex,
                 r->BlobOffset,
                 expectedChecksum,
-                DiskId);
+                VolumeLabels->DiskId,
+                VolumeLabels->CloudId,
+                VolumeLabels->FolderId);
 
             if (HasError(error)) {
                 return error;
@@ -2274,7 +2276,7 @@ void TPartitionActor::CompleteCompaction(
         ctx,
         args.RequestInfo,
         TabletID(),
-        PartitionConfig.GetDiskId(),
+        VolumeLabels,
         SelfId(),
         State->GetBlockSize(),
         Config->GetMaxAffectedBlocksPerCompaction(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
@@ -231,8 +231,10 @@ void TPartitionActor::HandleConfirmBlobsCompleted(
             msg->GetStatus(),
             FormatError(msg->GetError()).c_str());
         ReportConfirmBlobsError(
-            FormatError(msg->GetError()),
-            {{"disk", PartitionConfig.GetDiskId()}});
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
+            FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -194,14 +194,12 @@ void TPartitionActor::CompleteLoadState(
         // either a race or a bug (if this situation occurs again after tablet restart)
         // example: CLOUDINC-2027
         ReportInvalidTabletConfig(
-            partitionConfig.GetDiskId(),
-            partitionConfig.GetCloudId(),
-            partitionConfig.GetFolderId(),
+            VolumeLabels,
             TStringBuilder()
-            << LogTitle.GetWithTime()
-            << " tablet info differs from config: tabletChannelCount < "
-               "configChannelCount ("
-            << tabletChannelCount << " < " << configChannelCount << ")");
+                << LogTitle.GetWithTime()
+                << " tablet info differs from config: tabletChannelCount < "
+                   "configChannelCount ("
+                << tabletChannelCount << " < " << configChannelCount << ")");
     } else if (tabletChannelCount > configChannelCount) {
         // legacy channel configuration
         LOG_WARN(

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -194,6 +194,9 @@ void TPartitionActor::CompleteLoadState(
         // either a race or a bug (if this situation occurs again after tablet restart)
         // example: CLOUDINC-2027
         ReportInvalidTabletConfig(
+            partitionConfig.GetDiskId(),
+            partitionConfig.GetCloudId(),
+            partitionConfig.GetFolderId(),
             TStringBuilder()
             << LogTitle.GetWithTime()
             << " tablet info differs from config: tabletChannelCount < "

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -264,7 +264,7 @@ public:
     };
 
 private:
-    const TString DiskId;
+    const TVolumeLabelsConstPtr VolumeLabels;
 
     const TRequestInfoPtr RequestInfo;
 
@@ -297,7 +297,7 @@ private:
 
 public:
     TReadBlocksActor(
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         TRequestInfoPtr requestInfo,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui32 blockSize,
@@ -361,7 +361,7 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TReadBlocksActor::TReadBlocksActor(
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         TRequestInfoPtr requestInfo,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui32 blockSize,
@@ -376,7 +376,7 @@ TReadBlocksActor::TReadBlocksActor(
         TReadBlocksRequests ownRequests,
         TVector<IProfileLog::TBlockInfo> blockInfos,
         bool waitBaseDiskRequests)
-    : DiskId(std::move(diskId))
+    : VolumeLabels(std::move(volumeLabels))
     , RequestInfo(std::move(requestInfo))
     , BlockDigestGenerator(blockDigestGenerator)
     , BlockSize(blockSize)
@@ -578,7 +578,9 @@ bool TReadBlocksActor::VerifyChecksums(
             batch.Requests[i],
             batch.BlobOffsets[i],
             batch.Checksums[i],
-            DiskId);
+            VolumeLabels->DiskId,
+            VolumeLabels->CloudId,
+            VolumeLabels->FolderId);
 
         if (HasError(error)) {
             HandleError(ctx, error);
@@ -1262,7 +1264,7 @@ void TPartitionActor::CompleteReadBlocks(
     if (describeBlocksRange.Defined() || requests) {
         const auto readBlocksActorId = NCloud::Register<TReadBlocksActor>(
             ctx,
-            PartitionConfig.diskid(),
+            VolumeLabels,
             args.RequestInfo,
             BlockDigestGenerator,
             State->GetBlockSize(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -578,9 +578,7 @@ bool TReadBlocksActor::VerifyChecksums(
             batch.Requests[i],
             batch.BlobOffsets[i],
             batch.Checksums[i],
-            VolumeLabels->DiskId,
-            VolumeLabels->CloudId,
-            VolumeLabels->FolderId);
+            VolumeLabels);
 
         if (HasError(error)) {
             HandleError(ctx, error);

--- a/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
@@ -144,7 +144,7 @@ void TPartitionActor::HandleTrimFreshLog(
         Executor()->Generation(),
         nextPerGenerationCounter,
         std::move(freshChannels),
-        PartitionConfig.GetDiskId(),
+        VolumeLabels,
         Config->GetTrimFreshLogTimeout());
 
     Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -135,6 +135,7 @@ void TPartitionActor::WriteFreshBlocks(
             BlockDigestGenerator,
             true,   // waitForAddFreshBlocksResponseBeforeResponse
             TabletID(),
+            VolumeLabels,
             nullptr);   // sharedState
 
         Actors.Insert(actor);
@@ -519,6 +520,7 @@ void TPartitionActor::ZeroFreshBlocks(
             BlockDigestGenerator,
             true,   // waitForAddFreshBlocksResponseBeforeResponse
             TabletID(),
+            VolumeLabels,
             nullptr);   // sharedState
 
         Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -52,6 +52,10 @@ TPartitionActor::TPartitionActor(
     , TTabletBase(owner, std::move(storage), nullptr)
     , Config(std::move(config))
     , PartitionConfig(std::move(partitionConfig))
+    , VolumeLabels(MakeVolumeLabels(
+          PartitionConfig.GetDiskId(),
+          PartitionConfig.GetCloudId(),
+          PartitionConfig.GetFolderId()))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , BlockDigestGenerator(std::move(blockDigestGenerator))
@@ -260,8 +264,12 @@ void TPartitionActor::ReassignChannelsIfNeeded(const NActors::TActorContext& ctx
         std::move(channels));
 
     ReportReassignTablet(
-        TStringBuilder() << TabletID()
-                         << " Reassign request sent for channels: " << sb);
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
+        "Reassign request sent",
+        {{"tablet_id", TabletID()},
+         {"channels", sb}});
     ReassignRequestSentTs = ctx.Now();
 }
 

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -264,12 +264,9 @@ void TPartitionActor::ReassignChannelsIfNeeded(const NActors::TActorContext& ctx
         std::move(channels));
 
     ReportReassignTablet(
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeLabels,
         "Reassign request sent",
-        {{"tablet_id", TabletID()},
-         {"channels", sb}});
+        TCritEventParams{{"tablet_id", TabletID()}, {"channels", sb}});
     ReassignRequestSentTs = ctx.Now();
 }
 

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.h
@@ -8,10 +8,10 @@
 #include "part2_state.h"
 #include "part2_tx.h"
 
+#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
-#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/storage/api/partition2.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.h
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/storage/api/partition2.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
@@ -99,6 +100,7 @@ private:
     const ui64 StartTime = GetCycleCount();
     const TStorageConfigPtr Config;
     const NProto::TPartitionConfig PartitionConfig;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
@@ -36,6 +36,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 LastGCCommitId;
     const ui64 CollectCommitId;
@@ -57,6 +58,7 @@ public:
     TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
+        TVolumeLabelsConstPtr volumeLabels,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -99,6 +101,7 @@ private:
 TCollectGarbageActor::TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
+        TVolumeLabelsConstPtr volumeLabels,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -111,6 +114,7 @@ TCollectGarbageActor::TCollectGarbageActor(
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
+    , VolumeLabels(std::move(volumeLabels))
     , TabletInfo(std::move(tabletInfo))
     , LastGCCommitId(lastGCCommitId)
     , CollectCommitId(collectCommitId)
@@ -223,6 +227,7 @@ void TCollectGarbageActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
+            VolumeLabels,
             TStringBuilder()
             << "Garbage collection failed: " << FormatError(error));
         Error = std::move(error);
@@ -318,6 +323,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 CollectCommitId;
     const ui32 RecordGeneration;
@@ -335,6 +341,7 @@ public:
     TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
+        TVolumeLabelsConstPtr volumeLabels,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -369,6 +376,7 @@ private:
 TCollectGarbageHardActor::TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
+        TVolumeLabelsConstPtr volumeLabels,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -378,6 +386,7 @@ TCollectGarbageHardActor::TCollectGarbageHardActor(
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
+    , VolumeLabels(std::move(volumeLabels))
     , TabletInfo(std::move(tabletInfo))
     , CollectCommitId(collectCommitId)
     , RecordGeneration(recordGeneration)
@@ -461,6 +470,7 @@ void TCollectGarbageHardActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
+            VolumeLabels,
             TStringBuilder()
             << "Hard garbage collection failed: " << FormatError(error));
         Error = std::move(error);
@@ -680,6 +690,7 @@ void TPartitionActor::HandleCollectGarbage(
         ctx,
         requestInfo,
         SelfId(),
+        VolumeLabels,
         Info(),
         State->GetLastCollectCommitId(),
         commitId,
@@ -779,6 +790,7 @@ void TPartitionActor::CompleteCollectGarbage(
         ctx,
         args.RequestInfo,
         SelfId(),
+        VolumeLabels,
         Info(),
         args.CollectCommitId,
         Executor()->Generation(),

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
@@ -133,12 +133,9 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
             << " reason: " << msg->GetError().GetMessage().Quote());
 
         ReportInitFreshBlocksError(
-            PartitionConfig.GetDiskId(),
-            PartitionConfig.GetCloudId(),
-            PartitionConfig.GetFolderId(),
-            TStringBuilder()
-            << "[" << TabletID()
-            << "] LoadFreshBlobs failed: " << msg->GetStatus());
+            VolumeLabels,
+            TStringBuilder() << "[" << TabletID() << "] LoadFreshBlobs failed: "
+                             << msg->GetStatus());
         Suicide(ctx);
         return;
     }
@@ -169,12 +166,10 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
                 << FormatError(error));
 
             ReportInitFreshBlocksError(
-                PartitionConfig.GetDiskId(),
-                PartitionConfig.GetCloudId(),
-                PartitionConfig.GetFolderId(),
+                VolumeLabels,
                 TStringBuilder()
-                << "[" << TabletID() << "] Failed to parse fresh blob "
-                << "(blob commitId: " << blob.CommitId << ")");
+                    << "[" << TabletID() << "] Failed to parse fresh blob "
+                    << "(blob commitId: " << blob.CommitId << ")");
             Suicide(ctx);
             return;
         }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
@@ -133,6 +133,9 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
             << " reason: " << msg->GetError().GetMessage().Quote());
 
         ReportInitFreshBlocksError(
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             TStringBuilder()
             << "[" << TabletID()
             << "] LoadFreshBlobs failed: " << msg->GetStatus());
@@ -166,6 +169,9 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
                 << FormatError(error));
 
             ReportInitFreshBlocksError(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder()
                 << "[" << TabletID() << "] Failed to parse fresh blob "
                 << "(blob commitId: " << blob.CommitId << ")");

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_loadstate.cpp
@@ -156,14 +156,12 @@ void TPartitionActor::CompleteLoadState(
 
     if (tabletChannelCount != configChannelCount) {
         ReportInvalidTabletConfig(
-            args.Meta->GetConfig().GetDiskId(),
-            args.Meta->GetConfig().GetCloudId(),
-            args.Meta->GetConfig().GetFolderId(),
+            VolumeLabels,
             TStringBuilder()
-            << "[" << TabletID() << "] "
-            << "tablet info differs from config: "
-            << "tabletChannelCount != configChannelCount ("
-            << tabletChannelCount << " != " << configChannelCount << ")");
+                << "[" << TabletID() << "] "
+                << "tablet info differs from config: "
+                << "tabletChannelCount != configChannelCount ("
+                << tabletChannelCount << " != " << configChannelCount << ")");
 
         // FIXME(NBS-2088): do suicide
         // Suicide(ctx);

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_loadstate.cpp
@@ -156,6 +156,9 @@ void TPartitionActor::CompleteLoadState(
 
     if (tabletChannelCount != configChannelCount) {
         ReportInvalidTabletConfig(
+            args.Meta->GetConfig().GetDiskId(),
+            args.Meta->GetConfig().GetCloudId(),
+            args.Meta->GetConfig().GetFolderId(),
             TStringBuilder()
             << "[" << TabletID() << "] "
             << "tablet info differs from config: "

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
@@ -438,14 +438,13 @@ void TPartitionActor::HandleReadBlobCompleted(
                 >= Config->GetMaxReadBlobErrorsBeforeSuicide())
         {
             ReportTabletBSFailure(
-                PartitionConfig.GetDiskId(),
-                PartitionConfig.GetCloudId(),
-                PartitionConfig.GetFolderId(),
+                VolumeLabels,
                 TStringBuilder()
-                << TabletID()
-                << " Stop tablet because of too many ReadBlob errors (actor "
-                << ev->Sender.ToString() << " group " << msg->GroupId
-                << "): " << FormatError(msg->GetError()));
+                    << TabletID()
+                    << " Stop tablet because of too many ReadBlob errors "
+                       "(actor "
+                    << ev->Sender.ToString() << " group " << msg->GroupId
+                    << "): " << FormatError(msg->GetError()));
             Suicide(ctx);
         } else {
             LOG_WARN(ctx, TBlockStoreComponents::PARTITION,

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
@@ -438,6 +438,9 @@ void TPartitionActor::HandleReadBlobCompleted(
                 >= Config->GetMaxReadBlobErrorsBeforeSuicide())
         {
             ReportTabletBSFailure(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder()
                 << TabletID()
                 << " Stop tablet because of too many ReadBlob errors (actor "

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
@@ -131,7 +131,7 @@ void TPartitionActor::HandleTrimFreshLog(
         ParseCommitId(State->GetLastCommitId()).first,
         nextPerGenerationCounter,
         std::move(freshChannels),
-        "",
+        VolumeLabels,
         Config->GetTrimFreshLogTimeout());
 
     Actors.insert(actor);

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
@@ -380,6 +380,9 @@ void TPartitionActor::HandleWriteBlobCompleted(
 
     if (FAILED(msg->GetStatus())) {
         ReportTabletBSFailure(
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             TStringBuilder()
             << TabletID() << " Stop tablet because of WriteBlob error (actor "
             << ev->Sender.ToString() << " group " << group

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
@@ -380,13 +380,12 @@ void TPartitionActor::HandleWriteBlobCompleted(
 
     if (FAILED(msg->GetStatus())) {
         ReportTabletBSFailure(
-            PartitionConfig.GetDiskId(),
-            PartitionConfig.GetCloudId(),
-            PartitionConfig.GetFolderId(),
+            VolumeLabels,
             TStringBuilder()
-            << TabletID() << " Stop tablet because of WriteBlob error (actor "
-            << ev->Sender.ToString() << " group " << group
-            << "): " << FormatError(msg->GetError()));
+                << TabletID()
+                << " Stop tablet because of WriteBlob error (actor "
+                << ev->Sender.ToString() << " group " << group
+                << "): " << FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
@@ -26,7 +26,7 @@ TTrimFreshLogActor::TTrimFreshLogActor(
         ui32 recordGeneration,
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , PartitionActorId(partitionActorId)
@@ -35,7 +35,7 @@ TTrimFreshLogActor::TTrimFreshLogActor(
     , RecordGeneration(recordGeneration)
     , PerGenerationCounter(perGenerationCounter)
     , FreshChannels(std::move(freshChannels))
-    , DiskId(std::move(diskId))
+    , VolumeLabels(std::move(volumeLabels))
     , Timeout(timeout)
 {}
 
@@ -138,11 +138,17 @@ void TTrimFreshLogActor::HandleCollectGarbageResult(
         HasError(error))
     {
         TCritEventParams critEventParams =
-             {{"disk", DiskId}, {"TabletId", TabletInfo->TabletID}};
+             {{"TabletId", TabletInfo->TabletID}};
         if (msg->Status == NKikimrProto::EReplyStatus::DEADLINE) {
-            ReportTrimFreshLogTimeout(FormatError(error), critEventParams);
+            ReportTrimFreshLogTimeout(
+                VolumeLabels,
+                FormatError(error),
+                critEventParams);
         } else {
-            ReportTrimFreshLogError(FormatError(error), critEventParams);
+            ReportTrimFreshLogError(
+                VolumeLabels,
+                FormatError(error),
+                critEventParams);
         }
         Error = std::move(error);
     }

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>
@@ -26,7 +27,7 @@ private:
     const ui32 RecordGeneration;
     const ui32 PerGenerationCounter;
     const TVector<ui32> FreshChannels;
-    const TString DiskId;
+    const TVolumeLabelsConstPtr VolumeLabels;
     const TDuration Timeout;
 
     ui32 RequestsInFlight = 0;
@@ -41,7 +42,7 @@ public:
         ui32 recordGeneration,
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
-        TString diskId,
+        TVolumeLabelsConstPtr volumeLabels,
         TDuration timeout);
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
@@ -2,13 +2,13 @@
 
 #include "events_private.h"
 
+#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
-#include <cloud/blockstore/libs/common/volume_labels.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>
-
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
 namespace NCloud::NBlockStore::NStorage {

--- a/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.cpp
@@ -31,6 +31,7 @@ TWriteFreshBlocksActor::TWriteFreshBlocksActor(
         IBlockDigestGeneratorPtr blockDigestGenerator,
         bool waitForAddFreshBlocksResponseBeforeResponse,
         ui64 tabletId,
+        TVolumeLabelsConstPtr volumeLabels,
         TPartitionThreadSafeStatePtr sharedState)
     : Owner(owner)
     , ActorToAddFreshBlocks(actorToAddFreshBlocks)
@@ -47,6 +48,7 @@ TWriteFreshBlocksActor::TWriteFreshBlocksActor(
     , WaitForAddFreshBlocksResponseBeforeResponse(
           waitForAddFreshBlocksResponseBeforeResponse)
     , TabletId(tabletId)
+    , VolumeLabels(std::move(volumeLabels))
     , SharedState(std::move(sharedState))
 {
     if (!IsZeroRequest) {
@@ -370,9 +372,10 @@ void TWriteFreshBlocksActor::HandleAddFreshBlocksResponse(
         error.GetCode() != E_CANCELLED)
     {
         ReportAddFreshBlocksResultedInError(
+            VolumeLabels,
             "unexpected error in AddFreshBlocksResponse",
-            {{"error", FormatError(ev->Get()->GetError())},
-             {"tabletId", TabletId}});
+            TCritEventParams{{"error", FormatError(ev->Get()->GetError())},
+                             {"tabletId", TabletId}});
 
         // If WaitForAddFreshBlocksResponseBeforeResponse is false, this means
         // that we responded to the client with success before adding the blocks

--- a/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
@@ -3,6 +3,7 @@
 #include "events_private.h"
 
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
+#include <cloud/blockstore/libs/common/volume_labels.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
@@ -59,6 +60,7 @@ private:
     const bool IsZeroRequest;
     const bool WaitForAddFreshBlocksResponseBeforeResponse;
     const ui64 TabletId;
+    const TVolumeLabelsConstPtr VolumeLabels;
 
     TPartitionThreadSafeStatePtr SharedState;
 
@@ -85,6 +87,7 @@ public:
         IBlockDigestGeneratorPtr blockDigestGenerator,
         bool waitForAddFreshBlocksResponseBeforeResponse,
         ui64 tabletId,
+        TVolumeLabelsConstPtr volumeLabels,
         TPartitionThreadSafeStatePtr sharedState);
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
@@ -2,8 +2,8 @@
 
 #include "events_private.h"
 
-#include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/common/volume_labels.h>
+#include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 

--- a/cloud/blockstore/libs/storage/partition_common/fresh_blocks_companion_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/fresh_blocks_companion_initfreshblocks.cpp
@@ -40,9 +40,11 @@ void TFreshBlocksCompanion::HandleLoadFreshBlobsCompleted(
 
     if (FAILED(msg->GetStatus())) {
         ReportInitFreshBlocksError(
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             TStringBuilder() << "LoadFreshBlobs failed, error: "
-                             << FormatError(msg->GetError()),
-            {{"disk", PartitionConfig.GetDiskId()}});
+                             << FormatError(msg->GetError()));
         Client.Poison(ctx);
         return;
     }
@@ -66,10 +68,12 @@ void TFreshBlocksCompanion::HandleLoadFreshBlobsCompleted(
 
         if (FAILED(error.GetCode())) {
             ReportInitFreshBlocksError(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder() << "Failed to parse fresh blob error: "
                                  << FormatError(error),
-                {{"disk", PartitionConfig.GetDiskId()},
-                 {"commit_id", blob.CommitId}});
+                {{"commit_id", blob.CommitId}});
             Client.Poison(ctx);
             return;
         }

--- a/cloud/blockstore/libs/storage/partition_common/io_companion_patchblob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/io_companion_patchblob.cpp
@@ -351,9 +351,11 @@ void TIOCompanion::HandlePatchBlobCompleted(
 
     if (FAILED(msg->GetStatus())) {
         ReportTabletBSFailure(
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             TStringBuilder() << "Stop tablet because of PatchBlob error: "
-                             << FormatError(msg->GetError()),
-            {{"disk", PartitionConfig.GetDiskId()}});
+                             << FormatError(msg->GetError()));
         Client.Poison(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition_common/io_companion_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/io_companion_readblob.cpp
@@ -182,11 +182,13 @@ void TIOCompanion::HandleReadBlobCompleted(
         if (++ReadBlobErrorCount >= Config->GetMaxReadBlobErrorsBeforeSuicide())
         {
             ReportTabletBSFailure(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder()
                     << "Stop tablet because of too many ReadBlob errors"
                     << FormatError(msg->GetError()),
-                {{"disk", PartitionConfig.GetDiskId()},
-                 {"actor", ev->Sender.ToString()},
+                {{"actor", ev->Sender.ToString()},
                  {"group", groupId}});
             Client.Poison(ctx);
             return;

--- a/cloud/blockstore/libs/storage/partition_common/io_companion_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/io_companion_writeblob.cpp
@@ -469,11 +469,13 @@ void TIOCompanion::HandleWriteBlobCompleted(
             Config->GetMaxWriteBlobErrorsBeforeSuicide())
         {
             ReportTabletBSFailure(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder()
                     << "Stop tablet because of too many WriteBlob errors"
                     << FormatError(msg->GetError()),
-                {{"disk", PartitionConfig.GetDiskId()},
-                 {"actor", ev->Sender.ToString()},
+                {{"actor", ev->Sender.ToString()},
                  {"group", groupId}});
             Client.Poison(ctx);
             return;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -55,6 +55,8 @@ public:
         TInstant CreationTs;
         NProto::EStorageMediaKind MediaKind;
         NProto::EEncryptionMode EncryptionMode;
+        TString CloudId;
+        TString FolderId;
     };
 
     struct TNonreplicatedPartitionConfigInitParams
@@ -186,6 +188,16 @@ public:
     const TVolumeInfo& GetVolumeInfo() const
     {
         return VolumeInfo;
+    }
+
+    const TString& GetCloudId() const
+    {
+        return VolumeInfo.CloudId;
+    }
+
+    const TString& GetFolderId() const
+    {
+        return VolumeInfo.FolderId;
     }
 
     NActors::TActorId GetParentActorId() const

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -28,6 +28,8 @@ TLaggingAgentMigrationActor::TLaggingAgentMigrationActor(
           config,
           std::move(diagnosticsConfig),
           partConfig->GetName(),
+          partConfig->GetCloudId(),
+          partConfig->GetFolderId(),
           partConfig->GetBlockCount(),
           partConfig->GetBlockSize(),
           std::move(profileLog),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -69,6 +69,8 @@ TMirrorPartitionActor::TMirrorPartitionActor(
     , RdmaClient(std::move(rdmaClient))
     , PartitionBudgetManager(std::move(partitionBudgetManager))
     , DiskId(partConfig->GetName())
+    , CloudId(partConfig->GetCloudId())
+    , FolderId(partConfig->GetFolderId())
     , VolumeActorId(volumeActorId)
     , StatActorId(statActorId)
     , ResyncActorId(resyncActorId)
@@ -256,10 +258,16 @@ void TMirrorPartitionActor::CompareChecksums(const TActorContext& ctx)
         const bool hasQuorum = majorCount > checksums.size() / 2;
         if (hasQuorum) {
             ReportMirroredDiskMinorityChecksumMismatch(
-                {{"disk", DiskId}, {"range", GetScrubbingRange()}});
+                DiskId,
+                CloudId,
+                FolderId,
+                {{"range", GetScrubbingRange()}});
         } else {
             ReportMirroredDiskMajorityChecksumMismatch(
-                {{"disk", DiskId}, {"range", GetScrubbingRange()}});
+                DiskId,
+                CloudId,
+                FolderId,
+                {{"range", GetScrubbingRange()}});
         }
         if (Config->GetResyncRangeAfterScrubbing() &&
             CanFixMismatch(hasQuorum, Config->GetScrubbingResyncPolicy()))
@@ -714,8 +722,11 @@ void TMirrorPartitionActor::HandleAddTagsResponse(
 
     if (HasError(error)) {
         ReportMirroredDiskAddTagFailed(
+            DiskId,
+            CloudId,
+            FolderId,
             FormatError(error),
-            {{"disk", DiskId}, {"tag", IntermediateWriteBufferTagName}});
+            {{"tag", IntermediateWriteBufferTagName}});
         return;
     }
     LOG_WARN(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -75,6 +75,8 @@ private:
     NCloud::NStorage::NRdma::IClientPtr RdmaClient;
     const TPartitionBudgetManagerPtr PartitionBudgetManager;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const NActors::TActorId VolumeActorId;
     const NActors::TActorId StatActorId;
     const NActors::TActorId ResyncActorId;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -66,8 +66,10 @@ void TMirrorPartitionActor::HandleMirroredReadCompleted(
     if (it == DirtyReadRequestIds.end()) {
         if (ev->Get()->ChecksumMismatchObserved) {
             ReportMirroredDiskChecksumMismatchUponRead(
-                {{"disk", DiskId},
-                 {"range", (requestCtx ? requestCtx->Range.Print() : "")}});
+                DiskId,
+                CloudId,
+                FolderId,
+                {{"range", (requestCtx ? requestCtx->Range.Print() : "")}});
         }
     } else {
         DirtyReadRequestIds.erase(it);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
@@ -245,9 +245,11 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
             ScheduleRetryResyncNextRange(ctx);
         } else {
             ReportResyncFailed(
+                PartConfig->GetName(),
+                PartConfig->GetCloudId(),
+                PartConfig->GetFolderId(),
                 FormatError(msg->GetError()),
-                {{"disk", PartConfig->GetName()},
-                 {"range", DescribeRange(range)}});
+                {{"range", DescribeRange(range)}});
         }
 
         TDeque<TPostponedRead> postponedReads;
@@ -276,7 +278,10 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
 
     if (CritOnChecksumMismatch && msg->WriteStartTs > TInstant()) {
         ReportMirroredDiskResyncChecksumMismatch(
-            {{"disk", PartConfig->GetName()}, {"range", range}});
+            PartConfig->GetName(),
+            PartConfig->GetCloudId(),
+            PartConfig->GetFolderId(),
+            {{"range", range}});
     }
 
     auto resyncRange = State.BuildResyncRange();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_state.cpp
@@ -143,7 +143,10 @@ bool TMirrorPartitionState::PrepareMigrationConfigForWarningDevices()
     }
 
     ReportMigrationSourceNotFound(
-        {{"disk", PartConfig->GetName()}, {"RWClientId", RWClientId}});
+        PartConfig->GetName(),
+        PartConfig->GetCloudId(),
+        PartConfig->GetFolderId(),
+        TCritEventParams{{"RWClientId", RWClientId}});
 
     // TODO: log details
     return false;
@@ -198,11 +201,14 @@ bool TMirrorPartitionState::PrepareMigrationConfigForFreshDevices()
     }
 
     ReportMigrationSourceNotFound(
+        PartConfig->GetName(),
+        PartConfig->GetCloudId(),
+        PartConfig->GetFolderId(),
         "PrepareMigrationConfigForFreshDevices failed: no suitable source "
         "device found for fresh device",
-        {{"disk", PartConfig->GetName()},
-         {"index", deviceIdx},
-         {"total_replicas", ReplicaInfos.size()}});
+        TCritEventParams{
+            {"index", deviceIdx},
+            {"total_replicas", ReplicaInfos.size()}});
     return false;
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -325,7 +325,10 @@ bool TNonreplicatedPartitionActor::InitRequests(
             NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT)
     {
         ReportCrossPartitionRequestDetected(
-            {{"disk", PartConfig->GetName()}, {"range", blockRange}});
+            PartConfig->GetName(),
+            PartConfig->GetCloudId(),
+            PartConfig->GetFolderId(),
+            {{"range", blockRange}});
     }
 
     if (deviceRequests->empty()) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -33,6 +33,8 @@ TNonreplicatedPartitionMigrationActor::TNonreplicatedPartitionMigrationActor(
           config,
           std::move(diagnosticsConfig),
           srcConfig->GetName(),
+          srcConfig->GetCloudId(),
+          srcConfig->GetFolderId(),
           srcConfig->GetBlockCount(),
           srcConfig->GetBlockSize(),
           std::move(profileLog),
@@ -233,9 +235,11 @@ NActors::TActorId TNonreplicatedPartitionMigrationActor::CreateDstActor(
 
             if (device.GetBlocksCount() != target.GetBlocksCount()) {
                 ReportBadMigrationConfig(
+                    SrcConfig->GetName(),
+                    SrcConfig->GetCloudId(),
+                    SrcConfig->GetFolderId(),
                     "source != target blocks count",
-                    {{"disk", SrcConfig->GetName()},
-                     {"source", device.GetDeviceUUID()},
+                    {{"source", device.GetDeviceUUID()},
                      {"source_blocks_count", device.GetBlocksCount()},
                      {"target", target.GetDeviceUUID()},
                      {"target_blocks_count", target.GetBlocksCount()}});
@@ -293,8 +297,10 @@ void TNonreplicatedPartitionMigrationActor::HandleFinishMigrationResponse(
 
         if (GetErrorKind(error) != EErrorKind::ErrorRetriable) {
             ReportMigrationFailed(
-                "Finish migration failed",
-                {{"disk", SrcConfig->GetName()}});
+                SrcConfig->GetName(),
+                SrcConfig->GetCloudId(),
+                SrcConfig->GetFolderId(),
+                "Finish migration failed");
             return;
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -22,6 +22,8 @@ TNonreplicatedPartitionMigrationCommonActor::
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         ui64 blockCount,
         ui64 blockSize,
         IProfileLogPtr profileLog,
@@ -37,6 +39,8 @@ TNonreplicatedPartitionMigrationCommonActor::
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , BlockSize(blockSize)
     , BlockCount(blockCount)
     , BlockDigestGenerator(std::move(digestGenerator))
@@ -63,6 +67,8 @@ TNonreplicatedPartitionMigrationCommonActor::
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         ui64 blockCount,
         ui64 blockSize,
         IProfileLogPtr profileLog,
@@ -77,6 +83,8 @@ TNonreplicatedPartitionMigrationCommonActor::
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , BlockSize(blockSize)
     , BlockCount(blockCount)
     , BlockDigestGenerator(std::move(digestGenerator))

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -131,6 +131,8 @@ private:
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IProfileLogPtr ProfileLog;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const ui64 BlockSize;
     const ui64 BlockCount;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
@@ -212,6 +214,8 @@ public:
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         ui64 blockCount,
         ui64 blockSize,
         IProfileLogPtr profileLog,
@@ -228,6 +232,8 @@ public:
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         ui64 blockCount,
         ui64 blockSize,
         IProfileLogPtr profileLog,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -447,8 +447,10 @@ void TNonreplicatedPartitionMigrationCommonActor::OnMigrationNonRetriableError(
     const NActors::TActorContext& ctx)
 {
     ReportMigrationFailed(
-        "Non-retriable migration error occurred",
-        {{"disk", DiskId}});
+        DiskId,
+        CloudId,
+        FolderId,
+        "Non-retriable migration error occurred");
     MigrationOwner->OnMigrationError(ctx);
     MigrationEnabled = false;
 }

--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
@@ -50,6 +50,8 @@ TFollowerDiskActor::TFollowerDiskActor(
           config,
           std::move(diagnosticConfig),
           params.LeaderDiskId,
+          params.LeaderCloudId,
+          params.LeaderFolderId,
           params.LeaderBlockCount,
           params.LeaderBlockSize,
           std::move(profileLog),

--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.h
@@ -15,6 +15,8 @@ struct TFollowerDiskActorParams
     const NProto::EStorageMediaKind LeaderMediaKind =
         NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT;
     const TString LeaderDiskId;
+    const TString LeaderCloudId;
+    const TString LeaderFolderId;
     const ui64 LeaderBlockCount = 0;
     const ui32 LeaderBlockSize = 0;
 

--- a/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.cpp
@@ -38,12 +38,16 @@ TMultiPartitionWrapperActor::TMultiPartitionWrapperActor(
     TChildLogTitle logTitle,
     ITraceSerializerPtr traceSerializer,
     const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId,
     ui32 blockSize,
     ui32 blocksPerStripe,
     NProto::ERequestSplitterPolicy splitterPolicy,
     const TVector<NActors::TActorId>& partitionActors)
     : LogTitle(std::move(logTitle))
     , TraceSerializer(std::move(traceSerializer))
+    , CloudId(cloudId)
+    , FolderId(folderId)
     , BlockSize(blockSize)
     , BlocksPerStripe(blocksPerStripe)
     , SplitterPolicy(splitterPolicy)
@@ -187,7 +191,10 @@ void TMultiPartitionWrapperActor::HandleRequest(
             isCrossPartitionRequest)
         {
             ReportCrossPartitionRequestDetected(
-                {{"disk", Partitions.front().DiskId}, {"range", blockRange}});
+                Partitions.front().DiskId,
+                CloudId,
+                FolderId,
+                {{"range", blockRange}});
         }
     }
 

--- a/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.h
@@ -24,6 +24,8 @@ class TMultiPartitionWrapperActor final
 private:
     const TChildLogTitle LogTitle;
     const ITraceSerializerPtr TraceSerializer;
+    const TString CloudId;
+    const TString FolderId;
     const ui32 BlockSize = 0;
     const ui32 BlocksPerStripe = 0;
     const NProto::ERequestSplitterPolicy SplitterPolicy =
@@ -35,6 +37,8 @@ public:
         TChildLogTitle logTitle,
         ITraceSerializerPtr traceSerializer,
         const TString& diskId,
+        const TString& cloudId,
+        const TString& folderId,
         ui32 blockSize,
         ui32 blocksPerStripe,
         NProto::ERequestSplitterPolicy splitterPolicy,

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -562,6 +562,8 @@ TShadowDiskActor::TShadowDiskActor(
           config,
           std::move(diagnosticConfig),
           srcConfig->GetName(),
+          srcConfig->GetCloudId(),
+          srcConfig->GetFolderId(),
           srcConfig->GetBlockCount(),
           srcConfig->GetBlockSize(),
           std::move(profileLog),
@@ -822,7 +824,9 @@ void TShadowDiskActor::CreateShadowDiskConfig()
         .CreationTs = TInstant(),
         .MediaKind =
             GetCheckpointShadowDiskType(SrcConfig->GetVolumeInfo().MediaKind),
-        .EncryptionMode = SrcConfig->GetVolumeInfo().EncryptionMode};
+        .EncryptionMode = SrcConfig->GetVolumeInfo().EncryptionMode,
+        .CloudId = SrcConfig->GetVolumeInfo().CloudId,
+        .FolderId = SrcConfig->GetVolumeInfo().FolderId};
 
     TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
         params{

--- a/cloud/blockstore/libs/storage/volume/model/helpers.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/helpers.cpp
@@ -95,9 +95,11 @@ std::optional<TDeviceLocation> FindTargetMigrationDeviceLocation(
             FindReplicaDeviceLocation(meta, migration.GetSourceDeviceId());
         if (!sourceLocation) {
             ReportDiskAllocationFailure(
+                meta.GetConfig().GetDiskId(),
+                meta.GetConfig().GetCloudId(),
+                meta.GetConfig().GetFolderId(),
                 "Migration source device not found",
-                {{"disk", meta.GetConfig().GetDiskId()},
-                 {"target_device", migration.GetTargetDevice().GetDeviceUUID()},
+                {{"target_device", migration.GetTargetDevice().GetDeviceUUID()},
                  {"source_device", migration.GetSourceDeviceId()}});
             continue;
         }
@@ -192,9 +194,11 @@ TVector<NProto::TLaggingDevice> CollectLaggingDevices(
                 FindReplicaDeviceLocation(meta, migration.GetSourceDeviceId());
             if (!deviceLocation) {
                 ReportDiskAllocationFailure(
+                    meta.GetConfig().GetDiskId(),
+                    meta.GetConfig().GetCloudId(),
+                    meta.GetConfig().GetFolderId(),
                     "Migration inconsistency detected",
-                    {{"disk", meta.GetConfig().GetDiskId()},
-                     {"target_device", targetDevice.GetDeviceUUID()},
+                    {{"target_device", targetDevice.GetDeviceUUID()},
                      {"source_device", migration.GetSourceDeviceId()}});
                 continue;
             }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -379,8 +379,10 @@ void TVolumeActor::HandleAllocateDiskError(
     if (error.GetCode() != E_BS_RESOURCE_EXHAUSTED && !localDiskAllocationRetry)
     {
         ReportDiskAllocationFailure(
-            "allocation failed",
-            {{"disk", GetNewestConfig().GetDiskId()}});
+            GetNewestConfig().GetDiskId(),
+            GetNewestConfig().GetCloudId(),
+            GetNewestConfig().GetFolderId(),
+            "allocation failed");
     }
     LOG_ERROR(
         ctx,
@@ -615,8 +617,10 @@ bool TVolumeActor::CheckAllocationResult(
 
     if (!ok) {
         ReportDiskAllocationFailure(
-            "invalid disk allocation response received",
-            {{"disk", State->GetDiskId()}});
+            State->GetDiskId(),
+            State->GetMeta().GetVolumeConfig().GetCloudId(),
+            State->GetMeta().GetVolumeConfig().GetFolderId(),
+            "invalid disk allocation response received");
 
         if (State->GetAcceptInvalidDiskAllocationResponse()) {
             LOG_WARN(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -177,6 +177,8 @@ private:
     const TRequestInfoPtr RequestInfo;
     const ui64 RequestId;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TString CheckpointId;
     const ui64 VolumeTabletId;
     const TActorId VolumeActorId;
@@ -203,6 +205,8 @@ public:
         TRequestInfoPtr requestInfo,
         ui64 requestId,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TString checkpointId,
         ui64 volumeTabletId,
         TActorId volumeActorId,
@@ -297,6 +301,8 @@ TCheckpointActor<TMethod>::TCheckpointActor(
         TRequestInfoPtr requestInfo,
         ui64 requestId,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TString checkpointId,
         ui64 volumeTabletId,
         TActorId volumeActorId,
@@ -311,6 +317,8 @@ TCheckpointActor<TMethod>::TCheckpointActor(
     : RequestInfo(std::move(requestInfo))
     , RequestId(requestId)
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , CheckpointId(std::move(checkpointId))
     , VolumeTabletId(volumeTabletId)
     , VolumeActorId(volumeActorId)
@@ -779,6 +787,9 @@ void TCheckpointActor<TMethod>::HandleReleaseDiskResponse(
         }
 
         ReportReleaseShadowDiskError(
+            DiskId,
+            CloudId,
+            FolderId,
             FormatError(record.GetError()),
             {{"ShadowDiskId", ShadowDiskId}});
     }
@@ -1555,6 +1566,8 @@ void TVolumeActor::ExecuteCheckpointRequest(const TActorContext& ctx, ui64 reque
                     requestInfo->RequestInfo,
                     request.RequestId,
                     State->GetDiskId(),
+                    State->GetMeta().GetVolumeConfig().GetCloudId(),
+                    State->GetMeta().GetVolumeConfig().GetFolderId(),
                     request.CheckpointId,
                     TabletID(),
                     SelfId(),
@@ -1586,6 +1599,8 @@ void TVolumeActor::ExecuteCheckpointRequest(const TActorContext& ctx, ui64 reque
                     requestInfo->RequestInfo,
                     request.RequestId,
                     State->GetDiskId(),
+                    State->GetMeta().GetVolumeConfig().GetCloudId(),
+                    State->GetMeta().GetVolumeConfig().GetFolderId(),
                     request.CheckpointId,
                     TabletID(),
                     SelfId(),
@@ -1611,6 +1626,8 @@ void TVolumeActor::ExecuteCheckpointRequest(const TActorContext& ctx, ui64 reque
                     requestInfo->RequestInfo,
                     request.RequestId,
                     State->GetDiskId(),
+                    State->GetMeta().GetVolumeConfig().GetCloudId(),
+                    State->GetMeta().GetVolumeConfig().GetFolderId(),
                     request.CheckpointId,
                     TabletID(),
                     SelfId(),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -999,8 +999,10 @@ void TVolumeActor::ForwardRequest(
                                   ORP_ENABLE_WITH_CRIT_EVENT)
                 {
                     ReportOverlappingRequestsDetected(
-                        {{"disk", State->GetDiskId()},
-                         {"Inflight", *addResult.InflightRange},
+                        State->GetDiskId(),
+                        State->GetMeta().GetVolumeConfig().GetCloudId(),
+                        State->GetMeta().GetVolumeConfig().GetFolderId(),
+                        {{"Inflight", *addResult.InflightRange},
                          {"New", blockRange}});
                 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -158,6 +158,8 @@ void TVolumeActor::OnPartitionStateChanged(
                     LogTitle.GetChild(GetCycleCount()),
                     TraceSerializer,
                     GetDiskId(),
+                    State->GetMeta().GetVolumeConfig().GetCloudId(),
+                    State->GetMeta().GetVolumeConfig().GetFolderId(),
                     State->GetMeta().GetVolumeConfig().GetBlockSize(),
                     State->GetMeta().GetVolumeConfig().GetBlocksPerStripe(),
                     Config->GetRequestSplitterPolicy(),
@@ -246,7 +248,9 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
                 .CreationTs = State->GetCreationTs(),
                 .MediaKind = mediaKind,
                 .EncryptionMode = static_cast<NProto::EEncryptionMode>(
-                    volumeConfig.GetEncryptionDesc().GetMode())},
+                    volumeConfig.GetEncryptionDesc().GetMode()),
+                .CloudId = volumeConfig.GetCloudId(),
+                .FolderId = volumeConfig.GetFolderId()},
             State->GetDiskId(),
             State->GetMeta().GetConfig().GetBlockSize(),
             SelfId(),
@@ -440,6 +444,10 @@ TActorsStack TVolumeActor::WrapWithFollowerActorIfNeeded(
                     TFollowerDiskActorParams{
                         .LeaderMediaKind = State->GetStorageMediaKind(),
                         .LeaderDiskId = State->GetDiskId(),
+                        .LeaderCloudId =
+                            State->GetConfig().GetCloudId(),
+                        .LeaderFolderId =
+                            State->GetConfig().GetFolderId(),
                         .LeaderBlockCount = State->GetBlocksCount(),
                         .LeaderBlockSize = State->GetBlockSize(),
                         .LeaderVolumeActorId = SelfId(),

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -385,6 +385,8 @@ IDeviceHandlerPtr TServer::CreateDeviceHandler(
     TDeviceHandlerParams params{
         .Storage = std::move(storage),
         .DiskId = options.DiskId,
+        .CloudId = options.CloudId,
+        .FolderId = options.FolderId,
         .ClientId = options.ClientId,
         .BlockSize = options.BlockSize,
         .MaxZeroBlocksSubRequestSize = options.MaxZeroBlocksSubRequestSize,

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -23,6 +23,8 @@ struct TStorageOptions
 {
     TString DeviceName;
     TString DiskId;
+    TString CloudId;
+    TString FolderId;
     TString ClientId;
     ui32 BlockSize = 0;
     ui64 BlocksCount = 0;


### PR DESCRIPTION

### Notes
This PR is part of #6582 implementation.
This PR is stacked on #6708.

1. Per-disk critical events are removed form **AppCriticalEvent** API and now exiss only in **VolumeCriticalEvent** API
2. All call sites of **Report...()** for per-disk critical events are modified for new API with required **diskId**,  **cloudId** and **folderId** parameters. Per-request actors are now populated with **TVolumeLabelsConstPtr VolumeLabels** instead of the old single **TString DiskId** or the three new **TString** fields (**DiskId**, **CloudId**, **FolderId**) to avoid performance overhead from string copying (COW strings are deprecated).

### Issue
#6582 (detailed analysis and implementation description)
