### PR TITLE
[Disk Manager] Add S3 controlplane endpoint config

### DIFF
--- a/cloud/tasks/persistence/config/config.proto
+++ b/cloud/tasks/persistence/config/config.proto
@@ -25,10 +25,10 @@ message S3Config {
     required string CredentialsFilePath = 3;
     optional string CallTimeout = 4 [default = "60s"];
     optional uint64 MaxRetriableErrorCount = 5 [default = 3];
-    optional S3ControlplaneConfig ControlplaneConfig = 6;
+    optional S3ControlPlaneConfig ControlplaneConfig = 6;
 }
 
-message S3ControlplaneConfig {
+message S3ControlPlaneConfig {
     required string Endpoint = 1;
     optional string CallTimeout = 2 [default = "60s"];
 }

--- a/cloud/tasks/persistence/config/config.proto
+++ b/cloud/tasks/persistence/config/config.proto
@@ -30,5 +30,5 @@ message S3Config {
 
 message S3ControlplaneConfig {
     required string Endpoint = 1;
-    required string CallTimeout = 2 [default = "60s"];
+    optional string CallTimeout = 2 [default = "60s"];
 }

--- a/cloud/tasks/persistence/config/config.proto
+++ b/cloud/tasks/persistence/config/config.proto
@@ -25,4 +25,10 @@ message S3Config {
     required string CredentialsFilePath = 3;
     optional string CallTimeout = 4 [default = "60s"];
     optional uint64 MaxRetriableErrorCount = 5 [default = 3];
+    optional S3ControlplaneConfig ControlplaneConfig = 6;
+}
+
+message S3ControlplaneConfig {
+    required string Endpoint = 1;
+    required string CallTimeout = 2 [default = "60s"];
 }

--- a/cloud/tasks/persistence/config/config.proto
+++ b/cloud/tasks/persistence/config/config.proto
@@ -25,7 +25,7 @@ message S3Config {
     required string CredentialsFilePath = 3;
     optional string CallTimeout = 4 [default = "60s"];
     optional uint64 MaxRetriableErrorCount = 5 [default = 3];
-    optional S3ControlPlaneConfig ControlplaneConfig = 6;
+    optional S3ControlPlaneConfig ControlPlaneConfig = 6;
 }
 
 message S3ControlPlaneConfig {


### PR DESCRIPTION
We need to allow to interract with S3 controlplane API from disk-manager. It is logical to emplace it in the S3Config.
