### PR TITLE
Increase qemu memory for flapping tests

### DIFF
--- a/cloud/filestore/tests/fio/qemu-kikimr-mq-test/ya.make
+++ b/cloud/filestore/tests/fio/qemu-kikimr-mq-test/ya.make
@@ -30,7 +30,7 @@ SET(
 SET(QEMU_VIRTIO fs)
 SET(QEMU_ROOTFS cloud/storage/core/tools/testing/qemu/image-noble/rootfs.img)
 SET(QEMU_NUM_REQUEST_QUEUES 8)
-SET(QEMU_MEM 6G)
+SET(QEMU_MEM 8G)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)

--- a/cloud/filestore/tests/fio/qemu-local-noserver-mq-test/ya.make
+++ b/cloud/filestore/tests/fio/qemu-local-noserver-mq-test/ya.make
@@ -33,7 +33,7 @@ SET(
 SET(QEMU_VIRTIO fs)
 SET(QEMU_ROOTFS cloud/storage/core/tools/testing/qemu/image-noble/rootfs.img)
 SET(QEMU_NUM_REQUEST_QUEUES 8)
-SET(QEMU_MEM 6G)
+SET(QEMU_MEM 8G)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-local-noserver.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/6645

```
[  341.233715] Out of memory: Killed process 2538 (cloud-filestore) total-vm:9449392kB, anon-rss:5782864kB, file-rss:2124kB, shmem-rss:0kB, UID:0 pgtables:13948kB oom_score_adj:0
```