### PR TITLE
[Filestore] Fix stable plugin Sandbox resources after update

### DIFF
--- a/build/ext_mapping.conf.json
+++ b/build/ext_mapping.conf.json
@@ -2,8 +2,8 @@
     "bottles": {},
     "resources": {
         "4081472014": "https://storage.eu-north2.nebius.cloud/nbs-oss-resources/short.log",
-        "4312345600": "https://storage.eu-north2.nebius.cloud/nbs-oss-resources/libblockstore-plugin-amd64.tgz",
-        "4312345601": "https://storage.eu-north2.nebius.cloud/nbs-oss-resources/libblockstore-plugin-arm64.tgz",
+        "13124593141": "https://storage.eu-north2.nebius.cloud/nbs-oss-resources/libblockstore-plugin-amd64.tgz",
+        "13124596655": "https://storage.eu-north2.nebius.cloud/nbs-oss-resources/libblockstore-plugin-arm64.tgz",
         "12978105235": "https://storage.eu-north2.nebius.cloud/nbs-oss-resources/fio-static-fio-3.42-x86_64.tgz",
         "12978105361": "https://storage.eu-north2.nebius.cloud/nbs-oss-resources/fio-static-fio-3.42-aarch64.tgz",
         "4449551218": "https://storage.eu-north2.nebius.cloud/nbs-oss-resources/qemu-static.tgz",
@@ -33,8 +33,8 @@
     },
     "resources_descriptions": {
         "4081472014": "cloud/blockstore/tests/loadtest/selftest",
-        "4312345600": "cloud/blockstore/tools/testing/stable-plugin amd64",
-        "4312345601": "cloud/blockstore/tools/testing/stable-plugin arm64",
+        "13124593141": "cloud/blockstore/tools/testing/stable-plugin amd64",
+        "13124596655": "cloud/blockstore/tools/testing/stable-plugin arm64",
         "12978105235": "cloud/storage/core/tools/testing/fio/bin amd64",
         "12978105361": "cloud/storage/core/tools/testing/fio/bin arm64",
         "4449551218": "cloud/storage/core/tools/testing/qemu/bin amd64",

--- a/cloud/blockstore/tools/testing/stable-plugin/ya.make
+++ b/cloud/blockstore/tools/testing/stable-plugin/ya.make
@@ -3,11 +3,11 @@ PACKAGE()
 IF(ARCH_X86_64)
     # ya make -r -DALLOCATOR=TCMALLOC_256K cloud/vm/blockstore
     # tar -czvhf libblockstore-plugin-amd64.tgz libblockstore-plugin.so
-    FROM_SANDBOX(4312345600 OUT_NOAUTO libblockstore-plugin.so)
+    FROM_SANDBOX(13124593141 OUT_NOAUTO libblockstore-plugin.so)
 ELSEIF (ARCH_ARM64)
     # ya make -r -DALLOCATOR=TCMALLOC_256K --target-platform=default-linux-aarch64 cloud/vm/blockstore
     # tar -czvhf libblockstore-plugin-arm64.tgz libblockstore-plugin.so
-    FROM_SANDBOX(4312345601 OUT_NOAUTO libblockstore-plugin.so)
+    FROM_SANDBOX(13124596655 OUT_NOAUTO libblockstore-plugin.so)
 ELSE()
     MESSAGE(FATAL_ERROR "Unsupported platform")
 ENDIF()


### PR DESCRIPTION
## What changed

Replace the placeholder stable blockstore plugin resource ids with Sandbox resources uploaded from the existing OSS archives:

- amd64: `4312345600` -> `13124593141`
- arm64: `4312345601` -> `13124596655`

Updated both places that referenced these ids:

- `build/ext_mapping.conf.json`
- `cloud/blockstore/tools/testing/stable-plugin/ya.make`

## Issue

Tests failed in Arcadia sync because the placeholder Sandbox resources do not exist:

```text
ERROR: Failed to download resource: [Uri_ = sbr:4312345600], error: Failed to fetch sandbox resource meta: sbr=4312345600, status_code=404
```

The new resources have infinite TTL and contain `libblockstore-plugin.so` at the archive root, as expected by `FROM_SANDBOX`.
