### PR TITLE
issue-6751: add metric for compressed profile log frame size

### DIFF
--- a/cloud/filestore/libs/diagnostics/profile_log.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log.cpp
@@ -21,6 +21,7 @@ using namespace NMonitoring;
 
 class TProfileLog final
     : public IProfileLog
+    , public IEventLog::ISuccessCallback
     , public std::enable_shared_from_this<TProfileLog>
 {
 private:
@@ -28,6 +29,7 @@ private:
     {
         TDynamicCounters::TCounterPtr Requests;
         TDynamicCounters::TCounterPtr Bytes;
+        TDynamicCounters::TCounterPtr CompressedFrameBytes;
         TDynamicCounters::TCounterPtr Flushes;
         TDynamicCounters::TCounterPtr Discards;
     };
@@ -54,6 +56,7 @@ public:
         , Timer(std::move(timer))
         , Scheduler(std::move(scheduler))
     {
+        EventLog.SetSuccessCallback(this);
     }
 
     ~TProfileLog() override;
@@ -66,6 +69,8 @@ public:
     void RegisterCounters(NMonitoring::TDynamicCounters& root) override;
 
 private:
+    void OnWriteSuccess(const TBuffer& frameData) override;
+
     void ScheduleFlush();
     void Flush();
 };
@@ -100,9 +105,19 @@ void TProfileLog::RegisterCounters(NMonitoring::TDynamicCounters& root)
     auto pg = root.GetSubgroup("counters", "profile_log");
     Counters.Requests = pg->GetCounter("Count", true);
     Counters.Bytes = pg->GetCounter("RequestBytes", true);
+    Counters.CompressedFrameBytes =
+        pg->GetCounter("CompressedFrameBytes", true);
     Counters.Flushes = pg->GetCounter("FlushCount", true);
     Counters.Discards = pg->GetCounter("DiscardCount", true);
     CountersRegistered = true;
+}
+
+void TProfileLog::OnWriteSuccess(const TBuffer& frameData)
+{
+    if (CountersRegistered) {
+        Counters.CompressedFrameBytes->Add(
+            static_cast<i64>(frameData.Size()));
+    }
 }
 
 void TProfileLog::ScheduleFlush()

--- a/cloud/filestore/libs/diagnostics/profile_log_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_ut.cpp
@@ -12,6 +12,7 @@
 #include <util/folder/tempdir.h>
 #include <util/generic/algorithm.h>
 #include <util/string/builder.h>
+#include <util/system/fstat.h>
 
 namespace NCloud::NFileStore {
 
@@ -475,12 +476,17 @@ Y_UNIT_TEST_SUITE(TProfileLogTest)
         auto pg = Counters->GetSubgroup("counters", "profile_log");
         auto requests = pg->FindCounter("Count");
         auto bytes = pg->FindCounter("RequestBytes");
+        auto compressedFrameBytes = pg->FindCounter("CompressedFrameBytes");
         auto flushes = pg->FindCounter("FlushCount");
         auto discards = pg->FindCounter("DiscardCount");
         UNIT_ASSERT(requests);
         UNIT_ASSERT_VALUES_EQUAL(7, requests->Val());
         UNIT_ASSERT(bytes);
         UNIT_ASSERT_VALUES_EQUAL(177, bytes->Val());
+        UNIT_ASSERT(compressedFrameBytes);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetFileLength(ProfilePath.c_str()),
+            compressedFrameBytes->Val());
         UNIT_ASSERT(flushes);
         UNIT_ASSERT_VALUES_EQUAL(3, flushes->Val());
         UNIT_ASSERT(discards);
@@ -562,6 +568,7 @@ Y_UNIT_TEST_SUITE(TProfileLogTest)
         auto pg = env.Counters->GetSubgroup("counters", "profile_log");
         auto requests = pg->FindCounter("Count");
         auto bytes = pg->FindCounter("RequestBytes");
+        auto compressedFrameBytes = pg->FindCounter("CompressedFrameBytes");
         auto flushes = pg->FindCounter("FlushCount");
         auto discards = pg->FindCounter("DiscardCount");
         UNIT_ASSERT(requests);
@@ -570,6 +577,10 @@ Y_UNIT_TEST_SUITE(TProfileLogTest)
             requests->Val());
         UNIT_ASSERT(bytes);
         UNIT_ASSERT_VALUES_EQUAL(578, bytes->Val());
+        UNIT_ASSERT(compressedFrameBytes);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetFileLength(env.ProfilePath.c_str()),
+            compressedFrameBytes->Val());
         UNIT_ASSERT(flushes);
         UNIT_ASSERT_VALUES_EQUAL(1, flushes->Val());
         UNIT_ASSERT(discards);


### PR DESCRIPTION
### Notes
We want to estimate the total size of profile logs written to a file.
The EventLog library invokes the [OnWriteSuccess callback](https://github.com/ydb-platform/nbs/blob/b5adcaa39c830da97b010be0552df31042cc3e30/library/cpp/eventlog/eventlog.cpp#L477) after writing each serialized and compressed frame. This PR uses the callback to expose the total size of successfully written frames through the CompressedFrameBytes metric

### Issue
#6751
