### PR TITLE
[NBS] preserve source partition ownership after follower recovery

### DIFF
--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
@@ -92,6 +92,8 @@ void TFollowerDiskActor::OnBootstrap(const NActors::TActorContext& ctx)
         LogTitle.GetWithTime().c_str(),
         ToString(FollowerDiskInfo.State).Quote().c_str());
 
+    PoisonPillHelper.TakeOwnership(ctx, LeaderPartitionActorId);
+
     if (!ApplyLinkState(ctx)) {
         return;
     }
@@ -109,7 +111,7 @@ void TFollowerDiskActor::OnBootstrap(const NActors::TActorContext& ctx)
             .MigrationSrcActorId = LeaderPartitionActorId,
             .SrcActorId = LeaderPartitionActorId,
             .DstActorId = FollowerPartitionActorId,
-            .TakeOwnershipOverSrcActor = true,
+            .TakeOwnershipOverSrcActor = false, // already taken in the line 95
             .TakeOwnershipOverDstActor = true,
             .SendWritesToSrc = true,
             .TimeoutCalculator = std::make_unique<TMigrationTimeoutCalculator>(

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
@@ -67,8 +67,8 @@ void TVolumeAsPartitionActor::ForwardRequestToFollower(
     const ui64 requestId = RequestsInProgress.AddWriteRequest(
         BuildRequestBlockRange(*msg, OriginalBlockSize),
         TRequestCtx{
-            .OriginalSender = ev->Sender,
-            .OriginalCookie = ev->Cookie,
+            .Sender = ev->Sender,
+            .Cookie = ev->Cookie,
             .RequestType = requestType});
 
     NActors::TActorId nondeliveryActor = SelfId();
@@ -91,18 +91,16 @@ void TVolumeAsPartitionActor::ForwardResponse(
 
     if (auto requestCtx = RequestsInProgress.ExtractRequest(ev->Cookie)) {
         if (requestCtx->Value.RequestType == ERequestType::WriteBlocksLocal) {
-            ctx.Send(
-                requestCtx->Value.OriginalSender,
-                new TEvService::TEvWriteBlocksLocalResponse(
-                    msg->Record.GetError()),
-                0,   // flags
-                requestCtx->Value.OriginalCookie);
+            NCloud::Reply(
+                ctx,
+                requestCtx->Value,
+                std::make_unique<TEvService::TEvWriteBlocksLocalResponse>(
+                    msg->Record.GetError()));
         } else {
-            ctx.Send(
-                requestCtx->Value.OriginalSender,
-                ev->ReleaseBase().Release(),
-                0,   // flags
-                requestCtx->Value.OriginalCookie);
+            NCloud::Reply(
+                ctx,
+                requestCtx->Value,
+                NActors::IEventBasePtr(ev->ReleaseBase().Release()));
         }
     } else {
         LOG_ERROR(
@@ -136,20 +134,17 @@ void TVolumeAsPartitionActor::ReplyUndelivery(
             message.c_str());
 
         if (requestCtx->Value.RequestType == ERequestType::WriteBlocksLocal) {
-            ctx.Send(
-                requestCtx->Value.OriginalSender,
-                std::make_unique<
-                    TEvService::TWriteBlocksLocalMethod::TResponse>(
-                    MakeError(E_REJECTED, std::move(message))),
-                0,   // flags
-                requestCtx->Value.OriginalCookie);
+            NCloud::Reply(
+                ctx,
+                requestCtx->Value,
+                std::make_unique<TEvService::TEvWriteBlocksLocalResponse>(
+                    MakeError(E_REJECTED, std::move(message))));
         } else {
-            ctx.Send(
-                requestCtx->Value.OriginalSender,
+            NCloud::Reply(
+                ctx,
+                requestCtx->Value,
                 std::make_unique<typename TMethod::TResponse>(
-                    MakeError(E_REJECTED, std::move(message))),
-                0,   // flags
-                requestCtx->Value.OriginalCookie);
+                    MakeError(E_REJECTED, std::move(message))));
         }
     } else {
         LOG_ERROR(
@@ -213,7 +208,7 @@ void TVolumeAsPartitionActor::ReplyInvalidRange(
         NCloud::Reply(
             ctx,
             *ev,
-            std::make_unique<TEvService::TWriteBlocksLocalMethod::TResponse>(
+            std::make_unique<TEvService::TEvWriteBlocksLocalResponse>(
                 MakeError(E_ARGUMENT, std::move(message))));
     } else {
         NCloud::Reply(
@@ -249,20 +244,19 @@ void TVolumeAsPartitionActor::DoWriteBlocks(
             LogTitle.GetWithTime().c_str(),
             message.c_str());
 
+        auto error = MakeError(E_NOT_IMPLEMENTED, std::move(message));
         if (requestType == ERequestType::WriteBlocksLocal) {
-            ctx.Send(
-                ev->Sender,
+            NCloud::Reply(
+                ctx,
+                *ev,
                 std::make_unique<TEvService::TEvWriteBlocksLocalResponse>(
-                    MakeError(E_NOT_IMPLEMENTED, std::move(message))),
-                0,   // flags
-                ev->Cookie);
+                    std::move(error)));
         } else {
-            ctx.Send(
-                ev->Sender,
+            NCloud::Reply(
+                ctx,
+                *ev,
                 std::make_unique<TEvService::TEvWriteBlocksResponse>(
-                    MakeError(E_NOT_IMPLEMENTED, std::move(message))),
-                0,   // flags
-                ev->Cookie);
+                    std::move(error)));
         }
 
         return;
@@ -555,34 +549,33 @@ void TVolumeAsPartitionActor::CancelRequests(const TActorContext& ctx)
         }
 
         const auto& requestCtx = request->Value;
+        // The requester may still be alive, so return E_REJECTED to allow it to
+        // retry the request.
         auto error = MakeError(
             E_REJECTED,
             "Follower request timed out during shutdown");
 
         switch (requestCtx.RequestType) {
             case ERequestType::WriteBlocks:
-                ctx.Send(
-                    requestCtx.OriginalSender,
+                NCloud::Reply(
+                    ctx,
+                    requestCtx,
                     std::make_unique<TEvService::TEvWriteBlocksResponse>(
-                        std::move(error)),
-                    0,   // flags
-                    requestCtx.OriginalCookie);
+                        std::move(error)));
                 break;
             case ERequestType::WriteBlocksLocal:
-                ctx.Send(
-                    requestCtx.OriginalSender,
+                NCloud::Reply(
+                    ctx,
+                    requestCtx,
                     std::make_unique<TEvService::TEvWriteBlocksLocalResponse>(
-                        std::move(error)),
-                    0,   // flags
-                    requestCtx.OriginalCookie);
+                        std::move(error)));
                 break;
             case ERequestType::ZeroBlocks:
-                ctx.Send(
-                    requestCtx.OriginalSender,
+                NCloud::Reply(
+                    ctx,
+                    requestCtx,
                     std::make_unique<TEvService::TEvZeroBlocksResponse>(
-                        std::move(error)),
-                    0,   // flags
-                    requestCtx.OriginalCookie);
+                        std::move(error)));
                 break;
         }
     }

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.h
@@ -42,8 +42,8 @@ public:
 private:
     struct TRequestCtx
     {
-        const NActors::TActorId OriginalSender;
-        const ui64 OriginalCookie = 0;
+        const NActors::TActorId Sender;
+        const ui64 Cookie = 0;
         const ERequestType RequestType = ERequestType::WriteBlocks;
     };
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
@@ -48,6 +48,46 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TPoisonableTestActor final
+    : public TActorBootstrapped<TPoisonableTestActor>
+{
+public:
+    void Bootstrap(const TActorContext& ctx)
+    {
+        Become(&TThis::StateWork);
+        Y_UNUSED(ctx);
+    }
+
+private:
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        ctx.Send(
+            ev->Sender,
+            new TEvents::TEvPoisonTaken(),
+            0,   // flags
+            ev->Cookie);
+        Die(ctx);
+    }
+
+    STFUNC(StateWork)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+            default:
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::PARTITION,
+                    __PRETTY_FUNCTION__);
+                break;
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TFixture: public NUnitTest::TBaseFixture
 {
     struct TVolumeInfo
@@ -695,7 +735,7 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
     }
 
     void DoShouldPrepareFollowerVolume(
-        TFixture & fixture,
+        TFixture& fixture,
         NProto::EStorageMediaKind leaderMediaType,
         NProto::EStorageMediaKind followerMediaType,
         ECheckpointBehaviour checkpoint,
@@ -2258,6 +2298,94 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             followerPartitionStopped,
             "Follower partition adapter is still alive after graceful "
             "shutdown");
+    }
+
+    void DoShouldOwnSourcePartitionAfterRecovery(
+        TFixture& fixture,
+        TFollowerDiskInfo::EState persistedState)
+    {
+        auto config = std::make_shared<TStorageConfig>(
+            NProto::TStorageServiceConfig{},
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        const auto sourcePartitionActor =
+            fixture.Runtime->Register(new TPoisonableTestActor());
+        const auto leaderVolumeActor = fixture.Runtime->AllocateEdgeActor();
+        const auto poisoner = fixture.Runtime->AllocateEdgeActor();
+
+        auto followerDiskActor = std::make_unique<TFollowerDiskActor>(
+            TLogTitle(
+                GetCycleCount(),
+                TLogTitle::TVolume{
+                    .TabletId = TestVolumeTablets[0],
+                    .DiskId = "vol1"}),
+            std::move(config),
+            CreateTestDiagnosticsConfig(),
+            CreateProfileLogStub(),
+            CreateBlockDigestGeneratorStub(),
+            TFollowerDiskActorParams{
+                .LeaderMediaKind = NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+                .LeaderDiskId = "vol1",
+                .LeaderBlockCount = fixture.VolumeBlockCount,
+                .LeaderBlockSize = DefaultBlockSize,
+                .LeaderVolumeActorId = leaderVolumeActor,
+                .LeaderPartitionActorId = sourcePartitionActor,
+                .ClientId = "client",
+                .FollowerDiskInfo = {
+                    .Link =
+                        {.LinkUUID = "link-id",
+                         .LeaderDiskId = "vol1",
+                         .LeaderShardId = "leader-shard",
+                         .FollowerDiskId = "vol2",
+                         .FollowerShardId = "follower-shard"},
+                    .CreatedAt = TInstant::Now(),
+                    .State = persistedState,
+                    .MediaKind = NProto::STORAGE_MEDIA_SSD}});
+
+        const auto followerDiskActorId =
+            fixture.Runtime->Register(followerDiskActor.release());
+
+        fixture.Runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
+
+        fixture.Runtime->Send(new IEventHandle(
+            followerDiskActorId,
+            poisoner,
+            new TEvents::TEvPoisonPill()));
+
+        TAutoPtr<IEventHandle> handle;
+        fixture.Runtime->GrabEdgeEvent<TEvents::TEvPoisonTaken>(
+            handle,
+            TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(handle, "Follower disk actor did not complete shutdown");
+        UNIT_ASSERT_C(
+            !fixture.Runtime->FindActor(sourcePartitionActor),
+            TStringBuilder() << "Source partition " << sourcePartitionActor
+                             << " is still alive after recovery from "
+                             << ToString(persistedState));
+    }
+
+    Y_UNIT_TEST_F(ShouldOwnSourcePartitionAfterDataReadyRecovery, TFixture)
+    {
+        DoShouldOwnSourcePartitionAfterRecovery(
+            *this,
+            TFollowerDiskInfo::EState::DataReady);
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldOwnSourcePartitionAfterLeadershipTransferredRecovery,
+        TFixture)
+    {
+        DoShouldOwnSourcePartitionAfterRecovery(
+            *this,
+            TFollowerDiskInfo::EState::LeadershipTransferred);
+    }
+
+    Y_UNIT_TEST_F(ShouldOwnSourcePartitionAfterErrorRecovery, TFixture)
+    {
+        DoShouldOwnSourcePartitionAfterRecovery(
+            *this,
+            TFollowerDiskInfo::EState::Error);
     }
 }
 


### PR DESCRIPTION
### Issue
After a leader volume restart, TFollowerDiskActor may be restored with the persisted DataReady or LeadershipTransferred state. In these states, ApplyLinkState returns before InitWork, while ownership of the source partition was previously established only inside InitWork.
As a result, the restored follower wrapper could complete shutdown without stopping its source partition, leaving the partition actor alive.

### Fix
This change acquires ownership of the source partition before applying the persisted link state. It also adds tests covering recovery from both DataReady and LeadershipTransferred and verifies that shutting down the restored wrapper stops the source partition.