### PR TITLE
validate whole chain for expiration + removed unused function and tests

### DIFF
--- a/cloud/storage/core/libs/grpc/tls_utils.cpp
+++ b/cloud/storage/core/libs/grpc/tls_utils.cpp
@@ -148,6 +148,48 @@ bool IsEmptyPair(const TCertificateFiles& certPair)
     return !certPair.PrivateKeyPath && !certPair.CertChainPath;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+TMaybe<TString> UpdateRootCa(
+    const TRootCaPair& root,
+    TLog& Log)
+{
+    if (root.RootCaPath.empty()) {
+        return Nothing();
+    }
+
+    auto result = NTlsUtils::ReadAndValidateRootCertificate(root.RootCaPath);
+    if (HasError(result.GetError())) {
+        STORAGE_WARN(
+            "Root certificate update is skipped: "
+            << FormatError(result.GetError()));
+
+        return root.RootCa.empty()
+            ? Nothing()
+            : TMaybe<TString>(root.RootCa);
+    }
+
+    return result.ExtractResult();
+}
+
+TResultOrError<grpc_core::PemKeyCertPairList> ReadAndValidateIdentityCertificate(
+    const TCertificateFiles& files)
+{
+    auto identityResult = NTlsUtils::ReadAndValidateIdentityPair(files);
+    if (HasError(identityResult)) {
+        return identityResult.GetError();
+    }
+
+    const auto& pair = identityResult.GetResult().front();
+    auto validityResult =
+        NTlsUtils::ValidateIdentityCertificateValidity(pair.cert_chain());
+    if (HasError(validityResult)) {
+        return validityResult.GetError();
+    }
+
+    return identityResult.ExtractResult();
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -422,28 +464,18 @@ TCertificatesUpdateResult UpdateCertificates(
 
     TCertificatesUpdateResult updateResult;
     updateResult.Certificates.resize(certificates.size());
-
-    const bool needsRoot = !root.RootCaPath.empty();
-    if (!needsRoot) {
-        updateResult.RootCa = Nothing();
-    } else {
-        auto rootResult =
-            NTlsUtils::ReadAndValidateRootCertificate(root.RootCaPath);
-        if (HasError(rootResult.GetError())) {
-            STORAGE_WARN(
-                "Root certificate update is skipped: "
-                << FormatError(rootResult.GetError()));
-            updateResult.RootCa = root.RootCa.empty()
-                ? Nothing()
-                : TMaybe<TString>(root.RootCa);
-        } else {
-            updateResult.RootCa = rootResult.ExtractResult();
-        }
-    }
+    updateResult.RootCa = UpdateRootCa(root, Log);
 
     for (size_t i = 0; i < certificates.size(); ++i) {
-        const auto& cert = certificates[i];
-        const auto usePreviousCertificate = [&] {
+        const TCertificatePair& cert = certificates[i];
+        auto identityResult = ReadAndValidateIdentityCertificate(cert.Files);
+
+        if (HasError(identityResult)) {
+            STORAGE_WARN(
+                "Identity certificate update is skipped for "
+                << cert.Files.CertChainPath.Quote() << ": "
+                << FormatError(identityResult.GetError()));
+
             if (!cert.PrivateKey.empty() && !cert.CertChain.empty()) {
                 grpc_core::PemKeyCertPairList fallback;
                 fallback.emplace_back(cert.PrivateKey, cert.CertChain);
@@ -451,27 +483,7 @@ TCertificatesUpdateResult UpdateCertificates(
                     .CertificatesChain = std::move(fallback),
                 };
             }
-        };
 
-        auto identityResult = NTlsUtils::ReadAndValidateIdentityPair(cert.Files);
-        if (HasError(identityResult.GetError())) {
-            STORAGE_WARN(
-                "Identity certificate update is skipped for "
-                << cert.Files.CertChainPath.Quote() << ": "
-                << FormatError(identityResult.GetError()));
-            usePreviousCertificate();
-            continue;
-        }
-
-        const auto& pair = identityResult.GetResult().front();
-        auto validityResult =
-            NTlsUtils::ValidateIdentityCertificateValidity(pair.cert_chain());
-        if (HasError(validityResult.GetError())) {
-            STORAGE_WARN(
-                "Identity certificate update is skipped for "
-                << cert.Files.CertChainPath.Quote() << ": "
-                << FormatError(validityResult.GetError()));
-            usePreviousCertificate();
             continue;
         }
 
@@ -482,7 +494,7 @@ TCertificatesUpdateResult UpdateCertificates(
         auto notAfterTs =
             NTlsUtils::GetCertificateNotAfterTimestampSec(
                 identityPair.cert_chain());
-        if (HasError(notAfterTs.GetError())) {
+        if (HasError(notAfterTs)) {
             STORAGE_WARN(
                 "Unable to parse certificate notAfter date for "
                 << cert.Files.CertChainPath.Quote() << ": "

--- a/cloud/storage/core/libs/grpc/tls_utils.cpp
+++ b/cloud/storage/core/libs/grpc/tls_utils.cpp
@@ -9,7 +9,9 @@
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 
+#include <algorithm>
 #include <ctime>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -22,10 +24,6 @@ namespace {
 using TBioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
 using TX509Ptr = std::unique_ptr<X509, decltype(&X509_free)>;
 using TEvpPkeyPtr = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
-using TX509StorePtr = std::unique_ptr<X509_STORE, decltype(&X509_STORE_free)>;
-using TX509StoreCtxPtr =
-    std::unique_ptr<X509_STORE_CTX, decltype(&X509_STORE_CTX_free)>;
-using TX509StackPtr = std::unique_ptr<STACK_OF(X509), decltype(&sk_X509_free)>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -224,17 +222,9 @@ TResultOrError<void> PrivateKeyAndCertificateMatch(
     return {};
 }
 
-TResultOrError<void> ValidateIdentityCertificateWithRoot(
-    TStringBuf rootCertPem,
+TResultOrError<void> ValidateIdentityCertificateValidity(
     TStringBuf certChainPem)
 {
-    TSslErrorQueueGuard errorGuard;
-
-    auto rootsResult =
-        ParseNonEmptyPemCertificates(rootCertPem, "Root certificate chain");
-    if (HasError(rootsResult.GetError())) {
-        return rootsResult.GetError();
-    }
     auto identityChainResult = ParseNonEmptyPemCertificates(
         certChainPem,
         "Identity certificate chain");
@@ -242,76 +232,36 @@ TResultOrError<void> ValidateIdentityCertificateWithRoot(
         return identityChainResult.GetError();
     }
 
-    auto roots = rootsResult.ExtractResult();
-    auto identityChain = identityChainResult.ExtractResult();
-
-    const X509* leaf = identityChain.front().get();
-    if (X509_cmp_current_time(X509_get0_notBefore(leaf)) > 0 ||
-        X509_cmp_current_time(X509_get0_notAfter(leaf)) < 0)
-    {
-        return TErrorResponse(
-            E_INVALID_STATE,
-            "Identity certificate is not currently valid");
-    }
-
-    TX509StorePtr store(X509_STORE_new(), X509_STORE_free);
-    if (!store) {
-        return MakeOpenSslError("Failed to create X509_STORE");
-    }
-
-    for (const auto& root: roots) {
-        if (X509_STORE_add_cert(store.get(), root.get()) == 1) {
-            continue;
+    const auto& identityChain = identityChainResult.GetResult();
+    for (size_t i = 0; i < identityChain.size(); ++i) {
+        const X509* certificate = identityChain[i].get();
+        const int notBeforeComparison =
+            X509_cmp_current_time(X509_get0_notBefore(certificate));
+        const int notAfterComparison =
+            X509_cmp_current_time(X509_get0_notAfter(certificate));
+        if (notBeforeComparison == 0 || notAfterComparison == 0) {
+            return TErrorResponse(
+                E_INVALID_STATE,
+                TStringBuilder()
+                    << "Failed to parse validity period for identity "
+                    << "certificate #" << i);
         }
-        const ui64 error = ERR_peek_last_error();
-        if (ERR_GET_LIB(error) == ERR_LIB_X509 &&
-            ERR_GET_REASON(error) == X509_R_CERT_ALREADY_IN_HASH_TABLE)
-        {
-            // Duplicate root certificate, not an error.
-            ERR_clear_error();
-            continue;
+        if (notBeforeComparison > 0) {
+            return TErrorResponse(
+                E_INVALID_STATE,
+                TStringBuilder()
+                    << "Identity certificate #" << i
+                    << " is not valid yet");
         }
-        return MakeOpenSslError(
-            "Failed to add root certificates to X509_STORE");
-    }
-
-    TX509StackPtr untrusted(sk_X509_new_null(), sk_X509_free);
-    if (!untrusted) {
-        return MakeOpenSslError(
-            "Failed to allocate untrusted certificate stack");
-    }
-    bool chainOk = true;
-    for (size_t i = 1; i < identityChain.size(); ++i) {
-        if (sk_X509_push(untrusted.get(), identityChain[i].get()) == 0) {
-            chainOk = false;
-            break;
+        if (notAfterComparison < 0) {
+            return TErrorResponse(
+                E_INVALID_STATE,
+                TStringBuilder()
+                    << "Identity certificate #" << i
+                    << " has expired");
         }
     }
-    if (!chainOk) {
-        return MakeOpenSslError(
-            "Failed to build untrusted identity certificate chain");
-    }
 
-    TX509StoreCtxPtr ctx(X509_STORE_CTX_new(), X509_STORE_CTX_free);
-    if (!ctx) {
-        return MakeOpenSslError("Failed to create X509_STORE_CTX");
-    }
-    const bool initOk =
-        X509_STORE_CTX_init(
-            ctx.get(),
-            store.get(),
-            identityChain.front().get(),
-            untrusted.get()) == 1;
-    if (!initOk) {
-        return MakeOpenSslError("Failed to initialize X509_STORE_CTX");
-    }
-    if (X509_verify_cert(ctx.get()) != 1) {
-        const int verifyError = X509_STORE_CTX_get_error(ctx.get());
-        auto message = TStringBuilder()
-            << "X509_verify_cert failed for identity certificate chain: "
-            << X509_verify_cert_error_string(verifyError);
-        return TErrorResponse(MAKE_SYSTEM_ERROR(verifyError), message);
-    }
     return {};
 }
 
@@ -326,29 +276,40 @@ TResultOrError<ui64> GetCertificateNotAfterTimestampSec(TStringBuf certChainPem)
         return chainResult.GetError();
     }
 
-    auto chain = chainResult.ExtractResult();
+    const auto& chain = chainResult.GetResult();
+    ui64 earliestTimestamp = std::numeric_limits<ui64>::max();
+    for (size_t i = 0; i < chain.size(); ++i) {
+        const ASN1_TIME* notAfter = X509_get0_notAfter(chain[i].get());
+        if (!notAfter) {
+            return TErrorResponse(
+                E_INVALID_STATE,
+                TStringBuilder()
+                    << "Failed to get notAfter field for identity "
+                    << "certificate #" << i);
+        }
 
-    const X509* leaf = chain.front().get();
-    const ASN1_TIME* notAfter = X509_get0_notAfter(leaf);
-    if (!notAfter) {
-        return TErrorResponse(
-            E_INVALID_STATE,
-            "Failed to get certificate notAfter field");
+        tm tmValue{};
+        if (ASN1_TIME_to_tm(notAfter, &tmValue) != 1) {
+            return MakeOpenSslError(
+                TStringBuilder()
+                    << "Failed to parse notAfter field for identity "
+                    << "certificate #" << i);
+        }
+
+        const time_t timestamp = timegm(&tmValue);
+        if (timestamp < 0) {
+            return TErrorResponse(
+                E_INVALID_STATE,
+                TStringBuilder()
+                    << "Invalid notAfter timestamp for identity "
+                    << "certificate #" << i);
+        }
+        earliestTimestamp = std::min(
+            earliestTimestamp,
+            static_cast<ui64>(timestamp));
     }
 
-    tm tmValue{};
-    if (ASN1_TIME_to_tm(notAfter, &tmValue) != 1) {
-        return MakeOpenSslError("Failed to parse certificate notAfter field");
-    }
-
-    const time_t timestamp = timegm(&tmValue);
-    if (timestamp < 0) {
-        return TErrorResponse(
-            E_INVALID_STATE,
-            "Invalid certificate notAfter timestamp");
-    }
-
-    return static_cast<ui64>(timestamp);
+    return earliestTimestamp;
 }
 
 TResultOrError<TString> ReadAndValidateRootCertificate(
@@ -482,12 +443,7 @@ TCertificatesUpdateResult UpdateCertificates(
 
     for (size_t i = 0; i < certificates.size(); ++i) {
         const auto& cert = certificates[i];
-        auto identityResult = NTlsUtils::ReadAndValidateIdentityPair(cert.Files);
-        if (HasError(identityResult.GetError())) {
-            STORAGE_WARN(
-                "Identity certificate update is skipped for "
-                << cert.Files.CertChainPath.Quote() << ": "
-                << FormatError(identityResult.GetError()));
+        const auto usePreviousCertificate = [&] {
             if (!cert.PrivateKey.empty() && !cert.CertChain.empty()) {
                 grpc_core::PemKeyCertPairList fallback;
                 fallback.emplace_back(cert.PrivateKey, cert.CertChain);
@@ -495,15 +451,37 @@ TCertificatesUpdateResult UpdateCertificates(
                     .CertificatesChain = std::move(fallback),
                 };
             }
+        };
+
+        auto identityResult = NTlsUtils::ReadAndValidateIdentityPair(cert.Files);
+        if (HasError(identityResult.GetError())) {
+            STORAGE_WARN(
+                "Identity certificate update is skipped for "
+                << cert.Files.CertChainPath.Quote() << ": "
+                << FormatError(identityResult.GetError()));
+            usePreviousCertificate();
+            continue;
+        }
+
+        const auto& pair = identityResult.GetResult().front();
+        auto validityResult =
+            NTlsUtils::ValidateIdentityCertificateValidity(pair.cert_chain());
+        if (HasError(validityResult.GetError())) {
+            STORAGE_WARN(
+                "Identity certificate update is skipped for "
+                << cert.Files.CertChainPath.Quote() << ": "
+                << FormatError(validityResult.GetError()));
+            usePreviousCertificate();
             continue;
         }
 
         TCertificate newCert;
         newCert.CertificatesChain = identityResult.ExtractResult();
 
-        const auto& pair = newCert.CertificatesChain.front();
+        const auto& identityPair = newCert.CertificatesChain.front();
         auto notAfterTs =
-            NTlsUtils::GetCertificateNotAfterTimestampSec(pair.cert_chain());
+            NTlsUtils::GetCertificateNotAfterTimestampSec(
+                identityPair.cert_chain());
         if (HasError(notAfterTs.GetError())) {
             STORAGE_WARN(
                 "Unable to parse certificate notAfter date for "

--- a/cloud/storage/core/libs/grpc/tls_utils.h
+++ b/cloud/storage/core/libs/grpc/tls_utils.h
@@ -48,8 +48,7 @@ TResultOrError<void> PrivateKeyAndCertificateMatch(
     TStringBuf privateKey,
     TStringBuf certChain);
 
-TResultOrError<void> ValidateIdentityCertificateWithRoot(
-    TStringBuf rootCertPem,
+TResultOrError<void> ValidateIdentityCertificateValidity(
     TStringBuf certChainPem);
 
 TResultOrError<ui64> GetCertificateNotAfterTimestampSec(

--- a/cloud/storage/core/libs/grpc/tls_utils_ut.cpp
+++ b/cloud/storage/core/libs/grpc/tls_utils_ut.cpp
@@ -8,9 +8,19 @@
 #include <util/stream/file.h>
 #include <util/string/builder.h>
 
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+
+#include <memory>
+
 namespace NCloud::NTlsUtils {
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr long YearSeconds = 365 * 24 * 60 * 60;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -44,6 +54,54 @@ TCertificateFiles CreateCertificatePair(
         .PrivateKeyPath = privateKeyPath,
         .CertChainPath = certChainPath,
     };
+}
+
+TString SetCertificateValidity(
+    TStringBuf pem,
+    long notBeforeOffsetSec,
+    long notAfterOffsetSec)
+{
+    using TBioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
+    using TX509Ptr = std::unique_ptr<X509, decltype(&X509_free)>;
+    using TAsn1TimePtr =
+        std::unique_ptr<ASN1_TIME, decltype(&ASN1_TIME_free)>;
+
+    TBioPtr input(
+        BIO_new_mem_buf(pem.data(), static_cast<int>(pem.size())),
+        BIO_free);
+    UNIT_ASSERT(input);
+
+    TX509Ptr certificate(
+        PEM_read_bio_X509(input.get(), nullptr, nullptr, nullptr),
+        X509_free);
+    UNIT_ASSERT(certificate);
+
+    TAsn1TimePtr notBefore(
+        X509_gmtime_adj(nullptr, notBeforeOffsetSec),
+        ASN1_TIME_free);
+    TAsn1TimePtr notAfter(
+        X509_gmtime_adj(nullptr, notAfterOffsetSec),
+        ASN1_TIME_free);
+    UNIT_ASSERT(notBefore);
+    UNIT_ASSERT(notAfter);
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        X509_set1_notBefore(certificate.get(), notBefore.get()));
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        X509_set1_notAfter(certificate.get(), notAfter.get()));
+    UNIT_ASSERT(i2d_re_X509_tbs(certificate.get(), nullptr) > 0);
+
+    TBioPtr output(BIO_new(BIO_s_mem()), BIO_free);
+    UNIT_ASSERT(output);
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        PEM_write_bio_X509(output.get(), certificate.get()));
+
+    char* data = nullptr;
+    const long size = BIO_get_mem_data(output.get(), &data);
+    UNIT_ASSERT(size > 0);
+    return TString(data, size);
 }
 
 }   // namespace
@@ -81,12 +139,29 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
         UNIT_ASSERT(HasError(result.GetError()));
     }
 
-    Y_UNIT_TEST(ShouldValidateIdentityWithRoot)
+    Y_UNIT_TEST(ShouldValidateIdentityCertificateValidity)
     {
-        const auto root = ReadCertResource("ca.crt");
         const auto cert = ReadCertResource("server1.crt");
-        const auto result = ValidateIdentityCertificateWithRoot(root, cert);
+        const auto result = ValidateIdentityCertificateValidity(cert);
         UNIT_ASSERT(!HasError(result.GetError()));
+    }
+
+    Y_UNIT_TEST(ShouldRejectExpiredAndNotYetValidIdentityCertificates)
+    {
+        const auto cert = ReadCertResource("server1.crt");
+        const auto expired = SetCertificateValidity(
+            cert,
+            -10 * YearSeconds,
+            -5 * YearSeconds);
+        const auto notYetValid = SetCertificateValidity(
+            cert,
+            5 * YearSeconds,
+            10 * YearSeconds);
+
+        UNIT_ASSERT(HasError(
+            ValidateIdentityCertificateValidity(cert + expired).GetError()));
+        UNIT_ASSERT(HasError(
+            ValidateIdentityCertificateValidity(cert + notYetValid).GetError()));
     }
 
     Y_UNIT_TEST(ShouldExtractCertificateNotAfterTimestamp)
@@ -95,6 +170,30 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
         const auto result = GetCertificateNotAfterTimestampSec(cert);
         UNIT_ASSERT(!HasError(result.GetError()));
         UNIT_ASSERT(result.GetResult() > 0);
+    }
+
+    Y_UNIT_TEST(ShouldExtractEarliestNotAfterTimestampFromChain)
+    {
+        const auto cert = ReadCertResource("server1.crt");
+        const auto earlier = SetCertificateValidity(
+            cert,
+            -YearSeconds,
+            5 * YearSeconds);
+        const auto later = SetCertificateValidity(
+            cert,
+            -YearSeconds,
+            10 * YearSeconds);
+
+        const auto earlierResult =
+            GetCertificateNotAfterTimestampSec(earlier);
+        UNIT_ASSERT(!HasError(earlierResult.GetError()));
+
+        const auto chainResult =
+            GetCertificateNotAfterTimestampSec(later + earlier);
+        UNIT_ASSERT(!HasError(chainResult.GetError()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            earlierResult.GetResult(),
+            chainResult.GetResult());
     }
 
     Y_UNIT_TEST(ShouldReadAndValidateRootCertificate)
@@ -147,28 +246,6 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
         UNIT_ASSERT(HasError(result.GetError()));
     }
 
-    Y_UNIT_TEST(ShouldRejectIdentityNotSignedByRoot)
-    {
-        const auto root = ReadCertResource("server2.crt");
-        const auto cert = ReadCertResource("server1.crt");
-        const auto result = ValidateIdentityCertificateWithRoot(root, cert);
-        UNIT_ASSERT(HasError(result.GetError()));
-    }
-
-    Y_UNIT_TEST(ShouldRejectIdentityValidationWithEmptyRoot)
-    {
-        const auto cert = ReadCertResource("server1.crt");
-        const auto result = ValidateIdentityCertificateWithRoot("", cert);
-        UNIT_ASSERT(HasError(result.GetError()));
-    }
-
-    Y_UNIT_TEST(ShouldRejectIdentityValidationWithEmptyIdentity)
-    {
-        const auto root = ReadCertResource("ca.crt");
-        const auto result = ValidateIdentityCertificateWithRoot(root, "");
-        UNIT_ASSERT(HasError(result.GetError()));
-    }
-
     Y_UNIT_TEST(ShouldFailExtractingNotAfterFromInvalidCertificate)
     {
         const auto result =
@@ -197,17 +274,6 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
         };
         const auto result = ReadAndValidateIdentityPair(files);
         UNIT_ASSERT(HasError(result.GetError()));
-    }
-
-    Y_UNIT_TEST(ShouldReportSystemErrorOnVerificationFailure)
-    {
-        const auto root = ReadCertResource("server2.crt");
-        const auto cert = ReadCertResource("server1.crt");
-        const auto result = ValidateIdentityCertificateWithRoot(root, cert);
-        UNIT_ASSERT(HasError(result.GetError()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            static_cast<ui32>(FACILITY_SYSTEM),
-            FACILITY_FROM_CODE(result.GetError().GetCode()));
     }
 
     Y_UNIT_TEST(ShouldUpdateAllCertificatesWhenValid)
@@ -287,6 +353,67 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
             TString(result.Certificates[0]
                         ->CertificatesChain.front()
                         .cert_chain()));
+    }
+
+    Y_UNIT_TEST(ShouldFallBackToPreviousIdentityWhenValidityCheckFails)
+    {
+        TTempDir tempDir;
+        const auto validCert = ReadCertResource("server1.crt");
+        const auto privateKey = ReadCertResource("server1.key");
+        const auto files = CreateCertificatePair(
+            tempDir.Name(),
+            "server",
+            privateKey,
+            validCert);
+
+        TVector<TCertificatePair> certs{TCertificatePair{
+            .Files = files,
+            .PrivateKey = privateKey,
+            .CertChain = validCert,
+        }};
+        TLog log;
+
+        for (const auto& invalidCert: {
+                 SetCertificateValidity(
+                     validCert,
+                     -10 * YearSeconds,
+                     -5 * YearSeconds),
+                 SetCertificateValidity(
+                     validCert,
+                     5 * YearSeconds,
+                     10 * YearSeconds)})
+        {
+            WriteTextFile(files.CertChainPath, validCert + invalidCert);
+            const auto result =
+                UpdateCertificates(certs, TRootCaPair{}, log);
+
+            UNIT_ASSERT(result.Certificates[0].Defined());
+            UNIT_ASSERT_VALUES_EQUAL(
+                validCert,
+                TString(result.Certificates[0]
+                            ->CertificatesChain.front()
+                            .cert_chain()));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldAcceptExpiredIdentityDuringInitialLoad)
+    {
+        TTempDir tempDir;
+        const auto validCert = ReadCertResource("server1.crt");
+        const auto expiredCert = SetCertificateValidity(
+            validCert,
+            -10 * YearSeconds,
+            -5 * YearSeconds);
+        const auto files = CreateCertificatePair(
+            tempDir.Name(),
+            "server",
+            ReadCertResource("server1.key"),
+            validCert + expiredCert);
+
+        const auto pairs = LoadCertificatePairs({files});
+
+        UNIT_ASSERT_VALUES_EQUAL(1, pairs.size());
+        UNIT_ASSERT_VALUES_EQUAL(validCert + expiredCert, pairs[0].CertChain);
     }
 
     Y_UNIT_TEST(ShouldLeaveIdentityUndefinedWhenInvalidAndNoPrevious)


### PR DESCRIPTION
### Notes

- Validate NotBefore and NotAfter for every certificate in the identity chain during periodic TLS certificate reloads.

- Keep the last known-good identity chain when any certificate is expired or not yet valid.

- Preserve the existing initial-load behavior without validity-date checks.

- Report the earliest NotAfter value in ExpireTs, representing when the entire chain first becomes invalid.

- Keep root CA certificates outside of these validity checks.

- Remove the unused ValidateIdentityCertificateWithRoot helper and its tests.

### Issue
#5722
