### PR TITLE
Add additional external file mappings param to the config-generator

### DIFF
--- a/cloud/storage/core/tools/common/go/configurator/configurator.go
+++ b/cloud/storage/core/tools/common/go/configurator/configurator.go
@@ -47,6 +47,7 @@ type ClusterSpec struct {
 	ZoneCfgOverride                 map[string]CfgFileOverride `yaml:"zoneCfgOverride"`
 	ZoneCfgOverrideSeed             map[string]CfgFileOverride `yaml:"zoneCfgOverrideSeed"`
 	AdditionalFiles                 []string                   `yaml:"additionalFiles"`
+	AdditionalFileMappings          map[string]string          `yaml:"additionalFileMappings"`
 	AdditionalFilesPath             string                     `yaml:"additionalFilesPath"`
 	AdditionalFilesPathTargetPrefix string                     `yaml:"additionalFilesPathTargetPrefix"`
 	TargetForSeed                   string                     `yaml:"targetForSeed"`
@@ -307,7 +308,7 @@ func (g *ConfigGenerator) dumpConfigs(
 
 	clusterConfig := g.spec.ServiceSpec.Clusters[cluster]
 
-	for _, fileName := range clusterConfig.AdditionalFiles {
+	appendAdditionalFile := func(fileName string, resultFileName string) error {
 		var filePath string
 		if strings.HasPrefix(fileName, "/") {
 			filePath = path.Join(g.spec.ArcadiaPath, fileName)
@@ -338,7 +339,25 @@ func (g *ConfigGenerator) dumpConfigs(
 		}
 		resultConfigs = append(
 			resultConfigs,
-			ResultConfig{filepath.Base(fileName), string(fileData)})
+			ResultConfig{resultFileName, string(fileData)})
+		return nil
+	}
+
+	for _, fileName := range clusterConfig.AdditionalFiles {
+		if err := appendAdditionalFile(fileName, filepath.Base(fileName)); err != nil {
+			return err
+		}
+	}
+
+	mappedFiles := maps.Keys(clusterConfig.AdditionalFileMappings)
+	sort.Sort(sort.Reverse(sort.StringSlice(mappedFiles)))
+	for _, fileName := range mappedFiles {
+		if err := appendAdditionalFile(
+			fileName,
+			clusterConfig.AdditionalFileMappings[fileName],
+		); err != nil {
+			return err
+		}
 	}
 
 	if g.spec.ServiceSpec.Clusters[cluster].Configs.Generate && !seed {

--- a/cloud/storage/core/tools/common/go/configurator/configurator.go
+++ b/cloud/storage/core/tools/common/go/configurator/configurator.go
@@ -309,6 +309,16 @@ func (g *ConfigGenerator) dumpConfigs(
 	clusterConfig := g.spec.ServiceSpec.Clusters[cluster]
 
 	appendAdditionalFile := func(fileName string, resultFileName string) error {
+		for _, existing := range resultConfigs {
+			if existing.FileName == resultFileName {
+				return fmt.Errorf(
+					"duplicate additional file name %v (from %v)",
+					resultFileName,
+					fileName,
+				)
+			}
+		}
+
 		var filePath string
 		if strings.HasPrefix(fileName, "/") {
 			filePath = path.Join(g.spec.ArcadiaPath, fileName)

--- a/cloud/storage/core/tools/ops/config_generator/gotest/canondata/gotest.gotest.TestGenerator/test.golden
+++ b/cloud/storage/core/tools/ops/config_generator/gotest/canondata/gotest.gotest.TestGenerator/test.golden
@@ -1,5 +1,34 @@
+/extra_configs/nbs-domains.txt:
+Domain {
+  DomainId: 1
+  SchemeRoot: 1
+  SSId: 1
+  HiveUid: 1
+  PlanResolution: 10
+  Name: "example_global"
+}
+StateStorage {
+  SSId: 1
+  Ring {
+    NToSelect: 1
+    Node: 1
+  }
+}
+
 /extra_configs/nbs-names.txt:
-canonical data
+Node {
+  NodeId: 1
+  Port: 19001
+  Host: "node-1.example-cluster.internal"
+  InterconnectHost: "node-1.example-cluster.internal"
+  Location {
+    DataCenter: "zone-a"
+    Rack: "rack-1:1"
+    Body: 1
+  }
+}
+ClusterUUID: "00000000"
+AcceptUUID: "00000000"
 
 /generated-configs/cluster1/zone1/seed/values.yaml:
 config:
@@ -230,6 +259,35 @@ UseBlackBox: true
 /generated-configs/cluster2/zoneA/target1/nbs-storage.txt:
 SchemeShardDir: "/pre-prod_myt/NBS"
 
+/generated-configs/cluster2/zoneA/target1/nfs-domains.txt:
+Domain {
+  DomainId: 1
+  SchemeRoot: 1
+  SSId: 1
+  HiveUid: 1
+  PlanResolution: 10
+  Name: "example_global"
+}
+StateStorage {
+  SSId: 1
+  Ring {
+    NToSelect: 1
+    Node: 1
+  }
+}
+
 /generated-configs/cluster2/zoneA/target1/nfs-names.txt:
-canonical data
+Node {
+  NodeId: 1
+  Port: 19001
+  Host: "node-1.example-cluster.internal"
+  InterconnectHost: "node-1.example-cluster.internal"
+  Location {
+    DataCenter: "zone-a"
+    Rack: "rack-1:1"
+    Body: 1
+  }
+}
+ClusterUUID: "00000000"
+AcceptUUID: "00000000"
 

--- a/cloud/storage/core/tools/ops/config_generator/gotest/canondata/gotest.gotest.TestGenerator/test.golden
+++ b/cloud/storage/core/tools/ops/config_generator/gotest/canondata/gotest.gotest.TestGenerator/test.golden
@@ -1,3 +1,6 @@
+/extra_configs/nbs-names.txt:
+canonical data
+
 /generated-configs/cluster1/zone1/seed/values.yaml:
 config:
 
@@ -226,4 +229,7 @@ UseBlackBox: true
 
 /generated-configs/cluster2/zoneA/target1/nbs-storage.txt:
 SchemeShardDir: "/pre-prod_myt/NBS"
+
+/generated-configs/cluster2/zoneA/target1/nfs-names.txt:
+canonical data
 

--- a/cloud/storage/core/tools/ops/config_generator/gotest/test.go
+++ b/cloud/storage/core/tools/ops/config_generator/gotest/test.go
@@ -26,12 +26,17 @@ func TestGenerator(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
+	extraConfigsSrc := yatest.SourcePath(
+		"cloud/storage/core/tools/ops/config_generator/gotest/test_service/extra_configs")
 	extraConfigsDir := filepath.Join(tmpDir, "extra_configs")
 	require.NoError(t, os.MkdirAll(extraConfigsDir, 0755))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(extraConfigsDir, "nbs-names.txt"),
-		[]byte("canonical data\n"),
-		0644))
+	entries, err := os.ReadDir(extraConfigsSrc)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		require.NoError(t, os.Symlink(
+			filepath.Join(extraConfigsSrc, entry.Name()),
+			filepath.Join(extraConfigsDir, entry.Name())))
+	}
 
 	cmd := exec.Command(binary, "--arcadia-root-path", tmpDir, "--service-path", testServicePath)
 	cmd.Stderr = os.Stderr

--- a/cloud/storage/core/tools/ops/config_generator/gotest/test.go
+++ b/cloud/storage/core/tools/ops/config_generator/gotest/test.go
@@ -26,6 +26,13 @@ func TestGenerator(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
+	extraConfigsDir := filepath.Join(tmpDir, "extra_configs")
+	require.NoError(t, os.MkdirAll(extraConfigsDir, 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(extraConfigsDir, "nbs-names.txt"),
+		[]byte("canonical data\n"),
+		0644))
+
 	cmd := exec.Command(binary, "--arcadia-root-path", tmpDir, "--service-path", testServicePath)
 	cmd.Stderr = os.Stderr
 	_, err = cmd.Output()

--- a/cloud/storage/core/tools/ops/config_generator/gotest/test_service/extra_configs/nbs-domains.txt
+++ b/cloud/storage/core/tools/ops/config_generator/gotest/test_service/extra_configs/nbs-domains.txt
@@ -1,0 +1,15 @@
+Domain {
+  DomainId: 1
+  SchemeRoot: 1
+  SSId: 1
+  HiveUid: 1
+  PlanResolution: 10
+  Name: "example_global"
+}
+StateStorage {
+  SSId: 1
+  Ring {
+    NToSelect: 1
+    Node: 1
+  }
+}

--- a/cloud/storage/core/tools/ops/config_generator/gotest/test_service/extra_configs/nbs-names.txt
+++ b/cloud/storage/core/tools/ops/config_generator/gotest/test_service/extra_configs/nbs-names.txt
@@ -1,0 +1,13 @@
+Node {
+  NodeId: 1
+  Port: 19001
+  Host: "node-1.example-cluster.internal"
+  InterconnectHost: "node-1.example-cluster.internal"
+  Location {
+    DataCenter: "zone-a"
+    Rack: "rack-1:1"
+    Body: 1
+  }
+}
+ClusterUUID: "00000000"
+AcceptUUID: "00000000"

--- a/cloud/storage/core/tools/ops/config_generator/gotest/test_service/spec.yaml
+++ b/cloud/storage/core/tools/ops/config_generator/gotest/test_service/spec.yaml
@@ -33,6 +33,8 @@ clusters:
   cluster2:
     targets: ['target1']
     zones: ['zoneA']
+    additionalFileMappings:
+      /extra_configs/nbs-names.txt: 'nfs-names.txt'
     configs:
       generate: true
       dumpPath: 'generated-configs/cluster2'

--- a/cloud/storage/core/tools/ops/config_generator/gotest/test_service/spec.yaml
+++ b/cloud/storage/core/tools/ops/config_generator/gotest/test_service/spec.yaml
@@ -35,6 +35,7 @@ clusters:
     zones: ['zoneA']
     additionalFileMappings:
       /extra_configs/nbs-names.txt: 'nfs-names.txt'
+      /extra_configs/nbs-domains.txt: 'nfs-domains.txt'
     configs:
       generate: true
       dumpPath: 'generated-configs/cluster2'


### PR DESCRIPTION
### Notes
This way configs can be st up in the following way:

before:
```yaml
    additionalFiles: [ 'nbs-names.txt', 'nbs-domains.txt' ]
    additionalFilesPath: '/extra_configs/clustername'
```

after:
```yaml
    additionalFileMappings:
      /extra_configs/clustername/names.txt: nbs-names.txt
      /extra_configs/clustername/domains.txt: nbs-domains.txt
```

### Issue
Simple change for mostly internall purposes – no issue