### PR TITLE
[vhost] Serve endpoints with multiple executors

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -295,6 +295,19 @@ message TServerConfig
     // Certificate refresh period (in milliseconds) for automatic TLS certificate
     // reloading. Zero disables periodic certificate reloading.
     optional uint32 RefreshCertsPeriod = 134;
+
+    // Number of vhost server threads used to serve a single endpoint, per
+    // media kind. Zero (the default) means a single thread per endpoint.
+    //
+    // The actual number of threads is clamped by the number of virtqueues the
+    // guest has configured for the device (VhostQueuesCount of the
+    // StartEndpoint request) and by VhostThreadsCount - the total size of the
+    // vhost thread pool.
+    optional uint32 VhostEndpointThreadCountSSD = 135;
+    optional uint32 VhostEndpointThreadCountHDD = 136;
+    optional uint32 VhostEndpointThreadCountNonReplicated = 137;
+    optional uint32 VhostEndpointThreadCountMirror2 = 138;
+    optional uint32 VhostEndpointThreadCountMirror3 = 139;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -149,6 +149,18 @@ NVhost::TServerConfig CreateVhostServerConfig(const TServerAppConfig& config)
     };
 }
 
+TVhostEndpointThreadCounts CreateVhostEndpointThreadCounts(
+    const TServerAppConfig& config)
+{
+    return TVhostEndpointThreadCounts{
+        .SSD = config.GetVhostEndpointThreadCountSSD(),
+        .HDD = config.GetVhostEndpointThreadCountHDD(),
+        .NonReplicated = config.GetVhostEndpointThreadCountNonReplicated(),
+        .Mirror2 = config.GetVhostEndpointThreadCountMirror2(),
+        .Mirror3 = config.GetVhostEndpointThreadCountMirror3(),
+    };
+}
+
 NBD::TServerConfig CreateNbdServerConfig(const TServerAppConfig& config)
 {
     return NBD::TServerConfig {
@@ -525,6 +537,7 @@ void TBootstrapBase::Init()
         auto vhostEndpointListener = CreateVhostEndpointListener(
             VhostServer,
             checksumFlags,
+            CreateVhostEndpointThreadCounts(*Configs->ServerConfig),
             Configs->ServerConfig->GetVhostDiscardEnabled() ||
                 Configs->ServerConfig->GetVhostDiscardOnlyEnabled(),
             Configs->ServerConfig->GetVhostDiscardEnabled() ||

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -21,6 +21,7 @@ class TVhostEndpointListener final
 private:
     const NVhost::IServerPtr Server;
     const NProto::TChecksumFlags ChecksumFlags;
+    const TVhostEndpointThreadCounts ThreadCounts;
     const bool VhostDiscardEnabled;
     const bool VhostWriteZeroesEnabled;
     const bool DropDiscardRequests;
@@ -31,6 +32,7 @@ public:
     TVhostEndpointListener(
             NVhost::IServerPtr server,
             NProto::TChecksumFlags checksumFlags,
+            const TVhostEndpointThreadCounts& threadCounts,
             bool vhostDiscardEnabled,
             bool vhostWriteZeroesEnabled,
             bool dropDiscardRequests,
@@ -38,6 +40,7 @@ public:
             ui32 optimalIoSize)
         : Server(std::move(server))
         , ChecksumFlags(std::move(checksumFlags))
+        , ThreadCounts(threadCounts)
         , VhostDiscardEnabled(vhostDiscardEnabled)
         , VhostWriteZeroesEnabled(vhostWriteZeroesEnabled)
         , DropDiscardRequests(dropDiscardRequests)
@@ -58,7 +61,10 @@ public:
         options.ClientId = request.GetClientId();
         options.BlockSize = volume.GetBlockSize();
         options.BlocksCount = volume.GetBlocksCount();
-        options.VhostQueuesCount = request.GetVhostQueuesCount();
+        options.VhostQueuesCount = Max<ui32>(1, request.GetVhostQueuesCount());
+        options.ThreadCount = GetVhostEndpointThreadCount(
+            ThreadCounts,
+            volume.GetStorageMediaKind());
         options.UnalignedRequestsDisabled = request.GetUnalignedRequestsDisabled();
         options.StorageMediaKind = volume.GetStorageMediaKind();
         options.DiscardEnabled =
@@ -135,9 +141,33 @@ bool ShouldDropDiscardRequestsForVolume(
            IsDiskRegistryMediaKind(volume.GetStorageMediaKind());
 }
 
+ui32 GetVhostEndpointThreadCount(
+    const TVhostEndpointThreadCounts& threadCounts,
+    NCloud::NProto::EStorageMediaKind mediaKind)
+{
+    switch (mediaKind) {
+        case NCloud::NProto::STORAGE_MEDIA_SSD:
+            return threadCounts.SSD;
+        case NCloud::NProto::STORAGE_MEDIA_DEFAULT:
+        case NCloud::NProto::STORAGE_MEDIA_HYBRID:
+        case NCloud::NProto::STORAGE_MEDIA_HDD:
+            return threadCounts.HDD;
+        case NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
+        case NCloud::NProto::STORAGE_MEDIA_HDD_NONREPLICATED:
+            return threadCounts.NonReplicated;
+        case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2:
+            return threadCounts.Mirror2;
+        case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3:
+            return threadCounts.Mirror3;
+        default:
+            return 0;
+    }
+}
+
 IEndpointListenerPtr CreateVhostEndpointListener(
     NVhost::IServerPtr server,
     const NProto::TChecksumFlags& checksumFlags,
+    const TVhostEndpointThreadCounts& threadCounts,
     bool vhostDiscardEnabled,
     bool vhostWriteZeroesEnabled,
     bool dropDiscardRequests,
@@ -147,6 +177,7 @@ IEndpointListenerPtr CreateVhostEndpointListener(
     return std::make_shared<TVhostEndpointListener>(
         std::move(server),
         checksumFlags,
+        threadCounts,
         vhostDiscardEnabled,
         vhostWriteZeroesEnabled,
         dropDiscardRequests,

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -145,23 +145,30 @@ ui32 GetVhostEndpointThreadCount(
     const TVhostEndpointThreadCounts& threadCounts,
     NCloud::NProto::EStorageMediaKind mediaKind)
 {
+    ui32 threadCount = 0;
     switch (mediaKind) {
         case NCloud::NProto::STORAGE_MEDIA_SSD:
-            return threadCounts.SSD;
+            threadCount = threadCounts.SSD;
+            break;
         case NCloud::NProto::STORAGE_MEDIA_DEFAULT:
         case NCloud::NProto::STORAGE_MEDIA_HYBRID:
         case NCloud::NProto::STORAGE_MEDIA_HDD:
-            return threadCounts.HDD;
+            threadCount = threadCounts.HDD;
+            break;
         case NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
         case NCloud::NProto::STORAGE_MEDIA_HDD_NONREPLICATED:
-            return threadCounts.NonReplicated;
+            threadCount = threadCounts.NonReplicated;
+            break;
         case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2:
-            return threadCounts.Mirror2;
+            threadCount = threadCounts.Mirror2;
+            break;
         case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3:
-            return threadCounts.Mirror3;
+            threadCount = threadCounts.Mirror3;
+            break;
         default:
-            return 0;
+            break;
     }
+    return Max<ui32>(1, threadCount);
 }
 
 IEndpointListenerPtr CreateVhostEndpointListener(

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.h
@@ -2,12 +2,27 @@
 
 #include "public.h"
 
+#include <cloud/blockstore/config/server.pb.h>
 #include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/vhost/public.h>
-#include <cloud/blockstore/config/server.pb.h>
 #include <cloud/blockstore/public/api/protos/volume.pb.h>
 
+#include <cloud/storage/core/protos/media.pb.h>
+
 namespace NCloud::NBlockStore::NServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Number of vhost server threads used to serve a single endpoint, per media
+// kind. Zero means a single thread.
+struct TVhostEndpointThreadCounts
+{
+    ui32 SSD = 0;
+    ui32 HDD = 0;
+    ui32 NonReplicated = 0;
+    ui32 Mirror2 = 0;
+    ui32 Mirror3 = 0;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -19,9 +34,14 @@ bool ShouldDropDiscardRequestsForVolume(
     bool dropDiscardRequests,
     const NProto::TVolume& volume);
 
+ui32 GetVhostEndpointThreadCount(
+    const TVhostEndpointThreadCounts& threadCounts,
+    NCloud::NProto::EStorageMediaKind mediaKind);
+
 IEndpointListenerPtr CreateVhostEndpointListener(
     NVhost::IServerPtr server,
     const NProto::TChecksumFlags& checksumFlags,
+    const TVhostEndpointThreadCounts& threadCounts,
     bool vhostDiscardEnabled,
     bool vhostWriteZeroesEnabled,
     bool dropDiscardRequests,

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server_ut.cpp
@@ -151,12 +151,11 @@ Y_UNIT_TEST_SUITE(TVhostEndpointTest)
             6,
             threadCount(NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3));
 
-        // Local disks are served by a single thread.
         UNIT_ASSERT_VALUES_EQUAL(
-            0,
+            1,
             threadCount(NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL));
         UNIT_ASSERT_VALUES_EQUAL(
-            0,
+            1,
             threadCount(NCloud::NProto::STORAGE_MEDIA_HDD_LOCAL));
     }
 }

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server_ut.cpp
@@ -108,6 +108,57 @@ Y_UNIT_TEST_SUITE(TVhostEndpointTest)
                 ShouldDropDiscardRequestsForVolume(false, volume));
         }
     }
+
+    Y_UNIT_TEST(ShouldSelectThreadCountByMediaKind)
+    {
+        const TVhostEndpointThreadCounts threadCounts{
+            .SSD = 2,
+            .HDD = 3,
+            .NonReplicated = 4,
+            .Mirror2 = 5,
+            .Mirror3 = 6};
+
+        auto threadCount = [&] (NCloud::NProto::EStorageMediaKind mediaKind)
+        {
+            return GetVhostEndpointThreadCount(threadCounts, mediaKind);
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_SSD));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_HDD));
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_HYBRID));
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_DEFAULT));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED));
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_HDD_NONREPLICATED));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            5,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2));
+        UNIT_ASSERT_VALUES_EQUAL(
+            6,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3));
+
+        // Local disks are served by a single thread.
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL));
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            threadCount(NCloud::NProto::STORAGE_MEDIA_HDD_LOCAL));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -120,6 +120,11 @@ constexpr TDuration Seconds(int s)
     xxx(EnableRequestSplitter,       bool,                   false            )\
     xxx(ExternalVhostServerThreadPoolSize, ui64,             0                )\
     xxx(RefreshCertsPeriod,          TDuration,              Seconds(0)       )\
+    xxx(VhostEndpointThreadCountSSD,           ui32,         0                )\
+    xxx(VhostEndpointThreadCountHDD,           ui32,         0                )\
+    xxx(VhostEndpointThreadCountNonReplicated, ui32,         0                )\
+    xxx(VhostEndpointThreadCountMirror2,       ui32,         0                )\
+    xxx(VhostEndpointThreadCountMirror3,       ui32,         0                )\
 // BLOCKSTORE_SERVER_CONFIG
 
 // clang-format on

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -151,6 +151,11 @@ public:
     bool GetEnableRequestSplitter() const;
     ui64 GetExternalVhostServerThreadPoolSize() const;
     TDuration GetRefreshCertsPeriod() const;
+    ui32 GetVhostEndpointThreadCountSSD() const;
+    ui32 GetVhostEndpointThreadCountHDD() const;
+    ui32 GetVhostEndpointThreadCountNonReplicated() const;
+    ui32 GetVhostEndpointThreadCountMirror2() const;
+    ui32 GetVhostEndpointThreadCountMirror3() const;
 
     void Dump(IOutputStream& out) const override;
     void DumpHtml(IOutputStream& out) const override;

--- a/cloud/blockstore/libs/vhost/endpoint.cpp
+++ b/cloud/blockstore/libs/vhost/endpoint.cpp
@@ -73,21 +73,42 @@ struct TZeroBlocksMethod
 ////////////////////////////////////////////////////////////////////////////////
 
 TEndpoint::TEndpoint(
-    TAppContext& appCtx,
-    IDeviceHandlerPtr deviceHandler,
-    TString socketPath,
-    TStorageOptions options,
-    ui32 socketAccessMode,
-    TExecutor* executor)
+        TAppContext& appCtx,
+        IDeviceHandlerPtr deviceHandler,
+        TString socketPath,
+        TStorageOptions options,
+        ui32 socketAccessMode,
+        TVector<TExecutor*> executors)
     : AppCtx(appCtx)
     , DeviceHandler(std::move(deviceHandler))
     , SocketPath(std::move(socketPath))
     , Options(std::move(options))
     , SocketAccessMode(socketAccessMode)
-    , Executor(executor)
+    , Executors(std::move(executors))
 {
     Y_ABORT_UNLESS(DeviceHandler);
-    Y_ABORT_UNLESS(Executor);
+    Y_ABORT_UNLESS(!Executors.empty());
+    Y_ABORT_UNLESS(Options.VhostQueuesCount > 0);
+
+    const ui32 executorsCount = Executors.size();
+    Y_ABORT_UNLESS(executorsCount <= Options.VhostQueuesCount);
+
+    // Both counts are normally powers of two. Round up just in case.
+    const ui32 queuesPerExecutor = std::ceil(
+        static_cast<double>(Options.VhostQueuesCount) / executorsCount);
+    for (auto* executor: Executors) {
+        executor->OnVhostQueuesAssigned(queuesPerExecutor);
+    }
+}
+
+TEndpoint::~TEndpoint()
+{
+    // Both counts are normally powers of two. Round up just in case.
+    const ui32 queuesPerExecutor = std::ceil(
+        static_cast<double>(Options.VhostQueuesCount) / Executors.size());
+    for (auto* executor: Executors) {
+        executor->OnVhostQueuesReleased(queuesPerExecutor);
+    }
 }
 
 void TEndpoint::SetVhostDevice(IVhostDevicePtr vhostDevice)

--- a/cloud/blockstore/libs/vhost/endpoint.cpp
+++ b/cloud/blockstore/libs/vhost/endpoint.cpp
@@ -91,11 +91,13 @@ TEndpoint::TEndpoint(
     Y_ABORT_UNLESS(Options.VhostQueuesCount > 0);
 
     const ui32 executorsCount = Executors.size();
-    Y_ABORT_UNLESS(executorsCount <= Options.VhostQueuesCount);
+    Y_ABORT_UNLESS(
+        Options.VhostQueuesCount % executorsCount == 0,
+        "Vhost queues count '%u' must be divisible by executors count '%u'",
+        Options.VhostQueuesCount,
+        executorsCount);
 
-    // Both counts are normally powers of two. Round up just in case.
-    const ui32 queuesPerExecutor = std::ceil(
-        static_cast<double>(Options.VhostQueuesCount) / executorsCount);
+    const ui32 queuesPerExecutor = Options.VhostQueuesCount / executorsCount;
     for (auto* executor: Executors) {
         executor->OnVhostQueuesAssigned(queuesPerExecutor);
     }
@@ -112,9 +114,7 @@ void TEndpoint::ReleaseExecutorAssignments()
         return;
     }
 
-    // Both counts are normally powers of two. Round up just in case.
-    const ui32 queuesPerExecutor = std::ceil(
-        static_cast<double>(Options.VhostQueuesCount) / Executors.size());
+    const ui32 queuesPerExecutor = Options.VhostQueuesCount / Executors.size();
     for (auto* executor: Executors) {
         executor->OnVhostQueuesReleased(queuesPerExecutor);
     }

--- a/cloud/blockstore/libs/vhost/endpoint.cpp
+++ b/cloud/blockstore/libs/vhost/endpoint.cpp
@@ -103,6 +103,15 @@ TEndpoint::TEndpoint(
 
 TEndpoint::~TEndpoint()
 {
+    ReleaseExecutorAssignments();
+}
+
+void TEndpoint::ReleaseExecutorAssignments()
+{
+    if (ExecutorAssignmentsReleased.test_and_set()) {
+        return;
+    }
+
     // Both counts are normally powers of two. Round up just in case.
     const ui32 queuesPerExecutor = std::ceil(
         static_cast<double>(Options.VhostQueuesCount) / Executors.size());
@@ -183,7 +192,18 @@ TFuture<NProto::TError> TEndpoint::Stop(bool deleteSocket)
             });
     }
 
-    return future;
+    // Request continuations may keep the endpoint alive after device stop.
+    // Release queue assignments as part of stop completion instead of
+    // waiting for the endpoint destructor.
+    auto weakPtr = weak_from_this();
+    return future.Apply(
+        [weakPtr = std::move(weakPtr)](const auto& f)
+        {
+            if (auto p = weakPtr.lock()) {
+                p->ReleaseExecutorAssignments();
+            }
+            return f.GetValue();
+        });
 }
 
 void TEndpoint::Update(ui64 blocksCount)

--- a/cloud/blockstore/libs/vhost/endpoint.h
+++ b/cloud/blockstore/libs/vhost/endpoint.h
@@ -16,6 +16,7 @@
 
 #include <util/generic/intrlist.h>
 #include <util/generic/string.h>
+#include <util/generic/vector.h>
 #include <util/system/spinlock.h>
 
 #include <atomic>
@@ -47,8 +48,12 @@ using TRequestPtr = TIntrusivePtr<TRequest>;
 ////////////////////////////////////////////////////////////////////////////////
 
 // A single vhost block device exposed to the guest. Translates the vhost
-// requests dispatched to it by its executor into the IDeviceHandler API and
+// requests dispatched to it by its executors into the IDeviceHandler API and
 // keeps track of the requests in flight.
+//
+// The endpoint exposes VhostQueuesCount virtqueues to the guest. These are
+// spread over the executors assigned to the endpoint, so requests of a single
+// endpoint may be processed by several threads simultaneously.
 class TEndpoint final
     : public IRequestProcessor
     , public std::enable_shared_from_this<TEndpoint>
@@ -59,7 +64,7 @@ private:
     const TString SocketPath;
     const TStorageOptions Options;
     const ui32 SocketAccessMode;
-    TExecutor* const Executor;
+    const TVector<TExecutor*> Executors;
     IVhostDevicePtr VhostDevice;
 
     TIntrusiveList<TRequest> RequestsInFlight;
@@ -74,16 +79,13 @@ public:
         TString socketPath,
         TStorageOptions options,
         ui32 socketAccessMode,
-        TExecutor* executor);
+        TVector<TExecutor*> executors);
+
+    ~TEndpoint() override;
 
     void* GetCookie()
     {
         return static_cast<IRequestProcessor*>(this);
-    }
-
-    TExecutor* GetExecutor() const
-    {
-        return Executor;
     }
 
     void SetVhostDevice(IVhostDevicePtr vhostDevice);
@@ -93,11 +95,6 @@ public:
     NThreading::TFuture<NProto::TError> Stop(bool deleteSocket);
 
     void Update(ui64 blocksCount);
-
-    ui32 GetVhostQueuesCount() const
-    {
-        return Options.VhostQueuesCount;
-    }
 
     size_t CollectRequests(const TIncompleteRequestsCollector& collector);
 

--- a/cloud/blockstore/libs/vhost/endpoint.h
+++ b/cloud/blockstore/libs/vhost/endpoint.h
@@ -71,6 +71,7 @@ private:
     TAdaptiveLock RequestsLock;
 
     std::atomic_flag Stopped = false;
+    std::atomic_flag ExecutorAssignmentsReleased = false;
 
 public:
     TEndpoint(
@@ -109,6 +110,8 @@ private:
     void CompleteRequest(TRequest& request, const NProto::TError& error);
 
     void UnregisterRequest(TRequest& request);
+
+    void ReleaseExecutorAssignments();
 
     TVhostRequest::EResult GetResult(NProto::TError& error);
 };

--- a/cloud/blockstore/libs/vhost/executor.cpp
+++ b/cloud/blockstore/libs/vhost/executor.cpp
@@ -24,6 +24,13 @@ TExecutor::TExecutor(
 
 void TExecutor::Shutdown()
 {
+    const ui32 assigned = GetAssignedVhostQueuesCount();
+    Y_DEBUG_ABORT_UNLESS(
+        assigned == 0,
+        "Executor %s has %d assigned vhost queues",
+        Name.c_str(),
+        assigned);
+
     VhostQueue->Stop();
     Join();
 }

--- a/cloud/blockstore/libs/vhost/executor.cpp
+++ b/cloud/blockstore/libs/vhost/executor.cpp
@@ -22,15 +22,18 @@ TExecutor::TExecutor(
     , Affinity(std::move(affinity))
 {}
 
-void TExecutor::Shutdown()
+TExecutor::~TExecutor()
 {
     const ui32 assigned = GetAssignedVhostQueuesCount();
     Y_DEBUG_ABORT_UNLESS(
         assigned == 0,
-        "Executor %s has %d assigned vhost queues",
+        "Executor %s has %u assigned vhost queues",
         Name.c_str(),
         assigned);
+}
 
+void TExecutor::Shutdown()
+{
     VhostQueue->Stop();
     Join();
 }

--- a/cloud/blockstore/libs/vhost/executor.h
+++ b/cloud/blockstore/libs/vhost/executor.h
@@ -10,6 +10,7 @@
 #include <util/generic/string.h>
 #include <util/system/thread.h>
 
+#include <atomic>
 #include <memory>
 
 namespace NCloud::NBlockStore::NVhost {
@@ -17,8 +18,8 @@ namespace NCloud::NBlockStore::NVhost {
 ////////////////////////////////////////////////////////////////////////////////
 
 // Implemented by TEndpoint. A pointer to it is used as the vhost device
-// cookie, so that an executor can dispatch a request dequeued from its request
-// queue to the endpoint the request belongs to.
+// cookie, so that an executor can dispatch a request dequeued from a shared
+// request queue to the endpoint the request belongs to.
 struct IRequestProcessor
 {
     virtual ~IRequestProcessor() = default;
@@ -28,8 +29,9 @@ struct IRequestProcessor
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Owns a single vhost request queue and the thread that runs it. The queue is
-// shared by all endpoints assigned to this executor.
+// Owns a single vhost request queue and the thread that runs it. A queue is
+// shared by all endpoints assigned to this executor, and a single endpoint may
+// be assigned to several executors at once - see TServer::PickExecutors.
 class TExecutor final: public ISimpleThread
 {
 private:
@@ -37,6 +39,10 @@ private:
     TExecutorCounters::TExecutorScope ExecutorScope;
     const IVhostQueuePtr VhostQueue;
     TAffinity Affinity;
+
+    // Number of vhost queues currently assigned to this executor. Maintained
+    // by TEndpoint's ctor/dtor and used for load-balanced executor selection.
+    std::atomic<ui32> AssignedVhostQueuesCount = 0;
 
 public:
     TExecutor(
@@ -50,6 +56,21 @@ public:
     const IVhostQueuePtr& GetQueue() const
     {
         return VhostQueue;
+    }
+
+    void OnVhostQueuesAssigned(ui32 count)
+    {
+        AssignedVhostQueuesCount.fetch_add(count, std::memory_order_relaxed);
+    }
+
+    void OnVhostQueuesReleased(ui32 count)
+    {
+        AssignedVhostQueuesCount.fetch_sub(count, std::memory_order_relaxed);
+    }
+
+    ui32 GetAssignedVhostQueuesCount() const
+    {
+        return AssignedVhostQueuesCount.load(std::memory_order_relaxed);
     }
 
 private:

--- a/cloud/blockstore/libs/vhost/executor.h
+++ b/cloud/blockstore/libs/vhost/executor.h
@@ -41,7 +41,7 @@ private:
     TAffinity Affinity;
 
     // Number of vhost queues currently assigned to this executor. Maintained
-    // by TEndpoint's ctor/dtor and used for load-balanced executor selection.
+    // by TEndpoint and used for load-balanced executor selection.
     std::atomic<ui32> AssignedVhostQueuesCount = 0;
 
 public:
@@ -50,6 +50,8 @@ public:
         IServerStats& serverStats,
         IVhostQueuePtr vhostQueue,
         TAffinity affinity);
+
+    ~TExecutor() override;
 
     void Shutdown();
 

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -164,13 +164,13 @@ TFuture<NProto::TError> TServer::StartEndpoint(
     IStoragePtr storage,
     const TStorageOptions& options)
 {
-    Y_ABORT_UNLESS(options.VhostQueuesCount > 0);
+    if (options.VhostQueuesCount == 0) {
+        return MakeFuture(
+            MakeError(E_ARGUMENT, "Vhost queues count must be greater than 0"));
+    }
 
     if (ShouldStop.test()) {
-        NProto::TError error;
-        error.SetCode(E_FAIL);
-        error.SetMessage("Vhost server is stopped");
-        return MakeFuture(error);
+        return MakeFuture(MakeError(E_FAIL, "Vhost server is stopped"));
     }
 
     // There is no point in taking more executors than there are

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -13,6 +13,8 @@
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <util/generic/hash.h>
+#include <util/generic/map.h>
+#include <util/generic/utility.h>
 #include <util/generic/vector.h>
 #include <util/string/builder.h>
 #include <util/system/mutex.h>
@@ -41,7 +43,12 @@ private:
     TVector<TExecutorPtr> Executors;
 
     THashMap<TString, TEndpointPtr> Endpoints;
-    THashMap<TString, TEndpointPtr> StoppingEndpoints;
+    struct TStoppingEndpoint
+    {
+        TEndpointPtr Endpoint;
+        TFuture<NProto::TError> Future;
+    };
+    THashMap<TString, TStoppingEndpoint> StoppingEndpoints;
 
 public:
     TServer(
@@ -74,9 +81,9 @@ public:
 private:
     void InitExecutors();
 
-    TExecutor* PickExecutor() const;
-
-    ui32 GetVhostQueuesCount(const TExecutor* executor) const;
+    // Picks |count| distinct executors with the lowest number of assigned
+    // vhost queues. Must be called under Lock.
+    TVector<TExecutor*> PickExecutors(ui32 count);
 
     void StopAllEndpoints();
 
@@ -146,7 +153,7 @@ size_t TServer::CollectRequests(const TIncompleteRequestsCollector& collector)
             count += it.second->CollectRequests(collector);
         }
         for (auto& it: StoppingEndpoints) {
-            count += it.second->CollectRequests(collector);
+            count += it.second.Endpoint->CollectRequests(collector);
         }
     }
     return count;
@@ -157,6 +164,8 @@ TFuture<NProto::TError> TServer::StartEndpoint(
     IStoragePtr storage,
     const TStorageOptions& options)
 {
+    Y_ABORT_UNLESS(options.VhostQueuesCount > 0);
+
     if (ShouldStop.test()) {
         NProto::TError error;
         error.SetCode(E_FAIL);
@@ -164,7 +173,25 @@ TFuture<NProto::TError> TServer::StartEndpoint(
         return MakeFuture(error);
     }
 
-    TExecutor* executor;
+    // There is no point in taking more executors than there are
+    // virtqueues (and libvhost forbids it).
+    const ui32 maxExecutorsCount =
+        Min<ui32>(options.VhostQueuesCount, Executors.size());
+    const ui32 executorsCount =
+        std::clamp<ui32>(options.ThreadCount, 1, maxExecutorsCount);
+
+    if (options.ThreadCount > maxExecutorsCount) {
+        STORAGE_WARN(
+            "Endpoint " << socketPath.Quote() << " requested "
+                        << options.ThreadCount << " threads"
+                        << ", but only " << maxExecutorsCount << " can be used"
+                        << " (vhost queues: " << options.VhostQueuesCount
+                        << ", thread pool size: " << Executors.size() << ")");
+    }
+
+    auto deviceHandler = CreateDeviceHandler(options, std::move(storage));
+    TEndpointPtr endpoint;
+    TVector<IVhostQueuePtr> queues;
 
     with_lock (Lock) {
         auto it = Endpoints.find(socketPath);
@@ -177,19 +204,32 @@ TFuture<NProto::TError> TServer::StartEndpoint(
             return MakeFuture(error);
         }
 
-        executor = PickExecutor();
-        Y_ABORT_UNLESS(executor);
+        auto executors = PickExecutors(executorsCount);
+        Y_ABORT_UNLESS(executors.size() == executorsCount);
+
+        queues.reserve(executors.size());
+        for (auto* executor: executors) {
+            queues.push_back(executor->GetQueue());
+        }
+
+        // The ctor bumps the assignment counters of the picked executors, so
+        // it has to run under Lock together with PickExecutors.
+        endpoint = std::make_shared<TEndpoint>(
+            *this,
+            std::move(deviceHandler),
+            socketPath,
+            options,
+            Config.SocketAccessMode,
+            std::move(executors));
     }
 
-    auto endpoint = std::make_shared<TEndpoint>(
-        *this,
-        CreateDeviceHandler(options, std::move(storage)),
-        socketPath,
-        options,
-        Config.SocketAccessMode,
-        executor);
+    STORAGE_INFO(
+        "Start endpoint " << socketPath.Quote() << " with "
+                          << options.VhostQueuesCount << " vhost queues"
+                          << " served by " << executorsCount << " executors"
+                          << " (" << options.ThreadCount << " requested)");
 
-    auto vhostDevice = executor->GetQueue()->CreateDevice(
+    auto vhostDevice = VhostQueueFactory->CreateDevice(
         socketPath,
         options.DeviceName.empty() ? options.DiskId : options.DeviceName,
         options.BlockSize,
@@ -198,6 +238,7 @@ TFuture<NProto::TError> TServer::StartEndpoint(
         options.DiscardEnabled,
         options.WriteZeroesEnabled,
         options.OptimalIoSize,
+        std::move(queues),
         endpoint->GetCookie(),
         Callbacks,
         options.ReadOnly);
@@ -227,6 +268,7 @@ TFuture<NProto::TError> TServer::StopEndpoint(const TString& socketPath)
     }
 
     TEndpointPtr endpoint;
+    TFuture<NProto::TError> stopFuture;
 
     with_lock (Lock) {
         auto it = Endpoints.find(socketPath);
@@ -242,11 +284,14 @@ TFuture<NProto::TError> TServer::StopEndpoint(const TString& socketPath)
         endpoint = std::move(it->second);
         Endpoints.erase(it);
 
-        StoppingEndpoints.emplace(socketPath, endpoint);
+        stopFuture = endpoint->Stop(true);
+        StoppingEndpoints.emplace(
+            socketPath,
+            TStoppingEndpoint{endpoint, stopFuture});
     }
 
     auto ptr = shared_from_this();
-    return endpoint->Stop(true).Apply(
+    return stopFuture.Apply(
         [ptr = std::move(ptr), socketPath](const auto& future)
         {
             const auto& error = future.GetValue();
@@ -294,14 +339,22 @@ void TServer::StopAllEndpoints()
     TVector<TFuture<NProto::TError>> futures;
 
     with_lock (Lock) {
+        for (const auto& [socketPath, stoppingEndpoint]: StoppingEndpoints) {
+            sockets.push_back(socketPath);
+            futures.push_back(stoppingEndpoint.Future);
+        }
+
         for (auto& it: Endpoints) {
             const auto& socketPath = it.first;
             auto endpoint = std::move(it.second);
+            auto future = endpoint->Stop(false);
 
-            StoppingEndpoints.emplace(socketPath, endpoint);
+            StoppingEndpoints.emplace(
+                socketPath,
+                TStoppingEndpoint{endpoint, future});
 
             sockets.push_back(socketPath);
-            futures.push_back(endpoint->Stop(false));
+            futures.push_back(std::move(future));
         }
 
         Endpoints.clear();
@@ -320,17 +373,19 @@ void TServer::HandleStoppedEndpoint(
     const TString& socketPath,
     const NProto::TError& error)
 {
-    if (HasError(error)) {
-        STORAGE_ERROR(
-            "Failed to stop endpoint: " << socketPath.Quote()
-                                        << ". Error: " << error);
-    }
-
+    bool erased = false;
     with_lock (Lock) {
         auto it = StoppingEndpoints.find(socketPath);
         if (it != StoppingEndpoints.end()) {
             StoppingEndpoints.erase(it);
+            erased = true;
         }
+    }
+
+    if (erased && HasError(error)) {
+        STORAGE_ERROR(
+            "Failed to stop endpoint: " << socketPath.Quote()
+                                        << ". Error: " << error);
     }
 }
 
@@ -349,33 +404,31 @@ void TServer::InitExecutors()
     }
 }
 
-TExecutor* TServer::PickExecutor() const
+TVector<TExecutor*> TServer::PickExecutors(ui32 count)
 {
-    TExecutor* result = nullptr;
-    ui32 resultQueuesCount = 0;
+    Y_ABORT_UNLESS(count > 0);
+    Y_ABORT_UNLESS(count <= Executors.size());
 
+    TMultiMap<ui32, TExecutor*> byLoad;
     for (const auto& executor: Executors) {
-        const ui32 queuesCount = GetVhostQueuesCount(executor.get());
-        if (result == nullptr || queuesCount < resultQueuesCount) {
-            result = executor.get();
-            resultQueuesCount = queuesCount;
-        }
+        byLoad.emplace(
+            executor->GetAssignedVhostQueuesCount(),
+            executor.get());
     }
 
-    return result;
-}
-
-ui32 TServer::GetVhostQueuesCount(const TExecutor* executor) const
-{
-    ui32 queuesCount = 0;
-
-    for (const auto& it: Endpoints) {
-        if (it.second->GetExecutor() == executor) {
-            queuesCount += it.second->GetVhostQueuesCount();
+    TVector<TExecutor*> picked;
+    picked.reserve(count);
+    // NOTE: The order can be significant: libvhost assigns any remainder from
+    // the round-robin distribution to the first queues.
+    for (const auto& [_, executor]: byLoad) {
+        if (picked.size() == count) {
+            break;
         }
+        picked.push_back(executor);
     }
 
-    return queuesCount;
+    Y_ABORT_UNLESS(picked.size() == count);
+    return picked;
 }
 
 IDeviceHandlerPtr TServer::CreateDeviceHandler(

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -194,6 +194,11 @@ TFuture<NProto::TError> TServer::StartEndpoint(
     TVector<IVhostQueuePtr> queues;
 
     with_lock (Lock) {
+        // Check again under the lock to avoid races with Stop().
+        if (ShouldStop.test()) {
+            return MakeFuture(MakeError(E_FAIL, "Vhost server is stopped"));
+        }
+
         auto it = Endpoints.find(socketPath);
         if (it != Endpoints.end()) {
             NProto::TError error;
@@ -287,7 +292,7 @@ TFuture<NProto::TError> TServer::StopEndpoint(const TString& socketPath)
         stopFuture = endpoint->Stop(true);
         StoppingEndpoints.emplace(
             socketPath,
-            TStoppingEndpoint{endpoint, stopFuture});
+            TStoppingEndpoint{std::move(endpoint), stopFuture});
     }
 
     auto ptr = shared_from_this();

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -12,6 +12,8 @@
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
+#include <cloud/contrib/vhost/include/vhost/server.h>
+
 #include <util/generic/hash.h>
 #include <util/generic/map.h>
 #include <util/generic/utility.h>
@@ -24,6 +26,20 @@ namespace NCloud::NBlockStore::NVhost {
 using namespace NThreading;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVector<TExecutor*> NormalizeExecutors(
+    const TVector<TExecutor*>& executors,
+    ui32 vhostQueuesCount)
+{
+    TVector<TExecutor*> normalized;
+    normalized.reserve(vhostQueuesCount);
+    for (ui32 i = 0; i < vhostQueuesCount; ++i) {
+        normalized.push_back(executors[i % executors.size()]);
+    }
+    return normalized;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -164,9 +180,14 @@ TFuture<NProto::TError> TServer::StartEndpoint(
     IStoragePtr storage,
     const TStorageOptions& options)
 {
-    if (options.VhostQueuesCount == 0) {
-        return MakeFuture(
-            MakeError(E_ARGUMENT, "Vhost queues count must be greater than 0"));
+    if (options.VhostQueuesCount == 0 ||
+        options.VhostQueuesCount > VHD_MAX_REQUEST_QUEUES)
+    {
+        return MakeFuture(MakeError(
+            E_ARGUMENT,
+            TStringBuilder()
+                << "Vhost queues count must be in range [1, "
+                << VHD_MAX_REQUEST_QUEUES << "]"));
     }
 
     if (ShouldStop.test()) {
@@ -183,9 +204,9 @@ TFuture<NProto::TError> TServer::StartEndpoint(
     if (options.ThreadCount > maxExecutorsCount) {
         STORAGE_WARN(
             "Endpoint " << socketPath.Quote() << " requested "
-                        << options.ThreadCount << " threads"
-                        << ", but only " << maxExecutorsCount << " can be used"
-                        << " (vhost queues: " << options.VhostQueuesCount
+                        << options.ThreadCount << " threads, but only "
+                        << maxExecutorsCount << " can be used (vhost queues: "
+                        << options.VhostQueuesCount
                         << ", thread pool size: " << Executors.size() << ")");
     }
 
@@ -209,8 +230,11 @@ TFuture<NProto::TError> TServer::StartEndpoint(
             return MakeFuture(error);
         }
 
-        auto executors = PickExecutors(executorsCount);
+        TVector<TExecutor*> executors = PickExecutors(executorsCount);
         Y_ABORT_UNLESS(executors.size() == executorsCount);
+
+        executors = NormalizeExecutors(executors, options.VhostQueuesCount);
+        Y_ABORT_UNLESS(executors.size() == options.VhostQueuesCount);
 
         queues.reserve(executors.size());
         for (auto* executor: executors) {

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -28,7 +28,10 @@ struct TStorageOptions
     TString ClientId;
     ui32 BlockSize = 0;
     ui64 BlocksCount = 0;
+    // Number of virtqueues exposed to the guest.
     ui32 VhostQueuesCount = 0;
+    // Requested number of threads serving the endpoint.
+    ui32 ThreadCount = 0;
     bool UnalignedRequestsDisabled = false;
     NProto::EStorageMediaKind StorageMediaKind = NProto::STORAGE_MEDIA_DEFAULT;
     bool DiscardEnabled = false;

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -256,6 +256,71 @@ private:
     }
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
+// Starts a single endpoint on a server with |threadPoolSize| executors and
+// returns the number of executors that serve it, i.e. the number of request
+// queues the endpoint's vhost device got registered in.
+ui32 StartEndpointAndCountExecutors(
+    ui32 threadPoolSize,
+    ui32 vhostQueuesCount,
+    ui32 threadCount)
+{
+    const TString unixSocketPath = "testSocket";
+    TTempFile tempFile(unixSocketPath);
+
+    auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+
+    TServerConfig serverConfig;
+    serverConfig.ThreadsCount = threadPoolSize;
+
+    auto server = CreateServer(
+        CreateLoggingService("console"),
+        std::make_shared<TTestServerStats>(),
+        queueFactory,
+        CreateDefaultDeviceHandlerFactory(),
+        serverConfig,
+        TVhostCallbacks());
+
+    server->Start();
+    Y_DEFER {
+        server->Stop();
+    };
+
+    UNIT_ASSERT_VALUES_EQUAL(threadPoolSize, queueFactory->Queues.size());
+
+    // Every executor thread has to reach its queue before the server is
+    // stopped - the test queue does not allow stopping a queue that was never
+    // run.
+    const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+    for (const auto& queue: queueFactory->Queues) {
+        while (!queue->IsRun() && TInstant::Now() < deadline) {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queue->IsRun());
+    }
+
+    TStorageOptions options;
+    options.DiskId = "testDiskId";
+    options.BlockSize = 4096;
+    options.BlocksCount = 256;
+    options.VhostQueuesCount = vhostQueuesCount;
+    options.ThreadCount = threadCount;
+
+    auto future = server->StartEndpoint(
+        unixSocketPath,
+        std::make_shared<TTestStorage>(),
+        options);
+    const auto& error = future.GetValue(TDuration::Seconds(5));
+    UNIT_ASSERT_C(!HasError(error), error);
+
+    ui32 executorsCount = 0;
+    for (const auto& queue: queueFactory->Queues) {
+        executorsCount += queue->GetDevices().size();
+    }
+    return executorsCount;
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -792,6 +857,71 @@ Y_UNIT_TEST_SUITE(TServerTest)
         stopEvent.Wait();
     }
 
+    Y_UNIT_TEST(ShouldWaitForStoppingEndpointBeforeShuttingDownExecutors)
+    {
+        const TString unixSocketPath = CreateGuidAsString() + ".sock";
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            CreateServerStatsStub(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            TServerConfig(),
+            TVhostCallbacks());
+
+        server->Start();
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (!queueFactory->Queues.at(0)->IsRun() &&
+               TInstant::Now() < deadline)
+        {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+        TStorageOptions options;
+        options.DiskId = "testDiskId";
+        options.BlockSize = 4096;
+        options.BlocksCount = 256;
+        options.VhostQueuesCount = 1;
+
+        {
+            auto future = server->StartEndpoint(
+                unixSocketPath,
+                std::make_shared<TTestStorage>(),
+                options);
+            const auto& error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(error), error);
+        }
+
+        auto device = queueFactory->Queues.at(0)->GetDevices().at(0);
+        device->DisableAutostop(true);
+
+        auto stopEndpointFuture = server->StopEndpoint(unixSocketPath);
+        UNIT_ASSERT(!stopEndpointFuture.HasValue());
+
+        TManualEvent stopStarted;
+        TManualEvent stopCompleted;
+        auto stopThread = SystemThreadFactory()->Run([&] {
+            stopStarted.Signal();
+            server->Stop();
+            stopCompleted.Signal();
+        });
+
+        stopStarted.Wait();
+        UNIT_ASSERT(!stopCompleted.WaitT(TDuration::MilliSeconds(100)));
+
+        device->DisableAutostop(false);
+
+        const auto& error =
+            stopEndpointFuture.GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_C(!HasError(error), error);
+        UNIT_ASSERT(stopCompleted.WaitT(TDuration::Seconds(5)));
+        stopThread->Join();
+    }
+
     Y_UNIT_TEST(ShouldPassCorrectMetrics)
     {
         TString testDiskId = "testDiskId";
@@ -1159,6 +1289,408 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 request.BlocksCount * blockSize == totalSectors * sectorSize);
             UNIT_ASSERT(!environment.DequeueRequest(request));
         }
+    }
+
+    Y_UNIT_TEST(ShouldServeSingleEndpointByMultipleExecutors)
+    {
+        const ui32 blockSize = 4096;
+        const ui32 vhostQueuesCount = 4;
+        const TString unixSocketPath = "testSocket";
+        TTempFile tempFile(unixSocketPath);
+
+        // Every request blocks its executor thread until all of them have
+        // arrived. This can only be completed if the endpoint is served by
+        // |vhostQueuesCount| executors simultaneously.
+        std::atomic<ui32> arrivedCount = 0;
+        TManualEvent allArrived;
+
+        auto testStorage = std::make_shared<TTestStorage>();
+        testStorage->ReadBlocksLocalHandler = [&] (
+            TCallContextPtr ctx,
+            std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
+        {
+            Y_UNUSED(ctx);
+            Y_UNUSED(request);
+
+            if (arrivedCount.fetch_add(1) + 1 == vhostQueuesCount) {
+                allArrived.Signal();
+            }
+            UNIT_ASSERT(allArrived.WaitT(TDuration::Seconds(30)));
+
+            return MakeFuture(NProto::TReadBlocksLocalResponse());
+        };
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+
+        TServerConfig serverConfig;
+        serverConfig.ThreadsCount = vhostQueuesCount;
+
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            std::make_shared<TTestServerStats>(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            serverConfig,
+            TVhostCallbacks());
+
+        server->Start();
+        Y_DEFER {
+            server->Stop();
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            serverConfig.ThreadsCount,
+            queueFactory->Queues.size());
+
+        TStorageOptions options;
+        options.DiskId = "testDiskId";
+        options.BlockSize = blockSize;
+        options.BlocksCount = 256;
+        options.VhostQueuesCount = vhostQueuesCount;
+        options.ThreadCount = vhostQueuesCount;
+
+        {
+            auto future = server->StartEndpoint(
+                unixSocketPath,
+                testStorage,
+                options);
+            const auto& error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(error), error);
+        }
+
+        // The device has to be registered in every queue, otherwise its
+        // virtqueues would all be served by a single executor.
+        for (const auto& queue: queueFactory->Queues) {
+            UNIT_ASSERT_VALUES_EQUAL(1, queue->GetDevices().size());
+        }
+        auto device = queueFactory->Queues.at(0)->GetDevices().at(0);
+
+        TVector<TString> blocks;
+        auto sgList = ResizeBlocks(blocks, 1, TString(blockSize, 'f'));
+
+        TVector<TFuture<TVhostRequest::EResult>> futures;
+        for (ui32 i = 0; i < vhostQueuesCount; ++i) {
+            // Non-overlapping ranges, so that the requests aren't serialized
+            // by the device handler.
+            futures.push_back(device->SendTestRequest(
+                EBlockStoreRequest::ReadBlocks,
+                i * blockSize,
+                blockSize,
+                sgList));
+        }
+
+        for (auto& future: futures) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(TVhostRequest::SUCCESS),
+                static_cast<int>(future.GetValue(TDuration::Seconds(30))));
+        }
+
+        {
+            auto future = server->StopEndpoint(unixSocketPath);
+            const auto& error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(error), error);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleRequestsCorrectlyWhenServedByMultipleExecutors)
+    {
+        const ui32 blockSize = 4096;
+        const ui32 vhostQueuesCount = 4;
+        const ui32 threadCount = 4;
+        const ui32 blocksPerRequest = 4;
+        const ui32 requestCount = 16;
+        const ui64 blocksCount = requestCount * blocksPerRequest;
+        const TString unixSocketPath = "testSocket";
+        TTempFile tempFile(unixSocketPath);
+
+        // In-memory disk image. It is accessed from all the executor threads of
+        // the endpoint at once, hence the lock. Every request touches its own
+        // block range, so requests never overlap.
+        TVector<char> image(blocksCount * blockSize, 0);
+        TAdaptiveLock imageLock;
+
+        // The first |threadCount| requests block until all of them have
+        // arrived, so the data below is verified for requests that were really
+        // processed simultaneously.
+        std::atomic<ui32> arrivedCount = 0;
+        TManualEvent allArrived;
+
+        auto waitForAllExecutors = [&] {
+            if (arrivedCount.fetch_add(1) + 1 == threadCount) {
+                allArrived.Signal();
+            }
+            UNIT_ASSERT(allArrived.WaitT(TDuration::Seconds(30)));
+        };
+
+        auto testStorage = std::make_shared<TTestStorage>();
+
+        testStorage->WriteBlocksLocalHandler = [&] (
+            TCallContextPtr ctx,
+            std::shared_ptr<NProto::TWriteBlocksLocalRequest> request)
+        {
+            Y_UNUSED(ctx);
+
+            waitForAllExecutors();
+
+            auto guard = request->Sglist.Acquire();
+            UNIT_ASSERT(guard);
+            const auto& sgList = guard.Get();
+            UNIT_ASSERT_VALUES_EQUAL(
+                request->BlocksCount * blockSize,
+                SgListGetSize(sgList));
+
+            ui64 offset = request->GetStartIndex() * blockSize;
+            with_lock (imageLock) {
+                for (const auto& buffer: sgList) {
+                    UNIT_ASSERT(offset + buffer.Size() <= image.size());
+                    memcpy(image.data() + offset, buffer.Data(), buffer.Size());
+                    offset += buffer.Size();
+                }
+            }
+
+            return MakeFuture(NProto::TWriteBlocksLocalResponse());
+        };
+
+        testStorage->ReadBlocksLocalHandler = [&] (
+            TCallContextPtr ctx,
+            std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
+        {
+            Y_UNUSED(ctx);
+
+            waitForAllExecutors();
+
+            auto guard = request->Sglist.Acquire();
+            UNIT_ASSERT(guard);
+            const auto& sgList = guard.Get();
+            UNIT_ASSERT_VALUES_EQUAL(
+                request->GetBlocksCount() * blockSize,
+                SgListGetSize(sgList));
+
+            ui64 offset = request->GetStartIndex() * blockSize;
+            with_lock (imageLock) {
+                for (const auto& buffer: sgList) {
+                    UNIT_ASSERT(offset + buffer.Size() <= image.size());
+                    memcpy(
+                        const_cast<char*>(buffer.Data()),
+                        image.data() + offset,
+                        buffer.Size());
+                    offset += buffer.Size();
+                }
+            }
+
+            return MakeFuture(NProto::TReadBlocksLocalResponse());
+        };
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+
+        TServerConfig serverConfig;
+        serverConfig.ThreadsCount = threadCount;
+
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            std::make_shared<TTestServerStats>(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            serverConfig,
+            TVhostCallbacks());
+
+        server->Start();
+        Y_DEFER {
+            server->Stop();
+        };
+
+        TStorageOptions options;
+        options.DiskId = "testDiskId";
+        options.BlockSize = blockSize;
+        options.BlocksCount = blocksCount;
+        options.VhostQueuesCount = vhostQueuesCount;
+        options.ThreadCount = threadCount;
+
+        {
+            auto future = server->StartEndpoint(
+                unixSocketPath,
+                testStorage,
+                options);
+            const auto& error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(error), error);
+        }
+
+        auto device = queueFactory->Queues.at(0)->GetDevices().at(0);
+
+        // Every request gets its own pattern, so that data landing at a wrong
+        // offset or a response completing a wrong request is detected.
+        auto blockData = [&] (ui32 requestIndex) {
+            return TString(blockSize, 'a' + requestIndex % 26);
+        };
+
+        // All the requests are sent before any of them completes, so they are
+        // spread over all the executors of the endpoint.
+        auto sendRequests = [&] (
+            EBlockStoreRequest requestType,
+            TVector<TVector<TString>>& buffers)
+        {
+            TVector<TFuture<TVhostRequest::EResult>> futures;
+            for (ui32 i = 0; i < requestCount; ++i) {
+                futures.push_back(device->SendTestRequest(
+                    requestType,
+                    i * blocksPerRequest * blockSize,
+                    blocksPerRequest * blockSize,
+                    ResizeBlocks(
+                        buffers[i],
+                        blocksPerRequest,
+                        requestType == EBlockStoreRequest::WriteBlocks
+                            ? blockData(i)
+                            : TString(blockSize, 0))));
+            }
+
+            for (auto& future: futures) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    static_cast<int>(TVhostRequest::SUCCESS),
+                    static_cast<int>(future.GetValue(TDuration::Seconds(30))));
+            }
+        };
+
+        {
+            TVector<TVector<TString>> buffers(requestCount);
+            sendRequests(EBlockStoreRequest::WriteBlocks, buffers);
+        }
+
+        // Each request has to be written at its own offset.
+        for (ui32 i = 0; i < requestCount; ++i) {
+            for (ui32 j = 0; j < blocksPerRequest; ++j) {
+                const ui64 offset =
+                    (i * blocksPerRequest + j) * ui64(blockSize);
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    TStringBuf(blockData(i)),
+                    TStringBuf(image.data() + offset, blockSize),
+                    "request " << i << ", block " << j);
+            }
+        }
+
+        arrivedCount = 0;
+        allArrived.Reset();
+
+        TVector<TVector<TString>> readBuffers(requestCount);
+        sendRequests(EBlockStoreRequest::ReadBlocks, readBuffers);
+
+        // Each request has to read back the data written by itself.
+        for (ui32 i = 0; i < requestCount; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(blocksPerRequest, readBuffers[i].size());
+            for (ui32 j = 0; j < blocksPerRequest; ++j) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    blockData(i),
+                    readBuffers[i][j],
+                    "request " << i << ", block " << j);
+            }
+        }
+
+        {
+            auto future = server->StopEndpoint(unixSocketPath);
+            const auto& error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(error), error);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldBalanceVhostQueuesBetweenExecutors)
+    {
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+        TVector<std::unique_ptr<TTempFile>> socketFiles;
+
+        TServerConfig serverConfig;
+        serverConfig.ThreadsCount = 3;
+
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            std::make_shared<TTestServerStats>(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            serverConfig,
+            TVhostCallbacks());
+
+        server->Start();
+        Y_DEFER {
+            server->Stop();
+        };
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        for (const auto& queue: queueFactory->Queues) {
+            while (!queue->IsRun() && TInstant::Now() < deadline) {
+                Sleep(TDuration::MilliSeconds(10));
+            }
+            UNIT_ASSERT(queue->IsRun());
+        }
+
+        auto startEndpoint = [&] (ui32 vhostQueuesCount, ui32 threadCount) {
+            const TString socketPath = CreateGuidAsString() + ".sock";
+            socketFiles.push_back(std::make_unique<TTempFile>(socketPath));
+
+            TStorageOptions options;
+            options.DiskId = socketPath;
+            options.BlockSize = 4096;
+            options.BlocksCount = 256;
+            options.VhostQueuesCount = vhostQueuesCount;
+            options.ThreadCount = threadCount;
+
+            auto future = server->StartEndpoint(
+                socketPath,
+                std::make_shared<TTestStorage>(),
+                options);
+            const auto& error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(error), error);
+        };
+
+        // The first contributes four queues to executor 0. The second endpoint
+        // contributes three queues to executor 1 and three to executor 2.
+        startEndpoint(4, 1);
+        startEndpoint(5, 2);
+
+        // Executor 1 is now the least loaded one (three queues), so it must get
+        // the last endpoint.
+        startEndpoint(1, 1);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            queueFactory->Queues[0]->GetDevices().size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            queueFactory->Queues[1]->GetDevices().size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            queueFactory->Queues[2]->GetDevices().size());
+    }
+
+    Y_UNIT_TEST(ShouldUseRequestedThreadCount)
+    {
+        // Neither the thread pool nor the guest's virtqueues are the limit
+        // here, so the requested value is used as is.
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            StartEndpointAndCountExecutors(4, 4, 1));
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            StartEndpointAndCountExecutors(4, 4, 2));
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            StartEndpointAndCountExecutors(4, 4, 4));
+    }
+
+    Y_UNIT_TEST(ShouldClampRequestedThreadCount)
+    {
+        // Not more threads than there are virtqueues.
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            StartEndpointAndCountExecutors(4, 2, 4));
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            StartEndpointAndCountExecutors(4, 1, 4));
+
+        // Not more threads than there are in the thread pool.
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            StartEndpointAndCountExecutors(2, 4, 4));
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            StartEndpointAndCountExecutors(1, 4, 4));
     }
 }
 

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -13,11 +13,14 @@
 #include <cloud/storage/core/libs/common/sglist_test.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
+#include <cloud/contrib/vhost/include/vhost/server.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/folder/path.h>
 #include <util/generic/guid.h>
 #include <util/generic/scope.h>
+#include <util/string/builder.h>
 #include <util/system/tempfile.h>
 #include <util/thread/factory.h>
 #include <util/thread/lfqueue.h>
@@ -316,7 +319,7 @@ ui32 StartEndpointAndCountExecutors(
 
     ui32 executorsCount = 0;
     for (const auto& queue: queueFactory->Queues) {
-        executorsCount += queue->GetDevices().size();
+        executorsCount += !queue->GetDevices().empty();
     }
     return executorsCount;
 }
@@ -1735,23 +1738,82 @@ Y_UNIT_TEST_SUITE(TServerTest)
         };
 
         // The first contributes four queues to executor 0. The second endpoint
-        // contributes three queues to executor 1 and three to executor 2.
+        // contributes three queues to executor 1 and two to executor 2.
         startEndpoint(4, 1);
         startEndpoint(5, 2);
 
-        // Executor 1 is now the least loaded one (three queues), so it must get
-        // the last endpoint.
+        // Executor 2 is now the least loaded one (two queues), so it must get
+        // the last endpoint. All executors end up with their exact number of
+        // assigned virtqueues rather than a rounded-up approximation.
         startEndpoint(1, 1);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            1,
+            4,
             queueFactory->Queues[0]->GetDevices().size());
         UNIT_ASSERT_VALUES_EQUAL(
-            2,
+            3,
             queueFactory->Queues[1]->GetDevices().size());
         UNIT_ASSERT_VALUES_EQUAL(
-            1,
+            3,
             queueFactory->Queues[2]->GetDevices().size());
+    }
+
+    Y_UNIT_TEST(ShouldValidateVhostQueuesCount)
+    {
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            std::make_shared<TTestServerStats>(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            TServerConfig(),
+            TVhostCallbacks());
+
+        server->Start();
+        Y_DEFER {
+            server->Stop();
+        };
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (!queueFactory->Queues.at(0)->IsRun() &&
+               TInstant::Now() < deadline)
+        {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+        auto startEndpoint = [&] (ui32 vhostQueuesCount) {
+            TStorageOptions options;
+            options.DiskId = "testDiskId";
+            options.BlockSize = 4096;
+            options.BlocksCount = 256;
+            options.VhostQueuesCount = vhostQueuesCount;
+
+            return server->StartEndpoint(
+                "testSocket",
+                std::make_shared<TTestStorage>(),
+                options).GetValue(TDuration::Seconds(5));
+        };
+
+        for (ui32 invalidCount: {0, VHD_MAX_REQUEST_QUEUES + 1}) {
+            const auto error = startEndpoint(invalidCount);
+            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                TStringBuilder()
+                    << "Vhost queues count must be in range [1, "
+                    << VHD_MAX_REQUEST_QUEUES << "]",
+                error.GetMessage());
+        }
+
+        const auto error = startEndpoint(VHD_MAX_REQUEST_QUEUES);
+        UNIT_ASSERT_C(!HasError(error), error);
+        UNIT_ASSERT_VALUES_EQUAL(
+            VHD_MAX_REQUEST_QUEUES,
+            queueFactory->Queues.at(0)->GetDevices().size());
+
+        const auto stopError =
+            server->StopEndpoint("testSocket").GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_C(!HasError(stopError), stopError);
     }
 
     Y_UNIT_TEST(ShouldUseRequestedThreadCount)

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -922,6 +922,101 @@ Y_UNIT_TEST_SUITE(TServerTest)
         stopThread->Join();
     }
 
+    Y_UNIT_TEST(ShouldReleaseExecutorAssignmentsBeforeRequestCallbackReturns)
+    {
+        const TString unixSocketPath = CreateGuidAsString() + ".sock";
+
+        TManualEvent requestStarted;
+        TManualEvent completionPaused;
+        TManualEvent resumeCompletion;
+        auto storagePromise = NewPromise<void>();
+
+        auto storage = std::make_shared<TTestStorage>();
+        storage->ReadBlocksLocalHandler =
+            [&](TCallContextPtr ctx,
+                std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
+        {
+            Y_UNUSED(ctx);
+            Y_UNUSED(request);
+            requestStarted.Signal();
+            return storagePromise.GetFuture().Apply(
+                [](const auto&) { return NProto::TReadBlocksLocalResponse(); });
+        };
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+        queueFactory->RequestCompletionHandler = [&]
+        {
+            completionPaused.Signal();
+            resumeCompletion.Wait();
+        };
+
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            CreateServerStatsStub(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            TServerConfig(),
+            TVhostCallbacks());
+
+        server->Start();
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (!queueFactory->Queues.at(0)->IsRun() &&
+               TInstant::Now() < deadline)
+        {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+        TStorageOptions options;
+        options.DiskId = "testDiskId";
+        options.BlockSize = 4096;
+        options.BlocksCount = 256;
+        options.VhostQueuesCount = 1;
+
+        const auto startError =
+            server->StartEndpoint(unixSocketPath, storage, options)
+                .GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_C(!HasError(startError), startError);
+
+        auto device = queueFactory->Queues.at(0)->GetDevices().at(0);
+        TVector<TString> blocks;
+        auto sgList = ResizeBlocks(blocks, 1, TString(options.BlockSize, 'f'));
+        auto requestFuture = device->SendTestRequest(
+            EBlockStoreRequest::ReadBlocks,
+            0,
+            options.BlockSize,
+            sgList);
+        Y_DEFER
+        {
+            resumeCompletion.Signal();
+            storagePromise.TrySetValue();
+        };
+
+        UNIT_ASSERT(requestStarted.WaitT(TDuration::Seconds(5)));
+
+        auto completionThread =
+            SystemThreadFactory()->Run([&] { storagePromise.SetValue(); });
+        Y_DEFER
+        {
+            resumeCompletion.Signal();
+            completionThread->Join();
+        };
+
+        UNIT_ASSERT(completionPaused.WaitT(TDuration::Seconds(5)));
+        UNIT_ASSERT(requestFuture.HasValue());
+
+        const auto stopError = server->StopEndpoint(unixSocketPath)
+                                   .GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_C(!HasError(stopError), stopError);
+
+        // The request continuation still owns the endpoint and is paused
+        // before UnregisterRequest(). Executor shutdown must not depend on
+        // that endpoint being destroyed.
+        server->Stop();
+        server.reset();
+    }
+
     Y_UNIT_TEST(ShouldPassCorrectMetrics)
     {
         TString testDiskId = "testDiskId";

--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -123,11 +123,13 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// TVhostDevice owns a vhost block device that may be served by several
+// request queues simultaneously.
 class TVhostDevice final
     : public IVhostDevice
 {
 private:
-    vhd_request_queue* const VhdQueue;
+    TVector<vhd_request_queue*> VhdQueues;
     const TString SocketPath;
     const TString DeviceName;
     void* const Cookie;
@@ -139,7 +141,7 @@ private:
 
 public:
     TVhostDevice(
-            vhd_request_queue* vhdQueue,
+            TVector<vhd_request_queue*> vhdQueues,
             TString socketPath,
             TString deviceName,
             ui32 blockSize,
@@ -151,11 +153,17 @@ public:
             void* cookie,
             const TVhostCallbacks& callbacks,
             bool readOnly)
-        : VhdQueue(vhdQueue)
+        : VhdQueues(std::move(vhdQueues))
         , SocketPath(std::move(socketPath))
         , DeviceName(std::move(deviceName))
         , Cookie(cookie)
     {
+        Y_ABORT_UNLESS(!VhdQueues.empty());
+        // Libvhost distributes the guest's virtqueues over the registered
+        // request queues, so the number of request queues must not exceed the
+        // number of virtqueues advertised to the guest.
+        Y_ABORT_UNLESS(VhdQueues.size() <= queuesCount);
+
         Zero(VhdBdevInfo);
         VhdBdevInfo.serial = DeviceName.c_str();
         VhdBdevInfo.socket_path = SocketPath.c_str();
@@ -183,11 +191,10 @@ public:
 
     bool Start() override
     {
-        vhd_request_queue* queues[1] = { VhdQueue };
-
         VhdVdev = vhd_register_blockdev(
             &VhdBdevInfo,
-            queues, 1,
+            VhdQueues.data(),
+            static_cast<int>(VhdQueues.size()),
             Cookie);
 
         return VhdVdev != nullptr;
@@ -264,34 +271,6 @@ public:
         vhd_stop_queue(VhdRequestQueue);
     }
 
-    IVhostDevicePtr CreateDevice(
-        TString socketPath,
-        TString deviceName,
-        ui32 blockSize,
-        ui64 blocksCount,
-        ui32 queuesCount,
-        bool discardEnabled,
-        bool writeZeroesEnabled,
-        ui32 optimalIoSize,
-        void* cookie,
-        const TVhostCallbacks& callbacks,
-        bool readOnly) override
-    {
-        return std::make_shared<TVhostDevice>(
-            VhdRequestQueue,
-            std::move(socketPath),
-            std::move(deviceName),
-            blockSize,
-            blocksCount,
-            queuesCount,
-            discardEnabled,
-            writeZeroesEnabled,
-            optimalIoSize,
-            cookie,
-            callbacks,
-            readOnly);
-    }
-
     TVhostRequestPtr DequeueRequest() override
     {
         vhd_request vhdRequest;
@@ -307,6 +286,11 @@ public:
         }
 
         return nullptr;
+    }
+
+    vhd_request_queue* GetNativeQueue() const
+    {
+        return VhdRequestQueue;
     }
 
 private:
@@ -380,6 +364,44 @@ public:
     IVhostQueuePtr CreateQueue() override
     {
         return std::make_shared<TVhostQueue>();
+    }
+
+    IVhostDevicePtr CreateDevice(
+        TString socketPath,
+        TString deviceName,
+        ui32 blockSize,
+        ui64 blocksCount,
+        ui32 queuesCount,
+        bool discardEnabled,
+        bool writeZeroesEnabled,
+        ui32 optimalIoSize,
+        TVector<IVhostQueuePtr> queues,
+        void* cookie,
+        const TVhostCallbacks& callbacks,
+        bool readOnly) override
+    {
+        Y_ABORT_UNLESS(!queues.empty());
+
+        TVector<vhd_request_queue*> vhdQueues;
+        vhdQueues.reserve(queues.size());
+        for (const auto& queue: queues) {
+            vhdQueues.push_back(
+                static_cast<TVhostQueue*>(queue.get())->GetNativeQueue());
+        }
+
+        return std::make_shared<TVhostDevice>(
+            std::move(vhdQueues),
+            std::move(socketPath),
+            std::move(deviceName),
+            blockSize,
+            blocksCount,
+            queuesCount,
+            discardEnabled,
+            writeZeroesEnabled,
+            optimalIoSize,
+            cookie,
+            callbacks,
+            readOnly);
     }
 };
 

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -73,11 +73,11 @@ struct IVhostQueueFactory
     //
     // Note that |queuesCount| and |queues| are different things:
     // |queuesCount| is the number of virtqueues the guest may set up, while
-    // |queues| are the backend queues (one per executor thread) the requests
-    // are dispatched to. The guest's virtqueues are spread over |queues|
-    // round-robin by vring index, so a single device may be served by several
-    // executor threads simultaneously. |queues| must be non-empty and must
-    // not be larger than |queuesCount|.
+    // |queues| contains the backend queue selected for each round-robin slot.
+    // A backend queue may occur more than once so that an uneven number of
+    // virtqueues can be distributed exactly across the requested executor
+    // threads. |queues| must be non-empty and must not be larger than
+    // |queuesCount|.
     //
     // |cookie| is placed into TVhostRequest::Cookie of every request dequeued
     // from any of the device's queues, so that the executor can route the

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -11,6 +11,7 @@
 #include <library/cpp/threading/future/future.h>
 
 #include <util/generic/string.h>
+#include <util/generic/vector.h>
 
 namespace NCloud::NBlockStore::NVhost {
 
@@ -56,19 +57,6 @@ struct IVhostQueue
     virtual int Run() = 0;
     virtual void Stop() = 0;
 
-    virtual IVhostDevicePtr CreateDevice(
-        TString socketPath,
-        TString deviceName,
-        ui32 blockSize,
-        ui64 blocksCount,
-        ui32 queuesCount,
-        bool discardEnabled,
-        bool writeZeroesEnabled,
-        ui32 optimalIoSize,
-        void* cookie,
-        const TVhostCallbacks& callbacks,
-        bool readOnly) = 0;
-
     virtual TVhostRequestPtr DequeueRequest() = 0;
 };
 
@@ -79,6 +67,34 @@ struct IVhostQueueFactory
     virtual ~IVhostQueueFactory() = default;
 
     virtual IVhostQueuePtr CreateQueue() = 0;
+
+    // Creates a vhost block device that exposes |queuesCount| virtio queues
+    // to the guest and is served by the given set of request queues.
+    //
+    // Note that |queuesCount| and |queues| are different things:
+    // |queuesCount| is the number of virtqueues the guest may set up, while
+    // |queues| are the backend queues (one per executor thread) the requests
+    // are dispatched to. The guest's virtqueues are spread over |queues|
+    // round-robin by vring index, so a single device may be served by several
+    // executor threads simultaneously. |queues| must be non-empty and must
+    // not be larger than |queuesCount|.
+    //
+    // |cookie| is placed into TVhostRequest::Cookie of every request dequeued
+    // from any of the device's queues, so that the executor can route the
+    // request back to the endpoint it belongs to.
+    virtual IVhostDevicePtr CreateDevice(
+        TString socketPath,
+        TString deviceName,
+        ui32 blockSize,
+        ui64 blocksCount,
+        ui32 queuesCount,
+        bool discardEnabled,
+        bool writeZeroesEnabled,
+        ui32 optimalIoSize,
+        TVector<IVhostQueuePtr> queues,
+        void* cookie,
+        const TVhostCallbacks& callbacks,
+        bool readOnly) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/vhost/vhost_test.cpp
+++ b/cloud/blockstore/libs/vhost/vhost_test.cpp
@@ -210,37 +210,13 @@ public:
         Y_ABORT_UNLESS(wasRun || State.load() == Broken);
     }
 
-    IVhostDevicePtr CreateDevice(
-        TString socketPath,
-        TString deviceName,
-        ui32 blockSize,
-        ui64 blocksCount,
-        ui32 queuesCount,
-        bool discardEnabled,
-        bool writeZeroesEnabled,
-        ui32 optimalIoSize,
-        void* cookie,
-        const TVhostCallbacks& callbacks,
-        bool readOnly) override
+    // A device may be served by several queues at once, so the same device can
+    // be registered in more than one queue.
+    void AddDevice(std::weak_ptr<TTestVhostDevice> device)
     {
-        Y_UNUSED(deviceName);
-        Y_UNUSED(blockSize);
-        Y_UNUSED(blocksCount);
-        Y_UNUSED(queuesCount);
-        Y_UNUSED(discardEnabled);
-        Y_UNUSED(writeZeroesEnabled);
-        Y_UNUSED(callbacks);
-        Y_UNUSED(readOnly);
-
-        auto vhostDevice = std::make_shared<TTestVhostDevice>(
-            std::move(socketPath),
-            cookie,
-            optimalIoSize);
-
         with_lock (Lock) {
-            Devices.push_back(vhostDevice);
+            Devices.push_back(std::move(device));
         }
-        return vhostDevice;
     }
 
     TVhostRequestPtr DequeueRequest() override
@@ -293,6 +269,43 @@ IVhostQueuePtr TTestVhostQueueFactory::CreateQueue()
     auto queue = std::make_shared<TTestVhostQueue>(FailedEvent);
     Queues.push_back(queue);
     return queue;
+}
+
+IVhostDevicePtr TTestVhostQueueFactory::CreateDevice(
+    TString socketPath,
+    TString deviceName,
+    ui32 blockSize,
+    ui64 blocksCount,
+    ui32 queuesCount,
+    bool discardEnabled,
+    bool writeZeroesEnabled,
+    ui32 optimalIoSize,
+    TVector<IVhostQueuePtr> queues,
+    void* cookie,
+    const TVhostCallbacks& callbacks,
+    bool readOnly)
+{
+    Y_UNUSED(deviceName);
+    Y_UNUSED(blockSize);
+    Y_UNUSED(blocksCount);
+    Y_UNUSED(discardEnabled);
+    Y_UNUSED(writeZeroesEnabled);
+    Y_UNUSED(callbacks);
+    Y_UNUSED(readOnly);
+
+    Y_ABORT_UNLESS(!queues.empty());
+    Y_ABORT_UNLESS(queues.size() <= queuesCount);
+
+    auto vhostDevice = std::make_shared<TTestVhostDevice>(
+        std::move(socketPath),
+        cookie,
+        optimalIoSize);
+
+    for (const auto& queue: queues) {
+        static_cast<TTestVhostQueue*>(queue.get())->AddDevice(vhostDevice);
+    }
+
+    return vhostDevice;
 }
 
 }   // namespace NCloud::NBlockStore::NVhost

--- a/cloud/blockstore/libs/vhost/vhost_test.cpp
+++ b/cloud/blockstore/libs/vhost/vhost_test.cpp
@@ -21,17 +21,20 @@ class TTestVhostRequest final
 {
 private:
     TPromise<EResult> Promise;
+    const std::function<void()> CompletionHandler;
 
 public:
     TTestVhostRequest(
-            TPromise<EResult> promise,
-            EBlockStoreRequest type,
-            ui64 from,
-            ui64 length,
-            TSgList sgList,
-            void* cookie,
-            bool isDiscardRequest)
+        TPromise<EResult> promise,
+        EBlockStoreRequest type,
+        ui64 from,
+        ui64 length,
+        TSgList sgList,
+        void* cookie,
+        bool isDiscardRequest,
+        std::function<void()> completionHandler)
         : Promise(std::move(promise))
+        , CompletionHandler(std::move(completionHandler))
     {
         Type = type;
         From = from;
@@ -44,6 +47,9 @@ public:
     void Complete(EResult result) override
     {
         Promise.SetValue(result);
+        if (CompletionHandler) {
+            CompletionHandler();
+        }
     }
 };
 
@@ -57,6 +63,7 @@ private:
     const TString SocketPath;
     void* const Cookie;
     const ui32 OptimalIoSize;
+    const std::function<void()> RequestCompletionHandler;
 
     TLockFreeQueue<TVhostRequest*> Requests;
 
@@ -68,10 +75,15 @@ private:
     TPromise<void> Autostop;
 
 public:
-    TTestVhostDevice(TString socketPath, void* cookie, ui32 optimalIoSize)
+    TTestVhostDevice(
+        TString socketPath,
+        void* cookie,
+        ui32 optimalIoSize,
+        std::function<void()> requestCompletionHandler)
         : SocketPath(std::move(socketPath))
         , Cookie(cookie)
         , OptimalIoSize(optimalIoSize)
+        , RequestCompletionHandler(std::move(requestCompletionHandler))
     {
         Autostop = NewPromise<void>();
         Autostop.SetValue();
@@ -140,7 +152,8 @@ public:
             length,
             std::move(sgList),
             Cookie,
-            isDiscardRequest);
+            isDiscardRequest,
+            RequestCompletionHandler);
         Requests.Enqueue(request.release());
         return future;
     }
@@ -299,7 +312,8 @@ IVhostDevicePtr TTestVhostQueueFactory::CreateDevice(
     auto vhostDevice = std::make_shared<TTestVhostDevice>(
         std::move(socketPath),
         cookie,
-        optimalIoSize);
+        optimalIoSize,
+        RequestCompletionHandler);
 
     for (const auto& queue: queues) {
         static_cast<TTestVhostQueue*>(queue.get())->AddDevice(vhostDevice);

--- a/cloud/blockstore/libs/vhost/vhost_test.h
+++ b/cloud/blockstore/libs/vhost/vhost_test.h
@@ -50,6 +50,20 @@ struct TTestVhostQueueFactory final
     TVector<std::shared_ptr<ITestVhostQueue>> Queues;
 
     IVhostQueuePtr CreateQueue() override;
+
+    IVhostDevicePtr CreateDevice(
+        TString socketPath,
+        TString deviceName,
+        ui32 blockSize,
+        ui64 blocksCount,
+        ui32 queuesCount,
+        bool discardEnabled,
+        bool writeZeroesEnabled,
+        ui32 optimalIoSize,
+        TVector<IVhostQueuePtr> queues,
+        void* cookie,
+        const TVhostCallbacks& callbacks,
+        bool readOnly) override;
 };
 
 }   // namespace NCloud::NBlockStore::NVhost

--- a/cloud/blockstore/libs/vhost/vhost_test.h
+++ b/cloud/blockstore/libs/vhost/vhost_test.h
@@ -6,6 +6,8 @@
 
 #include <library/cpp/threading/future/future.h>
 
+#include <functional>
+
 namespace NCloud::NBlockStore::NVhost {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -48,6 +50,7 @@ struct TTestVhostQueueFactory final
 {
     TManualEvent FailedEvent;
     TVector<std::shared_ptr<ITestVhostQueue>> Queues;
+    std::function<void()> RequestCompletionHandler;
 
     IVhostQueuePtr CreateQueue() override;
 


### PR DESCRIPTION
### Notes
Allow a single vhost endpoint to distribute its virtqueues across multiple executor threads, so one disk can use more than one CPU. The feature can be enabled in server config. No behaviour changes by default.

- Add per-media endpoint thread settings and propagate them into vhost storage options.
- Register each device with multiple backend request queues and let libvhost distribute virtqueues between them.
- Select the least-loaded executors using their assigned vhost queue counts.

### Issue
https://github.com/ydb-platform/nbs/issues/6694
