### PR TITLE
[core] Set database in metadata for secure ydb node registration 

### DIFF
--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -185,7 +185,7 @@ TResultOrError<NKikimrConfig::TAppConfig> GetConfigsFromCms(
 TDriverConfig CreateDriverConfig(
     const TRegisterDynamicNodeOptions& options,
     const TString& addr,
-    const std::string& database)
+    const TString& database)
 {
     TDriverConfig config;
 
@@ -201,7 +201,7 @@ TDriverConfig CreateDriverConfig(
         config.UseClientCertificate(certificate.c_str(), privateKey.c_str());
     }
 
-    config.SetDatabase(TString(database));
+    config.SetDatabase(database);
     config.SetAuthToken(options.Settings.NodeRegistrationToken);
     config.SetEndpoint(addr);
 

--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -216,7 +216,7 @@ NDiscovery::TNodeRegistrationResult TryToRegisterDynamicNodeViaDiscoveryService(
     const NDiscovery::TNodeRegistrationSettings& settings)
 {
     auto connection =
-        TDriver(CreateDriverConfig(options, addr, settings.DomainPath_));
+        TDriver(CreateDriverConfig(options, addr, settings.Path_));
 
     auto client = NDiscovery::TDiscoveryClient(connection);
     NDiscovery::TNodeRegistrationResult result =

--- a/cloud/storage/core/libs/kikimr/node.cpp
+++ b/cloud/storage/core/libs/kikimr/node.cpp
@@ -184,7 +184,8 @@ TResultOrError<NKikimrConfig::TAppConfig> GetConfigsFromCms(
 
 TDriverConfig CreateDriverConfig(
     const TRegisterDynamicNodeOptions& options,
-    const TString& addr)
+    const TString& addr,
+    const std::string& database)
 {
     TDriverConfig config;
 
@@ -200,6 +201,7 @@ TDriverConfig CreateDriverConfig(
         config.UseClientCertificate(certificate.c_str(), privateKey.c_str());
     }
 
+    config.SetDatabase(TString(database));
     config.SetAuthToken(options.Settings.NodeRegistrationToken);
     config.SetEndpoint(addr);
 
@@ -213,7 +215,8 @@ NDiscovery::TNodeRegistrationResult TryToRegisterDynamicNodeViaDiscoveryService(
     const TString& addr,
     const NDiscovery::TNodeRegistrationSettings& settings)
 {
-    auto connection = TDriver(CreateDriverConfig(options, addr));
+    auto connection =
+        TDriver(CreateDriverConfig(options, addr, settings.DomainPath_));
 
     auto client = NDiscovery::TDiscoveryClient(connection);
     NDiscovery::TNodeRegistrationResult result =


### PR DESCRIPTION
## Summary

Set the YDB database in the SDK driver used by Discovery node registration. The value is taken from TNodeRegistrationSettings::DomainPath_, so the database metadata and the NodeRegistrationRequest.domain_path payload cannot diverge.

This shared registration path is used by both NBS (server and Disk Agent) and NFS (server and vhost).

## Root cause

YDB now rejects Discovery requests without database metadata on static nodes (EEmptyDatabaseMode::EmptyDatabaseForbidden; see ydb-platform/ydb#36761). NBS configured the domain path in the NodeRegistration payload, but did not set the database in TDriverConfig, so secure registration was rejected before the NodeRegistration handler processed the payload.

Legacy NodeBroker registration is not changed.

## Validation

Run on Linux with the cloud/contrib/vhost submodule initialized:

- ./ya make -r cloud/storage/core/libs/kikimr
- ./ya make -r cloud/blockstore/apps/server cloud/blockstore/apps/disk_agent cloud/filestore/apps/server cloud/filestore/apps/vhost
- ./ya make -r -tt cloud/blockstore/tests/registration cloud/filestore/tests/registration — 23/23 tests passed