### PR TITLE
[NBS] Add NVMe Lockdown command support

### DIFF
--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -164,6 +164,23 @@ public:
         return {};
     }
 
+    TResultOrError<TLockdownState> GetLockdownState(
+        const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return TLockdownState{};
+    }
+
+    NProto::TError EnsureLockdown(
+        const TString& ctrlPath,
+        const TLockdownConfig& config) final
+    {
+        Y_UNUSED(ctrlPath, config);
+
+        return {};
+    }
+
 public:
     void WaitSanitizeRequested()
     {

--- a/cloud/blockstore/libs/nvme/nvme.h
+++ b/cloud/blockstore/libs/nvme/nvme.h
@@ -8,6 +8,8 @@
 #include <cloud/storage/core/libs/common/startable.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
 
+#include <util/generic/vector.h>
+
 namespace NCloud::NBlockStore::NNvme {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -18,17 +20,14 @@ struct TSanitizeStatus
     double Progress = 0;
 };
 
-struct INvmeManager
-    : public IStartable
+struct INvmeManager: public IStartable
 {
     virtual NThreading::TFuture<NProto::TError> Format(
         const TString& path,
         nvme_secure_erase_setting ses) = 0;
 
-    virtual NThreading::TFuture<NProto::TError> Deallocate(
-        const TString& path,
-        ui64 offsetBytes,
-        ui64 sizeBytes) = 0;
+    virtual NThreading::TFuture<NProto::TError>
+    Deallocate(const TString& path, ui64 offsetBytes, ui64 sizeBytes) = 0;
 
     virtual NProto::TError StartSanitize(const TString& ctrlPath) = 0;
 
@@ -42,6 +41,38 @@ struct INvmeManager
     virtual NProto::TError ResetToSingleNamespace(const TString& ctrlPath) = 0;
 
     virtual TResultOrError<TString> GetDeviceModel(const TString& path) = 0;
+
+    struct TLockdownConfig
+    {
+        TVector<ui8> AllowedAdminOpcodes;
+        TVector<ui8> AllowedSetFeatureIds;
+        bool BlockLockdownCommand = false;
+    };
+
+    struct TLockdownScopeState
+    {
+        // Identifier may be prohibited using Command and Feature Lockdown.
+        TVector<ui8> Supported;
+
+        // Identifier is currently prohibited.
+        TVector<ui8> Prohibited;
+    };
+
+    struct TLockdownState
+    {
+        // Command and Feature Lockdown is supported by the controller.
+        bool Supported = false;
+
+        TLockdownScopeState AdminCmd;
+        TLockdownScopeState FeatureId;
+    };
+
+    virtual TResultOrError<TLockdownState> GetLockdownState(
+        const TString& ctrlPath) = 0;
+
+    virtual NProto::TError EnsureLockdown(
+        const TString& ctrlPath,
+        const TLockdownConfig& config) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/nvme/nvme_linux.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_linux.cpp
@@ -1,5 +1,7 @@
 #include "nvme.h"
 
+#include "utils.h"
+
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/thread_pool.h>
@@ -697,7 +699,7 @@ public:
             .data_len = sizeof(log),
             .cdw10 = (numd << 16) | (cntts << 12) | (scp << 8) |
                      NVME_LOG_LID_CMD_AND_FEAT_LOCKDOWN,
-            .cdw11 = 0, // LSI = 0, NUMDU = 0
+            .cdw11 = 0,   // LSI = 0, NUMDU = 0
             .timeout_ms = static_cast<ui32>(AdminCmdTimeout.MilliSeconds()),
         };
 
@@ -768,25 +770,12 @@ public:
 
     static TVector<ui8> CalculateOpcodesToLock(
         TVector<ui8> allowedOpcodes,
-        TLockdownScopeState scope)
+        const TLockdownScopeState& scope)
     {
-        SortUnique(scope.Supported);
-        SortUnique(scope.Prohibited);
-        SortUnique(allowedOpcodes);
-
-        TVector<ui8> supportedOpcodesToLock;
-        std::ranges::set_difference(
+        return NNvme::CalculateOpcodesToLock(
+            std::move(allowedOpcodes),
             scope.Supported,
-            allowedOpcodes,
-            std::back_inserter(supportedOpcodesToLock));
-
-        TVector<ui8> opcodesToLock;
-        std::ranges::set_difference(
-            supportedOpcodesToLock,
-            scope.Prohibited,
-            std::back_inserter(opcodesToLock));
-
-        return opcodesToLock;
+            scope.Prohibited);
     }
 
     NProto::TError EnsureLockdown(

--- a/cloud/blockstore/libs/nvme/nvme_linux.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_linux.cpp
@@ -7,7 +7,9 @@
 
 #include <util/generic/vector.h>
 #include <util/generic/yexception.h>
+#include <util/stream/format.h>
 #include <util/string/builder.h>
+#include <util/string/join.h>
 #include <util/system/file.h>
 
 #include <linux/fs.h>
@@ -27,7 +29,20 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void InvokeAdminCmd(TFileHandle& file, nvme_admin_cmd& cmd, const char* source)
+TString ToString(const TVector<ui8>& opcodes)
+{
+    TStringBuilder out;
+
+    out << "[ ";
+    for (ui8 opcode: opcodes) {
+        out << Hex(opcode, HF_ADDX) << " ";
+    }
+    out << "]";
+
+    return out;
+}
+
+void InvokeAdminCmd(TFileHandle& file, nvme_admin_cmd& cmd, TStringBuf source)
 {
     if (!ioctl(file, NVME_IOCTL_ADMIN_CMD, &cmd)) {
         return;
@@ -242,7 +257,7 @@ bool IsBlockOrCharDevice(TFileHandle& device)
 
 hd_driveid HDIdentity(TFileHandle& device)
 {
-    hd_driveid hd {};
+    hd_driveid hd{};
     int err = ioctl(device, HDIO_GET_IDENTITY, &hd);
 
     if (err) {
@@ -282,10 +297,21 @@ ui32 GetSanitizeAction(TFileHandle& device, TDuration timeout)
            "actions";
 }
 
+TFileHandle OpenCtrl(const TString& ctrlPath)
+{
+    TFileHandle device(ctrlPath, OpenExisting | RdWr);
+    if (!device.IsOpen()) {
+        int err = errno;
+        STORAGE_THROW_SERVICE_ERROR(MAKE_SYSTEM_ERROR(err))
+            << "Failed to open file " << ctrlPath.Quote();
+    }
+
+    return device;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
-class TNvmeManager final
-    : public INvmeManager
+class TNvmeManager final: public INvmeManager
 {
 private:
     const ILoggingServicePtr Logging;
@@ -295,20 +321,21 @@ private:
     TDuration SecureEraseTimeout;
     TDuration AdminCmdTimeout;
 
-    void FormatImpl(
-        const TString& path,
-        nvme_secure_erase_setting ses)
+    void FormatImpl(const TString& path, nvme_secure_erase_setting ses)
     {
         TFileHandle device(path, OpenExisting | RdOnly);
 
-        Y_ENSURE(IsBlockOrCharDevice(device), "expected block or character device");
+        Y_ENSURE(
+            IsBlockOrCharDevice(device),
+            "expected block or character device");
 
         nvme_ctrlr_data ctrl = NVMeIdentifyCtrl(device, AdminCmdTimeout);
 
         Y_ENSURE(ctrl.fna.format_all_ns == 0, "can't format single namespace");
         Y_ENSURE(ctrl.fna.erase_all_ns == 0, "can't erase single namespace");
         Y_ENSURE(
-            ses != NVME_FMT_NVM_SES_CRYPTO_ERASE || ctrl.fna.crypto_erase_supported == 1,
+            ses != NVME_FMT_NVM_SES_CRYPTO_ERASE ||
+                ctrl.fna.crypto_erase_supported == 1,
             "cryptographic erase is not supported");
 
         const int nsId = ioctl(device, NVME_IOCTL_ID);
@@ -320,10 +347,7 @@ private:
 
         Y_ENSURE(ns.lbaf[ns.flbas.format].ms == 0, "unexpected metadata");
 
-        nvme_format format {
-            .lbaf = ns.flbas.format,
-            .ses = ses
-        };
+        nvme_format format{.lbaf = ns.flbas.format, .ses = ses};
 
         NVMeFormatImpl(device, nsId, format, SecureEraseTimeout);
     }
@@ -331,7 +355,9 @@ private:
     void DeallocateImpl(const TString& path, ui64 offsetBytes, ui64 sizeBytes)
     {
         TFileHandle device(path, OpenExisting | RdWr);
-        Y_ENSURE(IsBlockOrCharDevice(device), "expected block or character device");
+        Y_ENSURE(
+            IsBlockOrCharDevice(device),
+            "expected block or character device");
 
         ui64 devSizeBytes = 0;
         int err = ioctl(device, BLKGETSIZE64, &devSizeBytes);
@@ -342,19 +368,19 @@ private:
                 << strerror(err);
         }
 
-        Y_ENSURE(offsetBytes + sizeBytes <= devSizeBytes,
+        Y_ENSURE(
+            offsetBytes + sizeBytes <= devSizeBytes,
             "invalid deallocate range: "
-            "offsetBytes=" << offsetBytes <<
-            ", sizeBytes=" << sizeBytes <<
-            ", devSizeBytes=" << devSizeBytes);
+            "offsetBytes="
+                << offsetBytes << ", sizeBytes=" << sizeBytes
+                << ", devSizeBytes=" << devSizeBytes);
 
-        ui64 range[2] = { offsetBytes, sizeBytes };
+        ui64 range[2] = {offsetBytes, sizeBytes};
         err = ioctl(device, BLKDISCARD, range);
         if (err) {
             err = errno;
             STORAGE_THROW_SERVICE_ERROR(MAKE_SYSTEM_ERROR(err))
-                << "NVMeDeallocateImpl failed to deallocate: "
-                << strerror(err);
+                << "NVMeDeallocateImpl failed to deallocate: " << strerror(err);
         }
     }
 
@@ -382,56 +408,61 @@ public:
         const TString& path,
         nvme_secure_erase_setting ses) override
     {
-        return Executor->Execute([=, this] {
-            try {
-                FormatImpl(path, ses);
-                return NProto::TError();
-            } catch (...) {
-                return MakeError(E_FAIL, CurrentExceptionMessage());
-            }
-        });
+        return Executor->Execute(
+            [=, this]
+            {
+                try {
+                    FormatImpl(path, ses);
+                    return NProto::TError();
+                } catch (...) {
+                    return MakeError(E_FAIL, CurrentExceptionMessage());
+                }
+            });
     }
 
-    TFuture<NProto::TError> Deallocate(
-        const TString& path,
-        ui64 offsetBytes,
-        ui64 sizeBytes) override
+    TFuture<NProto::TError>
+    Deallocate(const TString& path, ui64 offsetBytes, ui64 sizeBytes) override
     {
-        return Executor->Execute([=, this] {
-            try {
-                DeallocateImpl(path, offsetBytes, sizeBytes);
-                return NProto::TError();
-            } catch (const TServiceError &e) {
-                return MakeError(e.GetCode(), TString(e.GetMessage()));
-            } catch (...) {
-                return MakeError(E_FAIL, CurrentExceptionMessage());
-            }
-        });
+        return Executor->Execute(
+            [=, this]
+            {
+                try {
+                    DeallocateImpl(path, offsetBytes, sizeBytes);
+                    return NProto::TError();
+                } catch (const TServiceError& e) {
+                    return MakeError(e.GetCode(), TString(e.GetMessage()));
+                } catch (...) {
+                    return MakeError(E_FAIL, CurrentExceptionMessage());
+                }
+            });
     }
 
     TResultOrError<TString> GetSerialNumber(const TString& path) override
     {
-        return SafeExecute<TResultOrError<TString>>([&] {
-            TFileHandle device(path, OpenExisting | RdOnly);
+        return SafeExecute<TResultOrError<TString>>(
+            [&]
+            {
+                TFileHandle device(path, OpenExisting | RdOnly);
 
-            auto str = [] (auto& arr) {
-                auto* sn = std::bit_cast<const char*>(&arr[0]);
-                auto end = std::find(sn, sn + sizeof(arr), '\0');
+                auto str = [](auto& arr)
+                {
+                    auto* sn = std::bit_cast<const char*>(&arr[0]);
+                    auto end = std::find(sn, sn + sizeof(arr), '\0');
 
-                return TString(sn, end);
-            };
+                    return TString(sn, end);
+                };
 
-            auto [isRot, error] = IsRotational(device);
+                auto [isRot, error] = IsRotational(device);
 
-            if (!HasError(error) && isRot) {
-                auto hd = HDIdentity(device);
-                return str(hd.serial_no);
-            }
+                if (!HasError(error) && isRot) {
+                    auto hd = HDIdentity(device);
+                    return str(hd.serial_no);
+                }
 
                 auto ctrl = NVMeIdentifyCtrl(device, AdminCmdTimeout);
 
-            return str(ctrl.sn);
-        });
+                return str(ctrl.sn);
+            });
     }
 
     TResultOrError<TString> GetDeviceModel(const TString& path) override
@@ -464,17 +495,19 @@ public:
 
     TResultOrError<bool> IsSsd(const TString& path) override
     {
-        return SafeExecute<TResultOrError<bool>>([&] {
-            TFileHandle device(path, OpenExisting | RdOnly);
+        return SafeExecute<TResultOrError<bool>>(
+            [&]
+            {
+                TFileHandle device(path, OpenExisting | RdOnly);
 
-            auto [isRot, error] = IsRotational(device);
-            if (HasError(error)) {
-                STORAGE_THROW_SERVICE_ERROR(error.GetCode())
-                    << "NVMeIsSsd failed: " << error.GetMessage();
-            }
+                auto [isRot, error] = IsRotational(device);
+                if (HasError(error)) {
+                    STORAGE_THROW_SERVICE_ERROR(error.GetCode())
+                        << "NVMeIsSsd failed: " << error.GetMessage();
+                }
 
-            return TResultOrError { !isRot };
-        });
+                return TResultOrError{!isRot};
+            });
     }
 
     NProto::TError StartSanitize(const TString& ctrlPath) override
@@ -482,12 +515,7 @@ public:
         return SafeExecute<NProto::TError>(
             [&]
             {
-                TFileHandle device(ctrlPath, OpenExisting | RdWr);
-                if (!device.IsOpen()) {
-                    int err = errno;
-                    STORAGE_THROW_SERVICE_ERROR(MAKE_SYSTEM_ERROR(err))
-                        << "Failed to open file " << ctrlPath.Quote();
-                }
+                TFileHandle device = OpenCtrl(ctrlPath);
 
                 nvme_admin_cmd cmd{
                     .opcode = NVME_OPC_SANITIZE,
@@ -511,12 +539,7 @@ public:
         return SafeExecute<TResultOrError<TSanitizeStatus>>(
             [&]() -> TResultOrError<TSanitizeStatus>
             {
-                TFileHandle device(ctrlPath, OpenExisting | RdWr);
-                if (!device.IsOpen()) {
-                    int err = errno;
-                    STORAGE_THROW_SERVICE_ERROR(MAKE_SYSTEM_ERROR(err))
-                        << "Failed to open file " << ctrlPath.Quote();
-                }
+                TFileHandle device = OpenCtrl(ctrlPath);
 
                 char buffer[4]{};
 
@@ -526,8 +549,7 @@ public:
                     .opcode = NVME_OPC_GET_LOG_PAGE,
                     .addr = std::bit_cast<ui64>(&buffer[0]),
                     .data_len = sizeof(buffer),
-                    .cdw10 = 0x81   // Log Page ID: Sanitize Status
-                             | (numd << 16),
+                    .cdw10 = NVME_LOG_LID_SANITIZE | (numd << 16),
                     .timeout_ms =
                         static_cast<ui32>(AdminCmdTimeout.MilliSeconds())};
 
@@ -575,12 +597,7 @@ public:
         return SafeExecute<NProto::TError>(
             [&]
             {
-                TFileHandle device(ctrlPath, OpenExisting | RdWr);
-                if (!device.IsOpen()) {
-                    int err = errno;
-                    STORAGE_THROW_SERVICE_ERROR(MAKE_SYSTEM_ERROR(err))
-                        << "Failed to open file " << ctrlPath.Quote();
-                }
+                TFileHandle device = OpenCtrl(ctrlPath);
 
                 nvme_ctrlr_data ctrl =
                     NVMeIdentifyCtrl(device, AdminCmdTimeout);
@@ -645,6 +662,232 @@ public:
 
                 return MakeError(S_OK);
             });
+    }
+
+    TVector<ui8> ReadLockdownList(
+        TFileHandle& device,
+        nvme_lockdown_log_scope scope,
+        nvme_lockdown_log_contents contents)
+    {
+        nvme_lockdown_log log{};
+
+        //
+        // Get Log Page CDW10:
+        //
+        //   [31:16] NUMDL
+        //   [15]    RAE = 0
+        //   [14]    Reserved
+        //   [13:12] CNTTS (Contents)
+        //   [11:8]  SCP (Scope)
+        //   [7:0]   LID
+        //
+        // NUMDL and NUMDU form a 0-based number of dwords to transfer.
+        // nvme_lockdown_log is 512 bytes:
+        //     512 / sizeof(uint32_t) - 1 = 127
+        //
+
+        const uint32_t numd = sizeof(nvme_lockdown_log) / sizeof(uint32_t) - 1;
+        const uint32_t scp = static_cast<uint8_t>(scope);
+        const uint32_t cntts = static_cast<uint8_t>(contents);
+
+        nvme_admin_cmd cmd = {
+            .opcode = NVME_OPC_GET_LOG_PAGE,
+            .nsid = 0,
+            .addr = reinterpret_cast<uint64_t>(&log),
+            .data_len = sizeof(log),
+            .cdw10 = (numd << 16) | (cntts << 12) | (scp << 8) |
+                     NVME_LOG_LID_CMD_AND_FEAT_LOCKDOWN,
+            .cdw11 = 0, // LSI = 0, NUMDU = 0
+            .timeout_ms = static_cast<ui32>(AdminCmdTimeout.MilliSeconds()),
+        };
+
+        const int rc = ioctl(device, NVME_IOCTL_ADMIN_CMD, &cmd);
+        if (rc < 0) {
+            const int err = errno;
+            STORAGE_THROW_SERVICE_ERROR(MAKE_SYSTEM_ERROR(err))
+                << "NVME_IOCTL_ADMIN_CMD(Get Log Page)";
+        }
+
+        if (rc != 0) {
+            STORAGE_THROW_SERVICE_ERROR(E_FAIL)
+                << "Get Lockdown Log failed, NVMe status=" << Hex(rc, HF_ADDX);
+        }
+
+        // Validate what the controller says it returned.
+
+        const uint8_t returnedScope =
+            (log.cfila >> NVME_LOCKDOWN_SS_SHIFT) & NVME_LOCKDOWN_SS_MASK;
+        const uint8_t returnedContents =
+            (log.cfila >> NVME_LOCKDOWN_CS_SHIFT) & NVME_LOCKDOWN_CS_MASK;
+
+        if (returnedScope != scp || returnedContents != cntts) {
+            STORAGE_THROW_SERVICE_ERROR(E_INVALID_STATE)
+                << "Lockdown log returned unexpected scope/contents";
+        }
+
+        return {log.cfil, log.cfil + log.lngth};
+    }
+
+    TLockdownScopeState ReadLockdownScopeState(
+        TFileHandle& device,
+        nvme_lockdown_log_scope scope)
+    {
+        return {
+            .Supported =
+                ReadLockdownList(device, scope, NVME_LOCKDOWN_SUPPORTED_CMD),
+            .Prohibited =
+                ReadLockdownList(device, scope, NVME_LOCKDOWN_PROHIBITED_CMD),
+        };
+    }
+
+    TResultOrError<TLockdownState> GetLockdownState(
+        const TString& ctrlPath) final
+    {
+        return SafeExecute<TResultOrError<TLockdownState>>(
+            [&]
+            {
+                TFileHandle device = OpenCtrl(ctrlPath);
+
+                auto ctrl = NVMeIdentifyCtrl(device, AdminCmdTimeout);
+                if (!ctrl.oacs.lockdown) {
+                    return TLockdownState{
+                        .Supported = false,
+                    };
+                }
+
+                return TLockdownState{
+                    .Supported = true,
+                    .AdminCmd =
+                        ReadLockdownScopeState(device, NVME_LOCKDOWN_ADMIN_CMD),
+                    .FeatureId = ReadLockdownScopeState(
+                        device,
+                        NVME_LOCKDOWN_FEATURE_ID),
+                };
+            });
+    }
+
+    static TVector<ui8> CalculateOpcodesToLock(
+        TVector<ui8> allowedOpcodes,
+        TLockdownScopeState scope)
+    {
+        SortUnique(scope.Supported);
+        SortUnique(scope.Prohibited);
+        SortUnique(allowedOpcodes);
+
+        TVector<ui8> supportedOpcodesToLock;
+        std::ranges::set_difference(
+            scope.Supported,
+            allowedOpcodes,
+            std::back_inserter(supportedOpcodesToLock));
+
+        TVector<ui8> opcodesToLock;
+        std::ranges::set_difference(
+            supportedOpcodesToLock,
+            scope.Prohibited,
+            std::back_inserter(opcodesToLock));
+
+        return opcodesToLock;
+    }
+
+    NProto::TError EnsureLockdown(
+        const TString& ctrlPath,
+        const TLockdownConfig& config) final
+    {
+        return SafeExecute<NProto::TError>(
+            [&]
+            {
+                TFileHandle device = OpenCtrl(ctrlPath);
+
+                auto ctrl = NVMeIdentifyCtrl(device, AdminCmdTimeout);
+                if (!ctrl.oacs.lockdown) {
+                    return MakeError(
+                        MAKE_SYSTEM_ERROR(ENOTSUP),
+                        "Lockdown command is not supported");
+                }
+
+                auto allowedAdminOpcodes = config.AllowedAdminOpcodes;
+
+                if (config.BlockLockdownCommand) {
+                    std::erase(allowedAdminOpcodes, NVME_OPS_ADMIN_LOCKDOWN);
+                } else {
+                    allowedAdminOpcodes.push_back(NVME_OPS_ADMIN_LOCKDOWN);
+                }
+
+                auto adminOpcodesToLock = CalculateOpcodesToLock(
+                    std::move(allowedAdminOpcodes),
+                    ReadLockdownScopeState(device, NVME_LOCKDOWN_ADMIN_CMD));
+
+                auto featureIdsToLock = CalculateOpcodesToLock(
+                    config.AllowedSetFeatureIds,
+                    ReadLockdownScopeState(device, NVME_LOCKDOWN_FEATURE_ID));
+
+                if (adminOpcodesToLock.empty() && featureIdsToLock.empty()) {
+                    return MakeError(S_ALREADY);
+                }
+
+                Lockdown(
+                    device,
+                    std::move(adminOpcodesToLock),
+                    std::move(featureIdsToLock));
+
+                return MakeError(S_OK);
+            });
+    }
+
+    void LockdownItem(
+        TFileHandle& device,
+        nvme_lockdown_log_scope scope,
+        ui8 opcodeOrFeatureId)
+    {
+        constexpr ui32 ifc = 0;     // Admin Submission Queue
+        constexpr ui32 prhbt = 1;   // Prohibit
+
+        nvme_admin_cmd cmd = {
+            .opcode = NVME_OPS_ADMIN_LOCKDOWN,
+            .addr = 0,
+            .data_len = 0,
+            .cdw10 = (static_cast<ui32>(opcodeOrFeatureId) << 8) | (ifc << 5) |
+                     (prhbt << 4) | static_cast<ui32>(scope),
+            .cdw14 = 0,
+            .timeout_ms = static_cast<ui32>(AdminCmdTimeout.MilliSeconds()),
+        };
+
+        InvokeAdminCmd(
+            device,
+            cmd,
+            TStringBuilder()
+                << "Lockdown item " << Hex(opcodeOrFeatureId, HF_ADDX)
+                << " in scope " << Hex(scope, HF_ADDX));
+    }
+
+    void Lockdown(
+        TFileHandle& device,
+        TVector<ui8> adminOpcodesToLock,
+        TVector<ui8> featureIdsToLock)
+    {
+        SortUnique(adminOpcodesToLock);
+        SortUnique(featureIdsToLock);
+
+        STORAGE_INFO(
+            "Lockdown. Opcodes: " << ToString(adminOpcodesToLock)
+                                  << " features: "
+                                  << ToString(featureIdsToLock));
+
+        for (ui8 feat: featureIdsToLock) {
+            LockdownItem(device, NVME_LOCKDOWN_FEATURE_ID, feat);
+        }
+
+        // Lock the Lockdown command itself last, so that all other
+        // lockdown operations can still be performed.
+        auto it =
+            std::ranges::find(adminOpcodesToLock, NVME_OPS_ADMIN_LOCKDOWN);
+        if (it != adminOpcodesToLock.end()) {
+            std::iter_swap(it, adminOpcodesToLock.rbegin());
+        }
+
+        for (ui8 opcode: adminOpcodesToLock) {
+            LockdownItem(device, NVME_LOCKDOWN_ADMIN_CMD, opcode);
+        }
     }
 
     // returns (LBA format index, block size)

--- a/cloud/blockstore/libs/nvme/nvme_stub.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_stub.cpp
@@ -8,8 +8,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TNvmeManagerStub final
-    : public INvmeManager
+class TNvmeManagerStub final: public INvmeManager
 {
 private:
     bool IsDeviceSsd;
@@ -17,8 +16,8 @@ private:
 
 public:
     TNvmeManagerStub(
-            bool isDeviceSsd,
-            TNvmeDeallocateHistoryPtr deallocateHistory)
+        bool isDeviceSsd,
+        TNvmeDeallocateHistoryPtr deallocateHistory)
         : IsDeviceSsd(isDeviceSsd)
         , DeallocateHistory(std::move(deallocateHistory))
     {}
@@ -39,10 +38,8 @@ public:
         return MakeFuture(MakeError(S_OK));
     }
 
-    TFuture<NProto::TError> Deallocate(
-        const TString& path,
-        ui64 offsetBytes,
-        ui64 sizeBytes) override
+    TFuture<NProto::TError>
+    Deallocate(const TString& path, ui64 offsetBytes, ui64 sizeBytes) override
     {
         Y_UNUSED(path);
 
@@ -57,7 +54,7 @@ public:
     {
         Y_UNUSED(path);
 
-        return TString {};
+        return TString{};
     }
 
     TResultOrError<TString> GetDeviceModel(const TString& path) override
@@ -92,6 +89,23 @@ public:
     NProto::TError ResetToSingleNamespace(const TString& ctrlPath) final
     {
         Y_UNUSED(ctrlPath);
+
+        return {};
+    }
+
+    TResultOrError<TLockdownState> GetLockdownState(
+        const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return TLockdownState{};
+    }
+
+    NProto::TError EnsureLockdown(
+        const TString& ctrlPath,
+        const TLockdownConfig& config) final
+    {
+        Y_UNUSED(ctrlPath, config);
 
         return {};
     }

--- a/cloud/blockstore/libs/nvme/nvme_ut.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_ut.cpp
@@ -22,7 +22,7 @@ namespace {
 
 struct TFree
 {
-    void operator () (void* ptr) const
+    void operator()(void* ptr) const
     {
         std::free(ptr);
     }
@@ -77,10 +77,7 @@ Y_UNIT_TEST_SUITE(TNvmeManagerTest)
     Y_UNIT_TEST_F(ShouldGetSerialNumber, TFixture)
     {
         auto [sn, error] = NvmeManager->GetSerialNumber(DevicePath);
-        UNIT_ASSERT_VALUES_EQUAL_C(
-            S_OK,
-            error.GetCode(),
-            FormatError(error));
+        UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), FormatError(error));
         UNIT_ASSERT(sn);
     }
 
@@ -143,6 +140,29 @@ Y_UNIT_TEST_SUITE(TNvmeManagerTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 sizeBytes,
                 std::count(buffer.get(), buffer.get() + sizeBytes, 0));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldFailLockdownCommand, TFixture)
+    {
+        {
+            auto [state, error] = NvmeManager->GetLockdownState(DevicePath);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT(!state.Supported);
+        }
+        {
+            auto error = NvmeManager->EnsureLockdown(
+                DevicePath,
+                {
+                    .AllowedAdminOpcodes = {0x0},
+                });
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                MAKE_SYSTEM_ERROR(ENOTSUP),
+                error.GetCode(),
+                FormatError(error));
         }
     }
 }

--- a/cloud/blockstore/libs/nvme/spec.h
+++ b/cloud/blockstore/libs/nvme/spec.h
@@ -51,6 +51,8 @@ enum nvme_admin_opcode {
 
     NVME_OPC_DOORBELL_BUFFER_CONFIG = 0x7c,
 
+    NVME_OPS_ADMIN_LOCKDOWN = 0x24,
+
     NVME_OPC_FORMAT_NVM = 0x80,
     NVME_OPC_SECURITY_SEND = 0x81,
     NVME_OPC_SECURITY_RECEIVE = 0x82,
@@ -307,7 +309,10 @@ struct __attribute__((packed)) __attribute__((aligned)) nvme_ctrlr_data {
         /** Supports NVME_OPC_GET_LBA_STATUS */
         uint16_t get_lba_status : 1;
 
-        uint16_t oacs_rsvd : 6;
+        /** Command and Feature Lockdown Supported */
+        uint16_t lockdown : 1;
+
+        uint16_t oacs_rsvd : 5;
     } oacs;
 
     /** abort command limit */
@@ -827,6 +832,45 @@ enum nvme_sanitize_status
     NVME_SANITIZE_SSTAT_COMPLETED = 0x01,
     NVME_SANITIZE_SSTAT_IN_PROGRESS = 0x02,
     NVME_SANITIZE_SSTAT_FAILED = 0x03,
+};
+
+struct nvme_lockdown_log
+{
+    uint8_t cfila;
+    uint8_t rsvd1[2];
+    uint8_t lngth;
+    uint8_t cfil[508];
+};
+
+static_assert(sizeof(nvme_lockdown_log) == 512);
+
+enum nvme_cmd_get_log_lid
+{
+    NVME_LOG_LID_CMD_AND_FEAT_LOCKDOWN = 0x14,
+    NVME_LOG_LID_SANITIZE = 0x81,
+};
+
+enum nvme_lockdown_log_contents
+{
+    NVME_LOCKDOWN_SUPPORTED_CMD = 0x0,
+    NVME_LOCKDOWN_PROHIBITED_CMD = 0x1,
+    NVME_LOCKDOWN_PROHIBITED_OUTOFBAND_CMD = 0x2,
+};
+
+enum nvme_lockdown_log_scope
+{
+    NVME_LOCKDOWN_ADMIN_CMD = 0x0,
+    NVME_LOCKDOWN_FEATURE_ID = 0x2,
+    NVME_LOCKDOWN_MI_CMD_SET = 0x3,
+    NVME_LOCKDOWN_PCI_CMD_SET = 0x4,
+};
+
+enum nvme_lockdown_scope_contents
+{
+    NVME_LOCKDOWN_SS_SHIFT = 0,
+    NVME_LOCKDOWN_SS_MASK = 0xf,
+    NVME_LOCKDOWN_CS_SHIFT = 4,
+    NVME_LOCKDOWN_CS_MASK = 0x3,
 };
 
 }   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/nvme/ut_utils/ya.make
+++ b/cloud/blockstore/libs/nvme/ut_utils/ya.make
@@ -1,0 +1,9 @@
+UNITTEST_FOR(cloud/blockstore/libs/nvme)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+SRCS(
+    utils_ut.cpp
+)
+
+END()

--- a/cloud/blockstore/libs/nvme/utils.cpp
+++ b/cloud/blockstore/libs/nvme/utils.cpp
@@ -1,0 +1,33 @@
+#include "utils.h"
+
+#include <util/generic/algorithm.h>
+
+namespace NCloud::NBlockStore::NNvme {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVector<ui8> CalculateOpcodesToLock(
+    TVector<ui8> allowedOpcodes,
+    TVector<ui8> lockable,
+    TVector<ui8> prohibited)
+{
+    SortUnique(lockable);
+    SortUnique(prohibited);
+    SortUnique(allowedOpcodes);
+
+    TVector<ui8> supportedOpcodesToLock;
+    std::ranges::set_difference(
+        lockable,
+        allowedOpcodes,
+        std::back_inserter(supportedOpcodesToLock));
+
+    TVector<ui8> opcodesToLock;
+    std::ranges::set_difference(
+        supportedOpcodesToLock,
+        prohibited,
+        std::back_inserter(opcodesToLock));
+
+    return opcodesToLock;
+}
+
+}   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/nvme/utils.h
+++ b/cloud/blockstore/libs/nvme/utils.h
@@ -1,0 +1,14 @@
+#include <util/generic/vector.h>
+
+namespace NCloud::NBlockStore::NNvme {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Calculates which lockable opcodes should be prohibited, excluding explicitly
+// allowed and already prohibited opcodes.
+TVector<ui8> CalculateOpcodesToLock(
+    TVector<ui8> allowedOpcodes,
+    TVector<ui8> lockable,
+    TVector<ui8> prohibited);
+
+}   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/nvme/utils_ut.cpp
+++ b/cloud/blockstore/libs/nvme/utils_ut.cpp
@@ -1,0 +1,87 @@
+#include "utils.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/random/shuffle.h>
+#include <util/string/join.h>
+
+#include <array>
+
+namespace NCloud::NBlockStore::NNvme {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString ToString(const TVector<ui8>& opcodes)
+{
+    TStringBuilder out;
+
+    out << "[ ";
+    for (ui8 opcode: opcodes) {
+        out << Hex(opcode, HF_ADDX) << " ";
+    }
+    out << "]";
+
+    return out;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TNVMeUtilsTest)
+{
+    Y_UNIT_TEST(ShouldCalculateOpcodesToLock)
+    {
+        struct TCase
+        {
+            TVector<ui8> AllowedOpcodes;
+            TVector<ui8> Lockable;
+            TVector<ui8> Prohibited;
+            TVector<ui8> Expected;
+        };
+
+        const TCase cases[]{
+            {{}, {}, {}, {}},
+            {{}, {0x1, 0x2, 0x3}, {}, {0x1, 0x2, 0x3}},
+            {{}, {0x1, 0x2, 0x3}, {0x1, 0x2, 0x3}, {}},
+            {{}, {0x1, 0x2, 0x3, 0x4}, {0x1, 0x3}, {0x2, 0x4}},
+            {{0x1, 0x2, 0x3}, {0x1, 0x2, 0x3}, {0x1, 0x2, 0x3}, {}},
+            {{0x1}, {0x1, 0x2, 0x3}, {}, {0x2, 0x3}},
+            {{0x1}, {0x1, 0x2, 0x3}, {0x3}, {0x2}},
+            {{0x1, 0x2, 0x3, 0x4, 0x5, 0x6}, {0x1, 0x2, 0x3}, {}, {}},
+            {{0x1, 0x4, 0x5, 0x6}, {0x1, 0x2, 0x3}, {0x3}, {0x2}},
+            {{0x1, 0x3},
+             {0x1, 0x2, 0x3, 0x4, 0x5, 0x6},
+             {0x5, 0x6},
+             {0x2, 0x4}},
+        };
+
+        for (size_t i = 0; i != std::size(cases); ++i) {
+            auto t = cases[i];
+
+            ShuffleRange(t.AllowedOpcodes);
+            ShuffleRange(t.Lockable);
+            ShuffleRange(t.Prohibited);
+
+            auto result = CalculateOpcodesToLock(
+                t.AllowedOpcodes,
+                t.Lockable,
+                t.Prohibited);
+            UNIT_ASSERT_EQUAL_C(
+                t.Expected,
+                result,
+                " " << ToString(t.Expected) << " != " << ToString(result)
+                    << ". Test case #" << (i + 1) << " { "
+                    << JoinSeq(
+                           ", ",
+                           {ToString(t.AllowedOpcodes),
+                            ToString(t.Lockable),
+                            ToString(t.Prohibited)})
+                    << " }");
+        }
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NNvme

--- a/cloud/blockstore/libs/nvme/ya.make
+++ b/cloud/blockstore/libs/nvme/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     nvme.cpp
     nvme_stub.cpp
+    utils.cpp
 )
 
 IF(OS_LINUX)
@@ -19,6 +20,7 @@ END()
 
 RECURSE_FOR_TESTS(
     ut_nvme
+    ut_utils
 )
 
 RECURSE(testing)

--- a/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
+++ b/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
@@ -105,6 +105,23 @@ struct TTestNvmeManager final: NNvme::INvmeManager
 
         return {};
     }
+
+    TResultOrError<TLockdownState> GetLockdownState(
+        const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return TLockdownState{};
+    }
+
+    NProto::TError EnsureLockdown(
+        const TString& ctrlPath,
+        const TLockdownConfig& config) final
+    {
+        Y_UNUSED(ctrlPath, config);
+
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -197,6 +197,23 @@ struct TTestNvmeManager: NNvme::INvmeManager
 
         return {};
     }
+
+    TResultOrError<TLockdownState> GetLockdownState(
+        const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return TLockdownState{};
+    }
+
+    NProto::TError EnsureLockdown(
+        const TString& ctrlPath,
+        const TLockdownConfig& config) final
+    {
+        Y_UNUSED(ctrlPath, config);
+
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -127,6 +127,23 @@ struct TTestNvmeManager
 
         return {};
     }
+
+    TResultOrError<TLockdownState> GetLockdownState(
+        const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return TLockdownState{};
+    }
+
+    NProto::TError EnsureLockdown(
+        const TString& ctrlPath,
+        const TLockdownConfig& config) final
+    {
+        Y_UNUSED(ctrlPath, config);
+
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -115,6 +115,23 @@ struct TTestNvmeManager
 
         return {};
     }
+
+    TResultOrError<TLockdownState> GetLockdownState(
+        const TString& ctrlPath) final
+    {
+        Y_UNUSED(ctrlPath);
+
+        return TLockdownState{};
+    }
+
+    NProto::TError EnsureLockdown(
+        const TString& ctrlPath,
+        const TLockdownConfig& config) final
+    {
+        Y_UNUSED(ctrlPath, config);
+
+        return {};
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds NVMe Command and Feature Lockdown support.

* Add `GetLockdownState` to query supported and currently prohibited admin commands / feature IDs.
* Add `EnsureLockdown` to prohibit commands and features according to the provided allowlist.
* Support optionally locking the Lockdown command itself.
* Add helper utilities and unit tests for lockdown opcode calculation and unsupported devices.
