### PR TITLE
issue-6608: Implement quota inheritance in CreateNode and CreateHandle operations

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_quotas.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_quotas.cpp
@@ -20,12 +20,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NProto::TStorageConfig MakeStorageConfig()
-{
-    NProto::TStorageConfig config;
-    return config;
-}
-
 NProto::TStorageConfig MakeStorageConfigWithDirectoryCreationInShards()
 {
     NProto::TStorageConfig config;
@@ -58,8 +52,7 @@ protected:
         Service = MakeHolder<TServiceClient>(Env->GetRuntime(), nodeIdx);
 
         if (sharded) {
-            auto fsInfo = CreateFileSystem(*Service, fsConfig);
-            Y_UNUSED(fsInfo);
+            CreateFileSystem(*Service, fsConfig);
             FsId = fsConfig.FsId;
         } else {
             FsId = "test";
@@ -73,7 +66,7 @@ class TUnshardedFixture: public TShardingModeFixtureBase
 public:
     void SetUp(NUnitTest::TTestContext&) override
     {
-        Init(MakeStorageConfig(), false);
+        Init(NProto::TStorageConfig{}, false);
     }
 };
 
@@ -82,7 +75,7 @@ class TShardedFixture: public TShardingModeFixtureBase
 public:
     void SetUp(NUnitTest::TTestContext&) override
     {
-        Init(MakeStorageConfig(), true);
+        Init(NProto::TStorageConfig{}, true);
     }
 };
 

--- a/cloud/filestore/libs/storage/service/service_ut_quotas.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_quotas.cpp
@@ -1,0 +1,231 @@
+#include "service.h"
+#include "service_private.h"
+#include "service_ut_helpers.h"
+#include "service_ut_sharding.h"
+
+#include <cloud/filestore/libs/storage/model/utils.h>
+#include <cloud/filestore/libs/storage/testlib/service_client.h>
+#include <cloud/filestore/libs/storage/testlib/test_env.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TStorageConfig MakeStorageConfig()
+{
+    NProto::TStorageConfig config;
+    return config;
+}
+
+NProto::TStorageConfig MakeStorageConfigWithDirectoryCreationInShards()
+{
+    NProto::TStorageConfig config;
+    config.SetDirectoryCreationInShardsEnabled(true);
+    return config;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TShardingModeFixtureBase: public NUnitTest::TBaseTestCase
+{
+public:
+    THolder<TTestEnv> Env;
+    THolder<TServiceClient> Service;
+    TString FsId;
+
+protected:
+    void Init(NProto::TStorageConfig config, bool sharded)
+    {
+        TShardedFileSystemConfig fsConfig;
+        if (sharded) {
+            config.SetAutomaticShardCreationEnabled(true);
+            config.SetAutomaticallyCreatedShardSize(
+                fsConfig.ShardBlockCount * 4_KB);
+            config.SetShardAllocationUnit(fsConfig.ShardBlockCount * 4_KB);
+        }
+
+        Env = MakeHolder<TTestEnv>(TTestEnvConfig{}, config);
+        ui32 nodeIdx = Env->AddDynamicNode();
+        Service = MakeHolder<TServiceClient>(Env->GetRuntime(), nodeIdx);
+
+        if (sharded) {
+            auto fsInfo = CreateFileSystem(*Service, fsConfig);
+            Y_UNUSED(fsInfo);
+            FsId = fsConfig.FsId;
+        } else {
+            FsId = "test";
+            Service->CreateFileStore(FsId, 1'000);
+        }
+    }
+};
+
+class TUnshardedFixture: public TShardingModeFixtureBase
+{
+public:
+    void SetUp(NUnitTest::TTestContext&) override
+    {
+        Init(MakeStorageConfig(), false);
+    }
+};
+
+class TShardedFixture: public TShardingModeFixtureBase
+{
+public:
+    void SetUp(NUnitTest::TTestContext&) override
+    {
+        Init(MakeStorageConfig(), true);
+    }
+};
+
+class TShardedWithDirCreationFixture: public TShardingModeFixtureBase
+{
+public:
+    void SetUp(NUnitTest::TTestContext&) override
+    {
+        Init(MakeStorageConfigWithDirectoryCreationInShards(), true);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define SERVICE_TEST_DECL(name)                                                \
+    void RunTest##name(TShardingModeFixtureBase& fixture)                      \
+// SERVICE_TEST_DECL
+
+#define SERVICE_TEST(name)                                                     \
+    SERVICE_TEST_DECL(name);                                                   \
+    Y_UNIT_TEST_F(name, TUnshardedFixture)                                     \
+    {                                                                          \
+        RunTest##name(*this);                                                  \
+    }                                                                          \
+    Y_UNIT_TEST_F(name##WithShards, TShardedFixture)                           \
+    {                                                                          \
+        RunTest##name(*this);                                                  \
+    }                                                                          \
+    Y_UNIT_TEST_F(                                                             \
+        name##WithDirectoryCreationInShards,                                   \
+        TShardedWithDirCreationFixture)                                        \
+    {                                                                          \
+        RunTest##name(*this);                                                  \
+    }                                                                          \
+    SERVICE_TEST_DECL(name)                                                    \
+// SERVICE_TEST
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TStorageServiceQuotasTest)
+{
+    SERVICE_TEST(ShouldInheritQuotaIdOnCreateNode)
+    {
+        auto& service = *fixture.Service;
+        const auto& fsId = fixture.FsId;
+
+        auto headers = service.InitSession(fsId, "client");
+
+        const auto dirId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(
+            headers,
+            fsId,
+            TSetNodeAttrArgs(dirId).SetQuotaId(42));
+
+        const auto fileId =
+            service.CreateNode(headers, TCreateNodeArgs::File(dirId, "file"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_EQUAL(
+            42u,
+            service.GetNodeAttr(headers, fsId, fileId, "")
+                ->Record.GetNode()
+                .GetQuotaId());
+
+        const auto subdirId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(dirId, "subdir"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_EQUAL(
+            42u,
+            service.GetNodeAttr(headers, fsId, subdirId, "")
+                ->Record.GetNode()
+                .GetQuotaId());
+
+        // grandchildren keep inheriting through the subdirectory, even
+        // though it wasn't itself explicitly marked
+        const auto grandchildId =
+            service
+                .CreateNode(
+                    headers,
+                    TCreateNodeArgs::File(subdirId, "grandchild"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_EQUAL(
+            42u,
+            service.GetNodeAttr(headers, fsId, grandchildId, "")
+                ->Record.GetNode()
+                .GetQuotaId());
+
+        // unrelated siblings outside the quota'd subtree stay unquota'd
+        const auto otherId =
+            service.CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "other"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_EQUAL(
+            0u,
+            service.GetNodeAttr(headers, fsId, otherId, "")
+                ->Record.GetNode()
+                .GetQuotaId());
+    }
+
+    SERVICE_TEST(ShouldInheritQuotaIdOnCreateHandle)
+    {
+        auto& service = *fixture.Service;
+        const auto& fsId = fixture.FsId;
+
+        auto headers = service.InitSession(fsId, "client");
+
+        const auto dirId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(
+            headers,
+            fsId,
+            TSetNodeAttrArgs(dirId).SetQuotaId(42));
+
+        auto createHandleResponse = service.CreateHandle(
+            headers,
+            fsId,
+            dirId,
+            "file1",
+            TCreateHandleArgs::CREATE)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            42u,
+            createHandleResponse.GetNodeAttr().GetQuotaId());
+
+        const auto fileId = createHandleResponse.GetNodeAttr().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(
+            42u,
+            service.GetNodeAttr(headers, fsId, fileId, "")
+                ->Record.GetNode()
+                .GetQuotaId());
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/ut/ya.make
+++ b/cloud/filestore/libs/storage/service/ut/ya.make
@@ -8,6 +8,7 @@ SRCS(
     service_ut.cpp
     service_ut_helpers.cpp
     service_ut_parentless.cpp
+    service_ut_quotas.cpp
     service_ut_sharding.cpp
     service_ut_writedata_unconfirmed.cpp
     service_actor_actions_ut.cpp

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -225,6 +225,8 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
     // * access by parentId/name
     // * access by nodeId
     if (args.Name) {
+        const bool behaveAsShard = BehaveAsShard(args.Request.GetHeaders());
+
         // check that parent exists and is the directory;
         // TODO: what if symlink?
         if (!ReadNode(*db, args.NodeId, args.ReadCommitId, args.ParentNode)) {
@@ -247,7 +249,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
             }
         }
 
-        if (!BehaveAsShard(args.Request.GetHeaders())) {
+        if (!behaveAsShard) {
             // args.ParentNode is only a real parent when behaveAsShard is
             // false.
             args.QuotaId = args.ParentNode->Attrs.GetQuotaId();
@@ -265,8 +267,6 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
                 args.Error = ErrorInvalidTarget(args.NodeId, args.Name);
                 return true;
             }
-
-            const bool behaveAsShard = BehaveAsShard(args.Request.GetHeaders());
 
             // Validate there are enough free inodes. The restriction is not
             // enforced if the request comes from the main FS to the shard.

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -247,6 +247,12 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
             }
         }
 
+        if (!BehaveAsShard(args.Request.GetHeaders())) {
+            // args.ParentNode is only a real parent when behaveAsShard is
+            // false.
+            args.QuotaId = args.ParentNode->Attrs.GetQuotaId();
+        }
+
         // check whether child node exists
         TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
         if (!ReadNodeRef(*db, args.NodeId, args.ReadCommitId, args.Name, ref)) {
@@ -378,6 +384,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         if (args.ShardId.empty()) {
             NProto::TNode attrs =
                 CreateRegularAttrs(args.Mode, args.Uid, args.Gid);
+            attrs.SetQuotaId(args.QuotaId);
             args.TargetNodeId = CreateNode(
                 *db,
                 args.WriteCommitId,
@@ -496,6 +503,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         shardRequest->MutableFile()->SetMode(args.Mode);
         shardRequest->SetUid(args.Uid);
         shardRequest->SetGid(args.Gid);
+        shardRequest->SetQuotaId(args.QuotaId);
         shardRequest->SetFileSystemId(args.ShardId);
         shardRequest->SetNodeId(RootNodeId);
         shardRequest->SetName(args.ShardNodeName);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -87,6 +87,8 @@ void InitAttrs(NProto::TNode& attrs, const NProto::TCreateNodeRequest& request)
             request.GetGid(),
             bdev.GetDevice());
     }
+
+    attrs.SetQuotaId(request.GetQuotaId());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -646,6 +648,12 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
                 args.Request.MutableDirectory()->SetMode(args.Attrs.GetMode());
             }
         }
+    }
+
+    if (!behaveAsShard) {
+        // args.ParentNode is only a real parent when behaveAsShard is false.
+        args.Attrs.SetQuotaId(args.ParentNode->Attrs.GetQuotaId());
+        args.Request.SetQuotaId(args.ParentNode->Attrs.GetQuotaId());
     }
 
     // TODO: AccessCheck

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1921,6 +1921,7 @@ struct TTxIndexTablet
         const ui32 Mode;
         const ui32 Uid;
         ui32 Gid;
+        ui32 QuotaId = 0;
         const TString RequestShardId;
         NProto::TCreateHandleRequest Request;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1975,6 +1975,7 @@ struct TTxIndexTablet
             TargetNode.Clear();
             ParentNode.Clear();
             UpdatedNodes.clear();
+            QuotaId = 0;
 
             OpLogEntry.Clear();
 

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -207,6 +207,12 @@ message TCreateNodeRequest
     // on retry.
     // TODO(#2667): remove once hardlinks are created on the tablet side
     TNodeAttr ShardNodeAttr = 19;
+
+    // Id of the quota this node's parent is attached to (or inherited
+    // itself), 0 if none. Resolved by whichever tablet owns the real
+    // parent and carried along for the cross-shard hop, since the target
+    // shard doesn't have the real parent loaded locally.
+    uint32 QuotaId = 20;
 }
 
 message TCreateNodeResponse

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -208,7 +208,8 @@ message TCreateNodeRequest
     // TODO(#2667): remove once hardlinks are created on the tablet side
     TNodeAttr ShardNodeAttr = 19;
 
-    // Id of the quota this node's parent is attached to.
+    // The QuotaId this new node should inherit, resolved by whichever tablet
+    // owns the real parent and carried along for the cross-shard operation.
     uint32 QuotaId = 20;
 }
 

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -208,10 +208,7 @@ message TCreateNodeRequest
     // TODO(#2667): remove once hardlinks are created on the tablet side
     TNodeAttr ShardNodeAttr = 19;
 
-    // Id of the quota this node's parent is attached to (or inherited
-    // itself), 0 if none. Resolved by whichever tablet owns the real
-    // parent and carried along for the cross-shard hop, since the target
-    // shard doesn't have the real parent loaded locally.
+    // Id of the quota this node's parent is attached to.
     uint32 QuotaId = 20;
 }
 


### PR DESCRIPTION
### Notes
Creating new files should inherit the parent's quota_id (same as uid/guid in case of set_gid bits)

### Issue
#6608
