### PR TITLE
[Disk Manager] Fix SA4006 style lint error in pools/storage test

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -313,8 +313,7 @@ func TestStorageYDBCreateBaseDisksPool(t *testing.T) {
 	require.Equal(t, uint64(0), poolInfos[0].ImageSize)
 	require.NotZero(t, poolInfos[0].CreatedAt)
 
-	disks := make([]BaseDisk, 0)
-	disks, err = storage.GetIdleBaseDisks(
+	disks, err := storage.GetIdleBaseDisks(
 		ctx,
 		poolInfos[0].ImageID,
 		poolInfos[0].ZoneID,


### PR DESCRIPTION
### Notes
Fixes the SA4006 lint error in `storage_ydb_test.go`. The disks variable was initialized with an empty slice and immediately overwritten by the result of `GetIdleBaseDisks`, so the initial value was never used.

### Issue

```
$S/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go:316:2: "SA4006: this value of disks is never used"
$S/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go:316:2: "SA4006: if you believe this report is false positive, please silence it with //nolint:sa4006 comment"
```

GitHub and Arcadia currently use different Go analyzer sets. GitHub runs the standard `govet`, enabled in #6372, while Arcadia runs `yolint` util, which additionally includes Staticcheck analyzers such as `SA4006`. Since `yolint` is unavailable in opensource, the GitHub checks did not detect this unused assignment, but the subsequent Arcadia check failed.