### PR TITLE
issue-5895: explicitly state the copyright owner for the fastshard code

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/COPYRIGHT.md
+++ b/cloud/filestore/libs/storage/fastshard/COPYRIGHT.md
@@ -1,0 +1,7 @@
+# Copyright
+
+Copyright 2026 Nebius B.V.
+
+Unless otherwise noted, the files in this directory were developed by Nebius and are licensed under the Apache License, Version 2.0.
+
+See the repository's `LICENSE` file for the full license text.


### PR DESCRIPTION
### Notes
The copyright in code developed by Nebius B.V. employees in the course of their employment belongs to Nebius B.V. This PR makes that explicit for cloud/filestore/libs/storage/fastshard, since this entire subdirectory has been developed solely by Nebius B.V. employees. The notice is intended to avoid possible confusion about copyright ownership in the future.

### Issue
https://github.com/ydb-platform/nbs/issues/5895
