### PR TITLE
issue-6645 Fix test cloud/blockstore/tests/plugin/uds when built with forced allocator change (-DALLOCATOR=TCMALLOC_256K) 

### DIFF
--- a/cloud/vm/blockstore/ya.make
+++ b/cloud/vm/blockstore/ya.make
@@ -1,6 +1,12 @@
 DLL(blockstore-plugin)
 EXPORTS_SCRIPT(plugin.symlist)
 
+IF (ARCH_ARM64 AND ALLOCATOR == "TCMALLOC_256K")                                                                                                                           
+    # For arm builds with forced -DALLOCATOR=TCMALLOC_256K we should preserve FAKE allocator for DLL
+    # Without this plugin will be linked with tcmalloc and cant be used
+    DISABLE(COMMON_LINK_SETTINGS)                                                                                                                                              
+ENDIF()                                                                                                                                                                    
+
 SRCS(
     bootstrap.cpp
     logging.cpp

--- a/cloud/vm/blockstore/ya.make
+++ b/cloud/vm/blockstore/ya.make
@@ -1,11 +1,11 @@
 DLL(blockstore-plugin)
 EXPORTS_SCRIPT(plugin.symlist)
 
-IF (ARCH_ARM64 AND ALLOCATOR == "TCMALLOC_256K")                                                                                                                           
+IF (ARCH_ARM64 AND ALLOCATOR == "TCMALLOC_256K")
     # For arm builds with forced -DALLOCATOR=TCMALLOC_256K we should preserve FAKE allocator for DLL
     # Without this plugin will be linked with tcmalloc and cant be used
-    DISABLE(COMMON_LINK_SETTINGS)                                                                                                                                              
-ENDIF()                                                                                                                                                                    
+    DISABLE(COMMON_LINK_SETTINGS)
+ENDIF()
 
 SRCS(
     bootstrap.cpp


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/6645

Without this patch  -DALLOCATOR=TCMALLOC_256K changes FAKE allocator for plugin with TCMALLOC_256K
