### PR TITLE
issue-5894, issue-5895: fastshard server should listen on ipv6 as well as on ipv4

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server.cpp
@@ -45,6 +45,27 @@ constexpr ui64 MaxMessageSize = 64_MB;
 constexpr int SocketBacklog = 128;
 
 ////////////////////////////////////////////////////////////////////////////////
+
+int BindAndListen(int fd, const sockaddr* addr, socklen_t addrLen)
+{
+    int one = 1;
+    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    if (::bind(fd, addr, addrLen) < 0) {
+        SILK_ERROR("bind: %s", ::strerror(errno));
+        ::close(fd);
+        return -1;
+    }
+
+    if (::listen(fd, SocketBacklog) < 0) {
+        SILK_ERROR("listen: %s", ::strerror(errno));
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Handler bookkeeping.
 //
 // Every accepted connection is represented by a THandler which owns the
@@ -530,33 +551,70 @@ public:
 private:
     int MakeListenSocket()
     {
+        //
+        // Dual-stack listener: an AF_INET6 socket with IPV6_V6ONLY
+        // cleared accepts IPv6 connections directly and IPv4 ones as
+        // v4-mapped addresses. The clients connect to the FQDN published
+        // by the tablet, which resolves to AAAA records in IPv6-only
+        // networks - an AF_INET listener is unreachable there.
+        //
+
         int fd =
-            ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+            ::socket(AF_INET6, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+        if (fd >= 0) {
+            //
+            // The IPV6_V6ONLY default depends on net.ipv6.bindv6only, so
+            // clear it explicitly.
+            //
+
+            int zero = 0;
+            int r = ::setsockopt(
+                fd,
+                IPPROTO_IPV6,
+                IPV6_V6ONLY,
+                &zero,
+                sizeof(zero));
+            if (r < 0) {
+                SILK_WARN(
+                    "clear IPV6_V6ONLY: %s - IPv4 clients will be rejected",
+                    ::strerror(errno));
+            }
+
+            sockaddr_in6 addr{};
+            addr.sin6_family = AF_INET6;
+            addr.sin6_port = htons(Port);
+            addr.sin6_addr = in6addr_any;
+
+            return BindAndListen(
+                fd,
+                reinterpret_cast<sockaddr*>(&addr),
+                sizeof(addr));
+        }
+
+        //
+        // Hosts with IPv6 disabled fail socket(AF_INET6) with
+        // EAFNOSUPPORT - fall back to an IPv4-only listener.
+        //
+
+        SILK_WARN(
+            "socket(AF_INET6): %s - falling back to IPv4",
+            ::strerror(errno));
+
+        fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
         if (fd < 0) {
             SILK_ERROR("socket: %s", ::strerror(errno));
             return -1;
         }
-
-        int one = 1;
-        ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
 
         sockaddr_in addr{};
         addr.sin_family = AF_INET;
         addr.sin_port = htons(Port);
         addr.sin_addr.s_addr = INADDR_ANY;
 
-        if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-            SILK_ERROR("bind: %s", ::strerror(errno));
-            ::close(fd);
-            return -1;
-        }
-
-        if (::listen(fd, SocketBacklog) < 0) {
-            SILK_ERROR("listen: %s", ::strerror(errno));
-            ::close(fd);
-            return -1;
-        }
-        return fd;
+        return BindAndListen(
+            fd,
+            reinterpret_cast<sockaddr*>(&addr),
+            sizeof(addr));
     }
 
     ui16 Port;

--- a/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
@@ -16,6 +16,10 @@
 
 #include <gtest/gtest.h>
 
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 using namespace NCloud::NFileStore::NStorage::NFastShard;
 using namespace NCloud::NFileStore::NStorage::NFastShard::NProtoSrv;
 using silk::FiberFuture;
@@ -29,6 +33,25 @@ constexpr TDuration WaitTimeout = TDuration::Seconds(5);
 
 [[maybe_unused]] auto* const gEnv =
     ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool Ipv6LoopbackAvailable()
+{
+    int fd = ::socket(AF_INET6, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        return false;
+    }
+
+    sockaddr_in6 addr{};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_addr = in6addr_loopback;
+
+    const bool bound =
+        ::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
+    ::close(fd);
+    return bound;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Test fixture that runs the server in a fiber.
@@ -76,6 +99,45 @@ struct TServerFixture
         ServerFuture.wait();
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+// Connects to the server via the given loopback address and performs one
+// request round trip. Shared by the IPv4/IPv6 listener tests.
+
+struct THostParam
+{
+    const char* Host;
+};
+
+static_assert(sizeof(THostParam) <= silk::FIBER_PARAMETERS_SIZE);
+
+int LoopbackConnectFiber(THostParam* p) noexcept
+{
+    NCloud::NFileStore::NProtoPrivate::TMemFastShardConfig cfg;
+    cfg.SetCreateNodeUponAccess(true);
+    auto shard = CreateMemFileSystemShard(1, cfg);
+
+    TServerFixture fixture;
+    fixture.StartServer(shard);
+
+    TClient client;
+    auto endpoint = client.Connect(p->Host, fixture.Port);
+    EXPECT_NE(endpoint, nullptr) << "connect to " << p->Host;
+
+    if (endpoint) {
+        TRequest req;
+        req.SetFileSystemId("test-fs");
+        auto* body = req.MutableCreateNode();
+        body->SetNodeId(1);
+        body->MutableFile()->SetMode(0644);
+        body->SetName("loopback.txt");
+        auto resp = endpoint->Send(req);
+        EXPECT_TRUE(resp.HasCreateNode());
+    }
+
+    fixture.StopServer();
+    return 0;
+}
 
 }   // namespace
 
@@ -157,6 +219,26 @@ TEST(ServerTest, UnknownShardReturnsEmptyResponse)
         },
         0);
 
+    EXPECT_EQ(result, 0);
+}
+
+TEST(ServerTest, ListensOnIpv4Loopback)
+{
+    int result = FiberScheduler::run(
+        LoopbackConnectFiber,
+        THostParam{"127.0.0.1"});
+    EXPECT_EQ(result, 0);
+}
+
+TEST(ServerTest, ListensOnIpv6Loopback)
+{
+    if (!Ipv6LoopbackAvailable()) {
+        GTEST_SKIP() << "IPv6 loopback is not available on this host";
+    }
+
+    int result = FiberScheduler::run(
+        LoopbackConnectFiber,
+        THostParam{"::1"});
     EXPECT_EQ(result, 0);
 }
 


### PR DESCRIPTION
### Notes
Claude was so kind to fix its own bug regarding listening only on ipv4 address. I reviewed it, looks good. Just logging the cases when we trigger fallbacks to ipv6-only or ipv4-only is okay here. This is currently an experimental component AND ipv4 is needed for tests only AND it's still going to be immediately visible if it happens.

This server is used only for tcp-side-channel which is itself experimental.

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895
