### PR TITLE
feat: add ya trace to otlp span conversion + workflow run otlp spans

### DIFF
--- a/.github/scripts/tracing/YA_TRACE_TO_OTLP.md
+++ b/.github/scripts/tracing/YA_TRACE_TO_OTLP.md
@@ -762,6 +762,13 @@ job queue, job, and step spans, rewrites imported ya span IDs into the workflow
 trace ID, and attaches each imported root to the smallest containing/overlapping
 job. This step consumes OTLP; it does not reparse ya trace files.
 
+The CLI writes two bundles from the same GitHub metadata:
+
+| Prefix | Contents |
+| --- | --- |
+| `workflow-only-trace.*` | Workflow, queue, job, and step spans only |
+| `workflow-trace.*` | The same workflow spans plus imported ya spans |
+
 For the first attempt, the workflow root retains GitHub's creation-to-update
 interval and its queue span. For reruns, `created_at` still refers to the
 original attempt and is ignored. The root instead begins at the earliest usable
@@ -798,5 +805,5 @@ including `stale`, map to `ERROR`; neutral and skipped conclusions remain
 | [`render_ya_trace_bundle.sh`](render_ya_trace_bundle.sh) | Shared nonblocking CI wrapper |
 | [`pack_ya_trace_inputs.sh`](pack_ya_trace_inputs.sh) | Literal-path raw-input tar archive |
 | [`workflow_trace.py`](workflow_trace.py) | Workflow, queue, job, step, and imported-span projection |
-| [`workflow_trace_report.py`](workflow_trace_report.py) | GitHub/S3 input loading and combined workflow bundle CLI |
+| [`workflow_trace_report.py`](workflow_trace_report.py) | GitHub/S3 input loading and standalone/combined workflow bundle CLI |
 | [`render-workflow-trace.yaml`](../../workflows/render-workflow-trace.yaml) | Trusted post-workflow rendering and upload |

--- a/.github/scripts/tracing/workflow_trace_report.py
+++ b/.github/scripts/tracing/workflow_trace_report.py
@@ -7,11 +7,13 @@ import argparse
 import json
 import os
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping, Sequence
 
 import boto3
+from github.WorkflowJob import WorkflowJob
 
 from ..helpers import get_jobs, github_client
+from .otlp import Trace
 from .trace_io import (
     MAX_INPUT_BYTES,
     MAX_SPANS,
@@ -76,6 +78,37 @@ def download_s3_trace_inputs(
     return inputs
 
 
+def write_workflow_trace_bundles(
+    *,
+    output_dir: Path,
+    workflow_run: Mapping[str, Any],
+    jobs: Sequence[WorkflowJob],
+    imported: Trace,
+    test_log_url_prefix: str = "",
+    test_data_url_prefix: str = "",
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    workflow_only, metadata = build_workflow_trace(workflow_run, jobs, Trace())
+    workflow_only_manifest = write_trace_bundle(
+        output_dir,
+        workflow_only,
+        title=f"Workflow trace · {workflow_run.get('name', 'unknown')}",
+        metadata=metadata,
+        file_prefix="workflow-only-trace",
+    )
+
+    combined, _ = build_workflow_trace(workflow_run, jobs, imported)
+    combined_manifest = write_trace_bundle(
+        output_dir,
+        combined,
+        title=f"Workflow and ya trace · {workflow_run.get('name', 'unknown')}",
+        metadata=metadata,
+        file_prefix="workflow-trace",
+        test_log_url_prefix=test_log_url_prefix,
+        test_data_url_prefix=test_data_url_prefix,
+    )
+    return workflow_only_manifest, combined_manifest
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--event", required=True, type=Path)
@@ -134,19 +167,18 @@ def main() -> None:
         max_input_bytes=MAX_INPUT_BYTES,
         max_spans=MAX_SPANS,
     )
-    trace, metadata = build_workflow_trace(workflow_run, jobs, imported)
-    manifest = write_trace_bundle(
-        args.output_dir,
-        trace,
-        title=f"Workflow trace · {workflow_run.get('name', 'unknown')}",
-        metadata=metadata,
-        file_prefix="workflow-trace",
+    workflow_only_manifest, combined_manifest = write_workflow_trace_bundles(
+        output_dir=args.output_dir,
+        workflow_run=workflow_run,
+        jobs=jobs,
+        imported=imported,
         test_log_url_prefix=args.test_log_url_prefix,
         test_data_url_prefix=args.test_data_url_prefix,
     )
     print(
-        f"Wrote {manifest['span_count']} spans, including {len(imported)} "
-        f"imported ya spans, to {args.output_dir}"
+        f"Wrote {workflow_only_manifest['span_count']} workflow spans and "
+        f"{combined_manifest['span_count']} combined spans, including "
+        f"{len(imported)} imported ya spans, to {args.output_dir}"
     )
 
 

--- a/.github/scripts/tracing/workflow_trace_test.py
+++ b/.github/scripts/tracing/workflow_trace_test.py
@@ -14,8 +14,12 @@ from scripts.tracing.otlp import (
     span_status_code,
     span_status_message,
 )
+from scripts.tracing.trace_io import read_otlp_jsonl
 from scripts.tracing.workflow_trace import build_workflow_trace
-from scripts.tracing.workflow_trace_report import download_s3_trace_inputs
+from scripts.tracing.workflow_trace_report import (
+    download_s3_trace_inputs,
+    write_workflow_trace_bundles,
+)
 
 
 def _workflow_run() -> dict:
@@ -124,6 +128,23 @@ def test_workflow_projection_from_github_jobs_and_imported_trace() -> None:
         == "https://reports.example/logs/a/"
     )
     assert metadata["github.pull_request.number"] == [42]
+
+
+def test_report_writes_workflow_only_and_combined_bundles(tmp_path) -> None:
+    workflow_only_manifest, combined_manifest = write_workflow_trace_bundles(
+        output_dir=tmp_path,
+        workflow_run=_workflow_run(),
+        jobs=_jobs(),
+        imported=_imported_trace(),
+    )
+
+    workflow_only = read_otlp_jsonl([tmp_path / "workflow-only-trace.otlp.jsonl.gz"])
+    combined = read_otlp_jsonl([tmp_path / "workflow-trace.otlp.jsonl.gz"])
+
+    assert workflow_only_manifest["span_count"] == 5
+    assert combined_manifest["span_count"] == 6
+    assert "ya make tests" not in {span.name for span in workflow_only}
+    assert "ya make tests" in {span.name for span in combined}
 
 
 def test_rerun_timeline_ignores_original_creation_time() -> None:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,9 +41,12 @@ critical path. Critical-path build nodes are marked on their individual spans.
 
 `render-workflow-trace.yaml` runs after the main test workflows complete. It
 combines GitHub workflow, queue, job, and step timings with any available ya
-bundles and stores `workflow-trace.*` in the same S3 report prefix. The
-`workflow_run` job always checks out the default branch and bounds both S3
-downloads and parsed OTLP data before rendering PR-produced content.
+bundles. It stores `workflow-only-trace.*` without imported ya spans and
+`workflow-trace.*` with them in the same S3 report prefix. The `workflow_run`
+job always checks out the default branch and bounds both S3 downloads and
+parsed OTLP data before rendering PR-produced content. For a stacked pull
+request, it renders only the bottom PR whose stack base matches its target
+branch, mirroring the main PR workflow gates.
 
 To render a saved OTLP bundle locally:
 

--- a/.github/workflows/render-workflow-trace.yaml
+++ b/.github/workflows/render-workflow-trace.yaml
@@ -25,6 +25,10 @@ concurrency:
 
 jobs:
   render:
+    if: >-
+      github.event.workflow_run.pull_requests[0] == null ||
+      github.event.workflow_run.pull_requests[0].stack == null ||
+      github.event.workflow_run.pull_requests[0].stack.base.ref == github.event.workflow_run.pull_requests[0].base.ref
     name: Render workflow and ya traces
     runs-on: [self-hosted, runner_light]
     timeout-minutes: 15
@@ -76,6 +80,7 @@ jobs:
           {
               echo "REPORTS_PREFIX=$reports_prefix"
               echo "TRACE_REPORT_URL=https://${REPORTS_BUCKET}.${REPORTS_WEBSITE_SUFFIX}/${reports_prefix}/workflow-trace.html"
+              echo "WORKFLOW_ONLY_TRACE_REPORT_URL=https://${REPORTS_BUCKET}.${REPORTS_WEBSITE_SUFFIX}/${reports_prefix}/workflow-only-trace.html"
           } >> "$GITHUB_ENV"
 
       - name: Render workflow trace
@@ -96,12 +101,17 @@ jobs:
               --include "workflow-trace.html" \
               --include "workflow-trace.manifest.json" \
               --include "workflow-trace.otlp.jsonl.gz" \
+              --include "workflow-only-trace.html" \
+              --include "workflow-only-trace.manifest.json" \
+              --include "workflow-only-trace.otlp.jsonl.gz" \
               trace-output/ \
               "s3://${REPORTS_BUCKET}/${REPORTS_PREFIX}/"
           {
-              echo "### Workflow execution trace"
+              echo "### Execution traces"
               echo
-              echo "[Open the workflow/job/step/ya trace]($TRACE_REPORT_URL)"
+              echo "[Workflow/job/step trace]($WORKFLOW_ONLY_TRACE_REPORT_URL)"
+              echo
+              echo "[Workflow/job/step/ya trace]($TRACE_REPORT_URL)"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Keep trace as a GitHub artifact


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/issues/6809

For description how it works please refer to https://github.com/ydb-platform/nbs/blob/users/librarian/ya-otlp-static-report/.github/scripts/tracing/YA_TRACE_TO_OTLP.md

In future these OTLP spans will be either loaded to Grafana (or something similar) or will be used to produce static reports on how Github behaves