### PR TITLE
issue-6780: support for xattrs and locks in filestore-client

### DIFF
--- a/cloud/filestore/apps/client/lib/factory.cpp
+++ b/cloud/filestore/apps/client/lib/factory.cpp
@@ -43,6 +43,13 @@ TCommandPtr NewFindCommand();
 TCommandPtr NewDiffCommand();
 TCommandPtr NewPingCommand();
 TCommandPtr NewDiagnoseFilesystemCommand();
+TCommandPtr NewSetNodeXAttrCommand();
+TCommandPtr NewGetNodeXAttrCommand();
+TCommandPtr NewListNodeXAttrCommand();
+TCommandPtr NewRemoveNodeXAttrCommand();
+TCommandPtr NewAcquireLockCommand();
+TCommandPtr NewReleaseLockCommand();
+TCommandPtr NewTestLockCommand();
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -50,6 +57,7 @@ using TFactoryFunc = std::function<TCommandPtr()>;
 using TFactoryMap = TMap<TString, TFactoryFunc>;
 
 static const TMap<TString, TFactoryFunc> Commands = {
+    { "acquirelock", NewAcquireLockCommand },
     { "addclusternode", NewAddClusterNodeCommand },
     { "create", NewCreateCommand },
     { "createsession", NewCreateSessionCommand },
@@ -61,10 +69,12 @@ static const TMap<TString, TFactoryFunc> Commands = {
     { "find", NewFindCommand },
     { "findgarbage", NewFindGarbageCommand },
     { "forcedcompaction", NewForcedCompactionCommand },
+    { "getnodexattr", NewGetNodeXAttrCommand },
     { "kickendpoint", NewKickEndpointCommand },
     { "listclusternodes", NewListClusterNodesCommand },
     { "listendpoints", NewListEndpointsCommand },
     { "listfilestores", NewListFileStoresCommand },
+    { "listnodexattr", NewListNodeXAttrCommand },
     { "ln", NewLnCommand },
     { "ls", NewLsCommand },
     { "mkdir", NewMkDirCommand },
@@ -72,14 +82,18 @@ static const TMap<TString, TFactoryFunc> Commands = {
     { "mv", NewMvCommand },
     { "read", NewReadCommand },
     { "readlink", NewReadLinkCommand },
+    { "releaselock", NewReleaseLockCommand },
     { "removeclusternode", NewRemoveClusterNodeCommand },
+    { "removenodexattr", NewRemoveNodeXAttrCommand },
     { "resetsession", NewResetSessionCommand },
     { "resize", NewResizeCommand },
     { "rm", NewRmCommand },
     { "setnodeattr", NewSetNodeAttrCommand },
+    { "setnodexattr", NewSetNodeXAttrCommand },
     { "startendpoint", NewStartEndpointCommand },
     { "stat", NewStatCommand },
     { "stopendpoint", NewStopEndpointCommand },
+    { "testlock", NewTestLockCommand },
     { "touch", NewTouchCommand },
     { "write", NewWriteCommand },
     { "ping", NewPingCommand },

--- a/cloud/filestore/apps/client/lib/get_node_xattr.cpp
+++ b/cloud/filestore/apps/client/lib/get_node_xattr.cpp
@@ -1,0 +1,70 @@
+#include "command.h"
+
+#include <cloud/filestore/public/api/protos/node.pb.h>
+
+#include <library/cpp/json/json_value.h>
+#include <library/cpp/json/json_writer.h>
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TGetNodeXAttrCommand final: public TFileStoreCommand
+{
+private:
+    ui64 NodeId = 0;
+    TString Name;
+
+public:
+    TGetNodeXAttrCommand()
+    {
+        Opts.AddLongOption("node-id")
+            .Required()
+            .RequiredArgument("NODE_ID")
+            .StoreResult(&NodeId);
+
+        Opts.AddLongOption("name")
+            .Required()
+            .RequiredArgument("NAME")
+            .StoreResult(&Name);
+    }
+
+    bool Execute() override
+    {
+        auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
+
+        auto request = CreateRequest<NProto::TGetNodeXAttrRequest>();
+        request->SetNodeId(NodeId);
+        request->SetName(Name);
+
+        auto response = WaitFor(
+            session.GetNodeXAttr(PrepareCallContext(), std::move(request)));
+
+        CheckResponse(response);
+
+        if (JsonOutput) {
+            NJson::TJsonValue json;
+            json.InsertValue("Name", Name);
+            json.InsertValue("Value", response.GetValue());
+            json.InsertValue("Version", response.GetVersion());
+            Cout << NJson::WriteJson(json) << Endl;
+        } else {
+            Cout << response.GetValue() << Endl;
+        }
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewGetNodeXAttrCommand()
+{
+    return std::make_shared<TGetNodeXAttrCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/get_node_xattr.cpp
+++ b/cloud/filestore/apps/client/lib/get_node_xattr.cpp
@@ -4,6 +4,7 @@
 
 #include <library/cpp/json/json_value.h>
 #include <library/cpp/json/json_writer.h>
+#include <library/cpp/string_utils/base64/base64.h>
 
 namespace NCloud::NFileStore::NClient {
 
@@ -46,9 +47,14 @@ public:
         CheckResponse(response);
 
         if (JsonOutput) {
+            //
+            // Xattr values are arbitrary bytes; base64 keeps the JSON
+            // well-formed for non-UTF-8 values.
+            //
+
             NJson::TJsonValue json;
             json.InsertValue("Name", Name);
-            json.InsertValue("Value", response.GetValue());
+            json.InsertValue("ValueBase64", Base64Encode(response.GetValue()));
             json.InsertValue("Version", response.GetVersion());
             Cout << NJson::WriteJson(json) << Endl;
         } else {

--- a/cloud/filestore/apps/client/lib/list_node_xattr.cpp
+++ b/cloud/filestore/apps/client/lib/list_node_xattr.cpp
@@ -4,6 +4,7 @@
 
 #include <library/cpp/json/json_value.h>
 #include <library/cpp/json/json_writer.h>
+#include <library/cpp/string_utils/base64/base64.h>
 
 namespace NCloud::NFileStore::NClient {
 
@@ -38,17 +39,35 @@ public:
 
         CheckResponse(response);
 
+        //
+        // Values, when present, run parallel to Names. Xattr values are
+        // arbitrary bytes; base64 keeps the JSON well-formed for
+        // non-UTF-8 values.
+        //
+
+        const auto& names = response.GetNames();
+        const auto& values = response.GetValues();
+
         if (JsonOutput) {
-            NJson::TJsonValue names(NJson::JSON_ARRAY);
-            for (const auto& name: response.GetNames()) {
-                names.AppendValue(name);
+            NJson::TJsonValue namesJson(NJson::JSON_ARRAY);
+            for (const auto& name: names) {
+                namesJson.AppendValue(name);
+            }
+            NJson::TJsonValue valuesJson(NJson::JSON_ARRAY);
+            for (const auto& value: values) {
+                valuesJson.AppendValue(Base64Encode(value));
             }
             NJson::TJsonValue json;
-            json.InsertValue("Names", std::move(names));
+            json.InsertValue("Names", std::move(namesJson));
+            json.InsertValue("ValuesBase64", std::move(valuesJson));
             Cout << NJson::WriteJson(json) << Endl;
         } else {
-            for (const auto& name: response.GetNames()) {
-                Cout << name << Endl;
+            for (int i = 0; i < names.size(); ++i) {
+                Cout << names[i];
+                if (i < values.size()) {
+                    Cout << "=" << values[i];
+                }
+                Cout << Endl;
             }
         }
         return true;

--- a/cloud/filestore/apps/client/lib/list_node_xattr.cpp
+++ b/cloud/filestore/apps/client/lib/list_node_xattr.cpp
@@ -1,0 +1,67 @@
+#include "command.h"
+
+#include <cloud/filestore/public/api/protos/node.pb.h>
+
+#include <library/cpp/json/json_value.h>
+#include <library/cpp/json/json_writer.h>
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TListNodeXAttrCommand final: public TFileStoreCommand
+{
+private:
+    ui64 NodeId = 0;
+
+public:
+    TListNodeXAttrCommand()
+    {
+        Opts.AddLongOption("node-id")
+            .Required()
+            .RequiredArgument("NODE_ID")
+            .StoreResult(&NodeId);
+    }
+
+    bool Execute() override
+    {
+        auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
+
+        auto request = CreateRequest<NProto::TListNodeXAttrRequest>();
+        request->SetNodeId(NodeId);
+
+        auto response = WaitFor(
+            session.ListNodeXAttr(PrepareCallContext(), std::move(request)));
+
+        CheckResponse(response);
+
+        if (JsonOutput) {
+            NJson::TJsonValue names(NJson::JSON_ARRAY);
+            for (const auto& name: response.GetNames()) {
+                names.AppendValue(name);
+            }
+            NJson::TJsonValue json;
+            json.InsertValue("Names", std::move(names));
+            Cout << NJson::WriteJson(json) << Endl;
+        } else {
+            for (const auto& name: response.GetNames()) {
+                Cout << name << Endl;
+            }
+        }
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewListNodeXAttrCommand()
+{
+    return std::make_shared<TListNodeXAttrCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/locks.cpp
+++ b/cloud/filestore/apps/client/lib/locks.cpp
@@ -1,0 +1,304 @@
+#include "command.h"
+
+#include <cloud/filestore/public/api/protos/locks.pb.h>
+
+#include <library/cpp/json/json_value.h>
+#include <library/cpp/json/json_writer.h>
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::ELockType ParseLockType(const TString& s)
+{
+    if (s == "shared") {
+        return NProto::E_SHARED;
+    }
+    if (s == "exclusive") {
+        return NProto::E_EXCLUSIVE;
+    }
+    ythrow yexception() << "invalid lock type: " << s
+        << " (expected: shared|exclusive)";
+}
+
+NProto::ELockOrigin ParseLockOrigin(const TString& s)
+{
+    if (s == "fcntl") {
+        return NProto::E_FCNTL;
+    }
+    if (s == "flock") {
+        return NProto::E_FLOCK;
+    }
+    ythrow yexception() << "invalid lock origin: " << s
+        << " (expected: fcntl|flock)";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Common part of acquirelock/releaselock/testlock: they address a file by
+// path, open an IO handle on it and describe a byte range with an owner.
+
+class TLockCommandBase: public TFileStoreCommand
+{
+protected:
+    TString Path;
+    ui64 Owner = 0;
+    ui64 Offset = 0;
+    ui64 Length = 0;
+    i32 Pid = 0;
+    TString LockOriginStr;
+
+public:
+    TLockCommandBase()
+    {
+        Opts.AddLongOption("path")
+            .Required()
+            .RequiredArgument("PATH")
+            .StoreResult(&Path);
+
+        Opts.AddLongOption("owner")
+            .Required()
+            .RequiredArgument("OWNER")
+            .Help("lock owner id")
+            .StoreResult(&Owner);
+
+        Opts.AddLongOption("offset")
+            .Optional()
+            .RequiredArgument("OFFSET")
+            .DefaultValue(0)
+            .StoreResult(&Offset);
+
+        Opts.AddLongOption("length")
+            .Optional()
+            .RequiredArgument("LENGTH")
+            .Help("number of bytes to lock, 0 means till the end of file")
+            .DefaultValue(0)
+            .StoreResult(&Length);
+
+        Opts.AddLongOption("pid")
+            .Optional()
+            .RequiredArgument("PID")
+            .DefaultValue(0)
+            .StoreResult(&Pid);
+
+        Opts.AddLongOption("lock-origin")
+            .Optional()
+            .RequiredArgument("ORIGIN")
+            .Help("fcntl|flock")
+            .DefaultValue("fcntl")
+            .StoreResult(&LockOriginStr);
+    }
+
+protected:
+    struct TFileHandle
+    {
+        ui64 NodeId = 0;
+        ui64 Handle = 0;
+    };
+
+    TFileHandle OpenHandle(ISession& session)
+    {
+        const auto resolved = ResolvePath(session, Path, false);
+
+        Y_ENSURE(
+            resolved.back().Node.GetType() != NProto::E_DIRECTORY_NODE,
+            "can't lock a directory node");
+
+        Y_ABORT_UNLESS(resolved.size() >= 2);
+
+        const auto& parent = resolved[resolved.size() - 2];
+
+        static const int flags =
+            ProtoFlag(NProto::TCreateHandleRequest::E_READ) |
+            ProtoFlag(NProto::TCreateHandleRequest::E_WRITE);
+
+        auto request = CreateRequest<NProto::TCreateHandleRequest>();
+        request->SetNodeId(parent.Node.GetId());
+        request->SetName(ToString(resolved.back().Name));
+        request->SetFlags(flags);
+
+        auto response = WaitFor(
+            session.CreateHandle(PrepareCallContext(), std::move(request)));
+
+        CheckResponse(response);
+
+        return {
+            .NodeId = resolved.back().Node.GetId(),
+            .Handle = response.GetHandle(),
+        };
+    }
+
+    template <typename T>
+    std::shared_ptr<T> CreateLockRequest(const TFileHandle& fh)
+    {
+        auto request = CreateRequest<T>();
+        request->SetNodeId(fh.NodeId);
+        request->SetHandle(fh.Handle);
+        request->SetOwner(Owner);
+        request->SetOffset(Offset);
+        request->SetLength(Length);
+        request->SetPid(Pid);
+        request->SetLockOrigin(ParseLockOrigin(LockOriginStr));
+
+        return request;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TAcquireLockCommand final: public TLockCommandBase
+{
+private:
+    TString LockTypeStr;
+
+public:
+    TAcquireLockCommand()
+    {
+        Opts.AddLongOption("lock-type")
+            .Optional()
+            .RequiredArgument("TYPE")
+            .Help("shared|exclusive")
+            .DefaultValue("exclusive")
+            .StoreResult(&LockTypeStr);
+    }
+
+    bool Execute() override
+    {
+        auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
+
+        auto fh = OpenHandle(session);
+
+        auto request = CreateLockRequest<NProto::TAcquireLockRequest>(fh);
+        request->SetLockType(ParseLockType(LockTypeStr));
+
+        auto response = WaitFor(
+            session.AcquireLock(PrepareCallContext(), std::move(request)));
+
+        CheckResponse(response);
+        return true;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TReleaseLockCommand final: public TLockCommandBase
+{
+public:
+    bool Execute() override
+    {
+        auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
+
+        auto fh = OpenHandle(session);
+
+        auto request = CreateLockRequest<NProto::TReleaseLockRequest>(fh);
+
+        auto response = WaitFor(
+            session.ReleaseLock(PrepareCallContext(), std::move(request)));
+
+        CheckResponse(response);
+        return true;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTestLockCommand final: public TLockCommandBase
+{
+private:
+    TString LockTypeStr;
+
+public:
+    TTestLockCommand()
+    {
+        Opts.AddLongOption("lock-type")
+            .Optional()
+            .RequiredArgument("TYPE")
+            .Help("shared|exclusive")
+            .DefaultValue("exclusive")
+            .StoreResult(&LockTypeStr);
+    }
+
+    bool Execute() override
+    {
+        auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
+
+        auto fh = OpenHandle(session);
+
+        auto request = CreateLockRequest<NProto::TTestLockRequest>(fh);
+        request->SetLockType(ParseLockType(LockTypeStr));
+
+        auto response = WaitFor(
+            session.TestLock(PrepareCallContext(), std::move(request)));
+
+        if (response.GetError().GetCode() == E_FS_WOULDBLOCK) {
+            PrintConflict(response);
+            return true;
+        }
+
+        CheckResponse(response);
+
+        if (JsonOutput) {
+            NJson::TJsonValue json;
+            json.InsertValue("Compatible", true);
+            Cout << NJson::WriteJson(json) << Endl;
+        } else {
+            Cout << "compatible" << Endl;
+        }
+        return true;
+    }
+
+private:
+    void PrintConflict(const NProto::TTestLockResponse& response)
+    {
+        if (JsonOutput) {
+            NJson::TJsonValue json;
+            json.InsertValue("Compatible", false);
+            json.InsertValue("Owner", response.GetOwner());
+            json.InsertValue("Offset", response.GetOffset());
+            json.InsertValue("Length", response.GetLength());
+            if (response.HasLockType()) {
+                json.InsertValue(
+                    "LockType",
+                    NProto::ELockType_Name(response.GetLockType()));
+            }
+            if (response.HasPid()) {
+                json.InsertValue("Pid", response.GetPid());
+            }
+            if (response.HasIncompatibleLockOrigin()) {
+                json.InsertValue(
+                    "IncompatibleLockOrigin",
+                    NProto::ELockOrigin_Name(
+                        response.GetIncompatibleLockOrigin()));
+            }
+            Cout << NJson::WriteJson(json) << Endl;
+        } else {
+            Cout << "incompatible: "
+                << FormatError(response.GetError()) << Endl;
+        }
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewAcquireLockCommand()
+{
+    return std::make_shared<TAcquireLockCommand>();
+}
+
+TCommandPtr NewReleaseLockCommand()
+{
+    return std::make_shared<TReleaseLockCommand>();
+}
+
+TCommandPtr NewTestLockCommand()
+{
+    return std::make_shared<TTestLockCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/locks.cpp
+++ b/cloud/filestore/apps/client/lib/locks.cpp
@@ -91,13 +91,27 @@ public:
     }
 
 protected:
-    struct TFileHandle
+    struct TLockTarget
     {
         ui64 NodeId = 0;
         ui64 Handle = 0;
     };
 
-    TFileHandle OpenHandle(ISession& session)
+    //
+    // Handle access mode follows POSIX: a shared (read) lock needs read
+    // access, an exclusive (write) lock needs write access. Callers pass
+    // the flags matching the lock type they are about to use.
+    //
+
+    static int HandleFlags(NProto::ELockType lockType)
+    {
+        if (lockType == NProto::E_SHARED) {
+            return ProtoFlag(NProto::TCreateHandleRequest::E_READ);
+        }
+        return ProtoFlag(NProto::TCreateHandleRequest::E_WRITE);
+    }
+
+    TLockTarget OpenHandle(ISession& session, int flags)
     {
         const auto resolved = ResolvePath(session, Path, false);
 
@@ -108,10 +122,6 @@ protected:
         Y_ABORT_UNLESS(resolved.size() >= 2);
 
         const auto& parent = resolved[resolved.size() - 2];
-
-        static const int flags =
-            ProtoFlag(NProto::TCreateHandleRequest::E_READ) |
-            ProtoFlag(NProto::TCreateHandleRequest::E_WRITE);
 
         auto request = CreateRequest<NProto::TCreateHandleRequest>();
         request->SetNodeId(parent.Node.GetId());
@@ -130,16 +140,18 @@ protected:
     }
 
     template <typename T>
-    std::shared_ptr<T> CreateLockRequest(const TFileHandle& fh)
+    std::shared_ptr<T> CreateLockRequest(
+        const TLockTarget& target,
+        NProto::ELockOrigin origin)
     {
         auto request = CreateRequest<T>();
-        request->SetNodeId(fh.NodeId);
-        request->SetHandle(fh.Handle);
+        request->SetNodeId(target.NodeId);
+        request->SetHandle(target.Handle);
         request->SetOwner(Owner);
         request->SetOffset(Offset);
         request->SetLength(Length);
         request->SetPid(Pid);
-        request->SetLockOrigin(ParseLockOrigin(LockOriginStr));
+        request->SetLockOrigin(origin);
 
         return request;
     }
@@ -165,13 +177,18 @@ public:
 
     bool Execute() override
     {
+        // Validate the arguments before creating a session.
+        const auto lockType = ParseLockType(LockTypeStr);
+        const auto origin = ParseLockOrigin(LockOriginStr);
+
         auto sessionGuard = CreateSession();
         auto& session = sessionGuard.AccessSession();
 
-        auto fh = OpenHandle(session);
+        auto target = OpenHandle(session, HandleFlags(lockType));
 
-        auto request = CreateLockRequest<NProto::TAcquireLockRequest>(fh);
-        request->SetLockType(ParseLockType(LockTypeStr));
+        auto request =
+            CreateLockRequest<NProto::TAcquireLockRequest>(target, origin);
+        request->SetLockType(lockType);
 
         auto response = WaitFor(
             session.AcquireLock(PrepareCallContext(), std::move(request)));
@@ -188,12 +205,23 @@ class TReleaseLockCommand final: public TLockCommandBase
 public:
     bool Execute() override
     {
+        // Validate the arguments before creating a session.
+        const auto origin = ParseLockOrigin(LockOriginStr);
+
         auto sessionGuard = CreateSession();
         auto& session = sessionGuard.AccessSession();
 
-        auto fh = OpenHandle(session);
+        //
+        // Unlocking has no access-mode requirement of its own; open for
+        // read so that read-only files can be unlocked.
+        //
 
-        auto request = CreateLockRequest<NProto::TReleaseLockRequest>(fh);
+        auto target = OpenHandle(
+            session,
+            HandleFlags(NProto::E_SHARED));
+
+        auto request =
+            CreateLockRequest<NProto::TReleaseLockRequest>(target, origin);
 
         auto response = WaitFor(
             session.ReleaseLock(PrepareCallContext(), std::move(request)));
@@ -223,13 +251,18 @@ public:
 
     bool Execute() override
     {
+        // Validate the arguments before creating a session.
+        const auto lockType = ParseLockType(LockTypeStr);
+        const auto origin = ParseLockOrigin(LockOriginStr);
+
         auto sessionGuard = CreateSession();
         auto& session = sessionGuard.AccessSession();
 
-        auto fh = OpenHandle(session);
+        auto target = OpenHandle(session, HandleFlags(lockType));
 
-        auto request = CreateLockRequest<NProto::TTestLockRequest>(fh);
-        request->SetLockType(ParseLockType(LockTypeStr));
+        auto request =
+            CreateLockRequest<NProto::TTestLockRequest>(target, origin);
+        request->SetLockType(lockType);
 
         auto response = WaitFor(
             session.TestLock(PrepareCallContext(), std::move(request)));
@@ -276,8 +309,23 @@ private:
             }
             Cout << NJson::WriteJson(json) << Endl;
         } else {
-            Cout << "incompatible: "
-                << FormatError(response.GetError()) << Endl;
+            Cout << "incompatible:"
+                << " owner=" << response.GetOwner()
+                << " offset=" << response.GetOffset()
+                << " length=" << response.GetLength();
+            if (response.HasLockType()) {
+                Cout << " lock-type="
+                    << NProto::ELockType_Name(response.GetLockType());
+            }
+            if (response.HasPid()) {
+                Cout << " pid=" << response.GetPid();
+            }
+            if (response.HasIncompatibleLockOrigin()) {
+                Cout << " lock-origin="
+                    << NProto::ELockOrigin_Name(
+                        response.GetIncompatibleLockOrigin());
+            }
+            Cout << Endl;
         }
     }
 };

--- a/cloud/filestore/apps/client/lib/remove_node_xattr.cpp
+++ b/cloud/filestore/apps/client/lib/remove_node_xattr.cpp
@@ -1,0 +1,57 @@
+#include "command.h"
+
+#include <cloud/filestore/public/api/protos/node.pb.h>
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRemoveNodeXAttrCommand final: public TFileStoreCommand
+{
+private:
+    ui64 NodeId = 0;
+    TString Name;
+
+public:
+    TRemoveNodeXAttrCommand()
+    {
+        Opts.AddLongOption("node-id")
+            .Required()
+            .RequiredArgument("NODE_ID")
+            .StoreResult(&NodeId);
+
+        Opts.AddLongOption("name")
+            .Required()
+            .RequiredArgument("NAME")
+            .StoreResult(&Name);
+    }
+
+    bool Execute() override
+    {
+        auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
+
+        auto request = CreateRequest<NProto::TRemoveNodeXAttrRequest>();
+        request->SetNodeId(NodeId);
+        request->SetName(Name);
+
+        auto response = WaitFor(
+            session.RemoveNodeXAttr(PrepareCallContext(), std::move(request)));
+
+        CheckResponse(response);
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewRemoveNodeXAttrCommand()
+{
+    return std::make_shared<TRemoveNodeXAttrCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/set_node_xattr.cpp
+++ b/cloud/filestore/apps/client/lib/set_node_xattr.cpp
@@ -1,0 +1,92 @@
+#include "command.h"
+
+#include <cloud/filestore/public/api/protos/node.pb.h>
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSetNodeXAttrCommand final: public TFileStoreCommand
+{
+private:
+    ui64 NodeId = 0;
+    TString Name;
+    TString Value;
+    bool Create = false;
+    bool Replace = false;
+
+public:
+    TSetNodeXAttrCommand()
+    {
+        Opts.AddLongOption("node-id")
+            .Required()
+            .RequiredArgument("NODE_ID")
+            .StoreResult(&NodeId);
+
+        Opts.AddLongOption("name")
+            .Required()
+            .RequiredArgument("NAME")
+            .Help("attribute name, e.g. user.attr")
+            .StoreResult(&Name);
+
+        Opts.AddLongOption("value")
+            .Required()
+            .RequiredArgument("VALUE")
+            .StoreResult(&Value);
+
+        Opts.AddLongOption("create")
+            .Optional()
+            .NoArgument()
+            .Help("fail if the attribute already exists")
+            .StoreTrue(&Create);
+
+        Opts.AddLongOption("replace")
+            .Optional()
+            .NoArgument()
+            .Help("fail if the attribute does not exist")
+            .StoreTrue(&Replace);
+    }
+
+    bool Execute() override
+    {
+        Y_ENSURE(
+            !(Create && Replace),
+            "--create and --replace are mutually exclusive");
+
+        auto sessionGuard = CreateSession();
+        auto& session = sessionGuard.AccessSession();
+
+        auto request = CreateRequest<NProto::TSetNodeXAttrRequest>();
+        request->SetNodeId(NodeId);
+        request->SetName(Name);
+        request->SetValue(Value);
+
+        if (Create) {
+            request->SetFlags(
+                ProtoFlag(NProto::TSetNodeXAttrRequest::F_CREATE));
+        }
+        if (Replace) {
+            request->SetFlags(
+                ProtoFlag(NProto::TSetNodeXAttrRequest::F_REPLACE));
+        }
+
+        auto response = WaitFor(
+            session.SetNodeXAttr(PrepareCallContext(), std::move(request)));
+
+        CheckResponse(response);
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewSetNodeXAttrCommand()
+{
+    return std::make_shared<TSetNodeXAttrCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/ya.make
+++ b/cloud/filestore/apps/client/lib/ya.make
@@ -17,11 +17,14 @@ SRCS(
     find.cpp
     find_garbage.cpp
     forced_compaction.cpp
+    get_node_xattr.cpp
     kick_endpoint.cpp
     list_cluster_nodes.cpp
     list_endpoints.cpp
     list_filestores.cpp
+    list_node_xattr.cpp
     ln.cpp
+    locks.cpp
     ls.cpp
     mkdir.cpp
     mount.cpp
@@ -31,10 +34,12 @@ SRCS(
     read.cpp
     readlink.cpp
     remove_cluster_node.cpp
+    remove_node_xattr.cpp
     reset_session.cpp
     resize.cpp
     rm.cpp
     set_node_attr.cpp
+    set_node_xattr.cpp
     start_endpoint.cpp
     stat.cpp
     stop_endpoint.cpp

--- a/cloud/filestore/apps/client/lib/ya.make
+++ b/cloud/filestore/apps/client/lib/ya.make
@@ -63,6 +63,7 @@ PEERDIR(
     library/cpp/getopt
     library/cpp/logger
     library/cpp/protobuf/json
+    library/cpp/string_utils/base64
     library/cpp/threading/future
 )
 

--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import os
@@ -538,22 +539,30 @@ def test_node_xattrs():
     client.touch("fs0", "/file")
     node_id = json.loads(client.stat("fs0", "/file"))["Id"]
 
+    def xattr_value(attr):
+        return base64.b64decode(attr["ValueBase64"]).decode("utf-8")
+
     client.set_node_xattr("fs0", node_id, "user.attr1", "value1")
     attr = json.loads(client.get_node_xattr("fs0", node_id, "user.attr1"))
     assert attr["Name"] == "user.attr1"
-    assert attr["Value"] == "value1"
+    assert xattr_value(attr) == "value1"
 
     client.set_node_xattr("fs0", node_id, "user.attr2", "value2", "--create")
-    names = json.loads(client.list_node_xattr("fs0", node_id))["Names"]
-    assert sorted(names) == ["user.attr1", "user.attr2"]
+    listing = json.loads(client.list_node_xattr("fs0", node_id))
+    assert sorted(listing["Names"]) == ["user.attr1", "user.attr2"]
+    values = [
+        base64.b64decode(v).decode("utf-8")
+        for v in listing["ValuesBase64"]
+    ]
+    assert sorted(values) == ["value1", "value2"]
 
     client.set_node_xattr("fs0", node_id, "user.attr1", "value3", "--replace")
     attr = json.loads(client.get_node_xattr("fs0", node_id, "user.attr1"))
-    assert attr["Value"] == "value3"
+    assert xattr_value(attr) == "value3"
 
     client.remove_node_xattr("fs0", node_id, "user.attr1")
-    names = json.loads(client.list_node_xattr("fs0", node_id))["Names"]
-    assert names == ["user.attr2"]
+    listing = json.loads(client.list_node_xattr("fs0", node_id))
+    assert listing["Names"] == ["user.attr2"]
 
     # creating an existing attribute must fail
     failed = False

--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -532,6 +532,89 @@ def test_partial_set_node_attr():
     assert stat["Mode"] == new_stat["Mode"]
 
 
+def test_node_xattrs():
+    client, results_path = __init_test()
+    client.create("fs0", "test_cloud", "test_folder", BLOCK_SIZE, BLOCKS_COUNT)
+    client.touch("fs0", "/file")
+    node_id = json.loads(client.stat("fs0", "/file"))["Id"]
+
+    client.set_node_xattr("fs0", node_id, "user.attr1", "value1")
+    attr = json.loads(client.get_node_xattr("fs0", node_id, "user.attr1"))
+    assert attr["Name"] == "user.attr1"
+    assert attr["Value"] == "value1"
+
+    client.set_node_xattr("fs0", node_id, "user.attr2", "value2", "--create")
+    names = json.loads(client.list_node_xattr("fs0", node_id))["Names"]
+    assert sorted(names) == ["user.attr1", "user.attr2"]
+
+    client.set_node_xattr("fs0", node_id, "user.attr1", "value3", "--replace")
+    attr = json.loads(client.get_node_xattr("fs0", node_id, "user.attr1"))
+    assert attr["Value"] == "value3"
+
+    client.remove_node_xattr("fs0", node_id, "user.attr1")
+    names = json.loads(client.list_node_xattr("fs0", node_id))["Names"]
+    assert names == ["user.attr2"]
+
+    # creating an existing attribute must fail
+    failed = False
+    try:
+        client.set_node_xattr("fs0", node_id, "user.attr2", "x", "--create")
+    except Exception:
+        failed = True
+    assert failed
+
+    # reading a removed attribute must fail
+    failed = False
+    try:
+        client.get_node_xattr("fs0", node_id, "user.attr1")
+    except Exception:
+        failed = True
+    assert failed
+
+    client.destroy("fs0")
+
+
+def test_locks():
+    client, results_path = __init_test()
+    client.create("fs0", "test_cloud", "test_folder", BLOCK_SIZE, BLOCKS_COUNT)
+    client.touch("fs0", "/locked")
+
+    # every command runs its own session, so a lock it acquires dies with
+    # that session - each call below checks one API round trip
+
+    client.acquire_lock("fs0", "/locked", 1)
+    client.acquire_lock("fs0", "/locked", 1, "--lock-type", "shared")
+    client.acquire_lock(
+        "fs0", "/locked", 1,
+        "--lock-origin", "flock",
+        "--pid", 100)
+    client.acquire_lock(
+        "fs0", "/locked", 1,
+        "--offset", 4096,
+        "--length", 4096)
+
+    res = json.loads(client.test_lock("fs0", "/locked", 2))
+    assert res["Compatible"] is True
+
+    res = json.loads(
+        client.test_lock("fs0", "/locked", 2, "--lock-type", "shared"))
+    assert res["Compatible"] is True
+
+    client.release_lock("fs0", "/locked", 1)
+    client.release_lock("fs0", "/locked", 1, "--offset", 4096)
+
+    # locking a directory must fail
+    client.mkdir("fs0", "/dir")
+    failed = False
+    try:
+        client.acquire_lock("fs0", "/dir", 1)
+    except Exception:
+        failed = True
+    assert failed
+
+    client.destroy("fs0")
+
+
 def test_resize():
     client, results_path = __init_test()
     out = client.create(

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -292,6 +292,69 @@ class FilestoreCliClient:
 
         return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
 
+    def set_node_xattr(self, fs, node_id, name, value, *argv):
+        list_args = [str(x) for x in argv]
+        cmd = [
+            self.__binary_path, "setnodexattr",
+            "--filesystem", fs,
+            "--node-id", str(node_id),
+            "--name", name,
+            "--value", value,
+        ] + list_args + self.__cmd_opts()
+
+        return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
+
+    def get_node_xattr(self, fs, node_id, name):
+        cmd = [
+            self.__binary_path, "getnodexattr",
+            "--filesystem", fs,
+            "--node-id", str(node_id),
+            "--name", name,
+            "--json",
+        ] + self.__cmd_opts()
+
+        return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
+
+    def list_node_xattr(self, fs, node_id):
+        cmd = [
+            self.__binary_path, "listnodexattr",
+            "--filesystem", fs,
+            "--node-id", str(node_id),
+            "--json",
+        ] + self.__cmd_opts()
+
+        return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
+
+    def remove_node_xattr(self, fs, node_id, name):
+        cmd = [
+            self.__binary_path, "removenodexattr",
+            "--filesystem", fs,
+            "--node-id", str(node_id),
+            "--name", name,
+        ] + self.__cmd_opts()
+
+        return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
+
+    def __lock_cmd(self, command, fs, path, owner, *argv):
+        list_args = [str(x) for x in argv]
+        cmd = [
+            self.__binary_path, command,
+            "--filesystem", fs,
+            "--path", path,
+            "--owner", str(owner),
+        ] + list_args + self.__cmd_opts()
+
+        return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
+
+    def acquire_lock(self, fs, path, owner, *argv):
+        return self.__lock_cmd("acquirelock", fs, path, owner, *argv)
+
+    def release_lock(self, fs, path, owner, *argv):
+        return self.__lock_cmd("releaselock", fs, path, owner, *argv)
+
+    def test_lock(self, fs, path, owner, *argv):
+        return self.__lock_cmd("testlock", fs, path, owner, "--json", *argv)
+
     def forced_compaction(self, fs):
         cmd = [
             self.__binary_path, "forcedcompaction",


### PR DESCRIPTION
### Notes
Claude struggled for a couple hours but eventually spat out the implementation of:
* acquirelock
* releaselock
* testlock
* getnodexattr
* listnodexattr
* removenodexattr
* setnodexattr

together with `filestore/tests/client` testcases

This cost me around 30 euros of tokens for Fable5, better be good. Especially considering the fact that it's almost copy-paste of the implementation of the other commands - exactly the AGI type of task.

UPD: the extra fixes took 15 more euros
and 5 euros for the review

total: 50 euros
AGI-level stuff

### Issue
https://github.com/ydb-platform/nbs/issues/6780