### PR TITLE
[NBS] Don't check path symlinks in DA if device is detached or broken

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_integrity_check_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_integrity_check_actor.cpp
@@ -143,7 +143,26 @@ void TDeviceIntegrityCheckActor::Bootstrap(const TActorContext& ctx)
 
 void TDeviceIntegrityCheckActor::CheckSymlinks()
 {
+    THashMap<TString, bool> shouldCheckPathSymlink;
+    for (size_t i = 0; i < Devices.size(); ++i) {
+        const auto& device = Devices[i];
+        auto [it, _] =
+            shouldCheckPathSymlink.insert({device.GetDeviceName(), false});
+        it->second |= DevicesHealth[i] != EDeviceHealthStatus::Broken;
+    }
+
     for (const auto& [configPath, expected]: SymlinkSnapshot) {
+        const auto* shouldCheck = shouldCheckPathSymlink.FindPtr(configPath);
+
+        Y_DEBUG_ABORT_UNLESS(
+            shouldCheck,
+            "There is no device for path %s",
+            configPath.Quote().c_str());
+
+        if (!shouldCheck || !*shouldCheck) {
+            continue;
+        }
+
         TString current;
         TFsPath path(configPath);
         if (path.IsSymlink()) {

--- a/cloud/blockstore/libs/storage/disk_agent/actors/device_integrity_check_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/actors/device_integrity_check_actor.cpp
@@ -143,23 +143,15 @@ void TDeviceIntegrityCheckActor::Bootstrap(const TActorContext& ctx)
 
 void TDeviceIntegrityCheckActor::CheckSymlinks()
 {
-    THashMap<TString, bool> shouldCheckPathSymlink;
-    for (size_t i = 0; i < Devices.size(); ++i) {
-        const auto& device = Devices[i];
-        auto [it, _] =
-            shouldCheckPathSymlink.insert({device.GetDeviceName(), false});
-        it->second |= DevicesHealth[i] != EDeviceHealthStatus::Broken;
+    THashSet<TString> brokenPaths;
+    for (size_t i = 0; i != Devices.size(); ++i) {
+        if (DevicesHealth[i] == EDeviceHealthStatus::Broken) {
+            brokenPaths.insert(Devices[i].GetDeviceName());
+        }
     }
 
     for (const auto& [configPath, expected]: SymlinkSnapshot) {
-        const auto* shouldCheck = shouldCheckPathSymlink.FindPtr(configPath);
-
-        Y_DEBUG_ABORT_UNLESS(
-            shouldCheck,
-            "There is no device for path %s",
-            configPath.Quote().c_str());
-
-        if (!shouldCheck || !*shouldCheck) {
+        if (brokenPaths.contains(configPath)) {
             continue;
         }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_attach_detach_path.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_attach_detach_path.cpp
@@ -210,6 +210,8 @@ void TDiskAgentActor::HandlePathsDetached(
     auto response =
         std::make_unique<TEvDiskAgent::TEvDetachPathsResponse>(error);
     NCloud::Reply(ctx, *PendingControlPlaneRequest, std::move(response));
+
+    RestartDeviceHealthChecking(ctx);
 }
 
 void TDiskAgentActor::HandleAttachPaths(
@@ -323,6 +325,8 @@ void TDiskAgentActor::HandlePathsPrepared(
         std::make_move_iterator(deviceConfigs.end()));
 
     NCloud::Reply(ctx, *PendingControlPlaneRequest, std::move(response));
+
+    RestartDeviceHealthChecking(ctx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -7249,5 +7249,110 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1, mismatch->Val());
     }
+
+    Y_UNIT_TEST_F(ShouldNotCheckPartlabelForDetachedDevices, TFixture)
+    {
+        const TFsPath newDevice = DevPath / "nvme_new";
+        {
+            TFile file(newDevice, EOpenModeFlag::CreateNew);
+            file.Resize(DefaultFileSize);
+        }
+
+        auto counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        InitCriticalEventsCounter(counters);
+        auto mismatch = counters->GetCounter(
+            "DiskAgentCriticalEvents/DiskAgentDeviceSymlinkMismatch",
+            true);
+
+        auto storageConfig = NProto::TStorageServiceConfig();
+        storageConfig.SetAttachDetachPathsEnabled(true);
+
+        auto env = TTestEnvBuilder(*Runtime)
+                       .With(CreateDiskAgentConfig())
+                       .With(storageConfig)
+                       .Build();
+
+        TDiskAgentClient diskAgent(*Runtime);
+        diskAgent.WaitReady();
+
+        diskAgent.DetachPaths(
+            TVector<TString>{{PartLabels[0]}},
+            1,    // diskRegistryGeneration
+            1);   // requestNumber
+
+        Runtime->SetEventFilter(
+            [](auto&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskAgent::EvReadDeviceBlocksResponse)
+                {
+                    auto* msg =
+                        event->Get<TEvDiskAgent::TEvReadDeviceBlocksResponse>();
+                    msg->Record.MutableError()->Clear();
+                }
+                return false;
+            });
+
+        // Keep the detached device healthy to verify that either condition is
+        // sufficient for excluding it from the symlink check.
+        PartLabels[0].DeleteIfExists();
+        UNIT_ASSERT(NFs::SymLink(newDevice, PartLabels[0]));
+
+        Runtime->AdvanceCurrentTime(DefaultSymlinkCheckInterval + 1s);
+        Runtime->DispatchEvents(TDispatchOptions(), 1s);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, mismatch->Val());
+    }
+
+    Y_UNIT_TEST_F(ShouldNotCheckPartlabelForBrokenDevices, TFixture)
+    {
+        const TFsPath newDevice = DevPath / "nvme_new";
+        {
+            TFile file(newDevice, EOpenModeFlag::CreateNew);
+            file.Resize(DefaultFileSize);
+        }
+
+        auto counters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        InitCriticalEventsCounter(counters);
+        auto mismatch = counters->GetCounter(
+            "DiskAgentCriticalEvents/DiskAgentDeviceSymlinkMismatch",
+            true);
+
+        auto env =
+            TTestEnvBuilder(*Runtime).With(CreateDiskAgentConfig()).Build();
+
+        TDiskAgentClient diskAgent(*Runtime);
+        diskAgent.WaitReady();
+
+        Runtime->SetEventFilter(
+            [](auto&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskAgent::EvReadDeviceBlocksResponse)
+                {
+                    auto* msg =
+                        event->Get<TEvDiskAgent::TEvReadDeviceBlocksResponse>();
+                    *msg->Record.MutableError() =
+                        MakeError(E_IO, "device is broken");
+                }
+                return false;
+            });
+
+        Runtime->AdvanceCurrentTime(15s);
+        Runtime->DispatchEvents(
+            {.FinalEvents = {
+                 {TEvDiskAgent::EvReadDeviceBlocksResponse,
+                  static_cast<ui32>(PartLabels.size())}}});
+
+        // All devices remain enabled, so this verifies that broken devices are
+        // independently sufficient for excluding their paths.
+        PartLabels[0].DeleteIfExists();
+        UNIT_ASSERT(NFs::SymLink(newDevice, PartLabels[0]));
+
+        Runtime->AdvanceCurrentTime(DefaultSymlinkCheckInterval + 1s);
+        Runtime->DispatchEvents(TDispatchOptions(), 1s);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, mismatch->Val());
+    }
 }
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
### Notes
Don't fire DiskAgentDeviceSymlinkMismatch for broken or detached devices, because symlink can change  because of infra service