### PR TITLE
Run multiple AddBlob transactions on Flush: a AddBlob transaction should handle no more than MaxBlocksPerFlush blobs.

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1666,4 +1666,9 @@ message TStorageServiceConfig
 
     // Allowed CPU time spent on loading filter per second (in ms).
     optional uint64 MixedBlocksFilterAllowedCpuTimePerSecond = 523;
+
+    // Maximum number of blocks per AddBlobs transaction during flush.
+    // Flush may be split into several AddBlobs transactions so that each
+    // transaction handles no more than this many blocks.
+    optional uint32 MaxBlocksPerFlush = 524;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -9,6 +9,7 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 
 #include <util/generic/size_literals.h>
+#include <util/generic/utility.h>
 
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -189,6 +190,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(FlushThreshold,                ui32,      4_MB                        )\
     xxx(FreshBlobCountFlushThreshold,  ui32,      3200                        )\
     xxx(FreshBlobByteCountFlushThreshold,   ui32,      16_MB                  )\
+    xxx(MaxBlocksPerFlush,             ui32,      Max<ui32>()                 )\
                                                                                \
     xxx(SSDCompactionType,                                                     \
             NProto::ECompactionType,                                           \

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -86,6 +86,7 @@ public:
     ui32 GetFlushThreshold() const;
     ui32 GetFreshBlobCountFlushThreshold() const;
     ui32 GetFreshBlobByteCountFlushThreshold() const;
+    ui32 GetMaxBlocksPerFlush() const;
     ui32 GetFlushBlobSizeThreshold() const;
     bool GetFlushToDevNull() const;
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -758,6 +758,7 @@ void TPartitionActor::HandleAddBlobs(
             std::move(msg->MergedBlobs),
             std::move(msg->FreshBlobs),
             msg->Mode,
+            msg->AllowFlushCommitIdAsTrimFreshLogToCommitId,
             std::move(msg->AffectedBlobs),
             std::move(msg->AffectedBlocks),
             std::move(msg->MixedBlobCompactionInfos),
@@ -800,8 +801,8 @@ void TPartitionActor::ExecuteAddBlobs(
         PartitionConfig.GetDiskId(),
         args.DeletionCommitId,
         State->GetMaxBlocksInBlob(),
-        Config
-            ->GetWaitForFreshWritesBeforeFlushEnabled(),   // useFlushCommitIdAsTrimFreshLogToCommitId
+        Config->GetWaitForFreshWritesBeforeFlushEnabled() &&
+            args.AllowFlushCommitIdAsTrimFreshLogToCommitId,
         LogTitle.GetChild(GetCycleCount()));
     executor.Execute(ctx, db);
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -65,8 +65,11 @@ private:
     TFlushedCommitIds FlushedCommitIdsFromChannel;
     TVector<ui64> FlushedFreshBlobCommitIds;
     const TDuration BlobStorageAsyncRequestTimeout;
+    const ui32 MaxBlocksPerFlush;
 
     TVector<TRequest> Requests;
+    TVector<TAddFreshBlob> FreshBlobs;
+    size_t NextFreshBlobIndex = 0;
     TVector<TBlockRange64> AffectedRanges;
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
     size_t RequestsCompleted = 0;
@@ -86,6 +89,7 @@ public:
         TFlushedCommitIds flushedCommitIdsFromChannel,
         TVector<ui64> flushedFreshBlobCommitIds,
         TDuration blobStorageAsyncRequestTimeout,
+        ui32 maxBlocksPerFlush,
         TVector<TRequest> requests);
 
     void Bootstrap(const TActorContext& ctx);
@@ -128,6 +132,7 @@ TFlushActor::TFlushActor(
     TFlushedCommitIds flushedCommitIdsFromChannel,
     TVector<ui64> flushedFreshBlobCommitIds,
     TDuration blobStorageAsyncRequestTimeout,
+    ui32 maxBlocksPerFlush,
     TVector<TRequest> requests)
     : RequestInfo(std::move(requestInfo))
     , BlockSize(blockSize)
@@ -137,6 +142,7 @@ TFlushActor::TFlushActor(
     , FlushedCommitIdsFromChannel(std::move(flushedCommitIdsFromChannel))
     , FlushedFreshBlobCommitIds(std::move(flushedFreshBlobCommitIds))
     , BlobStorageAsyncRequestTimeout(blobStorageAsyncRequestTimeout)
+    , MaxBlocksPerFlush(maxBlocksPerFlush)
     , Requests(std::move(requests))
 {}
 
@@ -228,15 +234,37 @@ void TFlushActor::WriteBlobs(const TActorContext& ctx)
 
 void TFlushActor::AddBlobs(const TActorContext& ctx)
 {
-    TVector<TAddFreshBlob> freshBlobs(Reserve(Requests.size()));
+    if (!FreshBlobs) {
+        FreshBlobs.reserve(Requests.size());
+        for (auto& req: Requests) {
+            BlocksCount += req.Blocks.size();
+            FreshBlobs.emplace_back(
+                req.BlobId,
+                std::move(req.Blocks),
+                std::move(req.Checksums),
+                req.CompactionRangeCount);
+        }
+        Requests.clear();
+    }
 
-    for (auto& req: Requests) {
-        BlocksCount += req.Blocks.size();
-        freshBlobs.emplace_back(
-            req.BlobId,
-            std::move(req.Blocks),
-            std::move(req.Checksums),
-            req.CompactionRangeCount);
+    Y_ABORT_UNLESS(NextFreshBlobIndex < FreshBlobs.size());
+
+    TVector<TAddFreshBlob> batch;
+    ui64 blocksInBatch = 0;
+
+    while (NextFreshBlobIndex < FreshBlobs.size()) {
+        auto& blob = FreshBlobs[NextFreshBlobIndex];
+        const ui64 blobBlocks = blob.Blocks.size();
+
+        if (!batch.empty() &&
+            blocksInBatch + blobBlocks > MaxBlocksPerFlush)
+        {
+            break;
+        }
+
+        blocksInBatch += blobBlocks;
+        batch.push_back(std::move(blob));
+        ++NextFreshBlobIndex;
     }
 
     auto request = std::make_unique<TEvPartitionPrivate::TEvAddBlobsRequest>(
@@ -244,9 +272,20 @@ void TFlushActor::AddBlobs(const TActorContext& ctx)
         CommitId,
         TVector<TAddMixedBlob>(),
         TVector<TAddMergedBlob>(),
-        freshBlobs,
+        std::move(batch),
         ADD_FLUSH_RESULT
     );
+    request->AllowFlushCommitIdAsTrimFreshLogToCommitId =
+        NextFreshBlobIndex >= FreshBlobs.size();
+
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION,
+        "CHECK AddBlobs request on Flush @%lu (blobs: %lu, blocks: %lu), AllowFlushCommitIdAsTrimFreshLogToCommitId: %s",
+        CommitId,
+        batch.size(),
+        blocksInBatch,
+        request->AllowFlushCommitIdAsTrimFreshLogToCommitId ? "true" : "false");
 
     NCloud::Send(
         ctx,
@@ -367,6 +406,11 @@ void TFlushActor::HandleAddBlobsResponse(
     RequestInfo->AddExecCycles(msg->ExecCycles);
 
     if (HandleError(ctx, msg->GetError())) {
+        return;
+    }
+
+    if (NextFreshBlobIndex < FreshBlobs.size()) {
+        AddBlobs(ctx);
         return;
     }
 
@@ -710,6 +754,7 @@ void TPartitionActor::StartFlush(const TActorContext& ctx)
             std::move(flushedCommitIdsFromChannel),
             std::move(unflushedFreshBlobCommitIds),
             GetBlobStorageAsyncRequestTimeout(),
+            Config->GetMaxBlocksPerFlush(),
             std::move(requests));
 
         Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -266,6 +266,11 @@ struct TEvPartitionPrivate
         TVector<TAddFreshBlob> FreshBlobs;
         EAddBlobMode Mode = ADD_WRITE_RESULT;
 
+        // When false, AddBlobs must not advance TrimFreshLogToCommitId to the
+        // flush CommitId. Used for intermediate AddBlobs batches during a
+        // split flush so that a later failure cannot skip unflushed fresh data.
+        bool AllowFlushCommitIdAsTrimFreshLogToCommitId = true;
+
         // compaction
         TAffectedBlobs AffectedBlobs;
         TAffectedBlocks AffectedBlocks;

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -313,6 +313,7 @@ struct TTxPartition
         const TVector<TAddMergedBlob> MergedBlobs;
         const TVector<TAddFreshBlob> FreshBlobs;
         const EAddBlobMode Mode;
+        const bool AllowFlushCommitIdAsTrimFreshLogToCommitId;
 
         // compaction
         const TAffectedBlobs AffectedBlobs;
@@ -329,6 +330,7 @@ struct TTxPartition
                 TVector<TAddMergedBlob> mergedBlobs,
                 TVector<TAddFreshBlob> freshBlobs,
                 EAddBlobMode mode,
+                bool allowFlushCommitIdAsTrimFreshLogToCommitId,
                 TAffectedBlobs affectedBlobs,
                 TAffectedBlocks affectedBlocks,
                 TVector<TBlobCompactionInfo> mixedBlobCompactionInfos,
@@ -339,6 +341,8 @@ struct TTxPartition
             , MergedBlobs(std::move(mergedBlobs))
             , FreshBlobs(std::move(freshBlobs))
             , Mode(mode)
+            , AllowFlushCommitIdAsTrimFreshLogToCommitId(
+                  allowFlushCommitIdAsTrimFreshLogToCommitId)
             , AffectedBlobs(std::move(affectedBlobs))
             , AffectedBlocks(std::move(affectedBlocks))
             , MixedBlobCompactionInfos(std::move(mixedBlobCompactionInfos))

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -1915,6 +1915,66 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldSplitAddBlobsByMaxBlocksPerFlush)
+    {
+        auto config = DefaultConfig();
+        config.SetMaxBlocksPerFlush(2);
+
+        // One block per flush blob so MaxBlocksPerFlush limits AddBlobs batches.
+        TTestPartitionInfo partitionInfo;
+        partitionInfo.MaxBlocksInBlob = 1;
+
+        auto runtime = PrepareTestActorRuntime(config, 1024, {}, partitionInfo);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 i = 1; i <= 5; ++i) {
+            partition.WriteBlocks(i, i);
+        }
+
+        TVector<ui32> blocksPerAddBlobs;
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode == EAddBlobMode::ADD_FLUSH_RESULT) {
+                            ui32 blocks = 0;
+                            for (const auto& blob: msg->FreshBlobs) {
+                                blocks += blob.Blocks.size();
+                            }
+                            blocksPerAddBlobs.push_back(blocks);
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Flush();
+
+        UNIT_ASSERT_VALUES_EQUAL(3, blocksPerAddBlobs.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, blocksPerAddBlobs[0]);
+        UNIT_ASSERT_VALUES_EQUAL(2, blocksPerAddBlobs[1]);
+        UNIT_ASSERT_VALUES_EQUAL(1, blocksPerAddBlobs[2]);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMixedBlocksCount());
+        }
+
+        for (ui32 i = 1; i <= 5; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(i),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+    }
+
     Y_UNIT_TEST(ShouldFlushBlocksFromFreshChannelAsNewBlob)
     {
         auto config = DefaultConfig();


### PR DESCRIPTION
### Notes
Describe your PR - what it does and why this needs to be done.

### Issue
Put links to the related issues here
