### PR TITLE
feat: add bastion docker-compose to ansible, use more strict team for ssh keys pull

### DIFF
--- a/.github/ansible/playbooks/roles/cache/defaults/main.yml
+++ b/.github/ansible/playbooks/roles/cache/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+bastion_compose_dir: /home/ubuntu/bastion
+bastion_github_token: "{{ lookup('ansible.builtin.env', 'GITHUB_TOKEN') }}"
+bastion_github_org: ydb-platform
+bastion_github_team: nbs_nebius
+bastion_sync_interval_seconds: 3600

--- a/.github/ansible/playbooks/roles/cache/tasks/main.yml
+++ b/.github/ansible/playbooks/roles/cache/tasks/main.yml
@@ -57,16 +57,16 @@
   ansible.builtin.file:
     path: "{{ bastion_compose_dir }}"
     state: directory
-    owner: root
-    group: root
+    owner: 1000
+    group: 1000
     mode: "0755"
 
 - name: Copy bastion Compose files
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../../scripts/bastion/{{ item }}"
     dest: "{{ bastion_compose_dir }}/{{ item }}"
-    owner: root
-    group: root
+    owner: 1000
+    group: 1000
     mode: "0644"
   loop:
     - bastion-entrypoint.sh
@@ -76,8 +76,8 @@
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../../scripts/bastion/sync/"
     dest: "{{ bastion_compose_dir }}/sync/"
-    owner: root
-    group: root
+    owner: 1000
+    group: 1000
     mode: "0644"
     directory_mode: "0755"
 
@@ -89,8 +89,8 @@
       TEAM={{ bastion_github_team | ansible.builtin.to_json }}
       INTERVAL_SECONDS={{ bastion_sync_interval_seconds | int }}
     dest: "{{ bastion_compose_dir }}/.env"
-    owner: root
-    group: root
+    owner: 1000
+    group: 1000
     mode: "0600"
   no_log: true
 

--- a/.github/ansible/playbooks/roles/cache/tasks/main.yml
+++ b/.github/ansible/playbooks/roles/cache/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: Start bazel-remote
   community.docker.docker_container:
     name: bazel-remote
-    image: buchgr/bazel-remote-cache:v2.4.3
+    image: buchgr/bazel-remote-cache:v2.6.2
     detach: true
     restart_policy: always
     user: 1000:1000
@@ -34,6 +34,70 @@
       BAZEL_REMOTE_UNAUTHENTICATED_READS: "1"
       BAZEL_REMOTE_ACCESS_LOG_LEVEL: "all"
       BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION: "1"
+    log_driver: "json-file"
+    log_options:
+      max-size: "10m"
+      max-file: "3"
     volumes:
       - /home/ubuntu/bazel:/data
       - /etc/bazel-remote-htpasswd:/etc/bazel-remote/htpasswd
+
+- name: Validate bastion configuration
+  ansible.builtin.assert:
+    that:
+      - bastion_github_token | length > 0
+      - bastion_github_org | length > 0
+      - bastion_github_team | length > 0
+      - bastion_sync_interval_seconds | int > 0
+    fail_msg: >-
+      Set bastion_github_token (or GITHUB_TOKEN on the Ansible controller)
+      and valid bastion GitHub settings.
+
+- name: Create bastion Compose directory
+  ansible.builtin.file:
+    path: "{{ bastion_compose_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Copy bastion Compose files
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../scripts/bastion/{{ item }}"
+    dest: "{{ bastion_compose_dir }}/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - bastion-entrypoint.sh
+    - docker-compose.yml
+
+- name: Copy GitHub keys sync image sources
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../scripts/bastion/sync/"
+    dest: "{{ bastion_compose_dir }}/sync/"
+    owner: root
+    group: root
+    mode: "0644"
+    directory_mode: "0755"
+
+- name: Write bastion environment
+  ansible.builtin.copy:
+    content: |
+      GITHUB_TOKEN={{ bastion_github_token | ansible.builtin.to_json }}
+      ORG={{ bastion_github_org | ansible.builtin.to_json }}
+      TEAM={{ bastion_github_team | ansible.builtin.to_json }}
+      INTERVAL_SECONDS={{ bastion_sync_interval_seconds | int }}
+    dest: "{{ bastion_compose_dir }}/.env"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+
+- name: Build and start bastion services
+  community.docker.docker_compose_v2:
+    project_src: "{{ bastion_compose_dir }}"
+    state: present
+    build: always
+    pull: missing
+    remove_orphans: true

--- a/.github/packer/README.md
+++ b/.github/packer/README.md
@@ -7,7 +7,7 @@ export GITHUB_TOKEN=$(gh auth token)
 3. Set environmental variables:
 ```
 export ORG=ydb-platform
-export TEAM=nbs
+export TEAM=nbs_nebius
 export PARENT_ID="project-e02gfsnkpr00d7kw1dw8jw"
 export SUBNET_ID="vpcsubnet-e02dsth0aw7vwxzn77"
 export VM_USER_PASSWD=$(openssl passwd -6 -salt xyz  yourpass)

--- a/.github/packer/github-runner.pkr.hcl
+++ b/.github/packer/github-runner.pkr.hcl
@@ -34,7 +34,7 @@ variable "ORG" {
 
 variable "TEAM" {
   type    = string
-  default = "nbs"
+  default = "nbs_nebius"
 }
 
 variable "TMPFS_SIZE" {

--- a/.github/scripts/bastion/env.example
+++ b/.github/scripts/bastion/env.example
@@ -1,4 +1,4 @@
 GITHUB_TOKEN=""
 ORG="ydb-platform"
-TEAM="nbs"
+TEAM="nbs_nebius"
 INTERVAL_SECONDS=3600


### PR DESCRIPTION
This PR actualizes what is running on cache vms right now (except bastion, which is down to limit ways for Zapscape execution) + changes what team is used to pull ssh keys.
It was already configured to nbs_nebius on bastion container before, so no other team could've gained ssh access.