### PR TITLE
issue-5895: fastshard - sn client tcp connection pool and benchmark

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/sn/client/bench/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/bench/ya.make
@@ -1,0 +1,25 @@
+G_BENCHMARK()
+
+IF (SANITIZER_TYPE)
+    TAG(ya:manual)
+ENDIF()
+
+SRCS(
+    ../client_bench.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/sn/client
+    cloud/filestore/libs/storage/fastshard/sn/iface
+    cloud/filestore/libs/storage/fastshard/sn/server
+    cloud/filestore/libs/storage/fastshard/testlib
+
+    cloud/storage/core/libs/common
+    cloud/storage/core/protos
+
+    library/cpp/testing/common
+
+    contrib/libs/silk/src/fibers
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client.cpp
@@ -11,6 +11,7 @@
 
 #include <util/generic/scope.h>
 #include <util/generic/string.h>
+#include <util/generic/vector.h>
 #include <util/string/builder.h>
 
 #include <arpa/inet.h>
@@ -98,22 +99,95 @@ int OpenTcp(const TString& host, ui16 port)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// IStorageNode over a single TCP connection to an sn server.
+// Pool of idle TCP connections to one host:port. Acquire pops an idle
+// connection or opens a new one; a request uses the connection
+// exclusively until it releases it back. On an I/O error the caller
+// closes the connection instead of releasing it, so the pool never
+// stores a connection in an unknown protocol state. The pool is not
+// capped: it grows to the maximum number of concurrent requests
+// observed.
+
+struct TPooledConnection
+{
+    int Fd = -1;
+
+    // Whether this connection has completed at least one request;
+    // drives the ConnectionsUsed metric.
+    bool Used = false;
+};
+
+class TConnectionPool
+{
+public:
+    TConnectionPool(
+            TString host,
+            ui16 port,
+            TStorageNodeClientMetricsPtr metrics)
+        : Host(std::move(host))
+        , Port(port)
+        , Metrics(std::move(metrics))
+    {}
+
+    ~TConnectionPool()
+    {
+        for (const auto& conn: Idle) {
+            ::close(conn.Fd);
+        }
+    }
+
+    TPooledConnection Acquire()
+    {
+        {
+            std::lock_guard g(Lock);
+            if (!Idle.empty()) {
+                TPooledConnection conn = Idle.back();
+                Idle.pop_back();
+                return conn;
+            }
+        }
+
+        //
+        // Connect outside the lock: OpenTcp suspends the fiber, and
+        // holding a FiberMutex across it would serialize all concurrent
+        // connection attempts.
+        //
+
+        int fd = OpenTcp(Host, Port);
+        if (fd >= 0 && Metrics) {
+            Metrics->ConnectionsCreated.fetch_add(1);
+        }
+        return {.Fd = fd, .Used = false};
+    }
+
+    void Release(TPooledConnection conn)
+    {
+        std::lock_guard g(Lock);
+        Idle.push_back(conn);
+    }
+
+private:
+    const TString Host;
+    const ui16 Port;
+    const TStorageNodeClientMetricsPtr Metrics;
+    FiberMutex Lock;
+    TVector<TPooledConnection> Idle;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// IStorageNode over a pool of TCP connections to an sn server.
 
 class TStorageNodeClient: public IStorageNode
 {
 public:
-    TStorageNodeClient(TString host, ui16 port)
+    TStorageNodeClient(
+            TString host,
+            ui16 port,
+            TStorageNodeClientMetricsPtr metrics)
         : Host(std::move(host))
         , Port(port)
+        , Metrics(std::move(metrics))
+        , Pool(Host, Port, Metrics)
     {}
-
-    ~TStorageNodeClient() override
-    {
-        if (Fd >= 0) {
-            ::close(Fd);
-        }
-    }
 
 #define SN_CLIENT_METHOD(name, ...)                                            \
     NCloud::NProto::T##name##Response name(                                    \
@@ -146,61 +220,72 @@ public:
 private:
     TDeviceProtocolResponse Exchange(const TDeviceProtocolRequest& req)
     {
-        std::lock_guard g(ConnMutex);
-
         //
-        // Open the socket lazily and reopen it after any I/O error.
-        // Every failure path below closes Fd and sets it to -1 so the
-        // next call retries the connect.
+        // The connection is used by this request exclusively, so the
+        // request/response exchange needs no locking. On success the
+        // connection returns to the pool; on any error it is closed and
+        // dropped — the next request opens a fresh one.
         //
 
-        if (Fd < 0) {
-            Fd = OpenTcp(Host, Port);
-            if (Fd < 0) {
-                return MakeErrorResponse(
-                    req.GetRequestId(),
-                    E_REJECTED,
-                    TStringBuilder() << "sn client: connect to " << Host << ":"
-                                     << Port << " failed");
-            }
+        TPooledConnection conn = Pool.Acquire();
+        if (conn.Fd < 0) {
+            return MakeErrorResponse(
+                req.GetRequestId(),
+                E_REJECTED,
+                TStringBuilder() << "sn client: connect to " << Host << ":"
+                                 << Port << " failed");
         }
+        const int fd = conn.Fd;
 
         TString buf;
         Y_PROTOBUF_SUPPRESS_NODISCARD req.SerializeToString(&buf);
 
         ui32 lenBe = htonl(static_cast<ui32>(buf.size()));
-        if (int r = SendAll(Fd, &lenBe, sizeof(lenBe)); r) {
-            return CloseAndError(req.GetRequestId(), r, "send length");
+        if (int r = SendAll(fd, &lenBe, sizeof(lenBe)); r) {
+            return CloseAndError(fd, req.GetRequestId(), r, "send length");
         }
-        if (int r = SendAll(Fd, buf.data(), buf.size()); r) {
-            return CloseAndError(req.GetRequestId(), r, "send body");
+        if (int r = SendAll(fd, buf.data(), buf.size()); r) {
+            return CloseAndError(fd, req.GetRequestId(), r, "send body");
         }
 
         ui32 respLenBe = 0;
-        if (int r = RecvAll(Fd, &respLenBe, sizeof(respLenBe)); r) {
-            return CloseAndError(req.GetRequestId(), r, "recv length");
+        if (int r = RecvAll(fd, &respLenBe, sizeof(respLenBe)); r) {
+            return CloseAndError(fd, req.GetRequestId(), r, "recv length");
         }
         ui32 respLen = ntohl(respLenBe);
 
         TString respBuf;
         respBuf.ReserveAndResize(respLen);
-        if (int r = RecvAll(Fd, respBuf.begin(), respLen); r) {
-            return CloseAndError(req.GetRequestId(), r, "recv body");
+        if (int r = RecvAll(fd, respBuf.begin(), respLen); r) {
+            return CloseAndError(fd, req.GetRequestId(), r, "recv body");
         }
 
         TDeviceProtocolResponse resp;
         if (!resp.ParseFromString(respBuf)) {
-            return CloseAndError(req.GetRequestId(), EBADMSG, "parse response");
+            return CloseAndError(
+                fd,
+                req.GetRequestId(),
+                EBADMSG,
+                "parse response");
         }
+
+        if (Metrics) {
+            Metrics->RequestsCompleted.fetch_add(1);
+            if (!conn.Used) {
+                Metrics->ConnectionsUsed.fetch_add(1);
+            }
+        }
+        conn.Used = true;
+
+        Pool.Release(conn);
         return resp;
     }
 
     TDeviceProtocolResponse
-    CloseAndError(ui64 requestId, int err, const char* op)
+    CloseAndError(int fd, ui64 requestId, int err, const char* op)
     {
-        SILK_WARN("sn client fd=%d: %s: %s", Fd, op, ::strerror(err));
-        ::close(Fd);
-        Fd = -1;
+        SILK_WARN("sn client fd=%d: %s: %s", fd, op, ::strerror(err));
+        ::close(fd);
         return MakeErrorResponse(
             requestId,
             E_REJECTED,
@@ -221,8 +306,8 @@ private:
 private:
     const TString Host;
     const ui16 Port;
-    FiberMutex ConnMutex;
-    int Fd = -1;
+    const TStorageNodeClientMetricsPtr Metrics;
+    TConnectionPool Pool;
     std::atomic<ui64> NextRequestId{1};
 };
 
@@ -232,7 +317,18 @@ private:
 
 IStorageNodePtr CreateStorageNodeClient(TString host, ui16 port)
 {
-    return std::make_shared<TStorageNodeClient>(std::move(host), port);
+    return CreateStorageNodeClient(std::move(host), port, nullptr /* metrics */);
+}
+
+IStorageNodePtr CreateStorageNodeClient(
+    TString host,
+    ui16 port,
+    TStorageNodeClientMetricsPtr metrics)
+{
+    return std::make_shared<TStorageNodeClient>(
+        std::move(host),
+        port,
+        std::move(metrics));
 }
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client.h
@@ -5,25 +5,52 @@
 #include <util/generic/string.h>
 #include <util/system/types.h>
 
+#include <atomic>
+#include <memory>
+
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Returns an IStorageNode that forwards every call over a single TCP
- * connection to an sn server at `host:port`. Each call is wrapped in a
+ * Connection pool metrics of a storage node client. The client updates
+ * the counters; the owner reads them at any time (all fields are
+ * atomics, values are monotonically increasing).
+ */
+struct TStorageNodeClientMetrics
+{
+    // TCP connections successfully established.
+    std::atomic<ui64> ConnectionsCreated{0};
+
+    // Distinct connections that completed at least one request.
+    std::atomic<ui64> ConnectionsUsed{0};
+
+    // Requests that completed without a transport error.
+    std::atomic<ui64> RequestsCompleted{0};
+};
+
+using TStorageNodeClientMetricsPtr =
+    std::shared_ptr<TStorageNodeClientMetrics>;
+
+/**
+ * Returns an IStorageNode that forwards every call over TCP to an sn
+ * server at `host:port`. Each call is wrapped in a
  * TDeviceProtocolRequest, sent length-prefixed, and its
  * TDeviceProtocolResponse is unpacked into the matching concrete
  * response.
  *
  * Concurrency: methods on the returned client may be called from any
- * silk fiber; concurrent calls are serialized on a single shared
- * connection.
+ * silk fiber. Connections come from a pool: each call takes an idle
+ * connection (or opens a new one) for the duration of its round trip
+ * and returns it afterwards, so concurrent calls proceed in parallel.
+ * The pool grows to the maximum number of concurrent calls observed.
+ * The client must not be destroyed while a call is in flight.
  *
  * Errors:
  *   - I/O failures (connect / send / recv / parse) surface as a
- *     response whose Error field is set to E_REJECTED. The connection
- *     is closed and reopened on the next call.
+ *     response whose Error field is set to E_REJECTED. The failed
+ *     connection is closed and dropped from the pool; the next call
+ *     opens a fresh one.
  *   - A TDeviceProtocolResponse.ProtocolError from the server is
  *     copied into the concrete response's Error field.
  *
@@ -35,5 +62,19 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
  * @return - Shared owner of the client instance.
  */
 IStorageNodePtr CreateStorageNodeClient(TString host, ui16 port);
+
+/**
+ * Same as above, with connection pool metrics reported into `metrics`.
+ *
+ * @param host - Server hostname or IP.
+ * @param port - Server TCP port.
+ * @param metrics - (out) Counters updated by the client; may be null.
+ *
+ * @return - Shared owner of the client instance.
+ */
+IStorageNodePtr CreateStorageNodeClient(
+    TString host,
+    ui16 port,
+    TStorageNodeClientMetricsPtr metrics);
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client_bench.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client_bench.cpp
@@ -1,0 +1,207 @@
+#include <cloud/filestore/libs/storage/fastshard/sn/client/client.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/server/server.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h>
+
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/util/init.h>
+
+#include <library/cpp/testing/common/network.h>
+
+#include <util/generic/size_literals.h>
+#include <util/generic/string.h>
+#include <util/generic/yexception.h>
+
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+#include <memory>
+
+using namespace NCloud::NFileStore::NStorage::NFastShard;
+using silk::FiberFuture;
+using silk::FiberScheduler;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// The google benchmark module owns main(), so the silk runtime is
+// brought up lazily on first use and left to die with the process.
+
+void EnsureSilk()
+{
+    static const bool initialized = [] {
+        silk::initialize();
+        FiberScheduler::initialize();
+        return true;
+    }();
+    Y_UNUSED(initialized);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Fake storage node behind the real sn TCP server, with the pooled
+// client pointed at it over loopback.
+
+struct TBenchFixture
+{
+    std::shared_ptr<TFakeStorageNode> Storage;
+    NTesting::TPortHolder Port;
+    IServerPtr Server;
+    IStorageNodePtr Client;
+
+    TBenchFixture()
+        : Storage(std::make_shared<TFakeStorageNode>())
+        , Port(NTesting::GetFreePort())
+        , Server(CreateServer(Port, Storage))
+        , Client(CreateStorageNodeClient("localhost", Port))
+    {
+        Server->Start();
+    }
+
+    ~TBenchFixture()
+    {
+        Server->Stop();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// One benchmark iteration: `Concurrency` fibers, each doing
+// `CallsPerFiber` request round trips.
+
+struct TDriverParams
+{
+    TBenchFixture* Fixture;
+    ui32 Concurrency;
+    ui32 CallsPerFiber;
+    ui32 WritePageCount;
+    std::atomic<ui32>* ErrorCount;
+};
+
+static_assert(sizeof(TDriverParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+int CallFiberMain(TDriverParams* params) noexcept
+{
+    for (ui32 i = 0; i < params->CallsPerFiber; ++i) {
+        if (params->WritePageCount) {
+            NCloud::NProto::TWriteLogRecordRequest req;
+            req.SetDeviceUUID("bench-dev");
+            req.SetLogSequenceNumber(i);
+            auto* pg = req.AddPageGroups();
+            pg->SetFirstPageNo(0);
+            for (ui32 p = 0; p < params->WritePageCount; ++p) {
+                pg->AddContent(TString(4_KB, 'x'));
+            }
+            auto resp = params->Fixture->Client->WriteLogRecord(
+                std::move(req));
+            if (resp.GetError().GetCode()) {
+                params->ErrorCount->fetch_add(1);
+            }
+        } else {
+            NCloud::NProto::TAcquireDevicesRequest req;
+            req.AddDeviceUUIDs("bench-dev");
+            auto resp = params->Fixture->Client->AcquireDevices(
+                std::move(req));
+            if (resp.GetError().GetCode()) {
+                params->ErrorCount->fetch_add(1);
+            }
+        }
+    }
+    return 0;
+}
+
+int DriverFiberMain(TDriverParams* params) noexcept
+{
+    constexpr ui32 MaxConcurrency = 256U;
+    if (params->Concurrency > MaxConcurrency) {
+        return EINVAL;
+    }
+
+    FiberFuture futures[MaxConcurrency];
+    for (ui32 i = 0; i < params->Concurrency; ++i) {
+        const int r = FiberScheduler::run(
+            CallFiberMain,
+            TDriverParams(*params),
+            &futures[i]);
+        if (r) {
+            return r;
+        }
+    }
+    for (ui32 i = 0; i < params->Concurrency; ++i) {
+        futures[i].wait();
+    }
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void RunBench(benchmark::State& state, ui32 writePageCount)
+{
+    EnsureSilk();
+
+    TBenchFixture fixture;
+
+    const ui32 concurrency = static_cast<ui32>(state.range(0));
+    constexpr ui32 CallsPerFiber = 16U;
+
+    std::atomic<ui32> errorCount{0};
+
+    for (auto _: state) {
+        FiberFuture done;
+        const int r = FiberScheduler::run(
+            DriverFiberMain,
+            TDriverParams{
+                .Fixture = &fixture,
+                .Concurrency = concurrency,
+                .CallsPerFiber = CallsPerFiber,
+                .WritePageCount = writePageCount,
+                .ErrorCount = &errorCount,
+            },
+            &done);
+        Y_ENSURE(r == 0);
+        Y_ENSURE(done.wait() == 0);
+    }
+
+    Y_ENSURE(errorCount.load() == 0);
+
+    state.SetItemsProcessed(
+        state.iterations() * concurrency * CallsPerFiber);
+    if (writePageCount) {
+        state.SetBytesProcessed(
+            state.iterations() * concurrency * CallsPerFiber *
+            writePageCount * 4_KB);
+    }
+}
+
+void SnClientRoundTrip(benchmark::State& state)
+{
+    RunBench(state, 0 /* writePageCount */);
+}
+
+void SnClientWriteLogRecord4K(benchmark::State& state)
+{
+    RunBench(state, 1 /* writePageCount */);
+}
+
+void SnClientWriteLogRecord32K(benchmark::State& state)
+{
+    RunBench(state, 8 /* writePageCount */);
+}
+
+//
+// The requests run on silk scheduler threads, not on the benchmark
+// thread, so the meaningful clock is wall time.
+//
+
+BENCHMARK(SnClientRoundTrip)->Arg(1)->Arg(4)->Arg(16)->Arg(64)
+    ->Unit(benchmark::kMicrosecond)
+    ->UseRealTime();
+BENCHMARK(SnClientWriteLogRecord4K)->Arg(1)->Arg(4)->Arg(16)->Arg(64)
+    ->Unit(benchmark::kMicrosecond)
+    ->UseRealTime();
+BENCHMARK(SnClientWriteLogRecord32K)->Arg(1)->Arg(4)->Arg(16)->Arg(64)
+    ->Unit(benchmark::kMicrosecond)
+    ->UseRealTime();
+
+}   // namespace

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client_stub.cpp
@@ -11,4 +11,13 @@ IStorageNodePtr CreateStorageNodeClient(TString host, ui16 port)
     return CreateStorageNodeStub();
 }
 
+IStorageNodePtr CreateStorageNodeClient(
+    TString host,
+    ui16 port,
+    TStorageNodeClientMetricsPtr metrics)
+{
+    Y_UNUSED(metrics);
+    return CreateStorageNodeClient(std::move(host), port);
+}
+
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client_ut.cpp
@@ -8,13 +8,17 @@
 #include <cloud/storage/core/protos/device.pb.h>
 
 #include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
 
 #include <library/cpp/testing/common/network.h>
 
+#include <util/datetime/base.h>
 #include <util/generic/string.h>
 #include <util/string/cast.h>
 
 #include <gtest/gtest.h>
+
+#include <atomic>
 
 using namespace NCloud::NFileStore::NStorage::NFastShard;
 using silk::FiberScheduler;
@@ -35,13 +39,15 @@ struct TFixture
     std::shared_ptr<TFakeStorageNode> Storage;
     NTesting::TPortHolder Port;
     IServerPtr Server;
+    TStorageNodeClientMetricsPtr Metrics;
     IStorageNodePtr Client;
 
     TFixture()
         : Storage(std::make_shared<TFakeStorageNode>())
         , Port(NTesting::GetFreePort())
         , Server(CreateServer(Port, Storage))
-        , Client(CreateStorageNodeClient("localhost", Port))
+        , Metrics(std::make_shared<TStorageNodeClientMetrics>())
+        , Client(CreateStorageNodeClient("localhost", Port, Metrics))
     {
         Server->Start();
     }
@@ -73,6 +79,81 @@ struct TUnreachableFixture
         //
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+// IStorageNode wrapper that delays every call, then delegates. Used to
+// prove that concurrent client calls overlap on the wire.
+
+struct TSlowStorageNode: public IStorageNode
+{
+    IStorageNodePtr Inner;
+    ui64 DelayNs = 0;
+
+    TSlowStorageNode(IStorageNodePtr inner, ui64 delayNs)
+        : Inner(std::move(inner))
+        , DelayNs(delayNs)
+    {}
+
+#define SLOW_SN_METHOD(name, ...)                                              \
+    NCloud::NProto::T##name##Response name(                                    \
+        NCloud::NProto::T##name##Request request) override                     \
+    {                                                                          \
+        FiberScheduler::SleepFuture sf;                                        \
+        FiberScheduler::sleep(DelayNs, &sf);                                   \
+        sf.wait();                                                             \
+        return Inner->name(std::move(request));                                \
+    }                                                                          \
+    // SLOW_SN_METHOD
+
+    SN_METHODS(SLOW_SN_METHOD)
+
+#undef SLOW_SN_METHOD
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Fires Count concurrent AcquireDevices calls on `client` from separate
+// fibers and returns the number of failed responses.
+
+struct TBurstParams
+{
+    IStorageNode* Client;
+    std::atomic<ui32>* ErrorCount;
+};
+
+static_assert(sizeof(TBurstParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+int BurstCallFiber(TBurstParams* params) noexcept
+{
+    NCloud::NProto::TAcquireDevicesRequest req;
+    req.AddDeviceUUIDs("dev-burst");
+    auto resp = params->Client->AcquireDevices(std::move(req));
+    if (resp.GetError().GetCode()) {
+        params->ErrorCount->fetch_add(1);
+    }
+    return 0;
+}
+
+ui32 RunBurst(IStorageNode& client, ui32 count)
+{
+    std::atomic<ui32> errorCount{0};
+
+    constexpr ui32 MaxBurst = 64U;
+    Y_ABORT_UNLESS(count <= MaxBurst);
+    silk::FiberFuture futures[MaxBurst];
+
+    for (ui32 i = 0; i < count; ++i) {
+        const int r = FiberScheduler::run(
+            BurstCallFiber,
+            TBurstParams{.Client = &client, .ErrorCount = &errorCount},
+            &futures[i]);
+        Y_ABORT_UNLESS(r == 0);
+    }
+    for (ui32 i = 0; i < count; ++i) {
+        futures[i].wait();
+    }
+
+    return errorCount.load();
+}
 
 }   // namespace
 
@@ -251,6 +332,151 @@ TEST(ClientTest, ConnectFailureReturnsRejected)
     EXPECT_EQ(0, r);
 }
 
+TEST(ClientTest, ConcurrentCallsUseMultipleConnections)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            //
+            // Storage delays every call, so all concurrent calls are in
+            // flight at the same time and each needs its own connection.
+            // A client that serializes calls on one connection would
+            // create and use exactly one.
+            //
+
+            constexpr ui64 DelayNs = 100'000'000ULL;
+            constexpr ui32 Concurrency = 10U;
+
+            auto storage = std::make_shared<TFakeStorageNode>();
+            auto slow = std::make_shared<TSlowStorageNode>(storage, DelayNs);
+            NTesting::TPortHolder port = NTesting::GetFreePort();
+            auto server = CreateServer(port, slow);
+            server->Start();
+
+            auto metrics = std::make_shared<TStorageNodeClientMetrics>();
+            auto client =
+                CreateStorageNodeClient("localhost", port, metrics);
+
+            const ui32 errorCount = RunBurst(*client, Concurrency);
+
+            EXPECT_EQ(0u, errorCount);
+            EXPECT_EQ(Concurrency, storage->AcquireCalls.size());
+            EXPECT_GT(metrics->ConnectionsCreated.load(), 1u);
+            EXPECT_GT(metrics->ConnectionsUsed.load(), 1u);
+            EXPECT_EQ(Concurrency, metrics->RequestsCompleted.load());
+
+            server->Stop();
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ClientTest, ConcurrentBurstAllSucceed)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TFixture fx;
+
+            //
+            // Several waves through the same client: the first wave
+            // grows the pool, the following waves must reuse the pooled
+            // connections without errors.
+            //
+
+            constexpr ui32 Concurrency = 16U;
+            constexpr ui32 Waves = 4U;
+
+            for (ui32 wave = 0; wave < Waves; ++wave) {
+                EXPECT_EQ(0u, RunBurst(*fx.Client, Concurrency));
+            }
+
+            EXPECT_EQ(
+                Concurrency * Waves,
+                fx.Storage->AcquireCalls.size());
+
+            //
+            // A connection is only opened when a request finds the pool
+            // empty, and at most Concurrency requests are in flight at
+            // any moment - so the total across all waves stays bounded
+            // by one wave's parallelism no matter how the waves
+            // interleave.
+            //
+
+            EXPECT_LE(fx.Metrics->ConnectionsCreated.load(), Concurrency);
+            EXPECT_EQ(
+                Concurrency * Waves,
+                fx.Metrics->RequestsCompleted.load());
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ClientTest, ReconnectsAfterServerRestart)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            auto storage = std::make_shared<TFakeStorageNode>();
+            NTesting::TPortHolder port = NTesting::GetFreePort();
+            auto server = CreateServer(port, storage);
+            server->Start();
+
+            auto client = CreateStorageNodeClient("localhost", port);
+
+            {
+                NCloud::NProto::TAcquireDevicesRequest req;
+                req.AddDeviceUUIDs("dev-before");
+                auto resp = client->AcquireDevices(std::move(req));
+                EXPECT_EQ(0u, resp.GetError().GetCode());
+            }
+
+            server->Stop();
+
+            //
+            // The pooled connection is dead now: the call must fail with
+            // E_REJECTED and the client must drop the connection.
+            //
+
+            {
+                NCloud::NProto::TAcquireDevicesRequest req;
+                req.AddDeviceUUIDs("dev-down");
+                auto resp = client->AcquireDevices(std::move(req));
+                EXPECT_EQ(
+                    static_cast<ui32>(NCloud::E_REJECTED),
+                    resp.GetError().GetCode());
+            }
+
+            //
+            // A new server on the same port: the client must reconnect
+            // transparently. The first server must be destroyed first -
+            // Stop() ends the accept loop but the listening socket is
+            // closed by the destructor, and a lingering listener would
+            // both fail the new bind and swallow the reconnect into a
+            // dead backlog.
+            //
+
+            server = nullptr;
+
+            auto server2 = CreateServer(port, storage);
+            server2->Start();
+
+            {
+                NCloud::NProto::TAcquireDevicesRequest req;
+                req.AddDeviceUUIDs("dev-after");
+                auto resp = client->AcquireDevices(std::move(req));
+                EXPECT_EQ(0u, resp.GetError().GetCode());
+            }
+
+            server2->Stop();
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
 TEST(ClientTest, ReusesConnectionAcrossSequentialCalls)
 {
     const int r = FiberScheduler::run(
@@ -259,11 +485,9 @@ TEST(ClientTest, ReusesConnectionAcrossSequentialCalls)
             TFixture fx;
 
             //
-            // Three sequential AcquireDevices calls on the same client
-            // must all succeed. If the client tore the fd down between
-            // calls (e.g. on a spurious error path) the second or third
-            // call would still work — but the fake will show us the
-            // full sequence.
+            // Sequential calls never overlap, so the pool must serve
+            // all of them with the single connection opened by the
+            // first call.
             //
 
             for (ui32 i = 1; i <= 3; ++i) {
@@ -277,6 +501,10 @@ TEST(ClientTest, ReusesConnectionAcrossSequentialCalls)
             EXPECT_EQ("dev-1", fx.Storage->AcquireCalls[0].GetDeviceUUIDs(0));
             EXPECT_EQ("dev-2", fx.Storage->AcquireCalls[1].GetDeviceUUIDs(0));
             EXPECT_EQ("dev-3", fx.Storage->AcquireCalls[2].GetDeviceUUIDs(0));
+
+            EXPECT_EQ(1u, fx.Metrics->ConnectionsCreated.load());
+            EXPECT_EQ(1u, fx.Metrics->ConnectionsUsed.load());
+            EXPECT_EQ(3u, fx.Metrics->RequestsCompleted.load());
             return 0;
         },
         0);

--- a/cloud/filestore/libs/storage/fastshard/sn/client/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/ya.make
@@ -28,6 +28,7 @@ END()
 # TODO(#5895): fix silk bootstrap/shutdown under msan
 IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB AND SANITIZER_TYPE != "memory")
     RECURSE_FOR_TESTS(
+        bench
         ut
     )
 ENDIF()


### PR DESCRIPTION
### Notes
Currently fastshard storage node client is very simple and works via a single tcp connection. There's no multiplexing so there can be only 1 request in flight (which is of course terrible for highly parallel workloads). Implemented a tcp connection pool in this client.
<details>
<summary>Added a benchmark - looks more or less okay</summary>
<pre>
2026-08-14T17:56:14+02:00
Running ./bench
Run on (22 X 4700 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x11)
  L1 Instruction 64 KiB (x11)
  L2 Unified 2048 KiB (x11)
  L3 Unified 24576 KiB (x1)
Load Average: 0.54, 0.85, 0.70
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
2026-08-14 15:56:14.933 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 24288
2026-08-14 15:56:14.934 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:14.934 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 1119
2026-08-14 15:56:14.940 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:14.940 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 30095
2026-08-14 15:56:14.987 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:14.988 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 25576
2026-08-14 15:56:15.359 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:15.360 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 18976
2026-08-14 15:56:16.216 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
-------------------------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------
SnClientRoundTrip/1/real_time                 454 us         4.44 us         1885 items_per_second=35.2316k/s
2026-08-14 15:56:16.218 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 1511
2026-08-14 15:56:16.220 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:16.220 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 27762
2026-08-14 15:56:16.227 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:16.228 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 29346
2026-08-14 15:56:16.286 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:16.287 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 8289
2026-08-14 15:56:17.029 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientRoundTrip/4/real_time                 616 us         5.93 us         1205 items_per_second=103.941k/s
2026-08-14 15:56:17.035 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 10334
2026-08-14 15:56:17.038 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:17.038 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 65111
2026-08-14 15:56:17.049 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:17.050 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 5195
2026-08-14 15:56:17.133 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:17.135 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 18167
2026-08-14 15:56:17.808 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientRoundTrip/16/real_time                791 us         6.93 us          851 items_per_second=323.721k/s
2026-08-14 15:56:17.822 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 8669
2026-08-14 15:56:17.827 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:17.827 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 2212
2026-08-14 15:56:17.852 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:17.853 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 19140
2026-08-14 15:56:18.059 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:18.064 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 5352
2026-08-14 15:56:18.784 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientRoundTrip/64/real_time               2116 us         7.49 us          340 items_per_second=483.819k/s
2026-08-14 15:56:18.800 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 17592
2026-08-14 15:56:18.801 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:18.801 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 23631
2026-08-14 15:56:18.803 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:18.804 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 20111
2026-08-14 15:56:18.839 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:18.840 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 26848
2026-08-14 15:56:19.254 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:19.259 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 1888
2026-08-14 15:56:19.932 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientWriteLogRecord4K/1/real_time          398 us         5.03 us         1691 bytes_per_second=157.035Mi/s items_per_second=40.2011k/s
2026-08-14 15:56:19.940 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 18687
2026-08-14 15:56:19.941 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:19.941 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 5864
2026-08-14 15:56:19.948 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:19.949 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 30837
2026-08-14 15:56:20.009 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:20.012 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 1659
2026-08-14 15:56:20.704 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientWriteLogRecord4K/4/real_time          598 us         6.28 us         1157 bytes_per_second=418.082Mi/s items_per_second=107.029k/s
2026-08-14 15:56:20.730 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 13304
2026-08-14 15:56:20.732 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:20.732 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 12930
2026-08-14 15:56:20.745 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:20.748 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 20549
2026-08-14 15:56:20.834 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:20.839 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 61453
2026-08-14 15:56:21.524 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientWriteLogRecord4K/16/real_time         847 us         7.72 us          809 bytes_per_second=1.1536Gi/s items_per_second=302.41k/s
2026-08-14 15:56:21.597 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 29170
2026-08-14 15:56:21.606 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:21.607 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 25181
2026-08-14 15:56:21.632 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:21.636 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 3885
2026-08-14 15:56:21.848 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:21.868 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 30536
2026-08-14 15:56:22.628 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientWriteLogRecord4K/64/real_time        2294 us         8.49 us          331 bytes_per_second=1.70255Gi/s items_per_second=446.314k/s
2026-08-14 15:56:22.716 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 29313
2026-08-14 15:56:22.717 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:22.717 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 27151
2026-08-14 15:56:22.723 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:22.723 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 12481
2026-08-14 15:56:22.782 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:22.784 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 19718
2026-08-14 15:56:23.486 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientWriteLogRecord32K/1/real_time         590 us         5.12 us         1190 bytes_per_second=847.359Mi/s items_per_second=27.1155k/s
2026-08-14 15:56:23.509 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 23717
2026-08-14 15:56:23.512 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:23.512 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 62825
2026-08-14 15:56:23.523 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:23.524 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 20199
2026-08-14 15:56:23.603 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:23.607 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 4482
2026-08-14 15:56:24.472 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientWriteLogRecord32K/4/real_time         969 us         7.97 us          892 bytes_per_second=2.01587Gi/s items_per_second=66.056k/s
2026-08-14 15:56:24.534 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 23425
2026-08-14 15:56:24.537 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:24.539 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 27591
2026-08-14 15:56:24.556 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:24.561 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 3009
2026-08-14 15:56:24.680 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:24.699 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 1030
2026-08-14 15:56:25.504 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientWriteLogRecord32K/16/real_time       1371 us         9.20 us          587 bytes_per_second=5.69848Gi/s items_per_second=186.728k/s
2026-08-14 15:56:25.743 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 22301
2026-08-14 15:56:25.756 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:25.757 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 29625
2026-08-14 15:56:25.795 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:25.803 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 65419
2026-08-14 15:56:26.172 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
2026-08-14 15:56:26.240 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:437: sn server listening on port 28336
2026-08-14 15:56:26.988 [INFO ] /workspace/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp:489: sn server stopped
SnClientWriteLogRecord32K/64/real_time       3931 us         10.5 us          190 bytes_per_second=7.9496Gi/s items_per_second=260.492k/s
</pre>
</details>

### Issue
https://github.com/ydb-platform/nbs/issues/5894
