### PR TITLE
Force remote binding for cells

### DIFF
--- a/cloud/blockstore/libs/client/session.cpp
+++ b/cloud/blockstore/libs/client/session.cpp
@@ -555,6 +555,7 @@ std::shared_ptr<NProto::TMountVolumeRequest> TSession::PrepareMountRequest(
     request->SetDiskId(SessionConfig.DiskId);
     request->SetVolumeAccessMode(SessionConfig.AccessMode);
     request->SetVolumeMountMode(SessionConfig.MountMode);
+    request->SetForceRemoteBinding(SessionConfig.ForceRemoteBinding);
     request->SetMountFlags(SessionConfig.MountFlags);
     request->SetIpcType(SessionConfig.IpcType);
     request->SetInstanceId(SessionConfig.InstanceId);

--- a/cloud/blockstore/libs/client/session.h
+++ b/cloud/blockstore/libs/client/session.h
@@ -52,6 +52,7 @@ struct TSessionConfig
 
     NProto::EVolumeAccessMode AccessMode = NProto::VOLUME_ACCESS_READ_WRITE;
     NProto::EVolumeMountMode MountMode = NProto::VOLUME_MOUNT_LOCAL;
+    bool ForceRemoteBinding = false;
     ui32 MountFlags = 0;
 
     NProto::EClientIpcType IpcType = NProto::IPC_GRPC;

--- a/cloud/blockstore/libs/endpoints/session_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager.cpp
@@ -44,6 +44,15 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class ERemoteMountPolicy
+{
+    None,
+    ForceBinding,
+    ForceMountAndBinding,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TEndpoint
 {
 private:
@@ -552,8 +561,7 @@ private:
 
     static TSessionConfig CreateSessionConfig(
         const NProto::TStartEndpointRequest& request,
-        bool forceRemoteMount,
-        bool forceRemoteBinding);
+        ERemoteMountPolicy remoteMountPolicy);
 
     void SwitchSessionForEndpoint(
         const TString& socketPath,
@@ -997,6 +1005,13 @@ TResultOrError<TEndpointPtr> TSessionManager::CreateEndpoint(
             CreateCrcDigestCalculator());
     }
 
+    auto remoteMountPolicy = ERemoteMountPolicy::None;
+    if (!cellId.empty()) {
+        remoteMountPolicy = Options.TemporaryServer
+            ? ERemoteMountPolicy::ForceMountAndBinding
+            : ERemoteMountPolicy::ForceBinding;
+    }
+
     auto session = NClient::CreateSession(
         Timer,
         Scheduler,
@@ -1005,10 +1020,7 @@ TResultOrError<TEndpointPtr> TSessionManager::CreateEndpoint(
         VolumeStats,
         client,
         std::move(clientConfig),
-        CreateSessionConfig(
-            request,
-            !cellId.empty() && Options.TemporaryServer,
-            !cellId.empty()));
+        CreateSessionConfig(request, remoteMountPolicy));
 
     auto switchableSession = CreateSwitchableSession(
         Logging,
@@ -1063,17 +1075,18 @@ TClientAppConfigPtr TSessionManager::CreateClientConfig(
 // static
 TSessionConfig TSessionManager::CreateSessionConfig(
     const NProto::TStartEndpointRequest& request,
-    bool forceRemoteMount,
-    bool forceRemoteBinding)
+    ERemoteMountPolicy remoteMountPolicy)
 {
     TSessionConfig config;
     config.DiskId = request.GetDiskId();
     config.InstanceId = request.GetInstanceId();
     config.AccessMode = request.GetVolumeAccessMode();
-    config.MountMode = forceRemoteMount
-        ? NProto::VOLUME_MOUNT_REMOTE
-        : request.GetVolumeMountMode();
-    config.ForceRemoteBinding = forceRemoteBinding;
+    config.MountMode =
+        remoteMountPolicy == ERemoteMountPolicy::ForceMountAndBinding
+            ? NProto::VOLUME_MOUNT_REMOTE
+            : request.GetVolumeMountMode();
+    config.ForceRemoteBinding =
+        remoteMountPolicy != ERemoteMountPolicy::None;
     config.MountFlags = request.GetMountFlags();
     config.IpcType = request.GetIpcType();
     config.ClientVersionInfo = request.GetClientVersionInfo();

--- a/cloud/blockstore/libs/endpoints/session_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager.cpp
@@ -552,7 +552,8 @@ private:
 
     static TSessionConfig CreateSessionConfig(
         const NProto::TStartEndpointRequest& request,
-        bool forceRemoteMount);
+        bool forceRemoteMount,
+        bool forceRemoteBinding);
 
     void SwitchSessionForEndpoint(
         const TString& socketPath,
@@ -1004,7 +1005,10 @@ TResultOrError<TEndpointPtr> TSessionManager::CreateEndpoint(
         VolumeStats,
         client,
         std::move(clientConfig),
-        CreateSessionConfig(request, !cellId.empty() && Options.TemporaryServer));
+        CreateSessionConfig(
+            request,
+            !cellId.empty() && Options.TemporaryServer,
+            !cellId.empty()));
 
     auto switchableSession = CreateSwitchableSession(
         Logging,
@@ -1059,16 +1063,17 @@ TClientAppConfigPtr TSessionManager::CreateClientConfig(
 // static
 TSessionConfig TSessionManager::CreateSessionConfig(
     const NProto::TStartEndpointRequest& request,
-    bool forceRemouteMount)
+    bool forceRemoteMount,
+    bool forceRemoteBinding)
 {
     TSessionConfig config;
     config.DiskId = request.GetDiskId();
     config.InstanceId = request.GetInstanceId();
     config.AccessMode = request.GetVolumeAccessMode();
-    config.MountMode = request.GetVolumeMountMode();
-    if (forceRemouteMount) {
-        config.MountMode = NProto::VOLUME_MOUNT_REMOTE;
-    }
+    config.MountMode = forceRemoteMount
+        ? NProto::VOLUME_MOUNT_REMOTE
+        : request.GetVolumeMountMode();
+    config.ForceRemoteBinding = forceRemoteBinding;
     config.MountFlags = request.GetMountFlags();
     config.IpcType = request.GetIpcType();
     config.ClientVersionInfo = request.GetClientVersionInfo();

--- a/cloud/blockstore/libs/endpoints/session_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager_ut.cpp
@@ -720,11 +720,14 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
             };
 
         TVector<NProto::EVolumeMountMode> mountModes;
+        TVector<bool> forceRemoteBindings;
 
         auto cellService = std::make_shared<TTestService>();
         cellService->MountVolumeHandler =
             [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
                 mountModes.push_back(request->GetVolumeMountMode());
+                forceRemoteBindings.push_back(
+                    request->GetForceRemoteBinding());
 
                 NProto::TMountVolumeResponse response;
                 response.MutableVolume()->SetDiskId(request->GetDiskId());
@@ -806,6 +809,8 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
         UNIT_ASSERT_VALUES_EQUAL(
             static_cast<int>(expectedMountMode),
             static_cast<int>(mountModes.back()));
+        UNIT_ASSERT_VALUES_EQUAL(1, forceRemoteBindings.size());
+        UNIT_ASSERT(forceRemoteBindings.back());
 
         {
             auto future = sessionManager->AlterSession(
@@ -824,6 +829,8 @@ Y_UNIT_TEST_SUITE(TSessionManagerTest)
         UNIT_ASSERT_VALUES_EQUAL(
             static_cast<int>(expectedMountMode),
             static_cast<int>(mountModes.back()));
+        UNIT_ASSERT_VALUES_EQUAL(2, forceRemoteBindings.size());
+        UNIT_ASSERT(forceRemoteBindings.back());
     }
 
     Y_UNIT_TEST(ShouldForceRemoteMountModeForCellEndpointsWhenTemporaryServer)

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -569,6 +569,8 @@ private:
 
         Y_ENSURE_RETURN(requestData.length() == 0, "invalid request");
 
+        request->SetForceRemoteBinding(true);
+
         auto req =
             std::make_shared<NProto::TMountVolumeRequest>(std::move(*request));
 

--- a/cloud/blockstore/libs/service_rdma/rdma_target_ut.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target_ut.cpp
@@ -247,6 +247,56 @@ Y_UNIT_TEST_SUITE(TRequestHandlerTest)
 
         env.Target->Stop();
     }
+
+    Y_UNIT_TEST(ShouldForceRemoteBindingForMountVolume)
+    {
+        auto service = std::make_shared<TTestService>();
+
+        bool handlerCalled = false;
+        service->MountVolumeHandler =
+            [&](std::shared_ptr<NProto::TMountVolumeRequest> request)
+        {
+            handlerCalled = true;
+            UNIT_ASSERT(request->GetForceRemoteBinding());
+            UNIT_ASSERT(
+                request->GetVolumeMountMode() ==
+                NProto::VOLUME_MOUNT_LOCAL);
+            return NThreading::MakeFuture(NProto::TMountVolumeResponse{});
+        };
+
+        auto env = CreateTestEnv(service);
+        auto handler = env.GetHandler();
+        auto endpoint = env.GetEndpoint();
+
+        NProto::TMountVolumeRequest request;
+        request.SetVolumeMountMode(NProto::VOLUME_MOUNT_LOCAL);
+
+        const size_t inSize =
+            NCloud::NStorage::NRdma::TProtoMessageSerializer::MessageByteSize(
+                request,
+                0);
+        TString inBuf(inSize, 0);
+        NCloud::NStorage::NRdma::TProtoMessageSerializer::Serialize(
+            inBuf,
+            TBlockStoreServerProtocol::EvMountVolumeRequest,
+            0,
+            request);
+
+        TString outBuf(4_KB, 0);
+
+        auto doneFuture = endpoint->WaitDone();
+        handler->HandleRequest(
+            nullptr,
+            handler->CreateCallContext(),
+            inBuf,
+            outBuf);
+
+        doneFuture.Wait();
+
+        UNIT_ASSERT_C(handlerCalled, "MountVolume handler was not called");
+
+        env.Target->Stop();
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_state.cpp
+++ b/cloud/blockstore/libs/storage/service/service_state.cpp
@@ -233,12 +233,15 @@ NProto::EVolumeBinding TVolumeInfo::OnMountStarted(
     NProto::EPreemptionSource preemptionSource,
     NProto::EVolumeBinding explicitBindingType,
     NProto::EVolumeMountMode clientMode,
-    bool applyLocalVolumesLimit)
+    bool applyLocalVolumesLimit,
+    bool forceRemoteBinding)
 {
-    auto bindingType = CalcVolumeBinding(
-        preemptionSource,
-        explicitBindingType,
-        clientMode);
+    auto bindingType = forceRemoteBinding
+        ? NProto::BINDING_REMOTE
+        : CalcVolumeBinding(
+              preemptionSource,
+              explicitBindingType,
+              clientMode);
 
     if (applyLocalVolumesLimit &&
         bindingType != BindingType &&

--- a/cloud/blockstore/libs/storage/service/service_state.h
+++ b/cloud/blockstore/libs/storage/service/service_state.h
@@ -154,7 +154,7 @@ struct TVolumeInfo
         NProto::EVolumeBinding bindingMode,
         NProto::EVolumeMountMode clientMode,
         bool applyLocalVolumesLimit,
-        bool forceRemoteBinding = false);
+        bool forceRemoteBinding);
 
     void OnMountCancelled(
         TSharedServiceCounters& sharedCounters,

--- a/cloud/blockstore/libs/storage/service/service_state.h
+++ b/cloud/blockstore/libs/storage/service/service_state.h
@@ -153,7 +153,8 @@ struct TVolumeInfo
         NProto::EPreemptionSource preemptionSource,
         NProto::EVolumeBinding bindingMode,
         NProto::EVolumeMountMode clientMode,
-        bool applyLocalVolumesLimit);
+        bool applyLocalVolumesLimit,
+        bool forceRemoteBinding = false);
 
     void OnMountCancelled(
         TSharedServiceCounters& sharedCounters,

--- a/cloud/blockstore/libs/storage/service/service_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/service/service_state_ut.cpp
@@ -184,7 +184,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_REMOTE,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(0, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, remoteVolume->SharedCountersLockAcquired);
@@ -211,7 +212,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume1->SharedCountersLockAcquired);
@@ -231,7 +233,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, volume2->SharedCountersLockAcquired);
@@ -251,7 +254,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_BALANCER,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, volume2->SharedCountersLockAcquired);
@@ -278,7 +282,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -304,7 +309,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_REMOTE,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(0, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, remoteVolume->SharedCountersLockAcquired);
@@ -323,7 +329,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, remoteVolume->SharedCountersLockAcquired);
@@ -348,7 +355,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -367,7 +375,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_REMOTE,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -392,7 +401,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -411,7 +421,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -436,7 +447,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -455,7 +467,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_REMOTE,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -481,7 +494,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -500,7 +514,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_REMOTE,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -530,7 +545,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -549,7 +565,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_REMOTE,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -582,7 +599,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, b1);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, v1->SharedCountersLockAcquired);
@@ -592,7 +610,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, b2);
         UNIT_ASSERT_VALUES_EQUAL(NProto::SOURCE_INITIAL_MOUNT, v2->PreemptionSource);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
@@ -634,7 +653,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, b1);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, v1->SharedCountersLockAcquired);
@@ -644,7 +664,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, b2);
         UNIT_ASSERT_VALUES_EQUAL(NProto::SOURCE_INITIAL_MOUNT, v2->PreemptionSource);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
@@ -686,7 +707,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, b3);
         UNIT_ASSERT_VALUES_EQUAL(NProto::SOURCE_INITIAL_MOUNT, v2->PreemptionSource);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
@@ -714,7 +736,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, localVolume->SharedCountersLockAcquired);
@@ -741,7 +764,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -764,7 +788,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_REMOTE,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -786,7 +811,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -808,7 +834,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_LOCAL,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -835,7 +862,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -859,7 +887,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_BALANCER,
             NProto::BINDING_REMOTE,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -881,7 +910,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -903,7 +933,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_BALANCER,
             NProto::BINDING_LOCAL,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -930,6 +961,7 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
+            false,
             false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(0, sharedCounters->LocalVolumeCount);
@@ -956,6 +988,7 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_REMOTE,
             NProto::VOLUME_MOUNT_LOCAL,
+            false,
             false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(0, sharedCounters->LocalVolumeCount);
@@ -986,7 +1019,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType1);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume1->SharedCountersLockAcquired);
@@ -1014,7 +1048,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType2);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, volume2->SharedCountersLockAcquired);
@@ -1041,7 +1076,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_LOCAL,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType3);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, volume2->SharedCountersLockAcquired);
@@ -1065,7 +1101,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_LOCAL,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType4);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, volume2->SharedCountersLockAcquired);
@@ -1095,7 +1132,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_LOCAL,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType5);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume2->SharedCountersLockAcquired);
@@ -1126,7 +1164,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType1);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume1->SharedCountersLockAcquired);
@@ -1154,7 +1193,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType2);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, volume2->SharedCountersLockAcquired);
@@ -1181,7 +1221,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_LOCAL,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType3);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(false, volume2->SharedCountersLockAcquired);
@@ -1211,7 +1252,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_LOCAL,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType4);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume2->SharedCountersLockAcquired);
@@ -1266,7 +1308,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -1292,7 +1335,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_REMOTE,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -1317,7 +1361,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_NONE,
             NProto::BINDING_NOT_SET,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_REMOTE, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);
@@ -1342,7 +1387,8 @@ Y_UNIT_TEST_SUITE(TServiceStateTest)
             NProto::SOURCE_MANUAL,
             NProto::BINDING_LOCAL,
             NProto::VOLUME_MOUNT_LOCAL,
-            true);
+            true,
+            false);
         UNIT_ASSERT_VALUES_EQUAL(NProto::BINDING_LOCAL, bindingType);
         UNIT_ASSERT_VALUES_EQUAL(1, sharedCounters->LocalVolumeCount);
         UNIT_ASSERT_VALUES_EQUAL(true, volume->SharedCountersLockAcquired);

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -597,6 +597,134 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
         service1.UnmountVolume(DefaultDiskId, sessionId);
     }
 
+    Y_UNIT_TEST(ShouldPreserveBlueGreenHandoffThroughRemoteBindings)
+    {
+        TTestEnv env(1, 2);
+        ui32 nodeIdx1 = SetupTestEnv(env);
+        ui32 nodeIdx2 = SetupTestEnv(env);
+
+        auto& runtime = env.GetRuntime();
+
+        bool volumePipeResetSeen = false;
+        ui32 addClientSeen = 0;
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+            if (event->GetTypeRewrite() ==
+                TEvServicePrivate::EvVolumePipeReset)
+            {
+                volumePipeResetSeen = true;
+            } else if (event->GetTypeRewrite() ==
+                       TEvVolume::EvAddClientRequest)
+            {
+                ++addClientSeen;
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        TServiceClient temporaryService(runtime, nodeIdx1);
+        TServiceClient primaryService(runtime, nodeIdx2);
+
+        const TString clientId = "blue-green-client";
+        temporaryService.SetClientId(clientId);
+        primaryService.SetClientId(clientId);
+
+        temporaryService.CreateVolume();
+        temporaryService.AssignVolume(DefaultDiskId, "foo", "bar");
+
+        auto mount = [] (
+            TServiceClient& service,
+            NProto::EVolumeMountMode mountMode)
+        {
+            auto request = service.CreateMountVolumeRequest(
+                DefaultDiskId,
+                "foo",
+                "bar",
+                NProto::IPC_GRPC,
+                NProto::VOLUME_ACCESS_READ_WRITE,
+                mountMode);
+            request->Record.SetForceRemoteBinding(true);
+            service.SendRequest(MakeStorageServiceId(), std::move(request));
+            return service.RecvMountVolumeResponse();
+        };
+
+        auto temporaryMount =
+            mount(temporaryService, NProto::VOLUME_MOUNT_REMOTE);
+        UNIT_ASSERT_C(
+            !HasError(temporaryMount->GetError()),
+            temporaryMount->GetError());
+        auto temporarySessionId = temporaryMount->Record.GetSessionId();
+        temporaryService.WaitForVolume();
+
+        temporaryService.WriteBlocks(
+            DefaultDiskId,
+            TBlockRange64::MakeOneBlock(0),
+            temporarySessionId);
+
+        auto primaryMount =
+            mount(primaryService, NProto::VOLUME_MOUNT_LOCAL);
+        UNIT_ASSERT_C(
+            !HasError(primaryMount->GetError()),
+            primaryMount->GetError());
+        auto primarySessionId = primaryMount->Record.GetSessionId();
+        primaryService.WaitForVolume();
+
+        // Both services use remote tablet bindings. The logical LOCAL pipe
+        // must nevertheless preempt the temporary REMOTE pipe.
+        primaryService.WriteBlocks(
+            DefaultDiskId,
+            TBlockRange64::MakeOneBlock(0),
+            primarySessionId);
+
+        temporaryService.SendWriteBlocksRequest(
+            DefaultDiskId,
+            TBlockRange64::MakeOneBlock(0),
+            temporarySessionId);
+        auto response = temporaryService.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_BS_INVALID_SESSION,
+            response->GetStatus(),
+            response->GetErrorReason());
+
+        // The service state must be invalidated before E_BS_INVALID_SESSION is
+        // returned, so an immediate remount cannot take the stale S_ALREADY
+        // path.
+        UNIT_ASSERT(volumePipeResetSeen);
+
+        addClientSeen = 0;
+
+        temporaryMount =
+            mount(temporaryService, NProto::VOLUME_MOUNT_REMOTE);
+        UNIT_ASSERT_C(
+            !HasError(temporaryMount->GetError()),
+            temporaryMount->GetError());
+        UNIT_ASSERT_C(addClientSeen > 0, addClientSeen);
+        temporarySessionId = temporaryMount->Record.GetSessionId();
+        temporaryService.WaitForVolume();
+
+        // The fresh REMOTE pipe must not steal the session back from LOCAL.
+        temporaryService.SendWriteBlocksRequest(
+            DefaultDiskId,
+            TBlockRange64::MakeOneBlock(0),
+            temporarySessionId);
+        response = temporaryService.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            response->GetErrorReason());
+
+        // Stopping the temporary service removes only its pipe. It must not
+        // clear the ownership persisted for the primary pipe with the same
+        // client id.
+        temporaryService.UnmountVolume(
+            DefaultDiskId,
+            temporarySessionId);
+
+        // The primary path remains writable after the temporary pipe is gone.
+        primaryService.WriteBlocks(
+            DefaultDiskId,
+            TBlockRange64::MakeOneBlock(0),
+            primarySessionId);
+    }
+
     Y_UNIT_TEST(ShouldDisallowMountByAnotherClient)
     {
         static constexpr TDuration mountVolumeTimeout = TDuration::Seconds(3);
@@ -2841,6 +2969,51 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
         service.MountVolume();
 
         UNIT_ASSERT_VALUES_EQUAL(0, localStartSeen);
+    }
+
+    Y_UNIT_TEST(ShouldKeepLogicalLocalModeWithForcedRemoteBinding)
+    {
+        TTestEnv env;
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        auto& runtime = env.GetRuntime();
+
+        TServiceClient service(runtime, nodeIdx);
+
+        service.CreateVolume();
+        service.AssignVolume();
+
+        ui32 localStartSeen = 0;
+        ui32 addClientSeen = 0;
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvServicePrivate::EvStartVolumeResponse: {
+                    ++localStartSeen;
+                    break;
+                }
+                case TEvVolume::EvAddClientRequest: {
+                    const auto* request =
+                        event->Get<TEvVolume::TEvAddClientRequest>();
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        static_cast<int>(NProto::VOLUME_MOUNT_LOCAL),
+                        static_cast<int>(
+                            request->Record.GetVolumeMountMode()));
+                    ++addClientSeen;
+                    break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        auto request = service.CreateMountVolumeRequest();
+        request->Record.SetForceRemoteBinding(true);
+        service.SendRequest(MakeStorageServiceId(), std::move(request));
+
+        auto response = service.RecvMountVolumeResponse();
+        UNIT_ASSERT_C(!HasError(response->GetError()), response->GetError());
+        UNIT_ASSERT_VALUES_EQUAL(0, localStartSeen);
+        UNIT_ASSERT_C(addClientSeen > 0, addClientSeen);
     }
 
     Y_UNIT_TEST(ShouldExtendAddClientTimeoutForVolumesPreviouslyMountedLocal)

--- a/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
@@ -371,6 +371,8 @@ void TVolumeClientActor::HandleResponse(
     }
 
     auto* msg = ev->Get();
+    const bool invalidSession =
+        msg->GetError().GetCode() == E_BS_INVALID_SESSION;
 
     if (it->second.CallContext->LWOrbit.HasShuttles()) {
         TraceSerializer->HandleTraceInfo(
@@ -433,8 +435,24 @@ void TVolumeClientActor::HandleResponse(
             it->second.Request->Cookie);
     }
 
-    ctx.Send(event.release());
     ActiveRequests.erase(it);
+
+    if (invalidSession) {
+        // The tablet no longer recognizes this pipe. Notify the volume
+        // session before returning the error to the client and create a fresh
+        // tablet pipe; otherwise the remount may be answered from stale
+        // service state with S_ALREADY and never execute AddClient.
+        auto reset =
+            std::make_unique<TEvServicePrivate::TEvVolumePipeReset>(
+                GetCycleCount());
+        NCloud::Send(ctx, SessionActorId, std::move(reset));
+
+        CancelActiveRequests();
+        NTabletPipe::CloseClient(ctx, PipeClient);
+        PipeClient = {};
+    }
+
+    ctx.Send(event.release());
 }
 
 void TVolumeClientActor::HandlePoisonPill(

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -1421,7 +1421,8 @@ void TVolumeSessionActor::HandleInternalMountVolume(
                 msg->PreemptionSource,
                 msg->BindingType,
                 msg->Record.GetVolumeMountMode(),
-                !IsDiskRegistryMediaKind(VolumeInfo->StorageMediaKind));
+                !IsDiskRegistryMediaKind(VolumeInfo->StorageMediaKind),
+                msg->Record.GetForceRemoteBinding());
             shouldReply =
                 (bindingType == VolumeInfo->BindingType) &&
                 clientInfo &&

--- a/cloud/blockstore/libs/storage/volume/model/client_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.cpp
@@ -142,6 +142,11 @@ std::optional<TVolumeClientState::TPipeInfo> TVolumeClientState::GetPipeInfo(
 
 bool TVolumeClientState::IsLocalPipeActive() const
 {
+    return ActivePipe && ActivePipe->IsLocal;
+}
+
+bool TVolumeClientState::IsLocalMountPipeActive() const
+{
     return ActivePipe &&
            ActivePipe->MountMode == NProto::VOLUME_MOUNT_LOCAL;
 }
@@ -169,7 +174,7 @@ void TVolumeClientState::UpdateState()
                           : NProto::VOLUME_MOUNT_REMOTE);
 }
 
-void TVolumeClientState::ActivatePipe(TPipeInfo* pipe)
+void TVolumeClientState::ActivatePipe(TPipeInfo* pipe, bool isLocal)
 {
     Y_DEBUG_ABORT_UNLESS(pipe->State == EPipeState::WAIT_START);
 
@@ -178,6 +183,7 @@ void TVolumeClientState::ActivatePipe(TPipeInfo* pipe)
     }
 
     pipe->State = EPipeState::ACTIVE;
+    pipe->IsLocal = isLocal;
 
     UpdateState();
 }
@@ -233,7 +239,7 @@ NProto::TError TVolumeClientState::CheckPipeRequest(
                 TStringBuilder() << "No mounter found "
                                  << (pipe ? "(deactivated)" : "(nullptr)"));
         }
-        if (IsLocalPipeActive() &&
+        if (IsLocalMountPipeActive() &&
             pipe->MountMode == NProto::VOLUME_MOUNT_REMOTE)
         {
             // When the local pipe is ACTIVE response with retriable error
@@ -244,7 +250,7 @@ NProto::TError TVolumeClientState::CheckPipeRequest(
                 TStringBuilder() << "Local mounter is active");
         }
         if (ActivePipe != pipe) {
-            ActivatePipe(pipe);
+            ActivatePipe(pipe, false);
         }
     }
 
@@ -269,7 +275,6 @@ NProto::TError TVolumeClientState::CheckLocalRequest(
             [&](const auto& p)
             {
                 return p.second.SenderNodeId == nodeId &&
-                       p.second.MountMode == NProto::VOLUME_MOUNT_LOCAL &&
                        p.second.State != EPipeState::DEACTIVATED;
             });
 
@@ -280,7 +285,7 @@ NProto::TError TVolumeClientState::CheckLocalRequest(
         }
 
         if (ActivePipe != &it->second) {
-            ActivatePipe(&it->second);
+            ActivatePipe(&it->second, true);
         }
     }
 

--- a/cloud/blockstore/libs/storage/volume/model/client_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.cpp
@@ -26,7 +26,15 @@ void TVolumeClientState::SetDisconnectTimestamp(TInstant ts)
 void TVolumeClientState::UpdateClientInfo(
     const NProto::TVolumeClientInfo& info)
 {
+    const auto disconnectTimestamp =
+        VolumeClientInfo.GetDisconnectTimestamp();
+    const auto lastActivityTimestamp =
+        VolumeClientInfo.GetLastActivityTimestamp();
+
     VolumeClientInfo = info;
+    VolumeClientInfo.SetDisconnectTimestamp(disconnectTimestamp);
+    VolumeClientInfo.SetLastActivityTimestamp(lastActivityTimestamp);
+
     UpdateState();
 }
 
@@ -249,6 +257,10 @@ NProto::TError TVolumeClientState::CheckLocalRequest(
     const TString& methodName,
     const TString& diskId)
 {
+    if (IsLocalPipeActive() && ActivePipe->SenderNodeId == nodeId) {
+        return CheckWritePermission(isWrite, methodName, diskId);
+    }
+
     // Don't check if there is not a single pipe.
     if (!Pipes.empty()) {
         // Find alive local pipe to activate.

--- a/cloud/blockstore/libs/storage/volume/model/client_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.cpp
@@ -23,6 +23,13 @@ void TVolumeClientState::SetDisconnectTimestamp(TInstant ts)
     VolumeClientInfo.SetDisconnectTimestamp(ts.MicroSeconds());
 }
 
+void TVolumeClientState::UpdateClientInfo(
+    const NProto::TVolumeClientInfo& info)
+{
+    VolumeClientInfo = info;
+    UpdateState();
+}
+
 bool TVolumeClientState::IsPreempted(ui64 hostNodeId) const
 {
     return AnyOf(
@@ -127,7 +134,8 @@ std::optional<TVolumeClientState::TPipeInfo> TVolumeClientState::GetPipeInfo(
 
 bool TVolumeClientState::IsLocalPipeActive() const
 {
-    return ActivePipe && ActivePipe->IsLocal;
+    return ActivePipe &&
+           ActivePipe->MountMode == NProto::VOLUME_MOUNT_LOCAL;
 }
 
 void TVolumeClientState::UpdateState()
@@ -153,7 +161,7 @@ void TVolumeClientState::UpdateState()
                           : NProto::VOLUME_MOUNT_REMOTE);
 }
 
-void TVolumeClientState::ActivatePipe(TPipeInfo* pipe, bool isLocal)
+void TVolumeClientState::ActivatePipe(TPipeInfo* pipe)
 {
     Y_DEBUG_ABORT_UNLESS(pipe->State == EPipeState::WAIT_START);
 
@@ -162,7 +170,6 @@ void TVolumeClientState::ActivatePipe(TPipeInfo* pipe, bool isLocal)
     }
 
     pipe->State = EPipeState::ACTIVE;
-    pipe->IsLocal = isLocal;
 
     UpdateState();
 }
@@ -218,7 +225,9 @@ NProto::TError TVolumeClientState::CheckPipeRequest(
                 TStringBuilder() << "No mounter found "
                                  << (pipe ? "(deactivated)" : "(nullptr)"));
         }
-        if (IsLocalPipeActive()) {
+        if (IsLocalPipeActive() &&
+            pipe->MountMode == NProto::VOLUME_MOUNT_REMOTE)
+        {
             // When the local pipe is ACTIVE response with retriable error
             // E_REJECTED because the local pipe may disconnect and then the
             // request from remote pipe can be executed later.
@@ -227,7 +236,7 @@ NProto::TError TVolumeClientState::CheckPipeRequest(
                 TStringBuilder() << "Local mounter is active");
         }
         if (ActivePipe != pipe) {
-            ActivatePipe(pipe, false);
+            ActivatePipe(pipe);
         }
     }
 
@@ -240,15 +249,15 @@ NProto::TError TVolumeClientState::CheckLocalRequest(
     const TString& methodName,
     const TString& diskId)
 {
-    // Don't check if there is not a single pipe or if the local pipe is already
-    // active.
-    if (!Pipes.empty() && !IsLocalPipeActive()) {
+    // Don't check if there is not a single pipe.
+    if (!Pipes.empty()) {
         // Find alive local pipe to activate.
         const auto it = FindIf(
             Pipes,
             [&](const auto& p)
             {
                 return p.second.SenderNodeId == nodeId &&
+                       p.second.MountMode == NProto::VOLUME_MOUNT_LOCAL &&
                        p.second.State != EPipeState::DEACTIVATED;
             });
 
@@ -258,7 +267,9 @@ NProto::TError TVolumeClientState::CheckLocalRequest(
                 TStringBuilder() << "No local mounter found");
         }
 
-        ActivatePipe(&it->second, true);
+        if (ActivePipe != &it->second) {
+            ActivatePipe(&it->second);
+        }
     }
 
     return CheckWritePermission(isWrite, methodName, diskId);

--- a/cloud/blockstore/libs/storage/volume/model/client_state.h
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.h
@@ -61,6 +61,7 @@ public:
         NProto::EVolumeMountMode MountMode = NProto::VOLUME_MOUNT_REMOTE;
         EPipeState State = EPipeState::WAIT_START;
         ui32 SenderNodeId = 0;
+        bool IsLocal = false;
     };
 
     using TPipes = THashMap<NActors::TActorId, TPipeInfo>;
@@ -116,10 +117,11 @@ public:
 
 private:
     bool IsLocalPipeActive() const;
+    bool IsLocalMountPipeActive() const;
 
     void UpdateState();
 
-    void ActivatePipe(TPipeInfo* pipe);
+    void ActivatePipe(TPipeInfo* pipe, bool isLocal);
 
     bool CanWrite() const;
 

--- a/cloud/blockstore/libs/storage/volume/model/client_state.h
+++ b/cloud/blockstore/libs/storage/volume/model/client_state.h
@@ -61,7 +61,6 @@ public:
         NProto::EVolumeMountMode MountMode = NProto::VOLUME_MOUNT_REMOTE;
         EPipeState State = EPipeState::WAIT_START;
         ui32 SenderNodeId = 0;
-        bool IsLocal = false;
     };
 
     using TPipes = THashMap<NActors::TActorId, TPipeInfo>;
@@ -80,6 +79,7 @@ public:
 
     void SetLastActivityTimestamp(TInstant ts);
     void SetDisconnectTimestamp(TInstant ts);
+    void UpdateClientInfo(const NProto::TVolumeClientInfo& info);
 
     void RemovePipe(NActors::TActorId serverId, TInstant ts);
 
@@ -119,7 +119,7 @@ private:
 
     void UpdateState();
 
-    void ActivatePipe(TPipeInfo* pipe, bool isLocal);
+    void ActivatePipe(TPipeInfo* pipe);
 
     bool CanWrite() const;
 

--- a/cloud/blockstore/libs/storage/volume/model/client_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state_ut.cpp
@@ -525,6 +525,38 @@ Y_UNIT_TEST_SUITE(TVolumeClientStateTest)
             client.GetPipeInfo(localPipe2)->State);
     }
 
+    Y_UNIT_TEST(ShouldAllowRemoteMountPipeOnLocalDataPath)
+    {
+        auto info = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_ONLY,
+            NProto::VOLUME_MOUNT_REMOTE,
+            0);
+
+        TVolumeClientState client{info};
+        const auto pipe = CreateActor(1, 1);
+
+        auto addResult = client.AddPipe(
+            pipe,
+            pipe.NodeId(),
+            NProto::VOLUME_ACCESS_READ_ONLY,
+            NProto::VOLUME_MOUNT_REMOTE,
+            0);
+        UNIT_ASSERT_C(
+            !HasError(addResult.Error),
+            FormatError(addResult.Error));
+
+        // MountMode describes blue-green priority. A REMOTE mount can still
+        // use the local data path when the volume is physically bound to the
+        // same service node.
+        auto error = client.CheckLocalRequest(pipe.NodeId(), false, "", "");
+        UNIT_ASSERT_C(!HasError(error), FormatError(error));
+
+        const auto pipeInfo = client.GetPipeInfo(pipe);
+        UNIT_ASSERT(pipeInfo);
+        UNIT_ASSERT(pipeInfo->IsLocal);
+        UNIT_ASSERT_VALUES_EQUAL(NProto::VOLUME_MOUNT_REMOTE, pipeInfo->MountMode);
+    }
+
     Y_UNIT_TEST(ShouldSelectNewActiveLocalPipeOnReconnect)
     {
         auto initialMountMode = NProto::VOLUME_MOUNT_LOCAL;

--- a/cloud/blockstore/libs/storage/volume/model/client_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state_ut.cpp
@@ -207,6 +207,60 @@ Y_UNIT_TEST_SUITE(TVolumeClientStateTest)
             client.GetVolumeClientInfo().GetMountFlags());
     }
 
+    Y_UNIT_TEST(ShouldPreserveStateOwnedTimestampsOnClientInfoUpdate)
+    {
+        constexpr ui64 disconnectTimestamp = 123;
+        constexpr ui64 lastActivityTimestamp = 456;
+
+        auto info = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        info.SetDisconnectTimestamp(disconnectTimestamp);
+        info.SetLastActivityTimestamp(lastActivityTimestamp);
+
+        TVolumeClientState client{info};
+
+        auto updatedInfo = info;
+        updatedInfo.SetHost("new-host");
+        updatedInfo.SetMountSeqNumber(42);
+        updatedInfo.SetDisconnectTimestamp(0);
+        updatedInfo.SetLastActivityTimestamp(0);
+
+        client.UpdateClientInfo(updatedInfo);
+
+        const auto& result = client.GetVolumeClientInfo();
+        UNIT_ASSERT_VALUES_EQUAL("new-host", result.GetHost());
+        UNIT_ASSERT_VALUES_EQUAL(42, result.GetMountSeqNumber());
+        UNIT_ASSERT_VALUES_EQUAL(
+            disconnectTimestamp,
+            result.GetDisconnectTimestamp());
+        UNIT_ASSERT_VALUES_EQUAL(
+            lastActivityTimestamp,
+            result.GetLastActivityTimestamp());
+
+        auto addResult = client.AddPipe(
+            CreateActor(1, 1),
+            CreateActor(1, 1).NodeId(),
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        UNIT_ASSERT_C(
+            !HasError(addResult.Error),
+            FormatError(addResult.Error));
+
+        client.UpdateClientInfo(updatedInfo);
+
+        // AddPipe owns the transition back to the connected state. Preserve
+        // its zero value instead of restoring the stale disconnect timestamp.
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            client.GetVolumeClientInfo().GetDisconnectTimestamp());
+        UNIT_ASSERT_VALUES_EQUAL(
+            lastActivityTimestamp,
+            client.GetVolumeClientInfo().GetLastActivityTimestamp());
+    }
+
     Y_UNIT_TEST(ShouldHandlePipeActivationDeactivation)
     {
         auto initialMountMode = NProto::VOLUME_MOUNT_REMOTE;

--- a/cloud/blockstore/libs/storage/volume/model/client_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/client_state_ut.cpp
@@ -398,6 +398,79 @@ Y_UNIT_TEST_SUITE(TVolumeClientStateTest)
         UNIT_ASSERT_C(!HasError(ans), FormatError(ans));
     }
 
+    Y_UNIT_TEST(ShouldApplyLocalPriorityToForwardedPipes)
+    {
+        auto info = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_REMOTE,
+            0);
+
+        TVolumeClientState client{info};
+
+        const auto remotePipe1 = CreateActor(1, 1);
+        const auto localPipe1 = CreateActor(2, 2);
+        const auto remotePipe2 = CreateActor(3, 3);
+        const auto localPipe2 = CreateActor(4, 4);
+
+        UNIT_ASSERT(!HasError(client.AddPipe(
+            remotePipe1,
+            remotePipe1.NodeId(),
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_REMOTE,
+            0).Error));
+
+        UNIT_ASSERT(!HasError(client.AddPipe(
+            localPipe1,
+            localPipe1.NodeId(),
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0).Error));
+
+        auto error = client.CheckPipeRequest(remotePipe1, true, "", "");
+        UNIT_ASSERT_C(!HasError(error), error);
+
+        // A logically local mounter can preempt a remote mounter even though
+        // both requests are delivered through tablet pipes.
+        error = client.CheckPipeRequest(localPipe1, true, "", "");
+        UNIT_ASSERT_C(!HasError(error), error);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TVolumeClientState::EPipeState::DEACTIVATED,
+            client.GetPipeInfo(remotePipe1)->State);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TVolumeClientState::EPipeState::ACTIVE,
+            client.GetPipeInfo(localPipe1)->State);
+
+        UNIT_ASSERT(!HasError(client.AddPipe(
+            remotePipe2,
+            remotePipe2.NodeId(),
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_REMOTE,
+            0).Error));
+
+        // A fresh remote pipe must not steal the session back.
+        error = client.CheckPipeRequest(remotePipe2, true, "", "");
+        UNIT_ASSERT_VALUES_EQUAL_C(E_REJECTED, error.GetCode(), error);
+
+        UNIT_ASSERT(!HasError(client.AddPipe(
+            localPipe2,
+            localPipe2.NodeId(),
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0).Error));
+
+        // A new primary pipe may replace an old primary after a cell-host
+        // switch or reconnect.
+        error = client.CheckPipeRequest(localPipe2, true, "", "");
+        UNIT_ASSERT_C(!HasError(error), error);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TVolumeClientState::EPipeState::DEACTIVATED,
+            client.GetPipeInfo(localPipe1)->State);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TVolumeClientState::EPipeState::ACTIVE,
+            client.GetPipeInfo(localPipe2)->State);
+    }
+
     Y_UNIT_TEST(ShouldSelectNewActiveLocalPipeOnReconnect)
     {
         auto initialMountMode = NProto::VOLUME_MOUNT_LOCAL;

--- a/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_addclient.cpp
@@ -620,7 +620,9 @@ void TVolumeActor::ExecuteAddClient(
                 State->LogRemoveClient(ctx.Now(), clientId, "Stale", {}));
         }
 
-        db.WriteClient(args.Info);
+        const auto* clientInfo = State->GetClient(args.Info.GetClientId());
+        Y_ABORT_UNLESS(clientInfo);
+        db.WriteClient(*clientInfo);
 
         if (IsReadWriteMode(args.Info.GetVolumeAccessMode()) &&
             (args.Info.GetFillGeneration() > 0 ||

--- a/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_removeclient.cpp
@@ -258,7 +258,12 @@ void TVolumeActor::ExecuteRemoveClient(
         return;
     }
 
-    db.RemoveClient(args.ClientId);
+    if (const auto* clientInfo = State->GetClient(args.ClientId)) {
+        db.WriteClient(*clientInfo);
+    } else {
+        db.RemoveClient(args.ClientId);
+        args.ClientRemoved = true;
+    }
 }
 
 void TVolumeActor::CompleteRemoveClient(
@@ -269,6 +274,7 @@ void TVolumeActor::CompleteRemoveClient(
         State->IsDiskRegistryMediaKind() &&
         Config->GetAcquireNonReplicatedDevices() &&
         Config->GetNonReplicatedVolumeAcquireDiskAfterAddClientEnabled() &&
+        args.ClientRemoved &&
         !HasError(args.Error);
 
     Y_DEFER

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -791,6 +791,15 @@ TVolumeState::TAddClientResult TVolumeState::AddClient(
         return pipeRes.Error;
     }
 
+    clientInfoIt->second.UpdateClientInfo(info);
+
+    if (LocalMountClientId == clientId &&
+        clientInfoIt->second.GetVolumeClientInfo().GetVolumeMountMode() !=
+            NProto::VOLUME_MOUNT_LOCAL)
+    {
+        LocalMountClientId.clear();
+    }
+
     if (info.GetVolumeAccessMode() == NProto::VOLUME_ACCESS_REPAIR) {
         StorageAccessMode = EStorageAccessMode::Repair;
     }
@@ -913,25 +922,26 @@ NProto::TError TVolumeState::RemoveClient(
 
     auto& clientInfo = it->second;
 
-    const auto accessMode = clientInfo.GetVolumeClientInfo().GetVolumeAccessMode();
-    if (accessMode == NProto::VOLUME_ACCESS_REPAIR) {
-        StorageAccessMode = EStorageAccessMode::Default;
-    }
-
     UnmapClientFromPipeServerId(pipeServerActorId, clientId);
-
-    if (ReadWriteAccessClientId == clientId) {
-        ReadWriteAccessClientId.clear();
-        MountSeqNumber = 0;
-    }
-
-    if (LocalMountClientId == clientId) {
-        LocalMountClientId.clear();
-    }
 
     clientInfo.RemovePipe(pipeServerActorId, TInstant());
 
     if (!clientInfo.AnyPipeAlive()) {
+        const auto accessMode =
+            clientInfo.GetVolumeClientInfo().GetVolumeAccessMode();
+        if (accessMode == NProto::VOLUME_ACCESS_REPAIR) {
+            StorageAccessMode = EStorageAccessMode::Default;
+        }
+
+        if (ReadWriteAccessClientId == clientId) {
+            ReadWriteAccessClientId.clear();
+            MountSeqNumber = 0;
+        }
+
+        if (LocalMountClientId == clientId) {
+            LocalMountClientId.clear();
+        }
+
         // Drop any residual ClientIdsByPipeServerId entries (e.g. pointing to
         // DEACTIVATED pipes of the same client) to keep the invariant that
         // every clientId in ClientIdsByPipeServerId exists in
@@ -939,6 +949,11 @@ NProto::TError TVolumeState::RemoveClient(
         UnmapClientFromPipeServerId({}, clientId);
 
         ClientInfosByClientId.erase(it);
+    } else if (LocalMountClientId == clientId &&
+               clientInfo.GetVolumeClientInfo().GetVolumeMountMode() !=
+                   NProto::VOLUME_MOUNT_LOCAL)
+    {
+        LocalMountClientId.clear();
     }
 
     return {};

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -1406,6 +1406,16 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
         res = volumeState.RemoveClient(clientId, serverActor1);
         UNIT_ASSERT_C(!FAILED(res.Error.GetCode()), res.Error);
 
+        // The logical client and its write ownership must survive while the
+        // remote blue-green pipe is still alive.
+        UNIT_ASSERT_VALUES_EQUAL(
+            clientId,
+            volumeState.GetReadWriteAccessClientId());
+        UNIT_ASSERT_VALUES_EQUAL("", volumeState.GetLocalMountClientId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            NProto::VOLUME_MOUNT_REMOTE,
+            volumeState.GetClient(clientId)->GetVolumeMountMode());
+
         // Remote data path activated
         result = client.CheckPipeRequest(serverActor2, true, "", "");
         UNIT_ASSERT_C(!FAILED(result.GetCode()), result);
@@ -1617,6 +1627,15 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
 
             auto& client = clients[clientId];
             UNIT_ASSERT_VALUES_EQUAL(1, client.GetPipes().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                clientId,
+                volumeState.GetReadWriteAccessClientId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                clientId,
+                volumeState.GetLocalMountClientId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                NProto::VOLUME_MOUNT_LOCAL,
+                volumeState.GetClient(clientId)->GetVolumeMountMode());
         }
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -293,6 +293,7 @@ struct TTxVolume
         const bool IsMonRequest;
 
         NProto::TError Error;
+        bool ClientRemoved = false;
 
         TRemoveClient(
                 TRequestInfoPtr requestInfo,
@@ -310,6 +311,7 @@ struct TTxVolume
         void Clear()
         {
             Error.Clear();
+            ClientRemoved = false;
         }
     };
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -7418,6 +7418,15 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         volumeClient1.RemoveClient(clientInfo.GetClientId());
 
+        // Removing one pipe must persist the remaining logical client rather
+        // than deleting its DB row. Verify that it can reconnect after the
+        // tablet has loaded the client list from local DB.
+        volume.RebootTablet();
+        volumeClient1.ReconnectPipe();
+        volumeClient2.ReconnectPipe();
+        volumeClient2.AddClient(clientInfo);
+        volume.WaitReady();
+
         volumeClient2.WriteBlocks(
             TBlockRange64::MakeOneBlock(0),
             clientInfo.GetClientId(),

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -7419,13 +7419,32 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         volumeClient1.RemoveClient(clientInfo.GetClientId());
 
         // Removing one pipe must persist the remaining logical client rather
-        // than deleting its DB row. Verify that it can reconnect after the
-        // tablet has loaded the client list from local DB.
+        // than deleting its DB row.
         volume.RebootTablet();
+        volume.WaitReady();
+
+        // Check the state loaded from local DB before sending a new AddClient.
+        // Otherwise AddClient could recreate the missing row and make this
+        // test pass with an unconditional db.RemoveClient as well.
+        volume.SendStatVolumeRequest(
+            TString(),
+            TVector<TString>(),
+            true   // noPartition
+        );
+        {
+            auto response = volume.RecvStatVolumeResponse();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto& clients = response->Record.GetClients();
+            UNIT_ASSERT_VALUES_EQUAL(1, clients.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                clientInfo.GetClientId(),
+                clients[0].GetClientId());
+        }
+
         volumeClient1.ReconnectPipe();
         volumeClient2.ReconnectPipe();
         volumeClient2.AddClient(clientInfo);
-        volume.WaitReady();
 
         volumeClient2.WriteBlocks(
             TBlockRange64::MakeOneBlock(0),

--- a/cloud/blockstore/public/api/protos/mount.proto
+++ b/cloud/blockstore/public/api/protos/mount.proto
@@ -87,6 +87,11 @@ message TMountVolumeRequest
 
     // Forces MountVolume handler to ignore encryption spec.
     bool ForceDisableEncryption = 18;
+
+    // Forces the service handling this request to keep the volume tablet
+    // remotely bound. VolumeMountMode still describes the logical mounter
+    // priority and is passed to the volume tablet unchanged.
+    bool ForceRemoteBinding = 19;
 }
 
 message TMountVolumeResponse


### PR DESCRIPTION
## What changed

- Introduces ForceRemoteBinding to keep the volume tablet remotely bound while preserving the logical mount mode used for client arbitration.

- Forces remote binding for all MountVolume requests received through the RDMA transport.

- Replaces the forceRemoteMount and forceRemoteBinding boolean pair with ERemoteMountPolicy.

- Preserves a logical client while it still has live pipes and persists the remaining client state after one pipe is removed.

- Keeps state-owned activity and disconnect timestamps when client metadata is updated.

- Resets stale service-side pipe state after E_BS_INVALID_SESSION, allowing the session to remount through a fresh tablet pipe.

- Preserves the existing blue-green behavior for endpoints without cells.


### Issue
Put links to the related issues here
