### PR TITLE
[Blockstore] Stabilize mixed blocks filter loading test

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13325,6 +13325,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
     Y_UNIT_TEST(ShouldLoadMixedBlocksFilterByCompactionRanges)
     {
         constexpr ui32 rangeSize = 1024;
+        constexpr ui32 expectedLoadRequestCount = 4;
 
         auto config = DefaultConfig();
         config.SetMixedBlocksFilterEnabled(true);
@@ -13333,27 +13334,29 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         auto runtime = PrepareTestActorRuntime(config, 5 * rangeSize);
 
         TPartitionClient partition(*runtime);
-        partition.WaitReady();
-
-        partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 1);
-        partition.WriteBlocks(TBlockRange32::WithLength(4 * rangeSize, 1), 2);
-        partition.Flush();
 
         TVector<std::pair<ui32, char>> writtenBlocks;
         const auto writeClient = runtime->AllocateEdgeActor();
         ui32 flushCount = 0;
+        ui32 initialLoadRequestCount = 0;
         ui32 loadRequestCount = 0;
+        bool initialGeneration = true;
         auto observer = runtime->AddObserver<
             TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest>(
             [&](TEvPartitionPrivate::TEvLoadMixedBlocksFilterChunkRequest::TPtr&
                     event)
             {
+                if (initialGeneration) {
+                    ++initialLoadRequestCount;
+                    return;
+                }
+
                 ++loadRequestCount;
 
                 // The last request only discovers that all ranges have been
                 // loaded. The ranges themselves are selected by its handler,
                 // not carried by the scheduled event.
-                if (loadRequestCount > 3) {
+                if (loadRequestCount == expectedLoadRequestCount) {
                     return;
                 }
 
@@ -13384,11 +13387,29 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 ++flushCount;
             });
 
+        partition.WaitReady();
+
+        runtime->WaitFor(
+            "mixed blocks filter load for initial tablet generation",
+            [&] {
+                return initialLoadRequestCount == expectedLoadRequestCount;
+            });
+        initialGeneration = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(4 * rangeSize, 1), 2);
+        partition.Flush();
+
         partition.RebootTablet();
         partition.WaitReady();
-        runtime->DispatchEvents({}, TDuration::Seconds(1));
 
-        UNIT_ASSERT_VALUES_EQUAL(4, loadRequestCount);
+        runtime->WaitFor(
+            "mixed blocks filter load after tablet reboot",
+            [&] {
+                return loadRequestCount == expectedLoadRequestCount;
+            });
+
+        UNIT_ASSERT_VALUES_EQUAL(expectedLoadRequestCount, loadRequestCount);
 
         for (size_t i = 0; i < writtenBlocks.size(); ++i) {
             const auto response = runtime->GrabEdgeEventRethrow<


### PR DESCRIPTION
### Notes
Observe filter-loading requests from the initial tablet generation and wait for the terminal request before switching the observer to the reboot phase. The test also waits for the terminal request after reboot instead of relying on a fixed timeout. This prevents a delayed request from the old generation from being counted together with requests from the new generation and stabilizes `ShouldLoadMixedBlocksFilterByCompactionRanges` across test runtimes.

Wait for the terminal filter-loading request from the initial generation before switching the observer to the reboot phase, ensuring that it sees requests from the new generation only.

### Issue
Related issue: https://github.com/ydb-platform/nbs/issues/6390

Asynchronous mixed blocks filter loading is already enabled for the initial tablet generation. The test installs its observer only after the initial writes and immediately before `RebootTablet()`. 

In Arcadia the initial generation may stop before filter loading has finished, leaving a scheduled load request addressed to the old tablet. The observer then counts that stale request together with the four expected requests from the new generation, so `loadRequestCount` becomes 5 instead of 4. 

```
2026-08-13T16:28:21.386756Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor.cpp:374: [p:72075186223972353 g:2 d:test t:5.725ms] Activated executor
2026-08-13T16:28:21.409600Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor_initschema.cpp:47: [p:72075186223972353 g:2 d:test t:28.563ms] Schema initialized
2026-08-13T16:28:21.409841Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor_loadstate.cpp:95: [p:72075186223972353 g:2 d:test t:28.812ms] Reading state from local db
2026-08-13T16:28:21.410164Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor_loadstate.cpp:144: [p:72075186223972353 g:2 d:test t:29.139ms] State data loaded
2026-08-13T16:28:21.412950Z node 28 :BLOCKSTORE_PARTITION INFO: actor_loadfreshblobs.cpp:58: [72075186223972353] TLoadFreshBlobsActor: loading fresh blobs from channel 4
2026-08-13T16:28:21.413023Z node 28 :BLOCKSTORE_PARTITION INFO: actor_loadfreshblobs.cpp:113: [72075186223972353] TLoadFreshBlobsActor: sending EvRange 0:0, 4294967295:4294967295 to group 0
2026-08-13T16:28:21.413481Z node 28 :BLOCKSTORE_PARTITION INFO: actor_loadfreshblobs.cpp:194: [72075186223972353] Read fresh blobs (blob count: 0, total blob size: 0)
2026-08-13T16:28:21.413550Z node 28 :BLOCKSTORE_PARTITION INFO: fresh_blocks_companion_initfreshblocks.cpp:54: [p:72075186223972353 g:2 d:test t:32.525ms] Loaded fresh blobs
2026-08-13T16:28:21.413666Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor.cpp:154: [p:72075186223972353 g:2 d:test t:32.641ms] State initialization finished
2026-08-13T16:28:21.414628Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor.cpp:672: [p:72075186223972353 g:2 d:test t:33.595ms] Send garbage collector completed
2026-08-13T16:28:21.443912Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor.cpp:695: [p:72075186223972353 g:2 d:test t:62.870ms] Stop tablet because of PoisonPill request
Leader for TabletID 72075186223972353 is [28:117:2147] sender: [28:165:2059] recipient: [28:106:2140]
Leader for TabletID 72075186223972353 is [28:117:2147] sender: [28:168:2059] recipient: [28:167:2187]
Leader for TabletID 72075186223972353 is [28:169:2188] sender: [28:170:2059] recipient: [28:167:2187]
2026-08-13T16:28:21.459478Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor.cpp:374: [p:72075186223972353 g:3 d:test t:12.970ms] Activated executor
2026-08-13T16:28:21.461371Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor_initschema.cpp:47: [p:72075186223972353 g:3 d:test t:14.867ms] Schema initialized
2026-08-13T16:28:21.462170Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor_loadstate.cpp:95: [p:72075186223972353 g:3 d:test t:15.668ms] Reading state from local db
2026-08-13T16:28:21.462686Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor_loadstate.cpp:144: [p:72075186223972353 g:3 d:test t:16.189ms] State data loaded
2026-08-13T16:28:21.467094Z node 28 :BLOCKSTORE_PARTITION INFO: actor_loadfreshblobs.cpp:58: [72075186223972353] TLoadFreshBlobsActor: loading fresh blobs from channel 4
2026-08-13T16:28:21.467179Z node 28 :BLOCKSTORE_PARTITION INFO: actor_loadfreshblobs.cpp:113: [72075186223972353] TLoadFreshBlobsActor: sending EvRange 2:3, 4294967295:4294967295 to group 0
2026-08-13T16:28:21.470022Z node 28 :BLOCKSTORE_PARTITION INFO: actor_loadfreshblobs.cpp:194: [72075186223972353] Read fresh blobs (blob count: 0, total blob size: 0)
2026-08-13T16:28:21.470266Z node 28 :BLOCKSTORE_PARTITION INFO: fresh_blocks_companion_initfreshblocks.cpp:54: [p:72075186223972353 g:3 d:test t:23.767ms] Loaded fresh blobs
2026-08-13T16:28:21.470439Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor.cpp:154: [p:72075186223972353 g:3 d:test t:23.943ms] State initialization finished
2026-08-13T16:28:21.474280Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor.cpp:672: [p:72075186223972353 g:3 d:test t:27.764ms] Send garbage collector completed
2026-08-13T16:28:21.551632Z node 28 :BLOCKSTORE_PARTITION INFO: part_actor_loadstate.cpp:600: [p:72075186223972353 g:3 d:test t:105.116ms] Mixed blocks filter loaded
[[bad]]assertion failed at cloud/blockstore/libs/storage/partition/part_ut.cpp:13390, virtual void NCloud::NBlockStore::NStorage::NPartition::NTestSuiteTPartitionTest::TTestCaseShouldLoadMixedBlocksFilterByCompactionRanges::Execute_(NUnitTest::TTestContext &): (4 == loadRequestCount) failed: (4 != 5) [[rst]]
[[alt1]]TBackTrace::Capture()+31 (0x136DE11F)
NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char>> const&, bool)+590 (0x13BDB8CE)
NCloud::NBlockStore::NStorage::NPartition::NTestSuiteTPartitionTest::TTestCaseShouldLoadMixedBlocksFilterByCompactionRanges::Execute_(NUnitTest::TTestContext&)+5062 (0x130EFF86)
std::__y1::__function::__func<NCloud::NBlockStore::NStorage::NPartition::NTestSuiteTPartitionTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NStorage::NPartition::NTestSuiteTPartitionTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()()+466 (0x13233BC2)
TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+540 (0x13C0CD5C)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+504 (0x13BE2DF8)
NCloud::NBlockStore::NStorage::NPartition::NTestSuiteTPartitionTest::TCurrentTest::Execute()+1435 (0x13232DAB)
NUnitTest::TTestFactory::Execute()+2176 (0x13BE4600)
NUnitTest::RunMain(int, char**)+6429 (0x13C063DD)
__libc_start_main+243 (0x7F18D1A59083)
_start+41 (0x106D2029)
[[rst]]
```
