### PR TITLE
issue-6208: [Filestore] Introduce a new api action for diagnostic stats

### DIFF
--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -33,6 +33,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CreateSession,              __VA_ARGS__)                               \
     xxx(DestroySession,             __VA_ARGS__)                               \
     xxx(GetStorageStats,            __VA_ARGS__)                               \
+    xxx(GetDiagnosticStats,         __VA_ARGS__)                               \
     xxx(GetFileSystemConfig,        __VA_ARGS__)                               \
     xxx(GetStorageConfigFields,     __VA_ARGS__)                               \
     xxx(ChangeStorageConfig,        __VA_ARGS__)                               \
@@ -77,6 +78,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CreateSession,              __VA_ARGS__)                               \
     xxx(DestroySession,             __VA_ARGS__)                               \
     xxx(GetStorageStats,            __VA_ARGS__)                               \
+    xxx(GetDiagnosticStats,         __VA_ARGS__)                               \
     xxx(GetFileSystemConfig,        __VA_ARGS__)                               \
     xxx(GetStorageConfigFields,     __VA_ARGS__)                               \
     xxx(ChangeStorageConfig,        __VA_ARGS__)                               \
@@ -238,6 +240,9 @@ struct TEvIndexTablet
 
         EvListQuotasRequest = EvBegin + 89,
         EvListQuotasResponse,
+
+        EvGetDiagnosticStatsRequest = EvBegin + 91,
+        EvGetDiagnosticStatsResponse,
 
         // After the TABLET sub-namespace we have TABLET_WORKER and TABLET_PROXY
         // sub-namespaces which don't have any non-local events so if we run out

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -303,6 +303,10 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
+    NActors::IActorPtr CreateGetDiagnosticStatsActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
     NActors::IActorPtr CreateListLocalFileStoresActionActor(
         TRequestInfoPtr requestInfo,
         TString input);

--- a/cloud/filestore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions.cpp
@@ -121,6 +121,10 @@ void TStorageServiceActor::HandleExecuteAction(
             &TStorageServiceActor::CreateGetStorageStatsActionActor
         },
         {
+            "getdiagnosticstats",
+            &TStorageServiceActor::CreateGetDiagnosticStatsActionActor
+        },
+        {
             "listlocalfilestores",
             &TStorageServiceActor::CreateListLocalFileStoresActionActor,
         },

--- a/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
@@ -51,6 +51,18 @@ IActorPtr TStorageServiceActor::CreateGetStorageStatsActionActor(
         std::move(input));
 }
 
+IActorPtr TStorageServiceActor::CreateGetDiagnosticStatsActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TGetDiagnosticStatsActor = TTabletActionActor<
+        TEvIndexTablet::TEvGetDiagnosticStatsRequest,
+        TEvIndexTablet::TEvGetDiagnosticStatsResponse>;
+    return std::make_unique<TGetDiagnosticStatsActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // UnsafeNodeOps / UnsafeNodeRefOps
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -138,6 +138,29 @@ message TNodeLatencyStats
     uint64 LastAccessedTimestampUs = 7;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// GetDiagnosticStats request/response.
+
+message TGetDiagnosticStatsRequest
+{
+    // Optional request headers.
+    NProto.THeaders Headers = 1;
+
+    // FileSystem identifier.
+    string FileSystemId = 2;
+}
+
+message TGetDiagnosticStatsResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    repeated TNodeLatencyStats LatencyStats = 2;
+
+    repeated TNodeStats NodeStats = 3;
+}
+
+
 message TStorageStats
 {
     // index stats
@@ -191,11 +214,6 @@ message TStorageStats
 
     // shard stats
     repeated TShardStats ShardStats = 6001;
-
-    // recent node request stats
-    repeated TNodeStats NodeStats = 7001;
-
-    repeated TNodeLatencyStats LatencyStats = 8001;
 }
 
 enum EStatsRequestMode

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -214,6 +214,11 @@ message TStorageStats
 
     // shard stats
     repeated TShardStats ShardStats = 6001;
+
+    // recent node request stats
+    repeated TNodeStats NodeStats = 7001;
+
+    repeated TNodeLatencyStats LatencyStats = 8001;
 }
 
 enum EStatsRequestMode


### PR DESCRIPTION
### Notes
The goal is to be able to send a request to each shard, instead of having `getStorageStats` on the main tablet be responsible for aggregating results from all shards.

### Issue
https://github.com/ydb-platform/nbs/issues/6208
