### PR TITLE
Enable CI for stacked PRs

### DIFF
--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -52,6 +52,10 @@ concurrency:
 
 jobs:
   check-running-allowed:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.base.ref == github.event.pull_request.base.ref
     runs-on: [self-hosted, "self-hosted", "runner_light"]
     outputs:
       result: ${{ steps.allow-local.outputs.result || steps.check-ownership-membership.outputs.result }}

--- a/.github/workflows/pr-vscode-yatool-extension.yaml
+++ b/.github/workflows/pr-vscode-yatool-extension.yaml
@@ -25,6 +25,9 @@ defaults:
 
 jobs:
   check-running-allowed:
+    if: >-
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.base.ref == github.event.pull_request.base.ref
     runs-on: [self-hosted, "self-hosted", "runner_light"]
     outputs:
       result: ${{ steps.allow-local.outputs.result || steps.check-ownership-membership.outputs.result }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,6 +29,9 @@ concurrency:
 
 jobs:
   check-running-allowed:
+    if: >-
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.base.ref == github.event.pull_request.base.ref
     runs-on: [self-hosted, "self-hosted", "runner_light"]
     outputs:
       result: ${{ steps.check-ownership-membership.outputs.result }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,6 +23,9 @@ permissions:
 
 jobs:
   check-running-allowed:
+    if: >-
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.base.ref == github.event.pull_request.base.ref
     runs-on: [ self-hosted, "self-hosted", "runner_light" ]
     outputs:
       result: ${{ steps.check-ownership-membership.outputs.result }}


### PR DESCRIPTION
https://docs.github.com/en/pull-requests/get-started/stacked-prs-quickstart

TLDR: this is sugared version for the chain of branches, that is updated automagically. Useful for large PRs that should be reviewed separately but merged all at once.

Currently it will run checks only for the bottom branch (first in chain of commits) and in theory should launch checks on next commit when first one is merged. In ideal world we should launch checks on bottom and top of the stack, to prevent merging unchecked changes. But if used properly, e.g. merging changes bottom-up, we should have history of changes working.