### PR TITLE
[Disk Manager] Strip extra "Bearer " prefix in SetOutgoingAccessToken()

### DIFF
--- a/cloud/disk_manager/internal/pkg/headers/headers.go
+++ b/cloud/disk_manager/internal/pkg/headers/headers.go
@@ -75,11 +75,15 @@ func GetAccessToken(ctx context.Context) (string, error) {
 }
 
 func SetOutgoingAccessToken(ctx context.Context, token string) context.Context {
+	if !strings.HasPrefix(token, tokenPrefix) {
+		token = tokenPrefix + token
+	}
+
 	return appendToOutgoingContext(
 		ctx,
 		grpc_metadata.Pairs(
 			"authorization",
-			fmt.Sprintf("Bearer %v", token),
+			token,
 		),
 	)
 }

--- a/cloud/disk_manager/internal/pkg/headers/headers.go
+++ b/cloud/disk_manager/internal/pkg/headers/headers.go
@@ -75,6 +75,7 @@ func GetAccessToken(ctx context.Context) (string, error) {
 }
 
 func SetOutgoingAccessToken(ctx context.Context, token string) context.Context {
+	// Some credentials add "Bearer " prefix to the token, add prefix otherwise.
 	if !strings.HasPrefix(token, tokenPrefix) {
 		token = tokenPrefix + token
 	}


### PR DESCRIPTION
Some credentials add "Bearer " prefix to the token.
https://github.com/ydb-platform/nbs/blob/28e8e56f6eb017c65952b9d627170f54c77cfd7b/vendor/github.com/ydb-platform/ydb-go-sdk/v3/internal/credentials/oauth2.go#L457