### PR TITLE
issue-5894: fixing an accept/shutdown race in fastshard server and sn server

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server.cpp
@@ -447,6 +447,32 @@ int AcceptFiberMain(TAcceptParams* params) noexcept
         if (which == 1) {
             acceptFuture.cancel();
             acceptFuture.wait();
+
+            //
+            // Drain connections whose handshake has already completed:
+            // their clients saw connect() succeed, so they must go
+            // through the regular handler shutdown (FIN via
+            // THandlerRegistry::Stop) instead of being reset when the
+            // listening socket is closed. Stop() waits for this fiber
+            // before stopping the registry, so every handler
+            // registered here is shut down and waited for.
+            //
+
+            for (;;) {
+                int cfd = ::accept4(
+                    lfd,
+                    nullptr /* addr */,
+                    nullptr /* addrlen */,
+                    SOCK_NONBLOCK | SOCK_CLOEXEC);
+                if (cfd >= 0) {
+                    RegisterHandler(cfd, *handlers, registry);
+                    continue;
+                }
+                if (errno == EINTR || errno == ECONNABORTED) {
+                    continue;
+                }
+                break;
+            }
             return 0;
         }
 

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
@@ -392,6 +392,32 @@ int AcceptFiberMain(TAcceptParams* params) noexcept
         if (which == 1) {
             acceptFuture.cancel();
             acceptFuture.wait();
+
+            //
+            // Drain connections whose handshake has already completed:
+            // their clients saw connect() succeed, so they must go
+            // through the regular handler shutdown (FIN via
+            // THandlerRegistry::Stop) instead of being reset when the
+            // listening socket is closed. Stop() waits for this fiber
+            // before stopping the registry, so every handler
+            // registered here is shut down and waited for.
+            //
+
+            for (;;) {
+                int cfd = ::accept4(
+                    lfd,
+                    nullptr /* addr */,
+                    nullptr /* addrlen */,
+                    SOCK_NONBLOCK | SOCK_CLOEXEC);
+                if (cfd >= 0) {
+                    RegisterHandler(cfd, *handlers, storage);
+                    continue;
+                }
+                if (errno == EINTR || errno == ECONNABORTED) {
+                    continue;
+                }
+                break;
+            }
             return 0;
         }
 


### PR DESCRIPTION
### Notes
Caught an unexpected `ECONNRESET` error instead of the expected `EIO` (`EIO` is generated by the `RecvAll()` code itself when it receives 0 bytes from the socket) in the `ServerTest.StopClosesIdleConnection` sn server test. This is the result of returning `RST` by the server instead of gracefully shutting down the connection (`FIN -> FIN+ACK -> ACK`). Happens because there can be a pending connection in the listen socket's backlog at the time when we shut the server down and thus there's a small time window between shutdown and accept4 during which we might end up realizing that we need to shut down.

Fixing this simply by `accept4`-ing everything that we can accept before closing the listen socket. There's actually still a small time window within which a connection can fall into socket's backlog but then get `RST`-ed but now there's a guarantee that this doesn't happen for the connections that were received before `Stop()` was called. And it seems to be impossible to guarantee `FIN`s anyway because there's no way to force `connect()` to fail via Linux socket API. Anyway, any sane client needs to be able to process `RST` so this is not an issue.

### Issue
https://github.com/ydb-platform/nbs/issues/5894
