### PR TITLE
feat: allow one-off CI for stacked PRs

### DIFF
--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -54,6 +54,7 @@ jobs:
   check-running-allowed:
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'recheck') ||
       github.event.pull_request.stack == null ||
       github.event.pull_request.stack.base.ref == github.event.pull_request.base.ref
     runs-on: [self-hosted, "self-hosted", "runner_light"]

--- a/.github/workflows/pr-vscode-yatool-extension.yaml
+++ b/.github/workflows/pr-vscode-yatool-extension.yaml
@@ -26,6 +26,7 @@ defaults:
 jobs:
   check-running-allowed:
     if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'recheck') ||
       github.event.pull_request.stack == null ||
       github.event.pull_request.stack.base.ref == github.event.pull_request.base.ref
     runs-on: [self-hosted, "self-hosted", "runner_light"]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   check-running-allowed:
     if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'recheck') ||
       github.event.pull_request.stack == null ||
       github.event.pull_request.stack.base.ref == github.event.pull_request.base.ref
     runs-on: [self-hosted, "self-hosted", "runner_light"]

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   check-running-allowed:
     if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'recheck') ||
       github.event.pull_request.stack == null ||
       github.event.pull_request.stack.base.ref == github.event.pull_request.base.ref
     runs-on: [ self-hosted, "self-hosted", "runner_light" ]


### PR DESCRIPTION
Apply 'recheck' label to stacked PR and it should launch checks even if PR is not bottom of the stack.