### PR TITLE
issue-3781: TFileRingBuffer - allow ReadPos and WritePos to be non-aligned for an empty buffer

### DIFF
--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
@@ -201,6 +201,20 @@ NProto::TError ValidateData(
 {
     auto capabilities = dataProcessor.GetCapabilities(false);
 
+    // For an empty buffer, one of the following conditions should be met:
+    // - readPos == writePos (alignment doesn't matter);
+    // - writePos == 0 and readPos points to a slack space.
+    //
+    // For a non-empty buffer, all the following conditions should be met:
+    // - readPos points to the first entry;
+    // - writePos points to the next byte after the last entry.
+
+    if (readPos == writePos) {
+        // Empty buffer
+        // It is possible that ReadPos and WritePos are not properly aligned
+        return {};
+    }
+
     if (capabilities.Alignment > 0) {
         if (readPos % capabilities.Alignment != 0) {
             return MakeError(Sprintf(
@@ -217,19 +231,6 @@ NProto::TError ValidateData(
                 writePos,
                 capabilities.Alignment));
         }
-    }
-
-    // For an empty buffer, one of the following conditions should be met:
-    // - readPos == writePos;
-    // - writePos == 0 and readPos points to a slack space.
-    //
-    // For a non-empty buffer, all the following conditions should be met:
-    // - readPos points to the first entry;
-    // - writePos points to the next byte after the last entry.
-
-    if (readPos == writePos) {
-        // Empty buffer
-        return {};
     }
 
     if (writePos == 0) {

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -1267,7 +1267,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             auto* header = accessor.GetHeader();
 
             UNIT_ASSERT_VALUES_EQUAL(header->ReadPos, header->WritePos);
-            UNIT_ASSERT_VALUES_UNEQUAL(0, header->ReadPos % 8);
+            UNIT_ASSERT_VALUES_UNEQUAL(0, header->ReadPos % sizeof(ui64));
 
             header->Version = EVersion::V6;
         }

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -1,4 +1,5 @@
 #include "file_ring_buffer.h"
+#include "file_ring_buffer_accessor.h"
 
 #include <library/cpp/string_utils/base64/base64.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -1239,6 +1240,42 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         // Version downgrade
         check(EVersion::V6, EVersion::V5);
+    }
+
+    Y_UNIT_TEST(ShouldValidateEmptyBufferWithUnalignedPos)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 36;
+
+        {
+            TFileRingBuffer rb(f.GetName(), len, 0, EVersion::V5);
+            rb.PushBack("a");
+            rb.PopFront();
+        }
+
+        {
+            TFileMapFileRingBufferAccessor accessor(
+                f.GetName(),
+                EFileRingBufferAccessorValidationMode::Debug,
+                TMemoryMapCommon::EOpenModeFlag::oRdWr);
+
+            UNIT_ASSERT(!HasError(accessor.Map()));
+            UNIT_ASSERT_VALUES_EQUAL(
+                EFileRingBufferAccessorValidationStatus::Success,
+                accessor.ValidateAndInitialize());
+
+            auto* header = accessor.GetHeader();
+
+            UNIT_ASSERT_VALUES_EQUAL(header->ReadPos, header->WritePos);
+            UNIT_ASSERT_VALUES_UNEQUAL(0, header->ReadPos % 8);
+
+            header->Version = EVersion::V6;
+        }
+
+        {
+            TFileRingBuffer rb(f.GetName(), len, 0, EVersion::V6);
+            UNIT_ASSERT(rb.PushBack("b"));
+        }
     }
 }
 


### PR DESCRIPTION
### Notes

This PR resolves the issue:
```
2026-08-17T14:39:21.271700Z :NFS_VHOST INFO: CRITICAL_EVENT:AppCriticalEvents/WriteBackCacheCorruptionError: [f:***][c:***] WriteBackCache persistent storage initialization failed: { Code: 2147483648 Message: "Data structure is corrupted" }, FilePath: "***"
2026-08-17T14:36:28.154507Z :NFS_VHOST INFO: CRITICAL_EVENT:AppCriticalEvents/FileRingBufferCorruptionDetectedError: Corruption detected in FileRingBuffer, path: ***, message: E_FAIL Invalid file ring buffer read position 1570 (expected to be aligned to 8)
```

This happened after merging https://github.com/ydb-platform/nbs/pull/6654 — this PR introduced paranoidal checks for the `TFileRingBuffer` structure. In short, it fails to validate the structure that is technically valid but cannot be produced by the code.

Background info:
- There are two current formats of `TFileRingBuffer`: V5 and V6;
- Format V5 allows unaligned `ReadPos` and `WritePos`;
- Format V6 enforces alignment for all positions;
- Migration from V5 to V6 happens only when the buffer is empty;
- An empty condition is: `ReadPos == WritePos`, not necessarily zero.

Currently, the values of `ReadPos` and `WritePos` and set to zero before the migration:
https://github.com/ydb-platform/nbs/blob/23ebb66d2131b532868ed362f265466d76522ce4/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp#L280-L284
So unaligned `ReadPos` and `WritePos` in V6 are not possible.

Previously, only the version field was changed. After migration to V6, it started with unaligned `ReadPos` and `WritePos`. The values were reset to zero after the first `Alloc` call:
https://github.com/ydb-platform/nbs/blob/23ebb66d2131b532868ed362f265466d76522ce4/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp#L545-L553
An attempt to write a slack space marker at a non-aligned position failed but it was just ignored.

The requirements to trigger the problem:
1. WriteBackCache should be turned on for a filesystem.
2. A migration from V5 to V6 should happen before zeroing `ReadPos` and `WritePos` at migration was implemented.
3. No data was written after migration.

### Issue
https://github.com/ydb-platform/nbs/issues/1751