### PR TITLE
[Filestore] implement availability counters

### DIFF
--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -127,4 +127,10 @@ message TFileSystemConfig
 
     // Async processing of read-only create handle requests.
     optional bool AsyncCreateHandleEnabled = 37;
+
+    // Enables the per-client filesystem availability tracking.
+    optional bool AvailabilityTrackingEnabled = 38;
+
+    // Availability interval duration (in ms); 0 means the default.
+    optional uint32 AvailabilityTrackingInterval = 39;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -896,4 +896,10 @@ message TStorageConfig
 
     // Sets the time after which latency of a node + request tuple will decrease by half.
     optional uint32 NodeLatencyHalfLife = 538; // measured in ms
+
+    // Enables the per-client filesystem availability tracking on the guest.
+    optional bool AvailabilityTrackingEnabled = 539;
+
+    // Availability interval duration (in ms); 0 means the default.
+    optional uint32 AvailabilityTrackingInterval = 540;
 }

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -97,7 +97,7 @@ void TAvailabilityCounters::Register(NMonitoring::TDynamicCounters& counters)
         "Availability_MissingIntervals",
         true);   // derivative
 
-    // no intervals have been reported yet - start as available
+    // No intervals have been reported yet - start as available.
     *LastIntervalAvailableCounter = 1;
 
     // index 0 is EFileStoreAvailabilityRequestType::None and stays unused
@@ -264,20 +264,15 @@ void TAvailabilityCounters::FinishInterval()
 {
     bool intervalAvailable = true;
 
-    // index 0 is EFileStoreAvailabilityRequestType::None and stays unused
+    // Index 0 is EFileStoreAvailabilityRequestType::None and stays unused.
     for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
         auto& state = RequestTypeStates[i];
 
         TGuard g{state.Lock};
 
-        // Inflight >= InflightStartedInInterval holds because every
-        // registered completion consumes exactly one registration stamp:
-        // completions of requests started in the current interval decrement
-        // both counters, completions of older requests decrement Inflight
-        // only, and there can be no more of the latter than there are older
-        // requests still counted in Inflight. The subtraction is clamped
-        // defensively so that a violation can never wrap it into a huge
-        // hung count.
+        // Inflight >= InflightStartedInInterval holds but the subtraction is
+        // clamped defensively so that a violation can never wrap it into a
+        // huge hung count.
         Y_DEBUG_ABORT_UNLESS(
             state.Inflight >= state.InflightStartedInInterval);
         // Requests that were outstanding at the interval start and are still
@@ -301,8 +296,8 @@ void TAvailabilityCounters::FinishInterval()
         const bool requestTypeAvailable =
             !hadFailedRequest || hadNonFailedRequest;
         if (!requestTypeAvailable) {
-            // the aggregated interval availability is the logical AND over
-            // the request types
+            // The aggregated interval availability is the logical AND over
+            // the request types.
             intervalAvailable = false;
         }
 

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -15,11 +15,11 @@ namespace {
 
 // Limits the number of intervals finished by a single UpdateStats() call.
 // Protects against unbounded catch-up loops after large forward clock jumps.
-// With the default 5-minute interval this covers a stats-updater stall of up
+// With the default 2-minute interval this covers a stats-updater stall of up
 // to one hour, anything beyond that realigns without evaluation.
-constexpr size_t MaxIntervalsPerUpdate = 12;
+constexpr size_t MaxIntervalsPerUpdate = 30;
 
-constexpr TDuration DefaultIntervalDuration = TDuration::Minutes(5);
+constexpr TDuration DefaultIntervalDuration = TDuration::Minutes(2);
 
 }   // namespace
 

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -97,7 +97,7 @@ void TAvailabilityCounters::EnableAndRegister(
     // No intervals have been reported yet - start as available.
     *LastIntervalAvailableCounter = 1;
 
-    // index 0 is EFileStoreAvailabilityRequestType::None and stays unused
+    // Index 0 is EFileStoreAvailabilityRequestType::None and stays unused.
     for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
         auto& state = RequestTypeStates[i];
         auto requestCounters = counters.GetSubgroup(
@@ -121,7 +121,9 @@ void TAvailabilityCounters::EnableAndRegister(
     CountersRegistered.store(true, std::memory_order_release);
 }
 
-void TAvailabilityCounters::RequestStarted(TCallContext& callContext)
+void TAvailabilityCounters::RequestStarted(
+    TCallContext& callContext,
+    TInstant now)
 {
     if (!CountersRegistered.load(std::memory_order_acquire)) {
         return;
@@ -136,11 +138,35 @@ void TAvailabilityCounters::RequestStarted(TCallContext& callContext)
     auto& state = RequestTypeStates[
         static_cast<size_t>(callContext.AvailabilityRequestType)];
 
-    TGuard g{state.Lock};
+    for (;;) {
+        // Assign the event to its actual wall-clock interval: roll the
+        // elapsed intervals over before applying it.
+        RollIntervals(now);
 
-    // A repeated registration without a completion in between would leak the
-    // previous registration's accounting: only one completion follows, so
-    // the extra inflight unit would be reported as hung forever.
+        TGuard g{state.Lock};
+
+        // The interval may have rolled between RollIntervals() and taking
+        // the state lock - retry so that the event can never be applied to
+        // an interval that has already ended.
+        if (now.MicroSeconds() >=
+            CurrentIntervalEndUs.load(std::memory_order_acquire))
+        {
+            continue;
+        }
+
+        DoRequestStarted(callContext, state);
+        return;
+    }
+}
+
+// Protected by state.Lock.
+void TAvailabilityCounters::DoRequestStarted(
+    TCallContext& callContext,
+    TRequestTypeState& state)
+{
+    // A repeated registration without a completion in between would leak
+    // the previous registration's accounting: only one completion follows,
+    // so the extra inflight unit would be reported as hung forever.
     if (callContext.AvailabilityIntervalSeqNo != 0) {
         ReportAvailabilityCountersDoubleRegistration(
             TStringBuilder() << "request type: "
@@ -152,16 +178,11 @@ void TAvailabilityCounters::RequestStarted(TCallContext& callContext)
     ++state.InflightStartedInInterval;
 
     callContext.AvailabilityIntervalSeqNo = state.IntervalSeqNo;
-
-    // A registration starts a fresh attempt: clear the outcome of a possible
-    // previous attempt of this context. Production success replies do not
-    // write GuestReplyErrno - they rely on it being 0 - so a restarted
-    // context would otherwise be classified with the stale EIO of its
-    // previous attempt.
-    callContext.GuestReplyErrno = 0;
 }
 
-void TAvailabilityCounters::RequestCompleted(TCallContext& callContext)
+void TAvailabilityCounters::RequestCompleted(
+    TCallContext& callContext,
+    TInstant now)
 {
     if (!CountersRegistered.load(std::memory_order_acquire)) {
         return;
@@ -176,16 +197,39 @@ void TAvailabilityCounters::RequestCompleted(TCallContext& callContext)
     auto& state = RequestTypeStates[
         static_cast<size_t>(callContext.AvailabilityRequestType)];
 
-    TGuard g{state.Lock};
+    for (;;) {
+        // Assign the event to its actual wall-clock interval: roll the
+        // elapsed intervals over before applying it, so that a completion
+        // arriving after an interval boundary cannot retroactively make the
+        // interval it hung through available.
+        RollIntervals(now);
 
-    // Every completion is expected to pair with exactly one registration:
-    // the stamp is put there by RequestStarted() and consumed below by the
-    // first completion, so a zero stamp means an unregistered or repeated
-    // completion.
+        TGuard g{state.Lock};
+
+        // The interval may have rolled between RollIntervals() and taking
+        // the state lock - retry so that the event can never be applied to
+        // an interval that has already ended.
+        if (now.MicroSeconds() >=
+            CurrentIntervalEndUs.load(std::memory_order_acquire))
+        {
+            continue;
+        }
+
+        DoRequestCompleted(callContext, state);
+        return;
+    }
+}
+
+// Protected by state.Lock.
+void TAvailabilityCounters::DoRequestCompleted(
+    TCallContext& callContext,
+    TRequestTypeState& state)
+{
+    // The stamp is put there by RequestStarted() and consumed below by the
+    // first completion. A zero stamp means the request either started
+    // before the tracking was enabled or was already completed, it is
+    // ignored either way.
     if (callContext.AvailabilityIntervalSeqNo == 0) {
-        ReportAvailabilityCountersUnpairedCompletion(
-            TStringBuilder() << "request type: "
-                << static_cast<ui32>(callContext.AvailabilityRequestType));
         return;
     }
 
@@ -219,10 +263,31 @@ void TAvailabilityCounters::UpdateStats(TInstant now)
         return;
     }
 
+    RollIntervals(now);
+}
+
+void TAvailabilityCounters::RollIntervals(TInstant now)
+{
+    // Fast path: an event or update well inside the current interval.
+    if (now.MicroSeconds() <
+        CurrentIntervalEndUs.load(std::memory_order_acquire))
+    {
+        return;
+    }
+
+    TGuard g{RollLock};
+
     if (!CurrentIntervalStart) {
-        // First call - start measuring from the current wall-clock-aligned
-        // interval boundary so that intervals of all clients are aligned.
+        // First event or update - start measuring from the current
+        // wall-clock-aligned interval boundary so that intervals of all
+        // clients are aligned. If the measurement does not begin exactly at
+        // a boundary, the first interval is only partially observed and is
+        // rolled over without classification below.
         CurrentIntervalStart = AlignToInterval(now);
+        SkipCurrentInterval = now != CurrentIntervalStart;
+        CurrentIntervalEndUs.store(
+            (CurrentIntervalStart + IntervalDuration).MicroSeconds(),
+            std::memory_order_release);
         return;
     }
 
@@ -230,13 +295,90 @@ void TAvailabilityCounters::UpdateStats(TInstant now)
     while (now >= CurrentIntervalStart + IntervalDuration &&
            finishedIntervals < MaxIntervalsPerUpdate)
     {
-        // More than one interval may have elapsed if the stats updater was
-        // stalled. The first iteration evaluates all the accumulated data;
+        // More than one interval may have elapsed if neither the stats
+        // updater nor any request event has rolled the accounting for a
+        // while. The first iteration evaluates all the accumulated data;
         // subsequent iterations see empty per-interval counters, so a gap
         // interval is classified as unavailable iff some requests remained
-        // outstanding (i.e. hung) throughout it, which is exactly what the
-        // definition prescribes.
-        FinishInterval();
+        // outstanding (i.e. hung) throughout it.
+
+        // A partially observed interval (the one during which the
+        // measurement began mid-interval) is rolled over - accounting
+        // resets, outstanding requests become old - but is not classified
+        // or counted.
+        const bool skipClassification = SkipCurrentInterval;
+        SkipCurrentInterval = false;
+
+        bool intervalAvailable = true;
+
+        // Index 0 is EFileStoreAvailabilityRequestType::None, stays unused.
+        for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
+            auto& state = RequestTypeStates[i];
+
+            TGuard stateGuard{state.Lock};
+
+            // Inflight >= InflightStartedInInterval holds but the
+            // subtraction is clamped defensively so that a violation can
+            // never wrap it into a huge hung count.
+            Y_DEBUG_ABORT_UNLESS(
+                state.Inflight >= state.InflightStartedInInterval);
+            // Requests that were outstanding at the interval start and are
+            // still outstanding at the interval end, i.e. remained
+            // outstanding throughout the entire interval => hung.
+            const ui64 hung =
+                state.Inflight >= state.InflightStartedInInterval
+                    ? state.Inflight - state.InflightStartedInInterval
+                    : 0;
+
+            // A request type makes the interval unavailable if it shows
+            // failure evidence - at least one request completed with an EIO
+            // error during the interval or hung through it - and no success
+            // evidence - no request completed with a non-EIO outcome during
+            // the interval. Requests that were started during the interval
+            // and have not completed by its end count as neither: their
+            // outcome is not known yet and will be accounted for in the
+            // interval where they complete (or in the intervals they hang
+            // through).
+            const bool hadFailedRequest = state.CompletedEio > 0 || hung > 0;
+            const bool hadNonFailedRequest = state.CompletedNonEio > 0;
+
+            const bool requestTypeAvailable =
+                !hadFailedRequest || hadNonFailedRequest;
+            if (!requestTypeAvailable) {
+                // The aggregated interval availability is the logical AND
+                // over the request types.
+                intervalAvailable = false;
+            }
+
+            if (!skipClassification) {
+                if (requestTypeAvailable) {
+                    state.AvailableIntervalsCounter->Inc();
+                } else {
+                    state.UnavailableIntervalsCounter->Inc();
+                }
+                *state.LastIntervalAvailableCounter =
+                    requestTypeAvailable ? 1 : 0;
+            }
+
+            // Roll over to the next interval. All requests still
+            // outstanding become "outstanding since the interval start" for
+            // the new interval.
+            state.CompletedNonEio = 0;
+            state.CompletedEio = 0;
+            state.InflightStartedInInterval = 0;
+            ++state.IntervalSeqNo;
+        }
+
+        if (!skipClassification) {
+            TotalIntervalsCounter->Inc();
+            if (intervalAvailable) {
+                AvailableIntervalsCounter->Inc();
+            } else {
+                UnavailableIntervalsCounter->Inc();
+            }
+            *LastIntervalAvailableCounter = intervalAvailable ? 1 : 0;
+        }
+
         CurrentIntervalStart += IntervalDuration;
         ++finishedIntervals;
     }
@@ -251,73 +393,13 @@ void TAvailabilityCounters::UpdateStats(TInstant now)
             (alignedNow - CurrentIntervalStart).MicroSeconds() /
             IntervalDuration.MicroSeconds();
         MissingIntervalsCounter->Add(missingIntervals);
+
         CurrentIntervalStart = alignedNow;
     }
-}
 
-void TAvailabilityCounters::FinishInterval()
-{
-    bool intervalAvailable = true;
-
-    // Index 0 is EFileStoreAvailabilityRequestType::None and stays unused.
-    for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
-        auto& state = RequestTypeStates[i];
-
-        TGuard g{state.Lock};
-
-        // Inflight >= InflightStartedInInterval holds but the subtraction is
-        // clamped defensively so that a violation can never wrap it into a
-        // huge hung count.
-        Y_DEBUG_ABORT_UNLESS(
-            state.Inflight >= state.InflightStartedInInterval);
-        // Requests that were outstanding at the interval start and are still
-        // outstanding at the interval end, i.e. remained outstanding
-        // throughout the entire interval => hung.
-        const ui64 hung = state.Inflight >= state.InflightStartedInInterval
-            ? state.Inflight - state.InflightStartedInInterval
-            : 0;
-
-        // A request type makes the interval unavailable if it shows failure
-        // evidence - at least one request completed with an EIO error during
-        // the interval or hung through it - and no success evidence - no
-        // request completed with a non-EIO outcome during the interval.
-        // Requests that were started during the interval and have not
-        // completed by its end count as neither: their outcome is not known
-        // yet and will be accounted for in the interval where they complete
-        // (or in the intervals they hang through).
-        const bool hadFailedRequest = state.CompletedEio > 0 || hung > 0;
-        const bool hadNonFailedRequest = state.CompletedNonEio > 0;
-
-        const bool requestTypeAvailable =
-            !hadFailedRequest || hadNonFailedRequest;
-        if (!requestTypeAvailable) {
-            // The aggregated interval availability is the logical AND over
-            // the request types.
-            intervalAvailable = false;
-        }
-
-        if (requestTypeAvailable) {
-            state.AvailableIntervalsCounter->Inc();
-        } else {
-            state.UnavailableIntervalsCounter->Inc();
-        }
-        *state.LastIntervalAvailableCounter = requestTypeAvailable ? 1 : 0;
-
-        // Roll over to the next interval. All requests still outstanding
-        // become "outstanding since the interval start" for the new interval.
-        state.CompletedNonEio = 0;
-        state.CompletedEio = 0;
-        state.InflightStartedInInterval = 0;
-        ++state.IntervalSeqNo;
-    }
-
-    TotalIntervalsCounter->Inc();
-    if (intervalAvailable) {
-        AvailableIntervalsCounter->Inc();
-    } else {
-        UnavailableIntervalsCounter->Inc();
-    }
-    *LastIntervalAvailableCounter = intervalAvailable ? 1 : 0;
+    CurrentIntervalEndUs.store(
+        (CurrentIntervalStart + IntervalDuration).MicroSeconds(),
+        std::memory_order_release);
 }
 
 TInstant TAvailabilityCounters::AlignToInterval(TInstant instant) const

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -291,6 +291,20 @@ void TAvailabilityCounters::RollIntervals(TInstant now)
         return;
     }
 
+    if (SkipCurrentInterval &&
+        now >= CurrentIntervalStart + IntervalDuration)
+    {
+        // A partially observed interval (the one during which the
+        // measurement began mid-interval) is rolled over - accounting
+        // resets, outstanding requests become old - but is not classified
+        // or counted.
+        SkipCurrentInterval = false;
+        for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
+            RollRequestTypeState(RequestTypeStates[i], false /* publish */);
+        }
+        CurrentIntervalStart += IntervalDuration;
+    }
+
     size_t finishedIntervals = 0;
     while (now >= CurrentIntervalStart + IntervalDuration &&
            finishedIntervals < MaxIntervalsPerUpdate)
@@ -301,83 +315,25 @@ void TAvailabilityCounters::RollIntervals(TInstant now)
         // subsequent iterations see empty per-interval counters, so a gap
         // interval is classified as unavailable iff some requests remained
         // outstanding (i.e. hung) throughout it.
-
-        // A partially observed interval (the one during which the
-        // measurement began mid-interval) is rolled over - accounting
-        // resets, outstanding requests become old - but is not classified
-        // or counted.
-        const bool skipClassification = SkipCurrentInterval;
-        SkipCurrentInterval = false;
-
         bool intervalAvailable = true;
 
         // Index 0 is EFileStoreAvailabilityRequestType::None, stays unused.
         for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
-            auto& state = RequestTypeStates[i];
-
-            TGuard stateGuard{state.Lock};
-
-            // Inflight >= InflightStartedInInterval holds but the
-            // subtraction is clamped defensively so that a violation can
-            // never wrap it into a huge hung count.
-            Y_DEBUG_ABORT_UNLESS(
-                state.Inflight >= state.InflightStartedInInterval);
-            // Requests that were outstanding at the interval start and are
-            // still outstanding at the interval end, i.e. remained
-            // outstanding throughout the entire interval => hung.
-            const ui64 hung =
-                state.Inflight >= state.InflightStartedInInterval
-                    ? state.Inflight - state.InflightStartedInInterval
-                    : 0;
-
-            // A request type makes the interval unavailable if it shows
-            // failure evidence - at least one request completed with an EIO
-            // error during the interval or hung through it - and no success
-            // evidence - no request completed with a non-EIO outcome during
-            // the interval. Requests that were started during the interval
-            // and have not completed by its end count as neither: their
-            // outcome is not known yet and will be accounted for in the
-            // interval where they complete (or in the intervals they hang
-            // through).
-            const bool hadFailedRequest = state.CompletedEio > 0 || hung > 0;
-            const bool hadNonFailedRequest = state.CompletedNonEio > 0;
-
-            const bool requestTypeAvailable =
-                !hadFailedRequest || hadNonFailedRequest;
-            if (!requestTypeAvailable) {
+            if (!RollRequestTypeState(RequestTypeStates[i], true /* publish */))
+            {
                 // The aggregated interval availability is the logical AND
                 // over the request types.
                 intervalAvailable = false;
             }
-
-            if (!skipClassification) {
-                if (requestTypeAvailable) {
-                    state.AvailableIntervalsCounter->Inc();
-                } else {
-                    state.UnavailableIntervalsCounter->Inc();
-                }
-                *state.LastIntervalAvailableCounter =
-                    requestTypeAvailable ? 1 : 0;
-            }
-
-            // Roll over to the next interval. All requests still
-            // outstanding become "outstanding since the interval start" for
-            // the new interval.
-            state.CompletedNonEio = 0;
-            state.CompletedEio = 0;
-            state.InflightStartedInInterval = 0;
-            ++state.IntervalSeqNo;
         }
 
-        if (!skipClassification) {
-            TotalIntervalsCounter->Inc();
-            if (intervalAvailable) {
-                AvailableIntervalsCounter->Inc();
-            } else {
-                UnavailableIntervalsCounter->Inc();
-            }
-            *LastIntervalAvailableCounter = intervalAvailable ? 1 : 0;
+        TotalIntervalsCounter->Inc();
+        if (intervalAvailable) {
+            AvailableIntervalsCounter->Inc();
+        } else {
+            UnavailableIntervalsCounter->Inc();
         }
+        *LastIntervalAvailableCounter = intervalAvailable ? 1 : 0;
 
         CurrentIntervalStart += IntervalDuration;
         ++finishedIntervals;
@@ -400,6 +356,54 @@ void TAvailabilityCounters::RollIntervals(TInstant now)
     CurrentIntervalEndUs.store(
         (CurrentIntervalStart + IntervalDuration).MicroSeconds(),
         std::memory_order_release);
+}
+
+bool TAvailabilityCounters::RollRequestTypeState(
+    TRequestTypeState& state,
+    bool publish)
+{
+    TGuard g{state.Lock};
+
+    // Inflight >= InflightStartedInInterval holds but the subtraction is
+    // clamped defensively so that a violation can never wrap it into a huge
+    // hung count.
+    Y_DEBUG_ABORT_UNLESS(state.Inflight >= state.InflightStartedInInterval);
+    // Requests that were outstanding at the interval start and are still
+    // outstanding at the interval end, i.e. remained outstanding throughout
+    // the entire interval => hung.
+    const ui64 hung = state.Inflight >= state.InflightStartedInInterval
+        ? state.Inflight - state.InflightStartedInInterval
+        : 0;
+
+    // A request type makes the interval unavailable if it shows failure
+    // evidence - at least one request completed with an EIO error during
+    // the interval or hung through it - and no success evidence - no
+    // request completed with a non-EIO outcome during the interval.
+    // Requests that were started during the interval and have not completed
+    // by its end count as neither: their outcome is not known yet and will
+    // be accounted for in the interval where they complete (or in the
+    // intervals they hang through).
+    const bool hadFailedRequest = state.CompletedEio > 0 || hung > 0;
+    const bool hadNonFailedRequest = state.CompletedNonEio > 0;
+    const bool available = !hadFailedRequest || hadNonFailedRequest;
+
+    if (publish) {
+        if (available) {
+            state.AvailableIntervalsCounter->Inc();
+        } else {
+            state.UnavailableIntervalsCounter->Inc();
+        }
+        *state.LastIntervalAvailableCounter = available ? 1 : 0;
+    }
+
+    // Roll over to the next interval. All requests still outstanding become
+    // "outstanding since the interval start" for the new interval.
+    state.CompletedNonEio = 0;
+    state.CompletedEio = 0;
+    state.InflightStartedInInterval = 0;
+    ++state.IntervalSeqNo;
+
+    return available;
 }
 
 TInstant TAvailabilityCounters::AlignToInterval(TInstant instant) const

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -297,12 +297,10 @@ void TAvailabilityCounters::RollIntervals(TInstant now)
         // A partially observed interval (the one during which the
         // measurement began mid-interval) is rolled over - accounting
         // resets, outstanding requests become old - but is not classified
-        // or counted.
+        // or counted: neither the per-type nor the aggregated counters are
+        // published for it.
         SkipCurrentInterval = false;
-        for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
-            RollRequestTypeState(RequestTypeStates[i], false /* publish */);
-        }
-        CurrentIntervalStart += IntervalDuration;
+        RollInterval(false /* publishCounters */);
     }
 
     size_t finishedIntervals = 0;
@@ -315,27 +313,7 @@ void TAvailabilityCounters::RollIntervals(TInstant now)
         // subsequent iterations see empty per-interval counters, so a gap
         // interval is classified as unavailable iff some requests remained
         // outstanding (i.e. hung) throughout it.
-        bool intervalAvailable = true;
-
-        // Index 0 is EFileStoreAvailabilityRequestType::None, stays unused.
-        for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
-            if (!RollRequestTypeState(RequestTypeStates[i], true /* publish */))
-            {
-                // The aggregated interval availability is the logical AND
-                // over the request types.
-                intervalAvailable = false;
-            }
-        }
-
-        TotalIntervalsCounter->Inc();
-        if (intervalAvailable) {
-            AvailableIntervalsCounter->Inc();
-        } else {
-            UnavailableIntervalsCounter->Inc();
-        }
-        *LastIntervalAvailableCounter = intervalAvailable ? 1 : 0;
-
-        CurrentIntervalStart += IntervalDuration;
+        RollInterval(true /* publishCounters */);
         ++finishedIntervals;
     }
 
@@ -358,9 +336,38 @@ void TAvailabilityCounters::RollIntervals(TInstant now)
         std::memory_order_release);
 }
 
-bool TAvailabilityCounters::RollRequestTypeState(
+void TAvailabilityCounters::RollInterval(bool publishCounters)
+{
+    bool intervalAvailable = true;
+
+    // Index 0 is EFileStoreAvailabilityRequestType::None, stays unused.
+    for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
+        if (!RollRequestTypeStateAndReturnAvailability(
+                RequestTypeStates[i],
+                publishCounters))
+        {
+            // The aggregated interval availability is the logical AND over
+            // the request types.
+            intervalAvailable = false;
+        }
+    }
+
+    if (publishCounters) {
+        TotalIntervalsCounter->Inc();
+        if (intervalAvailable) {
+            AvailableIntervalsCounter->Inc();
+        } else {
+            UnavailableIntervalsCounter->Inc();
+        }
+        *LastIntervalAvailableCounter = intervalAvailable ? 1 : 0;
+    }
+
+    CurrentIntervalStart += IntervalDuration;
+}
+
+bool TAvailabilityCounters::RollRequestTypeStateAndReturnAvailability(
     TRequestTypeState& state,
-    bool publish)
+    bool publishCounters)
 {
     TGuard g{state.Lock};
 
@@ -387,7 +394,7 @@ bool TAvailabilityCounters::RollRequestTypeState(
     const bool hadNonFailedRequest = state.CompletedNonEio > 0;
     const bool available = !hadFailedRequest || hadNonFailedRequest;
 
-    if (publish) {
+    if (publishCounters) {
         if (available) {
             state.AvailableIntervalsCounter->Inc();
         } else {

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -1,0 +1,334 @@
+#include "availability_counters.h"
+
+#include "critical_events.h"
+
+#include <util/string/builder.h>
+#include <util/system/yassert.h>
+
+#include <cerrno>
+
+namespace NCloud::NFileStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Limits the number of intervals finished by a single UpdateStats() call.
+// Protects against unbounded catch-up loops after large forward clock jumps.
+// With the default 5-minute interval this covers a stats-updater stall of up
+// to one hour, anything beyond that realigns without evaluation.
+constexpr size_t MaxIntervalsPerUpdate = 12;
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+
+const char* GetAvailabilityRequestTypeName(
+    EFileStoreAvailabilityRequestType requestType)
+{
+    using EType = EFileStoreAvailabilityRequestType;
+    switch (requestType) {
+        case EType::Lookup: return "lookup";
+        case EType::GetAttr: return "getattr";
+        case EType::SetAttr: return "setattr";
+        case EType::ReadLink: return "readlink";
+        case EType::MkDir: return "mkdir";
+        case EType::RmDir: return "rmdir";
+        case EType::Unlink: return "unlink";
+        case EType::SymLink: return "symlink";
+        case EType::Link: return "link";
+        case EType::Rename: return "rename";
+        case EType::Open: return "open";
+        case EType::Create: return "create";
+        case EType::Read: return "read";
+        case EType::Write: return "write";
+        case EType::WriteBuf: return "write_buf";
+        case EType::Flush: return "flush";
+        case EType::Fsync: return "fsync";
+        case EType::Release: return "release";
+        case EType::OpenDir: return "opendir";
+        case EType::ReadDir: return "readdir";
+        case EType::ReadDirPlus: return "readdirplus";
+        case EType::ReleaseDir: return "releasedir";
+        case EType::None:
+        case EType::MAX:
+            break;
+    }
+    return "unknown";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TAvailabilityCounters::TAvailabilityCounters(TDuration intervalDuration)
+    : IntervalDuration(intervalDuration)
+{
+    Y_ABORT_UNLESS(IntervalDuration > TDuration::Zero());
+
+    // index 0 is EFileStoreAvailabilityRequestType::None and stays unused
+    for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
+        auto& state = RequestTypeStates[i];
+        // Availability intervals are numbered starting from 1.
+        state.IntervalSeqNo = 1;
+    }
+}
+
+void TAvailabilityCounters::Register(NMonitoring::TDynamicCounters& counters)
+{
+    TotalIntervalsCounter = counters.GetCounter(
+        "Availability_TotalIntervals",
+        true);   // derivative
+    AvailableIntervalsCounter = counters.GetCounter(
+        "Availability_AvailableIntervals",
+        true);   // derivative
+    UnavailableIntervalsCounter = counters.GetCounter(
+        "Availability_UnavailableIntervals",
+        true);   // derivative
+    LastIntervalAvailableCounter = counters.GetCounter(
+        "Availability_LastIntervalAvailable");
+    MissingIntervalsCounter = counters.GetCounter(
+        "Availability_MissingIntervals",
+        true);   // derivative
+
+    // no intervals have been reported yet - start as available
+    *LastIntervalAvailableCounter = 1;
+
+    // index 0 is EFileStoreAvailabilityRequestType::None and stays unused
+    for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
+        auto& state = RequestTypeStates[i];
+        auto requestCounters = counters.GetSubgroup(
+            "request",
+            GetAvailabilityRequestTypeName(
+                static_cast<EFileStoreAvailabilityRequestType>(i)));
+
+        state.AvailableIntervalsCounter = requestCounters->GetCounter(
+            "Availability_AvailableIntervals",
+            true);   // derivative
+        state.UnavailableIntervalsCounter = requestCounters->GetCounter(
+            "Availability_UnavailableIntervals",
+            true);   // derivative
+        state.LastIntervalAvailableCounter = requestCounters->GetCounter(
+            "Availability_LastIntervalAvailable");
+
+        *state.LastIntervalAvailableCounter = 1;
+    }
+
+    CountersRegistered = true;
+}
+
+void TAvailabilityCounters::RequestStarted(TCallContext& callContext)
+{
+    Y_DEBUG_ABORT_UNLESS(CountersRegistered);
+    if (!CountersRegistered) {
+        return;
+    }
+
+    if (callContext.AvailabilityRequestType ==
+        EFileStoreAvailabilityRequestType::None)
+    {
+        return;
+    }
+
+    auto& state = RequestTypeStates[
+        static_cast<size_t>(callContext.AvailabilityRequestType)];
+
+    TGuard g{state.Lock};
+
+    // A repeated registration without a completion in between would leak the
+    // previous registration's accounting: only one completion follows, so
+    // the extra inflight unit would be reported as hung forever.
+    if (callContext.AvailabilityIntervalSeqNo != 0) {
+        ReportAvailabilityCountersDoubleRegistration(
+            TStringBuilder() << "request type: "
+                << static_cast<ui32>(callContext.AvailabilityRequestType));
+        return;
+    }
+
+    ++state.Inflight;
+    ++state.InflightStartedInInterval;
+
+    callContext.AvailabilityIntervalSeqNo = state.IntervalSeqNo;
+
+    // A registration starts a fresh attempt: clear the outcome of a possible
+    // previous attempt of this context. Production success replies do not
+    // write GuestReplyErrno - they rely on it being 0 - so a restarted
+    // context would otherwise be classified with the stale EIO of its
+    // previous attempt.
+    callContext.GuestReplyErrno = 0;
+}
+
+void TAvailabilityCounters::RequestCompleted(TCallContext& callContext)
+{
+    Y_DEBUG_ABORT_UNLESS(CountersRegistered);
+    if (!CountersRegistered) {
+        return;
+    }
+
+    if (callContext.AvailabilityRequestType ==
+        EFileStoreAvailabilityRequestType::None)
+    {
+        return;
+    }
+
+    auto& state = RequestTypeStates[
+        static_cast<size_t>(callContext.AvailabilityRequestType)];
+
+    TGuard g{state.Lock};
+
+    // Every completion is expected to pair with exactly one registration:
+    // the stamp is put there by RequestStarted() and consumed below by the
+    // first completion, so a zero stamp means an unregistered or repeated
+    // completion.
+    if (callContext.AvailabilityIntervalSeqNo == 0) {
+        ReportAvailabilityCountersUnpairedCompletion(
+            TStringBuilder() << "request type: "
+                << static_cast<ui32>(callContext.AvailabilityRequestType));
+        return;
+    }
+
+    const ui64 startSeqNo = callContext.AvailabilityIntervalSeqNo;
+    callContext.AvailabilityIntervalSeqNo = 0;
+
+    Y_DEBUG_ABORT_UNLESS(state.Inflight);
+    if (state.Inflight > 0) {
+        --state.Inflight;
+    }
+
+    if (startSeqNo == state.IntervalSeqNo) {
+        Y_DEBUG_ABORT_UNLESS(state.InflightStartedInInterval);
+        // The request started in the current interval and thus can no longer
+        // be counted as a fresh outstanding request at the interval end.
+        if (state.InflightStartedInInterval > 0) {
+            --state.InflightStartedInInterval;
+        }
+    }
+
+    if (callContext.GuestReplyErrno == EIO) {
+        ++state.CompletedEio;
+    } else {
+        ++state.CompletedNonEio;
+    }
+}
+
+void TAvailabilityCounters::UpdateStats(TInstant now)
+{
+    Y_DEBUG_ABORT_UNLESS(CountersRegistered);
+    if (!CountersRegistered) {
+        return;
+    }
+
+    if (!CurrentIntervalStart) {
+        // First call - start measuring from the current wall-clock-aligned
+        // interval boundary so that intervals of all clients are aligned.
+        CurrentIntervalStart = AlignToInterval(now);
+        return;
+    }
+
+    size_t finishedIntervals = 0;
+    while (now >= CurrentIntervalStart + IntervalDuration &&
+           finishedIntervals < MaxIntervalsPerUpdate)
+    {
+        // More than one interval may have elapsed if the stats updater was
+        // stalled. The first iteration evaluates all the accumulated data;
+        // subsequent iterations see empty per-interval counters, so a gap
+        // interval is classified as unavailable iff some requests remained
+        // outstanding (i.e. hung) throughout it, which is exactly what the
+        // definition prescribes.
+        FinishInterval();
+        CurrentIntervalStart += IntervalDuration;
+        ++finishedIntervals;
+    }
+
+    if (now >= CurrentIntervalStart + IntervalDuration) {
+        // Too many intervals elapsed in a single update (e.g. after a large
+        // clock jump) - realign without evaluating the remaining ones, but
+        // report how many were skipped so they are not silently lost from
+        // the SLA denominator.
+        const TInstant alignedNow = AlignToInterval(now);
+        const ui64 missingIntervals =
+            (alignedNow - CurrentIntervalStart).MicroSeconds() /
+            IntervalDuration.MicroSeconds();
+        MissingIntervalsCounter->Add(missingIntervals);
+        CurrentIntervalStart = alignedNow;
+    }
+}
+
+void TAvailabilityCounters::FinishInterval()
+{
+    bool intervalAvailable = true;
+
+    // index 0 is EFileStoreAvailabilityRequestType::None and stays unused
+    for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
+        auto& state = RequestTypeStates[i];
+
+        TGuard g{state.Lock};
+
+        // Inflight >= InflightStartedInInterval holds because every
+        // registered completion consumes exactly one registration stamp:
+        // completions of requests started in the current interval decrement
+        // both counters, completions of older requests decrement Inflight
+        // only, and there can be no more of the latter than there are older
+        // requests still counted in Inflight. The subtraction is clamped
+        // defensively so that a violation can never wrap it into a huge
+        // hung count.
+        Y_DEBUG_ABORT_UNLESS(
+            state.Inflight >= state.InflightStartedInInterval);
+        // Requests that were outstanding at the interval start and are still
+        // outstanding at the interval end, i.e. remained outstanding
+        // throughout the entire interval => hung.
+        const ui64 hung = state.Inflight >= state.InflightStartedInInterval
+            ? state.Inflight - state.InflightStartedInInterval
+            : 0;
+
+        // A request type makes the interval unavailable if it shows failure
+        // evidence - at least one request completed with an EIO error during
+        // the interval or hung through it - and no success evidence - no
+        // request completed with a non-EIO outcome during the interval.
+        // Requests that were started during the interval and have not
+        // completed by its end count as neither: their outcome is not known
+        // yet and will be accounted for in the interval where they complete
+        // (or in the intervals they hang through).
+        const bool hadFailedRequest = state.CompletedEio > 0 || hung > 0;
+        const bool hadNonFailedRequest = state.CompletedNonEio > 0;
+
+        const bool requestTypeAvailable =
+            !hadFailedRequest || hadNonFailedRequest;
+        if (!requestTypeAvailable) {
+            // the aggregated interval availability is the logical AND over
+            // the request types
+            intervalAvailable = false;
+        }
+
+        if (requestTypeAvailable) {
+            state.AvailableIntervalsCounter->Inc();
+        } else {
+            state.UnavailableIntervalsCounter->Inc();
+        }
+        *state.LastIntervalAvailableCounter = requestTypeAvailable ? 1 : 0;
+
+        // Roll over to the next interval. All requests still outstanding
+        // become "outstanding since the interval start" for the new interval.
+        state.CompletedNonEio = 0;
+        state.CompletedEio = 0;
+        state.InflightStartedInInterval = 0;
+        ++state.IntervalSeqNo;
+    }
+
+    TotalIntervalsCounter->Inc();
+    if (intervalAvailable) {
+        AvailableIntervalsCounter->Inc();
+    } else {
+        UnavailableIntervalsCounter->Inc();
+    }
+    *LastIntervalAvailableCounter = intervalAvailable ? 1 : 0;
+}
+
+TInstant TAvailabilityCounters::AlignToInterval(TInstant instant) const
+{
+    const ui64 interval = IntervalDuration.MicroSeconds();
+    return TInstant::MicroSeconds(
+        instant.MicroSeconds() / interval * interval);
+}
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -19,6 +19,8 @@ namespace {
 // to one hour, anything beyond that realigns without evaluation.
 constexpr size_t MaxIntervalsPerUpdate = 12;
 
+constexpr TDuration DefaultIntervalDuration = TDuration::Minutes(5);
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -62,7 +64,11 @@ const char* GetAvailabilityRequestTypeName(
 ////////////////////////////////////////////////////////////////////////////////
 
 TAvailabilityCounters::TAvailabilityCounters(TDuration intervalDuration)
-    : IntervalDuration(intervalDuration)
+    // a zero interval duration selects the default one
+    : IntervalDuration(
+          intervalDuration == TDuration::Zero()
+              ? DefaultIntervalDuration
+              : intervalDuration)
 {
     Y_ABORT_UNLESS(IntervalDuration > TDuration::Zero());
 

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -63,25 +63,22 @@ const char* GetAvailabilityRequestTypeName(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TAvailabilityCounters::TAvailabilityCounters(TDuration intervalDuration)
-    // a zero interval duration selects the default one
-    : IntervalDuration(
-          intervalDuration == TDuration::Zero()
-              ? DefaultIntervalDuration
-              : intervalDuration)
+void TAvailabilityCounters::EnableAndRegister(
+    TDuration intervalDuration,
+    NMonitoring::TDynamicCounters& counters)
 {
-    Y_ABORT_UNLESS(IntervalDuration > TDuration::Zero());
+    // Serialize concurrent calls; the losers become no-ops.
+    TGuard g{EnableLock};
 
-    // index 0 is EFileStoreAvailabilityRequestType::None and stays unused
-    for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
-        auto& state = RequestTypeStates[i];
-        // Availability intervals are numbered starting from 1.
-        state.IntervalSeqNo = 1;
+    if (CountersRegistered.load(std::memory_order_acquire)) {
+        return;
     }
-}
 
-void TAvailabilityCounters::Register(NMonitoring::TDynamicCounters& counters)
-{
+    // A zero interval duration selects the default one.
+    IntervalDuration = intervalDuration == TDuration::Zero()
+        ? DefaultIntervalDuration
+        : intervalDuration;
+
     TotalIntervalsCounter = counters.GetCounter(
         "Availability_TotalIntervals",
         true);   // derivative
@@ -120,13 +117,13 @@ void TAvailabilityCounters::Register(NMonitoring::TDynamicCounters& counters)
         *state.LastIntervalAvailableCounter = 1;
     }
 
-    CountersRegistered = true;
+    // Publishes the fully initialized state for the methods below.
+    CountersRegistered.store(true, std::memory_order_release);
 }
 
 void TAvailabilityCounters::RequestStarted(TCallContext& callContext)
 {
-    Y_DEBUG_ABORT_UNLESS(CountersRegistered);
-    if (!CountersRegistered) {
+    if (!CountersRegistered.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -166,8 +163,7 @@ void TAvailabilityCounters::RequestStarted(TCallContext& callContext)
 
 void TAvailabilityCounters::RequestCompleted(TCallContext& callContext)
 {
-    Y_DEBUG_ABORT_UNLESS(CountersRegistered);
-    if (!CountersRegistered) {
+    if (!CountersRegistered.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -219,8 +215,7 @@ void TAvailabilityCounters::RequestCompleted(TCallContext& callContext)
 
 void TAvailabilityCounters::UpdateStats(TInstant now)
 {
-    Y_DEBUG_ABORT_UNLESS(CountersRegistered);
-    if (!CountersRegistered) {
+    if (!CountersRegistered.load(std::memory_order_acquire)) {
         return;
     }
 

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -43,7 +43,6 @@ const char* GetAvailabilityRequestTypeName(
 // Number of Available intervals / Total number of intervals in the measurement
 // period × 100%
 //
-//
 // A request is outstanding at a given point in time if it was submitted but had
 // received no response, success or error, by that point.
 // A request is hung if it was outstanding for the entire duration of the N-minute
@@ -70,10 +69,9 @@ const char* GetAvailabilityRequestTypeName(
 // Availability_LastIntervalAvailable are also published per availability
 // request type, on the "request=<type>" subgroup (e.g. request=lookup):
 // there an interval is available if that request type alone shows no
-// unavailability evidence. Availability_TotalIntervals is aggregated only -
-// it is identical for every request type and equals the per-request
-// Availability_AvailableIntervals + Availability_UnavailableIntervals. The
-// aggregated availability sensors are the logical AND over the request
+// unavailability evidence.
+//
+// The aggregated availability sensors are the logical AND over the request
 // types: an interval is available overall iff it is available for every
 // request type.
 //
@@ -93,11 +91,6 @@ const char* GetAvailabilityRequestTypeName(
 // Filesystem availability for an arbitrary measurement period is then
 // increment(Availability_AvailableIntervals) /
 // increment(Availability_TotalIntervals) * 100%.
-//
-// Thread safety: RequestStarted()/RequestCompleted() may be called
-// concurrently from any threads; UpdateStats() must not be called
-// concurrently with itself (it is invoked from the single stats-updater
-// thread, see IRequestStats::UpdateStats).
 class TAvailabilityCounters
 {
 private:
@@ -138,6 +131,7 @@ private:
         NMonitoring::TDynamicCounters::TCounterPtr AvailableIntervalsCounter;
         NMonitoring::TDynamicCounters::TCounterPtr
             UnavailableIntervalsCounter;
+        // Gauge counter.
         NMonitoring::TDynamicCounters::TCounterPtr
             LastIntervalAvailableCounter;
     };
@@ -151,42 +145,22 @@ private:
     // Only accessed from UpdateStats().
     TInstant CurrentIntervalStart;
 
-    // Published counters. Unset until Register() is called; intervals
-    // finished while unregistered are not reported anywhere.
+    // Published aggregated counters.
     NMonitoring::TDynamicCounters::TCounterPtr TotalIntervalsCounter;
     NMonitoring::TDynamicCounters::TCounterPtr AvailableIntervalsCounter;
     NMonitoring::TDynamicCounters::TCounterPtr UnavailableIntervalsCounter;
     NMonitoring::TDynamicCounters::TCounterPtr LastIntervalAvailableCounter;
     NMonitoring::TDynamicCounters::TCounterPtr MissingIntervalsCounter;
 
-    // Set once by Register(), which must be called before any other method:
-    // the request hooks and UpdateStats() abort debug builds and defensively
-    // return in release builds when invoked on an unregistered object. When
-    // set, all the counter pointers, aggregated and per-request-type ones,
-    // are valid.
     bool CountersRegistered = false;
 
 public:
     explicit TAvailabilityCounters(TDuration intervalDuration);
 
-    // Registers the published sensors on the given (per-filesystem
-    // per-client) counters subgroup.
     void Register(NMonitoring::TDynamicCounters& counters);
 
-    // Registers a submitted request: remembers the current interval
-    // sequence number in callContext.AvailabilityIntervalSeqNo and clears
-    // callContext.GuestReplyErrno, so that a re-registered (retried) context
-    // starts its new attempt without the outcome of the previous one.
-    // Requests with types for which IsAvailabilityTrackedRequestType()
-    // returns false are not tracked.
     void RequestStarted(TCallContext& callContext);
 
-    // Registers a terminal outcome for the request and consumes its
-    // registration stamp (unregistered and repeated completions are
-    // ignored). callContext.GuestReplyErrno == EIO indicates a completion
-    // with an EIO error, any other value (including 0 for successful replies
-    // and cancelled requests) - a terminal outcome that keeps the request
-    // type available.
     void RequestCompleted(TCallContext& callContext);
 
     // Rolls availability intervals over. Invoked periodically from the

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -214,9 +214,19 @@ private:
         TCallContext& callContext,
         TRequestTypeState& state);
 
+    // Finishes the current interval and advances to the next one: rolls
+    // every request type state over and, when publishCounters is set,
+    // classifies the interval and publishes both the per-type and the
+    // aggregated counters.
+    //
+    // Called under RollLock.
+    void RollInterval(bool publishCounters);
+
     // Rolls the state of one request type over to the next interval and
     // returns whether the finished interval was available for it.
-    bool RollRequestTypeState(TRequestTypeState& state, bool publish);
+    bool RollRequestTypeStateAndReturnAvailability(
+        TRequestTypeState& state,
+        bool publishCounters);
 
     TInstant AlignToInterval(TInstant instant) const;
 };

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -100,9 +100,6 @@ const char* GetAvailabilityRequestTypeName(
 // thread, see IRequestStats::UpdateStats).
 class TAvailabilityCounters
 {
-public:
-    static constexpr TDuration DefaultIntervalDuration = TDuration::Minutes(5);
-
 private:
     // Aligned to a cache line to avoid false sharing between request types.
     struct alignas(64) TRequestTypeState
@@ -170,8 +167,7 @@ private:
     bool CountersRegistered = false;
 
 public:
-    explicit TAvailabilityCounters(
-        TDuration intervalDuration = DefaultIntervalDuration);
+    explicit TAvailabilityCounters(TDuration intervalDuration);
 
     // Registers the published sensors on the given (per-filesystem
     // per-client) counters subgroup.

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -104,7 +104,7 @@ private:
         ui64 Inflight = 0;
 
         // The counters below describe the current (not yet finished)
-        // interval and are reset by FinishInterval().
+        // interval and are reset when the interval is rolled over.
 
         // Outstanding requests that were started in the current interval.
         // The remaining (Inflight - InflightStartedInInterval) requests were
@@ -123,9 +123,9 @@ private:
         ui64 CompletedEio = 0;
 
         // Sequence number of the current interval (availability intervals
-        // are numbered starting from 1), incremented by
-        // FinishInterval(). Used to detect whether a completing request was
-        // started in the current interval.
+        // are numbered starting from 1), incremented by the interval
+        // rollover. Used to detect whether a completing request was started
+        // in the current interval.
         ui64 IntervalSeqNo = 1;
 
         // Per-request-type published counters (on the "request=<type>"
@@ -145,8 +145,22 @@ private:
     std::array<TRequestTypeState, FileStoreAvailabilityRequestTypeCount>
         RequestTypeStates;
 
-    // Only accessed from UpdateStats().
+    // Guarded by RollLock.
     TInstant CurrentIntervalStart;
+
+    // The first interval after enabling may begin mid-interval (measurement
+    // starts at the enabling instant, aligned backward): such a partially
+    // observed interval is rolled over without classification.
+    //
+    // Guarded by RollLock.
+    bool SkipCurrentInterval = false;
+
+    // End of the current interval in microseconds, 0 until the first event
+    // or update initializes the measurement.
+    std::atomic<ui64> CurrentIntervalEndUs = 0;
+
+    // Serializes interval rolling, see RollIntervals().
+    TAdaptiveLock RollLock;
 
     // Published aggregated counters.
     NMonitoring::TDynamicCounters::TCounterPtr TotalIntervalsCounter;
@@ -156,7 +170,7 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr MissingIntervalsCounter;
 
     // Set by EnableAndRegister() with release ordering once the interval
-    // duration and the sensors are fully initialized; the methods below
+    // duration and the sensors are fully initialized, the methods below
     // load it with acquire ordering and are no-ops until then.
     std::atomic<bool> CountersRegistered = false;
 
@@ -171,16 +185,34 @@ public:
         TDuration intervalDuration,
         NMonitoring::TDynamicCounters& counters);
 
-    void RequestStarted(TCallContext& callContext);
+    // The request hooks take the actual event time and assign the event to
+    // its wall-clock interval: elapsed intervals are rolled over first, so
+    // an event arriving after an interval boundary but before the periodic
+    // updater tick is never attributed to the interval that has already
+    // ended.
+    void RequestStarted(TCallContext& callContext, TInstant now);
 
-    void RequestCompleted(TCallContext& callContext);
+    void RequestCompleted(TCallContext& callContext, TInstant now);
 
     // Rolls availability intervals over. Invoked periodically from the
-    // stats-updater thread.
+    // stats-updater thread; the request hooks roll on demand as well, so
+    // this only bounds the classification latency of quiet periods.
     void UpdateStats(TInstant now);
 
 private:
-    void FinishInterval();
+    // Rolls all the intervals that have fully elapsed by the given
+    // instant: classifies and publishes each one (except a partially
+    // observed first interval), bounded by MaxIntervalsPerUpdate with the
+    // overflow reported as missing intervals.
+    void RollIntervals(TInstant now);
+
+    void DoRequestStarted(
+        TCallContext& callContext,
+        TRequestTypeState& state);
+
+    void DoRequestCompleted(
+        TCallContext& callContext,
+        TRequestTypeState& state);
 
     TInstant AlignToInterval(TInstant instant) const;
 };

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -214,6 +214,10 @@ private:
         TCallContext& callContext,
         TRequestTypeState& state);
 
+    // Rolls the state of one request type over to the next interval and
+    // returns whether the finished interval was available for it.
+    bool RollRequestTypeState(TRequestTypeState& state, bool publish);
+
     TInstant AlignToInterval(TInstant instant) const;
 };
 

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/filestore/libs/service/context.h>
+#include <cloud/filestore/libs/service/request.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+
+#include <util/datetime/base.h>
+#include <util/system/guard.h>
+#include <util/system/spinlock.h>
+#include <util/system/types.h>
+
+#include <array>
+
+namespace NCloud::NFileStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// The value of the "request" label of the per-request-type availability
+// sensors: the FUSE request name in lower case, as listed in the SLA (e.g.
+// "lookup", "write_buf").
+const char* GetAvailabilityRequestTypeName(
+    EFileStoreAvailabilityRequestType requestType);
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Implements the per-client (instance, filesystem) availability metric on top
+// of the request stats hooks.
+//
+// Definitions
+//
+// A Shared Filesystem is considered unavailable during any N-minute interval in
+// which, for at least one filesystem request type, at least one request was
+// outstanding and every such request either failed with an EIO error, or hung.
+//
+// In all N-minute intervals in which the unavailability condition is not met,
+// a Shared Filesystem is considered available.
+//
+// Shared Filesystem availability for the measurement period shall be calculated
+// as:
+// Number of Available intervals / Total number of intervals in the measurement
+// period × 100%
+//
+//
+// A request is outstanding at a given point in time if it was submitted but had
+// received no response, success or error, by that point.
+// A request is hung if it was outstanding for the entire duration of the N-minute
+// interval.
+//
+// Request type - an individual FUSE request type subject to the SLA, see
+// EFileStoreAvailabilityRequestType. Distinct FUSE request types are
+// accounted independently even when they map to the same backend request
+// type, and requests outside the SLA (AvailabilityRequestType == None) are
+// ignored entirely.
+//
+// The EIO classification is based on TCallContext::GuestReplyErrno - the
+// errno actually sent to the guest - because the internal request error does
+// not always match the guest-visible outcome.
+//
+// Published sensors (registered on the per-filesystem per-client counters
+// subgroup of the request stats):
+//  * Availability_TotalIntervals       - derivative, finished 5-min intervals;
+//  * Availability_AvailableIntervals   - derivative, available intervals;
+//  * Availability_UnavailableIntervals - derivative, unavailable intervals;
+//  * Availability_LastIntervalAvailable - gauge, 1 if the last finished
+//                                        interval was available, 0 otherwise;
+// Availability_{Available,Unavailable}Intervals and
+// Availability_LastIntervalAvailable are also published per availability
+// request type, on the "request=<type>" subgroup (e.g. request=lookup):
+// there an interval is available if that request type alone shows no
+// unavailability evidence. Availability_TotalIntervals is aggregated only -
+// it is identical for every request type and equals the per-request
+// Availability_AvailableIntervals + Availability_UnavailableIntervals. The
+// aggregated availability sensors are the logical AND over the request
+// types: an interval is available overall iff it is available for every
+// request type.
+//
+//  * Availability_MissingIntervals     - derivative, elapsed intervals that
+//                                        were not evaluated because a single
+//                                        update had to catch up with more
+//                                        than MaxIntervalsPerUpdate of them
+//                                        (e.g. after a large clock jump).
+//                                        Such intervals are excluded from
+//                                        Availability_TotalIntervals, so the
+//                                        SLA computation can decide how to
+//                                        account for them. Aggregated only:
+//                                        missed intervals are a property of
+//                                        the updater and are identical for
+//                                        all request types.
+//
+// Filesystem availability for an arbitrary measurement period is then
+// increment(Availability_AvailableIntervals) /
+// increment(Availability_TotalIntervals) * 100%.
+//
+// Thread safety: RequestStarted()/RequestCompleted() may be called
+// concurrently from any threads; UpdateStats() must not be called
+// concurrently with itself (it is invoked from the single stats-updater
+// thread, see IRequestStats::UpdateStats).
+class TAvailabilityCounters
+{
+public:
+    static constexpr TDuration DefaultIntervalDuration = TDuration::Minutes(5);
+
+private:
+    // Aligned to a cache line to avoid false sharing between request types.
+    struct alignas(64) TRequestTypeState
+    {
+        TAdaptiveLock Lock;
+
+        // Total number of outstanding requests of this type. Never reset.
+        ui64 Inflight = 0;
+
+        // The counters below describe the current (not yet finished)
+        // interval and are reset by FinishInterval().
+
+        // Outstanding requests that were started in the current interval.
+        // The remaining (Inflight - InflightStartedInInterval) requests were
+        // started in earlier intervals, i.e. have been outstanding since the
+        // beginning of the current interval and will be classified as hung
+        // if they do not complete before the interval ends.
+        ui64 InflightStartedInInterval = 0;
+
+        // Requests that reached a terminal outcome other than an EIO error
+        // response during the current interval (successful completions and
+        // completions with any other error response).
+        ui64 CompletedNonEio = 0;
+
+        // Requests that completed with an EIO error response during the
+        // current interval.
+        ui64 CompletedEio = 0;
+
+        // Sequence number of the current interval, incremented by
+        // FinishInterval(). Used to detect whether a completing request was
+        // started in the current interval.
+        ui64 IntervalSeqNo = 0;
+
+        // Per-request-type published counters (on the "request=<type>"
+        // subgroup). Unset until Register() is called.
+        NMonitoring::TDynamicCounters::TCounterPtr AvailableIntervalsCounter;
+        NMonitoring::TDynamicCounters::TCounterPtr
+            UnavailableIntervalsCounter;
+        NMonitoring::TDynamicCounters::TCounterPtr
+            LastIntervalAvailableCounter;
+    };
+
+private:
+    const TDuration IntervalDuration;
+
+    std::array<TRequestTypeState, FileStoreAvailabilityRequestTypeCount>
+        RequestTypeStates;
+
+    // Only accessed from UpdateStats().
+    TInstant CurrentIntervalStart;
+
+    // Published counters. Unset until Register() is called; intervals
+    // finished while unregistered are not reported anywhere.
+    NMonitoring::TDynamicCounters::TCounterPtr TotalIntervalsCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr AvailableIntervalsCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr UnavailableIntervalsCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr LastIntervalAvailableCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr MissingIntervalsCounter;
+
+    // Set once by Register(), which must be called before any other method:
+    // the request hooks and UpdateStats() abort debug builds and defensively
+    // return in release builds when invoked on an unregistered object. When
+    // set, all the counter pointers, aggregated and per-request-type ones,
+    // are valid.
+    bool CountersRegistered = false;
+
+public:
+    explicit TAvailabilityCounters(
+        TDuration intervalDuration = DefaultIntervalDuration);
+
+    // Registers the published sensors on the given (per-filesystem
+    // per-client) counters subgroup.
+    void Register(NMonitoring::TDynamicCounters& counters);
+
+    // Registers a submitted request: remembers the current interval
+    // sequence number in callContext.AvailabilityIntervalSeqNo and clears
+    // callContext.GuestReplyErrno, so that a re-registered (retried) context
+    // starts its new attempt without the outcome of the previous one.
+    // Requests with types for which IsAvailabilityTrackedRequestType()
+    // returns false are not tracked.
+    void RequestStarted(TCallContext& callContext);
+
+    // Registers a terminal outcome for the request and consumes its
+    // registration stamp (unregistered and repeated completions are
+    // ignored). callContext.GuestReplyErrno == EIO indicates a completion
+    // with an EIO error, any other value (including 0 for successful replies
+    // and cancelled requests) - a terminal outcome that keeps the request
+    // type available.
+    void RequestCompleted(TCallContext& callContext);
+
+    // Rolls availability intervals over. Invoked periodically from the
+    // stats-updater thread.
+    void UpdateStats(TInstant now);
+
+private:
+    void FinishInterval();
+
+    TInstant AlignToInterval(TInstant instant) const;
+};
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -13,6 +13,7 @@
 #include <util/system/types.h>
 
 #include <array>
+#include <atomic>
 
 namespace NCloud::NFileStore {
 
@@ -121,13 +122,14 @@ private:
         // current interval.
         ui64 CompletedEio = 0;
 
-        // Sequence number of the current interval, incremented by
+        // Sequence number of the current interval (availability intervals
+        // are numbered starting from 1), incremented by
         // FinishInterval(). Used to detect whether a completing request was
         // started in the current interval.
-        ui64 IntervalSeqNo = 0;
+        ui64 IntervalSeqNo = 1;
 
         // Per-request-type published counters (on the "request=<type>"
-        // subgroup). Unset until Register() is called.
+        // subgroup). Unset until EnableAndRegister() is called.
         NMonitoring::TDynamicCounters::TCounterPtr AvailableIntervalsCounter;
         NMonitoring::TDynamicCounters::TCounterPtr
             UnavailableIntervalsCounter;
@@ -137,7 +139,8 @@ private:
     };
 
 private:
-    const TDuration IntervalDuration;
+    // Assigned by EnableAndRegister().
+    TDuration IntervalDuration;
 
     std::array<TRequestTypeState, FileStoreAvailabilityRequestTypeCount>
         RequestTypeStates;
@@ -152,12 +155,21 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr LastIntervalAvailableCounter;
     NMonitoring::TDynamicCounters::TCounterPtr MissingIntervalsCounter;
 
-    bool CountersRegistered = false;
+    // Set by EnableAndRegister() with release ordering once the interval
+    // duration and the sensors are fully initialized; the methods below
+    // load it with acquire ordering and are no-ops until then.
+    std::atomic<bool> CountersRegistered = false;
+
+    // Serializes EnableAndRegister() calls.
+    TAdaptiveLock EnableLock;
 
 public:
-    explicit TAvailabilityCounters(TDuration intervalDuration);
-
-    void Register(NMonitoring::TDynamicCounters& counters);
+    // Registers the sensors and enables the tracking with the given
+    // interval duration (zero selects the default one). Thread-safe;
+    // repeated calls are no-ops.
+    void EnableAndRegister(
+        TDuration intervalDuration,
+        NMonitoring::TDynamicCounters& counters);
 
     void RequestStarted(TCallContext& callContext);
 

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -143,10 +143,18 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         env.FinishInterval();
-        env.AssertIntervals(2, 2, 0, true);
+        env.AssertIntervals(
+            2,   // total
+            2,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldReportSuccessfulRequestsAsAvailable)
@@ -157,7 +165,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteOk(callContext);
 
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldReportNonEioErrorsAsAvailable)
@@ -171,7 +183,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteWithErrno(callContext, ENOENT);
 
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldReportEioOnlyIntervalAsUnavailable)
@@ -185,11 +201,19 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         }
 
         env.FinishInterval();
-        env.AssertIntervals(1, 0, 1, false);
+        env.AssertIntervals(
+            1,   // total
+            0,   // available
+            1,   // unavailable
+            false);   // last interval available
 
         // the next interval has no requests => available again
         env.FinishInterval();
-        env.AssertIntervals(2, 1, 1, true);
+        env.AssertIntervals(
+            2,   // total
+            1,   // available
+            1,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldReportMixedEioAndSuccessAsAvailable)
@@ -203,7 +227,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteOk(good);
 
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldReportHungRequestAsUnavailable)
@@ -216,18 +244,34 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // ...so it is not hung during interval 1 (it has not been
         // outstanding throughout the entire interval)
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         // it remains outstanding throughout intervals 2 and 3 => hung
         env.FinishInterval();
-        env.AssertIntervals(2, 1, 1, false);
+        env.AssertIntervals(
+            2,   // total
+            1,   // available
+            1,   // unavailable
+            false);   // last interval available
         env.FinishInterval();
-        env.AssertIntervals(3, 1, 2, false);
+        env.AssertIntervals(
+            3,   // total
+            1,   // available
+            2,   // unavailable
+            false);   // last interval available
 
         // once it completes successfully, the interval becomes available
         env.CompleteOk(callContext);
         env.FinishInterval();
-        env.AssertIntervals(4, 2, 2, true);
+        env.AssertIntervals(
+            4,   // total
+            2,   // available
+            2,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldTreatLateNonEioCompletionOfOldRequestAsAvailable)
@@ -236,14 +280,22 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         auto callContext = env.Start(EFileStoreAvailabilityRequestType::Open);
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         // the request was outstanding at the interval start and completed
         // with a non-EIO outcome during the interval => available
         env.AdvanceWithinInterval(TDuration::Minutes(1));
         env.CompleteOk(callContext);
         env.FinishInterval();
-        env.AssertIntervals(2, 2, 0, true);
+        env.AssertIntervals(
+            2,   // total
+            2,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldTreatLateEioCompletionOfOldRequestAsUnavailable)
@@ -252,13 +304,21 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         auto callContext = env.Start(EFileStoreAvailabilityRequestType::Open);
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         // the only outstanding request of this type completed with EIO
         // during the interval => unavailable
         env.CompleteWithErrno(callContext, EIO);
         env.FinishInterval();
-        env.AssertIntervals(2, 1, 1, false);
+        env.AssertIntervals(
+            2,   // total
+            1,   // available
+            1,   // unavailable
+            false);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldNotCountPendingRequestsAsAvailable)
@@ -269,7 +329,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // end is neutral: alone it does not make the interval unavailable...
         auto hungContext = env.Start(EFileStoreAvailabilityRequestType::Read);
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         // ...but it is not success evidence either: it does not make an
         // interval with a hung request available
@@ -278,16 +342,28 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Start(EFileStoreAvailabilityRequestType::Read);
 
         env.FinishInterval();
-        env.AssertIntervals(2, 1, 1, false);
+        env.AssertIntervals(
+            2,   // total
+            1,   // available
+            1,   // unavailable
+            false);   // last interval available
 
         // in the next interval both requests are hung
         env.FinishInterval();
-        env.AssertIntervals(3, 1, 2, false);
+        env.AssertIntervals(
+            3,   // total
+            1,   // available
+            2,   // unavailable
+            false);   // last interval available
 
         env.CompleteOk(hungContext);
         env.CompleteOk(freshContext);
         env.FinishInterval();
-        env.AssertIntervals(4, 2, 2, true);
+        env.AssertIntervals(
+            4,   // total
+            2,   // available
+            2,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldNotCountPendingRequestsAgainstEioCompletions)
@@ -303,11 +379,19 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Start(EFileStoreAvailabilityRequestType::Write);
 
         env.FinishInterval();
-        env.AssertIntervals(1, 0, 1, false);
+        env.AssertIntervals(
+            1,   // total
+            0,   // available
+            1,   // unavailable
+            false);   // last interval available
 
         env.CompleteOk(pendingContext);
         env.FinishInterval();
-        env.AssertIntervals(2, 1, 1, true);
+        env.AssertIntervals(
+            2,   // total
+            1,   // available
+            1,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldDistinguishOldAndFreshRequestsOnCompletion)
@@ -317,7 +401,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // a pending request started within the interval is neutral
         auto oldContext = env.Start(EFileStoreAvailabilityRequestType::Read);
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         // The old request completes while a fresh one is also outstanding.
         // The completion must consume the old registration via the interval
@@ -330,15 +418,27 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteOk(oldContext);
 
         env.FinishInterval();
-        env.AssertIntervals(2, 2, 0, true);
+        env.AssertIntervals(
+            2,   // total
+            2,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         // the fresh request is old by now and hangs the third interval
         env.FinishInterval();
-        env.AssertIntervals(3, 2, 1, false);
+        env.AssertIntervals(
+            3,   // total
+            2,   // available
+            1,   // unavailable
+            false);   // last interval available
 
         env.CompleteOk(freshContext);
         env.FinishInterval();
-        env.AssertIntervals(4, 3, 1, true);
+        env.AssertIntervals(
+            4,   // total
+            3,   // available
+            1,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldClassifyRequestTypesIndependently)
@@ -358,7 +458,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteWithErrno(badContext, EIO);
 
         env.FinishInterval();
-        env.AssertIntervals(1, 0, 1, false);
+        env.AssertIntervals(
+            1,   // total
+            0,   // available
+            1,   // unavailable
+            false);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldNotTrackUntrackedRequestTypes)
@@ -378,10 +482,18 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.Start(EFileStoreAvailabilityRequestType::None);
 
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         env.FinishInterval();
-        env.AssertIntervals(2, 2, 0, true);
+        env.AssertIntervals(
+            2,   // total
+            2,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldNotFinishIntervalBeforeItsEnd)
@@ -389,15 +501,27 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         env.AdvanceWithinInterval(TDuration::Minutes(4));
-        env.AssertIntervals(0, 0, 0, true);
+        env.AssertIntervals(
+            0,   // total
+            0,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         env.AdvanceWithinInterval(
             TDuration::Minutes(1) - TDuration::Seconds(1));
-        env.AssertIntervals(0, 0, 0, true);
+        env.AssertIntervals(
+            0,   // total
+            0,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         env.Now += TDuration::Seconds(1);
         env.Counters.UpdateStats(env.Now);
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldCountIntervalsMissedBeyondCatchUpLimit)
@@ -407,7 +531,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             TEnv env;
             env.Now += IntervalDuration * 12;
             env.Counters.UpdateStats(env.Now);
-            env.AssertIntervals(12, 12, 0, true);
+            env.AssertIntervals(
+                12,   // total
+                12,   // available
+                0,   // unavailable
+                true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
         }
 
@@ -416,7 +544,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             TEnv env;
             env.Now += IntervalDuration * 13;
             env.Counters.UpdateStats(env.Now);
-            env.AssertIntervals(12, 12, 0, true);
+            env.AssertIntervals(
+                12,   // total
+                12,   // available
+                0,   // unavailable
+                true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
         }
 
@@ -425,12 +557,20 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             TEnv env;
             env.Now += IntervalDuration * 24;
             env.Counters.UpdateStats(env.Now);
-            env.AssertIntervals(12, 12, 0, true);
+            env.AssertIntervals(
+                12,   // total
+                12,   // available
+                0,   // unavailable
+                true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
 
             // measurement continues normally afterwards
             env.FinishInterval();
-            env.AssertIntervals(13, 13, 0, true);
+            env.AssertIntervals(
+                13,   // total
+                13,   // available
+                0,   // unavailable
+                true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
         }
     }
@@ -446,7 +586,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Start(EFileStoreAvailabilityRequestType::Read);
             env.Now += IntervalDuration * 12;
             env.Counters.UpdateStats(env.Now);
-            env.AssertIntervals(12, 1, 11, false);
+            env.AssertIntervals(
+                12,   // total
+                1,   // available
+                11,   // unavailable
+                false);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
         }
 
@@ -455,7 +599,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Start(EFileStoreAvailabilityRequestType::Read);
             env.Now += IntervalDuration * 13;
             env.Counters.UpdateStats(env.Now);
-            env.AssertIntervals(12, 1, 11, false);
+            env.AssertIntervals(
+                12,   // total
+                1,   // available
+                11,   // unavailable
+                false);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
         }
 
@@ -464,7 +612,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Start(EFileStoreAvailabilityRequestType::Read);
             env.Now += IntervalDuration * 24;
             env.Counters.UpdateStats(env.Now);
-            env.AssertIntervals(12, 1, 11, false);
+            env.AssertIntervals(
+                12,   // total
+                1,   // available
+                11,   // unavailable
+                false);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
         }
     }
@@ -477,17 +629,29 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         auto callContext =
             env.Start(EFileStoreAvailabilityRequestType::GetAttr);
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         env.Now += IntervalDuration * 3;
         env.Counters.UpdateStats(env.Now);
 
         // the request remained outstanding throughout all 3 intervals
-        env.AssertIntervals(4, 1, 3, false);
+        env.AssertIntervals(
+            4,   // total
+            1,   // available
+            3,   // unavailable
+            false);   // last interval available
 
         env.CompleteOk(callContext);
         env.FinishInterval();
-        env.AssertIntervals(5, 2, 3, true);
+        env.AssertIntervals(
+            5,   // total
+            2,   // available
+            3,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldCountRequestStartedAndFailedWithinOneInterval)
@@ -502,7 +666,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteWithErrno(callContext, EIO);
 
         env.FinishInterval();
-        env.AssertIntervals(1, 0, 1, false);
+        env.AssertIntervals(
+            1,   // total
+            0,   // available
+            1,   // unavailable
+            false);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldAccountRequestTypesIndependently)
@@ -523,11 +691,21 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.CompleteOk(good);
 
             env.FinishInterval();
-            env.AssertIntervals(1, 0, 1, false);
+            env.AssertIntervals(
+                1,   // total
+                0,   // available
+                1,   // unavailable
+                false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::Lookup, 0, 1, false);
+                EFileStoreAvailabilityRequestType::Lookup,
+                0,   // available
+                1,   // unavailable
+                false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::GetAttr, 1, 0, true);
+                EFileStoreAvailabilityRequestType::GetAttr,
+                1,   // available
+                0,   // unavailable
+                true);   // last interval available
         }
 
         {
@@ -539,11 +717,21 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.CompleteOk(good);
 
             env.FinishInterval();
-            env.AssertIntervals(1, 0, 1, false);
+            env.AssertIntervals(
+                1,   // total
+                0,   // available
+                1,   // unavailable
+                false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::Open, 0, 1, false);
+                EFileStoreAvailabilityRequestType::Open,
+                0,   // available
+                1,   // unavailable
+                false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::Create, 1, 0, true);
+                EFileStoreAvailabilityRequestType::Create,
+                1,   // available
+                0,   // unavailable
+                true);   // last interval available
         }
 
         {
@@ -555,11 +743,21 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.CompleteOk(good);
 
             env.FinishInterval();
-            env.AssertIntervals(1, 0, 1, false);
+            env.AssertIntervals(
+                1,   // total
+                0,   // available
+                1,   // unavailable
+                false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::MkDir, 0, 1, false);
+                EFileStoreAvailabilityRequestType::MkDir,
+                0,   // available
+                1,   // unavailable
+                false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::SymLink, 1, 0, true);
+                EFileStoreAvailabilityRequestType::SymLink,
+                1,   // available
+                0,   // unavailable
+                true);   // last interval available
         }
 
         {
@@ -572,11 +770,21 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.CompleteOk(good);
 
             env.FinishInterval();
-            env.AssertIntervals(1, 0, 1, false);
+            env.AssertIntervals(
+                1,   // total
+                0,   // available
+                1,   // unavailable
+                false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::Write, 0, 1, false);
+                EFileStoreAvailabilityRequestType::Write,
+                0,   // available
+                1,   // unavailable
+                false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::WriteBuf, 1, 0, true);
+                EFileStoreAvailabilityRequestType::WriteBuf,
+                1,   // available
+                0,   // unavailable
+                true);   // last interval available
         }
     }
 
@@ -596,7 +804,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // the EIO completion of the first attempt is failure evidence, and
         // the pending restarted attempt is neutral => unavailable
         env.FinishInterval();
-        env.AssertIntervals(1, 0, 1, false);
+        env.AssertIntervals(
+            1,   // total
+            0,   // available
+            1,   // unavailable
+            false);   // last interval available
 
         // the successful completion of the restarted attempt is classified
         // as a success: the re-registration cleared the stale EIO of the
@@ -604,7 +816,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // does not write GuestReplyErrno
         env.CompleteOk(callContext);
         env.FinishInterval();
-        env.AssertIntervals(2, 1, 1, true);
+        env.AssertIntervals(
+            2,   // total
+            1,   // available
+            1,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldNotCountRequestStartedAfterBoundaryAsHung)
@@ -622,11 +838,19 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // the late tick closes the first interval: the request counts as
         // fresh-pending (neutral) there, not hung
         env.Counters.UpdateStats(env.Now);
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         env.CompleteOk(context);
         env.FinishInterval();
-        env.AssertIntervals(2, 2, 0, true);
+        env.AssertIntervals(
+            2,   // total
+            2,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldAccountActivityDuringUpdaterStall)
@@ -636,7 +860,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // a request outstanding from before the stall
         auto hungContext = env.Start(EFileStoreAvailabilityRequestType::Read);
         env.FinishInterval();
-        env.AssertIntervals(1, 1, 0, true);
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
 
         // the updater stalls for three intervals; requests keep starting
         // and completing meanwhile
@@ -654,11 +882,19 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // (any success => available). The remaining two stalled intervals
         // see only the still-outstanding old request => hung =>
         // unavailable.
-        env.AssertIntervals(4, 2, 2, false);
+        env.AssertIntervals(
+            4,   // total
+            2,   // available
+            2,   // unavailable
+            false);   // last interval available
 
         env.CompleteOk(hungContext);
         env.FinishInterval();
-        env.AssertIntervals(5, 3, 2, true);
+        env.AssertIntervals(
+            5,   // total
+            3,   // available
+            2,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldEnableConcurrentlyWithRequestProcessing)
@@ -719,12 +955,22 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // the failing request type is unavailable in its own counters...
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Write, 0, 1, false);
+            EFileStoreAvailabilityRequestType::Write,
+            0,   // available
+            1,   // unavailable
+            false);   // last interval available
         // ...while an idle request type is available in the same interval...
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Read, 1, 0, true);
+            EFileStoreAvailabilityRequestType::Read,
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
         // ...and the aggregated counters are the AND over the request types
-        env.AssertIntervals(1, 0, 1, false);
+        env.AssertIntervals(
+            1,   // total
+            0,   // available
+            1,   // unavailable
+            false);   // last interval available
 
         auto goodContext =
             env.Start(EFileStoreAvailabilityRequestType::Write);
@@ -732,10 +978,20 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.FinishInterval();
 
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Write, 1, 1, true);
+            EFileStoreAvailabilityRequestType::Write,
+            1,   // available
+            1,   // unavailable
+            true);   // last interval available
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Read, 2, 0, true);
-        env.AssertIntervals(2, 1, 1, true);
+            EFileStoreAvailabilityRequestType::Read,
+            2,   // available
+            0,   // unavailable
+            true);   // last interval available
+        env.AssertIntervals(
+            2,   // total
+            1,   // available
+            1,   // unavailable
+            true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldStartAsAvailable)
@@ -744,9 +1000,16 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // before any interval is finished the gauges report available, both
         // aggregated and per request type
-        env.AssertIntervals(0, 0, 0, true);
+        env.AssertIntervals(
+            0,   // total
+            0,   // available
+            0,   // unavailable
+            true);   // last interval available
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Lookup, 0, 0, true);
+            EFileStoreAvailabilityRequestType::Lookup,
+            0,   // available
+            0,   // unavailable
+            true);   // last interval available
     }
 }
 

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -68,7 +68,7 @@ struct TEnv
     }
 
     // Maps the published label back to the request type through the
-    // production forward mapping; an unknown name fails the test.
+    // production forward mapping.
     static ERequestType RequestTypeByName(const TString& requestName)
     {
         // index 0 is ERequestType::None, which has no published name
@@ -82,9 +82,6 @@ struct TEnv
         return ERequestType::None;
     }
 
-    // Starts a request of the type whose published label is requestName,
-    // so that the tests drive requests by the same literal name they
-    // assert on.
     TCallContextPtr Start(const TString& requestName)
     {
         auto callContext = MakeIntrusive<TCallContext>();
@@ -483,13 +480,6 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        // Requests with ERequestType::None do not affect the metric even
-        // if they fail with EIO or hang. (The FUSE dispatch assigns None to
-        // the requests outside the availability SLA - e.g. mknod, access,
-        // xattr and lock requests; that assignment lives in the CALL table
-        // in loop.cpp and is not covered here.) None has no published name,
-        // so these requests are driven directly rather than through
-        // Start().
         auto eioContext = MakeIntrusive<TCallContext>();
         eioContext->AvailabilityRequestType = ERequestType::None;
         env.Counters.RequestStarted(*eioContext, env.Now);
@@ -597,8 +587,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         // the request is started right away: the first interval sees a fresh
         // pending request (neutral => available), the remaining evaluated
-        // intervals see it hung (=> unavailable); the intervals beyond the
-        // catch-up limit are reported as missing, not as unavailable
+        // intervals see it hung (=> unavailable)
+        //
+        // the intervals beyond the catch-up limit are reported as missing,
+        // not as unavailable
         {
             TEnv env;
             env.Start("read");
@@ -691,13 +683,6 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
     Y_UNIT_TEST(ShouldAccountRequestTypesIndependently)
     {
-        // EFileStoreRequest maps each of these request pairs onto one
-        // backend request type; the SLA accounts them independently, so a
-        // request type failing with EIO makes the interval unavailable even
-        // when its backend sibling succeeds in the same interval. (That the
-        // FUSE callbacks assign these enums is a property of the CALL table
-        // in loop.cpp and is not covered here.)
-
         {
             // lookup and getattr both map to GetNodeAttr
             TEnv env;
@@ -819,9 +804,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // exist
         env.Counters.UpdateStats(env.Now);
 
-        // Reach the end of the interval in which the request actually
-        // started: it was fresh-pending there => neutral, not hung. Both
-        // intervals must be available.
+        // reach the end of the interval in which the request actually
+        // started: it was fresh-pending there => neutral, not hung
+        //
+        // both intervals must be available
         env.Now += IntervalDuration - TDuration::Seconds(1);
         env.Counters.UpdateStats(env.Now);
 
@@ -845,11 +831,13 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             0,   // unavailable
             true);   // last interval available
 
-        // It stays outstanding through the entire second interval and
+        // it stays outstanding through the entire second interval and
         // completes successfully one second after the boundary, before any
-        // updater tick. The completion event rolls the accounting first, so
+        // updater tick
+        //
+        // the completion event rolls the accounting first, so
         // the second interval is still classified with the request hung
-        // through it, and the success lands in the third interval.
+        // through it, and the success lands in the third interval
         env.Now += IntervalDuration + TDuration::Seconds(1);
         env.CompleteOk(callContext);
         env.Counters.UpdateStats(env.Now);
@@ -873,9 +861,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        // No updater ticks happen between the events below: every event is
+        // no updater ticks happen between the events below: every event is
         // still assigned to its actual wall-clock interval because the
-        // request hooks roll the accounting on demand.
+        // request hooks roll the accounting on demand
 
         env.Now += IntervalDuration + TDuration::Seconds(1);
         // interval 2: a starts (interval 1 elapsed empty => available)
@@ -935,9 +923,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // two racing EnableAndRegister() calls. The updater advances the
         // shared clock, so interval boundaries are crossed while requests
         // are processed: the on-demand rollover in the request hooks races
-        // the updater rollover. The gates guarantee full iterations both
-        // before and after enabling and several boundaries crossed after
-        // enabling; run under TSAN to verify the publication.
+        // the updater rollover.
         std::atomic<ui64> nowUs = start.MicroSeconds();
         std::atomic<ui64> iterations = 0;
         std::atomic<bool> stop = false;
@@ -990,7 +976,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // The pre-enable request completes after enabling: it carries no
         // stamp and is ignored. A repeated completion of a tracked request
-        // is ignored the same way; neither may disturb the accounting.
+        // is ignored the same way, neither may disturb the accounting.
         const auto end = TInstant::MicroSeconds(nowUs.load());
         counters.RequestCompleted(*preEnable, end);
         auto repeated = MakeIntrusive<TCallContext>();

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -530,11 +530,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // exactly at the catch-up limit every elapsed interval is evaluated
         {
             TEnv env;
-            env.Now += IntervalDuration * 12;
+            env.Now += IntervalDuration * 30;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                12,   // total
-                12,   // available
+                30,   // total
+                30,   // available
                 0,   // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
@@ -543,36 +543,36 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // one interval beyond the limit is reported as missing, not dropped
         {
             TEnv env;
-            env.Now += IntervalDuration * 13;
+            env.Now += IntervalDuration * 31;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                12,   // total
-                12,   // available
+                30,   // total
+                30,   // available
                 0,   // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
         }
 
-        // a two-hour gap: half evaluated, half reported as missing
+        // a five-hour gap: half evaluated, half reported as missing
         {
             TEnv env;
-            env.Now += IntervalDuration * 24;
+            env.Now += IntervalDuration * 60;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                12,   // total
-                12,   // available
+                30,   // total
+                30,   // available
                 0,   // unavailable
                 true);   // last interval available
-            UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
+            UNIT_ASSERT_VALUES_EQUAL(30, env.MissingIntervals->Val());
 
             // measurement continues normally afterwards
             env.FinishInterval();
             env.AssertIntervals(
-                13,   // total
-                13,   // available
+                31,   // total
+                31,   // available
                 0,   // unavailable
                 true);   // last interval available
-            UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
+            UNIT_ASSERT_VALUES_EQUAL(30, env.MissingIntervals->Val());
         }
     }
 
@@ -585,12 +585,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             TEnv env;
             env.Start(EFileStoreAvailabilityRequestType::Read);
-            env.Now += IntervalDuration * 12;
+            env.Now += IntervalDuration * 30;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                12,   // total
+                30,   // total
                 1,   // available
-                11,   // unavailable
+                29,   // unavailable
                 false);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
         }
@@ -598,12 +598,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             TEnv env;
             env.Start(EFileStoreAvailabilityRequestType::Read);
-            env.Now += IntervalDuration * 13;
+            env.Now += IntervalDuration * 31;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                12,   // total
+                30,   // total
                 1,   // available
-                11,   // unavailable
+                29,   // unavailable
                 false);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
         }
@@ -611,14 +611,14 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             TEnv env;
             env.Start(EFileStoreAvailabilityRequestType::Read);
-            env.Now += IntervalDuration * 24;
+            env.Now += IntervalDuration * 60;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                12,   // total
+                30,   // total
                 1,   // available
-                11,   // unavailable
+                29,   // unavailable
                 false);   // last interval available
-            UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
+            UNIT_ASSERT_VALUES_EQUAL(30, env.MissingIntervals->Val());
         }
     }
 

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -18,7 +18,7 @@ struct TEnv
 {
     NMonitoring::TDynamicCountersPtr CounterGroup =
         MakeIntrusive<NMonitoring::TDynamicCounters>();
-    TAvailabilityCounters Counters{IntervalDuration};
+    TAvailabilityCounters Counters;
     TInstant Now;
 
     NMonitoring::TDynamicCounters::TCounterPtr TotalIntervals;
@@ -32,7 +32,7 @@ struct TEnv
         // obvious
         : Now(TInstant::Hours(100))
     {
-        Counters.Register(*CounterGroup);
+        Counters.EnableAndRegister(IntervalDuration, *CounterGroup);
         // the first call only initializes the interval boundary
         Counters.UpdateStats(Now);
 

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -162,16 +162,16 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            2,   // available
-            0,   // unavailable
+            2,       // total
+            2,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -184,9 +184,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -201,9 +201,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -218,17 +218,17 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            0,   // available
-            1,   // unavailable
-            false);   // last interval available
+            1,       // total
+            0,       // available
+            1,       // unavailable
+            false);  // last interval available
 
         // the next interval has no requests => available again
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            1,   // available
-            1,   // unavailable
+            2,       // total
+            1,       // available
+            1,       // unavailable
             true);   // last interval available
     }
 
@@ -244,9 +244,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -261,32 +261,32 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // outstanding throughout the entire interval)
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         // it remains outstanding throughout intervals 2 and 3 => hung
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            1,   // available
-            1,   // unavailable
-            false);   // last interval available
+            2,       // total
+            1,       // available
+            1,       // unavailable
+            false);  // last interval available
         env.FinishInterval();
         env.AssertIntervals(
-            3,   // total
-            1,   // available
-            2,   // unavailable
-            false);   // last interval available
+            3,       // total
+            1,       // available
+            2,       // unavailable
+            false);  // last interval available
 
         // once it completes successfully, the interval becomes available
         env.CompleteOk(callContext);
         env.FinishInterval();
         env.AssertIntervals(
-            4,   // total
-            2,   // available
-            2,   // unavailable
+            4,       // total
+            2,       // available
+            2,       // unavailable
             true);   // last interval available
     }
 
@@ -297,9 +297,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         auto callContext = env.Start("open");
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         // the request was outstanding at the interval start and completed
@@ -308,9 +308,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteOk(callContext);
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            2,   // available
-            0,   // unavailable
+            2,       // total
+            2,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -321,9 +321,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         auto callContext = env.Start("open");
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         // the only outstanding request of this type completed with EIO
@@ -331,10 +331,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteWithErrno(callContext, EIO);
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            1,   // available
-            1,   // unavailable
-            false);   // last interval available
+            2,       // total
+            1,       // available
+            1,       // unavailable
+            false);  // last interval available
     }
 
     Y_UNIT_TEST(ShouldNotCountPendingRequestsAsAvailable)
@@ -346,9 +346,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         auto hungContext = env.Start("read");
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         // ...but it is not success evidence either: it does not make an
@@ -358,26 +358,26 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            1,   // available
-            1,   // unavailable
-            false);   // last interval available
+            2,       // total
+            1,       // available
+            1,       // unavailable
+            false);  // last interval available
 
         // in the next interval both requests are hung
         env.FinishInterval();
         env.AssertIntervals(
-            3,   // total
-            1,   // available
-            2,   // unavailable
-            false);   // last interval available
+            3,       // total
+            1,       // available
+            2,       // unavailable
+            false);  // last interval available
 
         env.CompleteOk(hungContext);
         env.CompleteOk(freshContext);
         env.FinishInterval();
         env.AssertIntervals(
-            4,   // total
-            2,   // available
-            2,   // unavailable
+            4,       // total
+            2,       // available
+            2,       // unavailable
             true);   // last interval available
     }
 
@@ -394,17 +394,17 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            0,   // available
-            1,   // unavailable
-            false);   // last interval available
+            1,       // total
+            0,       // available
+            1,       // unavailable
+            false);  // last interval available
 
         env.CompleteOk(pendingContext);
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            1,   // available
-            1,   // unavailable
+            2,       // total
+            1,       // available
+            1,       // unavailable
             true);   // last interval available
     }
 
@@ -416,9 +416,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         auto oldContext = env.Start("read");
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         // The old request completes while a fresh one is also outstanding.
@@ -432,25 +432,25 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            2,   // available
-            0,   // unavailable
+            2,       // total
+            2,       // available
+            0,       // unavailable
             true);   // last interval available
 
         // the fresh request is old by now and hangs the third interval
         env.FinishInterval();
         env.AssertIntervals(
-            3,   // total
-            2,   // available
-            1,   // unavailable
-            false);   // last interval available
+            3,       // total
+            2,       // available
+            1,       // unavailable
+            false);  // last interval available
 
         env.CompleteOk(freshContext);
         env.FinishInterval();
         env.AssertIntervals(
-            4,   // total
-            3,   // available
-            1,   // unavailable
+            4,       // total
+            3,       // available
+            1,       // unavailable
             true);   // last interval available
     }
 
@@ -470,10 +470,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            0,   // available
-            1,   // unavailable
-            false);   // last interval available
+            1,       // total
+            0,       // available
+            1,       // unavailable
+            false);  // last interval available
     }
 
     Y_UNIT_TEST(ShouldNotTrackUntrackedRequestTypes)
@@ -491,16 +491,16 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         env.FinishInterval();
         env.AssertIntervals(
-            2,   // total
-            2,   // available
-            0,   // unavailable
+            2,       // total
+            2,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -510,25 +510,25 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.AdvanceWithinInterval(TDuration::Minutes(4));
         env.AssertIntervals(
-            0,   // total
-            0,   // available
-            0,   // unavailable
+            0,       // total
+            0,       // available
+            0,       // unavailable
             true);   // last interval available
 
         env.AdvanceWithinInterval(
             TDuration::Minutes(1) - TDuration::Seconds(1));
         env.AssertIntervals(
-            0,   // total
-            0,   // available
-            0,   // unavailable
+            0,       // total
+            0,       // available
+            0,       // unavailable
             true);   // last interval available
 
         env.Now += TDuration::Seconds(1);
         env.Counters.UpdateStats(env.Now);
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -540,9 +540,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Now += IntervalDuration * 30;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                30,   // total
-                30,   // available
-                0,   // unavailable
+                30,      // total
+                30,      // available
+                0,       // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
         }
@@ -553,9 +553,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Now += IntervalDuration * 31;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                30,   // total
-                30,   // available
-                0,   // unavailable
+                30,      // total
+                30,      // available
+                0,       // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
         }
@@ -566,18 +566,18 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Now += IntervalDuration * 60;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                30,   // total
-                30,   // available
-                0,   // unavailable
+                30,      // total
+                30,      // available
+                0,       // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(30, env.MissingIntervals->Val());
 
             // measurement continues normally afterwards
             env.FinishInterval();
             env.AssertIntervals(
-                31,   // total
-                31,   // available
-                0,   // unavailable
+                31,      // total
+                31,      // available
+                0,       // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(30, env.MissingIntervals->Val());
         }
@@ -597,10 +597,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Now += IntervalDuration * 30;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                30,   // total
-                1,   // available
-                29,   // unavailable
-                false);   // last interval available
+                30,      // total
+                1,       // available
+                29,      // unavailable
+                false);  // last interval available
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
         }
 
@@ -610,10 +610,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Now += IntervalDuration * 31;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                30,   // total
-                1,   // available
-                29,   // unavailable
-                false);   // last interval available
+                30,      // total
+                1,       // available
+                29,      // unavailable
+                false);  // last interval available
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
         }
 
@@ -623,10 +623,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             env.Now += IntervalDuration * 60;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
-                30,   // total
-                1,   // available
-                29,   // unavailable
-                false);   // last interval available
+                30,      // total
+                1,       // available
+                29,      // unavailable
+                false);  // last interval available
             UNIT_ASSERT_VALUES_EQUAL(30, env.MissingIntervals->Val());
         }
     }
@@ -639,9 +639,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         auto callContext = env.Start("getattr");
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         env.Now += IntervalDuration * 3;
@@ -649,17 +649,17 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // the request remained outstanding throughout all 3 intervals
         env.AssertIntervals(
-            4,   // total
-            1,   // available
-            3,   // unavailable
-            false);   // last interval available
+            4,       // total
+            1,       // available
+            3,       // unavailable
+            false);  // last interval available
 
         env.CompleteOk(callContext);
         env.FinishInterval();
         env.AssertIntervals(
-            5,   // total
-            2,   // available
-            3,   // unavailable
+            5,       // total
+            2,       // available
+            3,       // unavailable
             true);   // last interval available
     }
 
@@ -675,10 +675,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            0,   // available
-            1,   // unavailable
-            false);   // last interval available
+            1,       // total
+            0,       // available
+            1,       // unavailable
+            false);  // last interval available
     }
 
     Y_UNIT_TEST(ShouldAccountRequestTypesIndependently)
@@ -693,19 +693,19 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
             env.FinishInterval();
             env.AssertIntervals(
-                1,   // total
-                0,   // available
-                1,   // unavailable
-                false);   // last interval available
+                1,       // total
+                0,       // available
+                1,       // unavailable
+                false);  // last interval available
             env.AssertRequestIntervals(
                 "lookup",
-                0,   // available
-                1,   // unavailable
-                false);   // last interval available
+                0,       // available
+                1,       // unavailable
+                false);  // last interval available
             env.AssertRequestIntervals(
                 "getattr",
-                1,   // available
-                0,   // unavailable
+                1,       // available
+                0,       // unavailable
                 true);   // last interval available
         }
 
@@ -719,19 +719,19 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
             env.FinishInterval();
             env.AssertIntervals(
-                1,   // total
-                0,   // available
-                1,   // unavailable
-                false);   // last interval available
+                1,       // total
+                0,       // available
+                1,       // unavailable
+                false);  // last interval available
             env.AssertRequestIntervals(
                 "open",
-                0,   // available
-                1,   // unavailable
-                false);   // last interval available
+                0,       // available
+                1,       // unavailable
+                false);  // last interval available
             env.AssertRequestIntervals(
                 "create",
-                1,   // available
-                0,   // unavailable
+                1,       // available
+                0,       // unavailable
                 true);   // last interval available
         }
 
@@ -745,19 +745,19 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
             env.FinishInterval();
             env.AssertIntervals(
-                1,   // total
-                0,   // available
-                1,   // unavailable
-                false);   // last interval available
+                1,       // total
+                0,       // available
+                1,       // unavailable
+                false);  // last interval available
             env.AssertRequestIntervals(
                 "mkdir",
-                0,   // available
-                1,   // unavailable
-                false);   // last interval available
+                0,       // available
+                1,       // unavailable
+                false);  // last interval available
             env.AssertRequestIntervals(
                 "symlink",
-                1,   // available
-                0,   // unavailable
+                1,       // available
+                0,       // unavailable
                 true);   // last interval available
         }
 
@@ -771,19 +771,19 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
             env.FinishInterval();
             env.AssertIntervals(
-                1,   // total
-                0,   // available
-                1,   // unavailable
-                false);   // last interval available
+                1,       // total
+                0,       // available
+                1,       // unavailable
+                false);  // last interval available
             env.AssertRequestIntervals(
                 "write",
-                0,   // available
-                1,   // unavailable
-                false);   // last interval available
+                0,       // available
+                1,       // unavailable
+                false);  // last interval available
             env.AssertRequestIntervals(
                 "write_buf",
-                1,   // available
-                0,   // unavailable
+                1,       // available
+                0,       // unavailable
                 true);   // last interval available
         }
     }
@@ -812,9 +812,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.Counters.UpdateStats(env.Now);
 
         env.AssertIntervals(
-            2,   // total
-            2,   // available
-            0,   // unavailable
+            2,       // total
+            2,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -826,9 +826,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         auto callContext = env.Start("read");
         env.FinishInterval();
         env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
+            1,       // total
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
 
         // it stays outstanding through the entire second interval and
@@ -842,18 +842,18 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteOk(callContext);
         env.Counters.UpdateStats(env.Now);
         env.AssertIntervals(
-            2,   // total
-            1,   // available
-            1,   // unavailable
-            false);   // last interval available
+            2,       // total
+            1,       // available
+            1,       // unavailable
+            false);  // last interval available
 
         // the third interval carries the successful completion
         env.Now += IntervalDuration - TDuration::Seconds(1);
         env.Counters.UpdateStats(env.Now);
         env.AssertIntervals(
-            3,   // total
-            2,   // available
-            1,   // unavailable
+            3,       // total
+            2,       // available
+            1,       // unavailable
             true);   // last interval available
     }
 
@@ -882,28 +882,28 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.Counters.UpdateStats(env.Now);
         env.AssertIntervals(
-            3,   // total
-            3,   // available
-            0,   // unavailable
+            3,       // total
+            3,       // available
+            0,       // unavailable
             true);   // last interval available
 
         // interval 4 carries only b's EIO completion => unavailable
         env.Now += IntervalDuration - TDuration::Seconds(1);
         env.Counters.UpdateStats(env.Now);
         env.AssertIntervals(
-            4,   // total
-            3,   // available
-            1,   // unavailable
-            false);   // last interval available
+            4,       // total
+            3,       // available
+            1,       // unavailable
+            false);  // last interval available
         env.AssertRequestIntervals(
             "write",
-            3,   // available
-            1,   // unavailable
-            false);   // last interval available
+            3,       // available
+            1,       // unavailable
+            false);  // last interval available
         env.AssertRequestIntervals(
             "read",
-            4,   // available
-            0,   // unavailable
+            4,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 
@@ -1072,21 +1072,21 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // the failing request type is unavailable in its own counters...
         env.AssertRequestIntervals(
             "write",
-            0,   // available
-            1,   // unavailable
-            false);   // last interval available
+            0,       // available
+            1,       // unavailable
+            false);  // last interval available
         // ...while an idle request type is available in the same interval...
         env.AssertRequestIntervals(
             "read",
-            1,   // available
-            0,   // unavailable
+            1,       // available
+            0,       // unavailable
             true);   // last interval available
         // ...and the aggregated counters are the AND over the request types
         env.AssertIntervals(
-            1,   // total
-            0,   // available
-            1,   // unavailable
-            false);   // last interval available
+            1,       // total
+            0,       // available
+            1,       // unavailable
+            false);  // last interval available
 
         auto goodContext = env.Start("write");
         env.CompleteOk(goodContext);
@@ -1094,18 +1094,18 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.AssertRequestIntervals(
             "write",
-            1,   // available
-            1,   // unavailable
+            1,       // available
+            1,       // unavailable
             true);   // last interval available
         env.AssertRequestIntervals(
             "read",
-            2,   // available
-            0,   // unavailable
+            2,       // available
+            0,       // unavailable
             true);   // last interval available
         env.AssertIntervals(
-            2,   // total
-            1,   // available
-            1,   // unavailable
+            2,       // total
+            1,       // available
+            1,       // unavailable
             true);   // last interval available
     }
 
@@ -1116,14 +1116,14 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // before any interval is finished the gauges report available, both
         // aggregated and per request type
         env.AssertIntervals(
-            0,   // total
-            0,   // available
-            0,   // unavailable
+            0,       // total
+            0,       // available
+            0,       // unavailable
             true);   // last interval available
         env.AssertRequestIntervals(
             "lookup",
-            0,   // available
-            0,   // unavailable
+            0,       // available
+            0,       // unavailable
             true);   // last interval available
     }
 }

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -1,0 +1,636 @@
+#include "availability_counters.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/ptr.h>
+
+#include <cerrno>
+
+namespace NCloud::NFileStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr TDuration Interval = TAvailabilityCounters::DefaultIntervalDuration;
+
+struct TEnv
+{
+    NMonitoring::TDynamicCountersPtr CounterGroup =
+        MakeIntrusive<NMonitoring::TDynamicCounters>();
+    TAvailabilityCounters Counters;
+    TInstant Now;
+
+    NMonitoring::TDynamicCounters::TCounterPtr TotalIntervals;
+    NMonitoring::TDynamicCounters::TCounterPtr AvailableIntervals;
+    NMonitoring::TDynamicCounters::TCounterPtr UnavailableIntervals;
+    NMonitoring::TDynamicCounters::TCounterPtr LastIntervalAvailable;
+    NMonitoring::TDynamicCounters::TCounterPtr MissingIntervals;
+
+    TEnv()
+        // start from an interval-aligned instant to make the test arithmetic
+        // obvious
+        : Now(TInstant::Hours(100))
+    {
+        Counters.Register(*CounterGroup);
+        // the first call only initializes the interval boundary
+        Counters.UpdateStats(Now);
+
+        TotalIntervals =
+            CounterGroup->GetCounter("Availability_TotalIntervals", true);
+        AvailableIntervals =
+            CounterGroup->GetCounter("Availability_AvailableIntervals", true);
+        UnavailableIntervals =
+            CounterGroup->GetCounter("Availability_UnavailableIntervals", true);
+        LastIntervalAvailable =
+            CounterGroup->GetCounter("Availability_LastIntervalAvailable");
+        MissingIntervals =
+            CounterGroup->GetCounter("Availability_MissingIntervals", true);
+    }
+
+    // Advances time to the end of the current interval and rolls it over.
+    void FinishInterval()
+    {
+        Now += Interval;
+        Counters.UpdateStats(Now);
+    }
+
+    void AdvanceWithinInterval(TDuration duration)
+    {
+        Now += duration;
+        UNIT_ASSERT(duration < Interval);
+        Counters.UpdateStats(Now);
+    }
+
+    TCallContextPtr Start(EFileStoreAvailabilityRequestType requestType)
+    {
+        auto callContext = MakeIntrusive<TCallContext>();
+        callContext->AvailabilityRequestType = requestType;
+        Counters.RequestStarted(*callContext);
+        return callContext;
+    }
+
+    void CompleteOk(const TCallContextPtr& callContext)
+    {
+        // production success replies do not write GuestReplyErrno: they rely
+        // on it being 0 for the current attempt
+        Counters.RequestCompleted(*callContext);
+    }
+
+    void CompleteWithErrno(
+        const TCallContextPtr& callContext,
+        int guestReplyErrno)
+    {
+        callContext->GuestReplyErrno = guestReplyErrno;
+        Counters.RequestCompleted(*callContext);
+    }
+
+    // Asserts against the per-request-type published counters on the
+    // "request=<type>" subgroup.
+    void AssertRequestIntervals(
+        EFileStoreAvailabilityRequestType requestType,
+        i64 available,
+        i64 unavailable,
+        bool lastAvailable)
+    {
+        auto group = CounterGroup->FindSubgroup(
+            "request",
+            GetAvailabilityRequestTypeName(requestType));
+        UNIT_ASSERT(group);
+        // the total is aggregated only - per-request it would be identical
+        // for every request type
+        UNIT_ASSERT(!group->FindCounter("Availability_TotalIntervals"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            available,
+            group->GetCounter("Availability_AvailableIntervals", true)->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            unavailable,
+            group->GetCounter(
+                "Availability_UnavailableIntervals", true)->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            lastAvailable,
+            group->GetCounter("Availability_LastIntervalAvailable")->Val()
+                != 0);
+    }
+
+    // Asserts against the aggregated published counters - the logical AND
+    // over the request types.
+    void AssertIntervals(
+        i64 total,
+        i64 available,
+        i64 unavailable,
+        bool lastAvailable)
+    {
+        UNIT_ASSERT_VALUES_EQUAL(total, TotalIntervals->Val());
+        UNIT_ASSERT_VALUES_EQUAL(available, AvailableIntervals->Val());
+        UNIT_ASSERT_VALUES_EQUAL(unavailable, UnavailableIntervals->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            lastAvailable,
+            LastIntervalAvailable->Val() != 0);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
+{
+    Y_UNIT_TEST(ShouldReportEmptyIntervalAsAvailable)
+    {
+        TEnv env;
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        env.FinishInterval();
+        env.AssertIntervals(2, 2, 0, true);
+    }
+
+    Y_UNIT_TEST(ShouldReportSuccessfulRequestsAsAvailable)
+    {
+        TEnv env;
+
+        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.CompleteOk(callContext);
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+    }
+
+    Y_UNIT_TEST(ShouldReportNonEioErrorsAsAvailable)
+    {
+        TEnv env;
+
+        // completion with an error response other than EIO is a normal
+        // terminal outcome
+        auto callContext =
+            env.Start(EFileStoreAvailabilityRequestType::GetAttr);
+        env.CompleteWithErrno(callContext, ENOENT);
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+    }
+
+    Y_UNIT_TEST(ShouldReportEioOnlyIntervalAsUnavailable)
+    {
+        TEnv env;
+
+        for (int i = 0; i < 3; ++i) {
+            auto callContext =
+                env.Start(EFileStoreAvailabilityRequestType::Write);
+            env.CompleteWithErrno(callContext, EIO);
+        }
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 0, 1, false);
+
+        // the next interval has no requests => available again
+        env.FinishInterval();
+        env.AssertIntervals(2, 1, 1, true);
+    }
+
+    Y_UNIT_TEST(ShouldReportMixedEioAndSuccessAsAvailable)
+    {
+        TEnv env;
+
+        auto bad = env.Start(EFileStoreAvailabilityRequestType::Write);
+        env.CompleteWithErrno(bad, EIO);
+
+        auto good = env.Start(EFileStoreAvailabilityRequestType::Write);
+        env.CompleteOk(good);
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+    }
+
+    Y_UNIT_TEST(ShouldReportHungRequestAsUnavailable)
+    {
+        TEnv env;
+
+        // the request is started in interval 1...
+        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Fsync);
+
+        // ...so it is not hung during interval 1 (it has not been
+        // outstanding throughout the entire interval)
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        // it remains outstanding throughout intervals 2 and 3 => hung
+        env.FinishInterval();
+        env.AssertIntervals(2, 1, 1, false);
+        env.FinishInterval();
+        env.AssertIntervals(3, 1, 2, false);
+
+        // once it completes successfully, the interval becomes available
+        env.CompleteOk(callContext);
+        env.FinishInterval();
+        env.AssertIntervals(4, 2, 2, true);
+    }
+
+    Y_UNIT_TEST(ShouldTreatLateNonEioCompletionOfOldRequestAsAvailable)
+    {
+        TEnv env;
+
+        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Open);
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        // the request was outstanding at the interval start and completed
+        // with a non-EIO outcome during the interval => available
+        env.AdvanceWithinInterval(TDuration::Minutes(1));
+        env.CompleteOk(callContext);
+        env.FinishInterval();
+        env.AssertIntervals(2, 2, 0, true);
+    }
+
+    Y_UNIT_TEST(ShouldTreatLateEioCompletionOfOldRequestAsUnavailable)
+    {
+        TEnv env;
+
+        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Open);
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        // the only outstanding request of this type completed with EIO
+        // during the interval => unavailable
+        env.CompleteWithErrno(callContext, EIO);
+        env.FinishInterval();
+        env.AssertIntervals(2, 1, 1, false);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountPendingRequestsAsAvailable)
+    {
+        TEnv env;
+
+        // a request started during the interval and still outstanding at its
+        // end is neutral: alone it does not make the interval unavailable...
+        auto hungContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        // ...but it is not success evidence either: it does not make an
+        // interval with a hung request available
+        env.AdvanceWithinInterval(TDuration::Minutes(2));
+        auto freshContext =
+            env.Start(EFileStoreAvailabilityRequestType::Read);
+
+        env.FinishInterval();
+        env.AssertIntervals(2, 1, 1, false);
+
+        // in the next interval both requests are hung
+        env.FinishInterval();
+        env.AssertIntervals(3, 1, 2, false);
+
+        env.CompleteOk(hungContext);
+        env.CompleteOk(freshContext);
+        env.FinishInterval();
+        env.AssertIntervals(4, 2, 2, true);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountPendingRequestsAgainstEioCompletions)
+    {
+        TEnv env;
+
+        // an EIO completion is failure evidence; a request started during
+        // the interval and still pending at its end does not neutralize it
+        auto eioContext = env.Start(EFileStoreAvailabilityRequestType::Write);
+        env.CompleteWithErrno(eioContext, EIO);
+
+        auto pendingContext =
+            env.Start(EFileStoreAvailabilityRequestType::Write);
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 0, 1, false);
+
+        env.CompleteOk(pendingContext);
+        env.FinishInterval();
+        env.AssertIntervals(2, 1, 1, true);
+    }
+
+    Y_UNIT_TEST(ShouldDistinguishOldAndFreshRequestsOnCompletion)
+    {
+        TEnv env;
+
+        // An old hung request together with a fresh EIO completion: every
+        // outstanding request is either hung or completed with EIO =>
+        // unavailable. This requires correctly attributing the completion to
+        // the fresh request via the interval sequence number.
+        auto hungContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        auto freshContext =
+            env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.CompleteWithErrno(freshContext, EIO);
+
+        env.FinishInterval();
+        env.AssertIntervals(2, 1, 1, false);
+
+        env.CompleteOk(hungContext);
+        env.FinishInterval();
+        env.AssertIntervals(3, 2, 1, true);
+    }
+
+    Y_UNIT_TEST(ShouldClassifyRequestTypesIndependently)
+    {
+        TEnv env;
+
+        // plenty of successful reads...
+        for (int i = 0; i < 100; ++i) {
+            auto callContext =
+                env.Start(EFileStoreAvailabilityRequestType::Read);
+            env.CompleteOk(callContext);
+        }
+
+        // ...do not mask a fully failed write type
+        auto badContext =
+            env.Start(EFileStoreAvailabilityRequestType::Write);
+        env.CompleteWithErrno(badContext, EIO);
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 0, 1, false);
+    }
+
+    Y_UNIT_TEST(ShouldNotTrackUntrackedRequestTypes)
+    {
+        TEnv env;
+
+        // requests outside the availability SLA - e.g. mknod, access, xattr
+        // and lock requests - get no availability request type at the FUSE
+        // dispatch and do not affect the metric even if they fail with EIO
+        // or hang
+        auto eioContext =
+            env.Start(EFileStoreAvailabilityRequestType::None);
+        env.CompleteWithErrno(eioContext, EIO);
+        // never completed
+        env.Start(EFileStoreAvailabilityRequestType::None);
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        env.FinishInterval();
+        env.AssertIntervals(2, 2, 0, true);
+    }
+
+    Y_UNIT_TEST(ShouldNotFinishIntervalBeforeItsEnd)
+    {
+        TEnv env;
+
+        env.AdvanceWithinInterval(TDuration::Minutes(4));
+        env.AssertIntervals(0, 0, 0, true);
+
+        env.AdvanceWithinInterval(
+            TDuration::Minutes(1) - TDuration::Seconds(1));
+        env.AssertIntervals(0, 0, 0, true);
+
+        env.Now += TDuration::Seconds(1);
+        env.Counters.UpdateStats(env.Now);
+        env.AssertIntervals(1, 1, 0, true);
+    }
+
+    Y_UNIT_TEST(ShouldCountIntervalsMissedBeyondCatchUpLimit)
+    {
+        // exactly at the catch-up limit every elapsed interval is evaluated
+        {
+            TEnv env;
+            env.Now += Interval * 12;
+            env.Counters.UpdateStats(env.Now);
+            env.AssertIntervals(12, 12, 0, true);
+            UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
+        }
+
+        // one interval beyond the limit is reported as missing, not dropped
+        {
+            TEnv env;
+            env.Now += Interval * 13;
+            env.Counters.UpdateStats(env.Now);
+            env.AssertIntervals(12, 12, 0, true);
+            UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
+        }
+
+        // a two-hour gap: half evaluated, half reported as missing
+        {
+            TEnv env;
+            env.Now += Interval * 24;
+            env.Counters.UpdateStats(env.Now);
+            env.AssertIntervals(12, 12, 0, true);
+            UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
+
+            // measurement continues normally afterwards
+            env.FinishInterval();
+            env.AssertIntervals(13, 13, 0, true);
+            UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCountIntervalsMissedWithHungRequest)
+    {
+        // the request is started right away: the first interval sees a fresh
+        // pending request (neutral => available), the remaining evaluated
+        // intervals see it hung (=> unavailable); the intervals beyond the
+        // catch-up limit are reported as missing, not as unavailable
+        {
+            TEnv env;
+            env.Start(EFileStoreAvailabilityRequestType::Read);
+            env.Now += Interval * 12;
+            env.Counters.UpdateStats(env.Now);
+            env.AssertIntervals(12, 1, 11, false);
+            UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
+        }
+
+        {
+            TEnv env;
+            env.Start(EFileStoreAvailabilityRequestType::Read);
+            env.Now += Interval * 13;
+            env.Counters.UpdateStats(env.Now);
+            env.AssertIntervals(12, 1, 11, false);
+            UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
+        }
+
+        {
+            TEnv env;
+            env.Start(EFileStoreAvailabilityRequestType::Read);
+            env.Now += Interval * 24;
+            env.Counters.UpdateStats(env.Now);
+            env.AssertIntervals(12, 1, 11, false);
+            UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCatchUpAfterUpdateStall)
+    {
+        TEnv env;
+
+        // a request hangs and the stats updater stalls for 3 intervals
+        auto callContext =
+            env.Start(EFileStoreAvailabilityRequestType::GetAttr);
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        env.Now += Interval * 3;
+        env.Counters.UpdateStats(env.Now);
+
+        // the request remained outstanding throughout all 3 intervals
+        env.AssertIntervals(4, 1, 3, false);
+
+        env.CompleteOk(callContext);
+        env.FinishInterval();
+        env.AssertIntervals(5, 2, 3, true);
+    }
+
+    Y_UNIT_TEST(ShouldCountRequestStartedAndFailedWithinOneInterval)
+    {
+        TEnv env;
+
+        // an EIO completion of a request that both started and finished
+        // within the interval still makes the interval unavailable
+        auto callContext =
+            env.Start(EFileStoreAvailabilityRequestType::MkDir);
+        env.AdvanceWithinInterval(TDuration::Seconds(30));
+        env.CompleteWithErrno(callContext, EIO);
+
+        env.FinishInterval();
+        env.AssertIntervals(1, 0, 1, false);
+    }
+
+    Y_UNIT_TEST(ShouldAccountFuseRequestTypesIndependently)
+    {
+        // EFileStoreRequest maps each of these FUSE request pairs onto one
+        // backend request type; the SLA accounts them independently, so a
+        // FUSE request type failing with EIO makes the interval unavailable
+        // even when its backend sibling succeeds in the same interval
+
+        {
+            // lookup and getattr both map to GetNodeAttr
+            TEnv env;
+            auto bad = env.Start(EFileStoreAvailabilityRequestType::Lookup);
+            env.CompleteWithErrno(bad, EIO);
+            auto good = env.Start(EFileStoreAvailabilityRequestType::GetAttr);
+            env.CompleteOk(good);
+
+            env.FinishInterval();
+            env.AssertIntervals(1, 0, 1, false);
+            env.AssertRequestIntervals(
+                EFileStoreAvailabilityRequestType::Lookup, 0, 1, false);
+            env.AssertRequestIntervals(
+                EFileStoreAvailabilityRequestType::GetAttr, 1, 0, true);
+        }
+
+        {
+            // open and create both map to CreateHandle
+            TEnv env;
+            auto bad = env.Start(EFileStoreAvailabilityRequestType::Open);
+            env.CompleteWithErrno(bad, EIO);
+            auto good = env.Start(EFileStoreAvailabilityRequestType::Create);
+            env.CompleteOk(good);
+
+            env.FinishInterval();
+            env.AssertIntervals(1, 0, 1, false);
+        }
+
+        {
+            // mkdir and symlink both map to CreateNode
+            TEnv env;
+            auto bad = env.Start(EFileStoreAvailabilityRequestType::MkDir);
+            env.CompleteWithErrno(bad, EIO);
+            auto good = env.Start(EFileStoreAvailabilityRequestType::SymLink);
+            env.CompleteOk(good);
+
+            env.FinishInterval();
+            env.AssertIntervals(1, 0, 1, false);
+        }
+
+        {
+            // write and write_buf both map to WriteData
+            TEnv env;
+            auto bad = env.Start(EFileStoreAvailabilityRequestType::Write);
+            env.CompleteWithErrno(bad, EIO);
+            auto good =
+                env.Start(EFileStoreAvailabilityRequestType::WriteBuf);
+            env.CompleteOk(good);
+
+            env.FinishInterval();
+            env.AssertIntervals(1, 0, 1, false);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldSupportRestartedRequests)
+    {
+        TEnv env;
+
+        // some request types are retried by the vfs layer by completing and
+        // re-starting the same call context
+        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.CompleteWithErrno(callContext, EIO);
+
+        env.Counters.RequestStarted(*callContext);
+
+        // the EIO completion of the first attempt is failure evidence, and
+        // the pending restarted attempt is neutral => unavailable
+        env.FinishInterval();
+        env.AssertIntervals(1, 0, 1, false);
+
+        // the successful completion of the restarted attempt is classified
+        // as a success: the re-registration cleared the stale EIO of the
+        // first attempt, and the success reply itself - as in production -
+        // does not write GuestReplyErrno
+        env.CompleteOk(callContext);
+        env.FinishInterval();
+        env.AssertIntervals(2, 1, 1, true);
+    }
+
+    Y_UNIT_TEST(ShouldPublishPerRequestTypeCounters)
+    {
+        TEnv env;
+
+        // the "request" label value is the lower-case FUSE request name as
+        // listed in the SLA
+        UNIT_ASSERT_VALUES_EQUAL(
+            "write",
+            TString(GetAvailabilityRequestTypeName(
+                EFileStoreAvailabilityRequestType::Write)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "write_buf",
+            TString(GetAvailabilityRequestTypeName(
+                EFileStoreAvailabilityRequestType::WriteBuf)));
+
+        auto badContext = env.Start(EFileStoreAvailabilityRequestType::Write);
+        env.CompleteWithErrno(badContext, EIO);
+
+        env.FinishInterval();
+
+        // the failing request type is unavailable in its own counters...
+        env.AssertRequestIntervals(
+            EFileStoreAvailabilityRequestType::Write, 0, 1, false);
+        // ...while an idle request type is available in the same interval...
+        env.AssertRequestIntervals(
+            EFileStoreAvailabilityRequestType::Read, 1, 0, true);
+        // ...and the aggregated counters are the AND over the request types
+        env.AssertIntervals(1, 0, 1, false);
+
+        auto goodContext =
+            env.Start(EFileStoreAvailabilityRequestType::Write);
+        env.CompleteOk(goodContext);
+        env.FinishInterval();
+
+        env.AssertRequestIntervals(
+            EFileStoreAvailabilityRequestType::Write, 1, 1, true);
+        env.AssertRequestIntervals(
+            EFileStoreAvailabilityRequestType::Read, 2, 0, true);
+        env.AssertIntervals(2, 1, 1, true);
+    }
+
+    Y_UNIT_TEST(ShouldStartAsAvailable)
+    {
+        TEnv env;
+
+        // before any interval is finished the gauges report available, both
+        // aggregated and per request type
+        env.AssertIntervals(0, 0, 0, true);
+        env.AssertRequestIntervals(
+            EFileStoreAvailabilityRequestType::Lookup, 0, 0, true);
+    }
+}
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -15,6 +15,8 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using ERequestType = EFileStoreAvailabilityRequestType;
+
 constexpr TDuration IntervalDuration = TDuration::Minutes(5);
 
 struct TEnv
@@ -65,10 +67,28 @@ struct TEnv
         Counters.UpdateStats(Now);
     }
 
-    TCallContextPtr Start(EFileStoreAvailabilityRequestType requestType)
+    // Maps the published label back to the request type through the
+    // production forward mapping; an unknown name fails the test.
+    static ERequestType RequestTypeByName(const TString& requestName)
+    {
+        // index 0 is ERequestType::None, which has no published name
+        for (size_t i = 1; i < FileStoreAvailabilityRequestTypeCount; ++i) {
+            const auto requestType = static_cast<ERequestType>(i);
+            if (requestName == GetAvailabilityRequestTypeName(requestType)) {
+                return requestType;
+            }
+        }
+        UNIT_FAIL("unknown availability request name: " << requestName);
+        return ERequestType::None;
+    }
+
+    // Starts a request of the type whose published label is requestName,
+    // so that the tests drive requests by the same literal name they
+    // assert on.
+    TCallContextPtr Start(const TString& requestName)
     {
         auto callContext = MakeIntrusive<TCallContext>();
-        callContext->AvailabilityRequestType = requestType;
+        callContext->AvailabilityRequestType = RequestTypeByName(requestName);
         Counters.RequestStarted(*callContext, Now);
         return callContext;
     }
@@ -90,15 +110,15 @@ struct TEnv
 
     // Asserts against the per-request-type published counters on the
     // "request=<type>" subgroup.
+    // The name is passed as the literal expected label so that the test
+    // does not use the production mapping function as its own oracle.
     void AssertRequestIntervals(
-        EFileStoreAvailabilityRequestType requestType,
+        const TString& requestName,
         i64 available,
         i64 unavailable,
         bool lastAvailable)
     {
-        auto group = CounterGroup->FindSubgroup(
-            "request",
-            GetAvailabilityRequestTypeName(requestType));
+        auto group = CounterGroup->FindSubgroup("request", requestName);
         UNIT_ASSERT(group);
         // the total is aggregated only - per-request it would be identical
         // for every request type
@@ -162,7 +182,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        auto callContext = env.Start("read");
         env.CompleteOk(callContext);
 
         env.FinishInterval();
@@ -179,8 +199,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // completion with an error response other than EIO is a normal
         // terminal outcome
-        auto callContext =
-            env.Start(EFileStoreAvailabilityRequestType::GetAttr);
+        auto callContext = env.Start("getattr");
         env.CompleteWithErrno(callContext, ENOENT);
 
         env.FinishInterval();
@@ -196,8 +215,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         for (int i = 0; i < 3; ++i) {
-            auto callContext =
-                env.Start(EFileStoreAvailabilityRequestType::Write);
+            auto callContext = env.Start("write");
             env.CompleteWithErrno(callContext, EIO);
         }
 
@@ -221,10 +239,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        auto bad = env.Start(EFileStoreAvailabilityRequestType::Write);
+        auto bad = env.Start("write");
         env.CompleteWithErrno(bad, EIO);
 
-        auto good = env.Start(EFileStoreAvailabilityRequestType::Write);
+        auto good = env.Start("write");
         env.CompleteOk(good);
 
         env.FinishInterval();
@@ -240,7 +258,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         // the request is started in interval 1...
-        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Fsync);
+        auto callContext = env.Start("fsync");
 
         // ...so it is not hung during interval 1 (it has not been
         // outstanding throughout the entire interval)
@@ -279,7 +297,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Open);
+        auto callContext = env.Start("open");
         env.FinishInterval();
         env.AssertIntervals(
             1,   // total
@@ -303,7 +321,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Open);
+        auto callContext = env.Start("open");
         env.FinishInterval();
         env.AssertIntervals(
             1,   // total
@@ -328,7 +346,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // a request started during the interval and still outstanding at its
         // end is neutral: alone it does not make the interval unavailable...
-        auto hungContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        auto hungContext = env.Start("read");
         env.FinishInterval();
         env.AssertIntervals(
             1,   // total
@@ -339,8 +357,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // ...but it is not success evidence either: it does not make an
         // interval with a hung request available
         env.AdvanceWithinInterval(TDuration::Minutes(2));
-        auto freshContext =
-            env.Start(EFileStoreAvailabilityRequestType::Read);
+        auto freshContext = env.Start("read");
 
         env.FinishInterval();
         env.AssertIntervals(
@@ -373,11 +390,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // an EIO completion is failure evidence; a request started during
         // the interval and still pending at its end does not neutralize it
-        auto eioContext = env.Start(EFileStoreAvailabilityRequestType::Write);
+        auto eioContext = env.Start("write");
         env.CompleteWithErrno(eioContext, EIO);
 
-        auto pendingContext =
-            env.Start(EFileStoreAvailabilityRequestType::Write);
+        auto pendingContext = env.Start("write");
 
         env.FinishInterval();
         env.AssertIntervals(
@@ -400,7 +416,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         // a pending request started within the interval is neutral
-        auto oldContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        auto oldContext = env.Start("read");
         env.FinishInterval();
         env.AssertIntervals(
             1,   // total
@@ -414,8 +430,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // (neutral) and the successful completion is the only evidence =>
         // available. Decrementing the fresh request's accounting instead
         // would classify it as hung and flip the interval to unavailable.
-        auto freshContext =
-            env.Start(EFileStoreAvailabilityRequestType::Read);
+        auto freshContext = env.Start("read");
         env.CompleteOk(oldContext);
 
         env.FinishInterval();
@@ -448,14 +463,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // plenty of successful reads...
         for (int i = 0; i < 100; ++i) {
-            auto callContext =
-                env.Start(EFileStoreAvailabilityRequestType::Read);
+            auto callContext = env.Start("read");
             env.CompleteOk(callContext);
         }
 
         // ...do not mask a fully failed write type
-        auto badContext =
-            env.Start(EFileStoreAvailabilityRequestType::Write);
+        auto badContext = env.Start("write");
         env.CompleteWithErrno(badContext, EIO);
 
         env.FinishInterval();
@@ -470,17 +483,21 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        // Requests with EFileStoreAvailabilityRequestType::None do not
-        // affect the metric even if they fail with EIO or hang. (The FUSE
-        // dispatch assigns None to the requests outside the availability
-        // SLA - e.g. mknod, access, xattr and lock requests; that
-        // assignment lives in the CALL table in loop.cpp and is not covered
-        // here.)
-        auto eioContext =
-            env.Start(EFileStoreAvailabilityRequestType::None);
+        // Requests with ERequestType::None do not affect the metric even
+        // if they fail with EIO or hang. (The FUSE dispatch assigns None to
+        // the requests outside the availability SLA - e.g. mknod, access,
+        // xattr and lock requests; that assignment lives in the CALL table
+        // in loop.cpp and is not covered here.) None has no published name,
+        // so these requests are driven directly rather than through
+        // Start().
+        auto eioContext = MakeIntrusive<TCallContext>();
+        eioContext->AvailabilityRequestType = ERequestType::None;
+        env.Counters.RequestStarted(*eioContext, env.Now);
         env.CompleteWithErrno(eioContext, EIO);
         // never completed
-        env.Start(EFileStoreAvailabilityRequestType::None);
+        auto hungContext = MakeIntrusive<TCallContext>();
+        hungContext->AvailabilityRequestType = ERequestType::None;
+        env.Counters.RequestStarted(*hungContext, env.Now);
 
         env.FinishInterval();
         env.AssertIntervals(
@@ -584,7 +601,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // catch-up limit are reported as missing, not as unavailable
         {
             TEnv env;
-            env.Start(EFileStoreAvailabilityRequestType::Read);
+            env.Start("read");
             env.Now += IntervalDuration * 30;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
@@ -597,7 +614,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         {
             TEnv env;
-            env.Start(EFileStoreAvailabilityRequestType::Read);
+            env.Start("read");
             env.Now += IntervalDuration * 31;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
@@ -610,7 +627,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         {
             TEnv env;
-            env.Start(EFileStoreAvailabilityRequestType::Read);
+            env.Start("read");
             env.Now += IntervalDuration * 60;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
@@ -627,8 +644,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         // a request hangs and the stats updater stalls for 3 intervals
-        auto callContext =
-            env.Start(EFileStoreAvailabilityRequestType::GetAttr);
+        auto callContext = env.Start("getattr");
         env.FinishInterval();
         env.AssertIntervals(
             1,   // total
@@ -661,8 +677,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // an EIO completion of a request that both started and finished
         // within the interval still makes the interval unavailable
-        auto callContext =
-            env.Start(EFileStoreAvailabilityRequestType::MkDir);
+        auto callContext = env.Start("mkdir");
         env.AdvanceWithinInterval(TDuration::Seconds(30));
         env.CompleteWithErrno(callContext, EIO);
 
@@ -686,9 +701,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             // lookup and getattr both map to GetNodeAttr
             TEnv env;
-            auto bad = env.Start(EFileStoreAvailabilityRequestType::Lookup);
+            auto bad = env.Start("lookup");
             env.CompleteWithErrno(bad, EIO);
-            auto good = env.Start(EFileStoreAvailabilityRequestType::GetAttr);
+            auto good = env.Start("getattr");
             env.CompleteOk(good);
 
             env.FinishInterval();
@@ -698,12 +713,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 1,   // unavailable
                 false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::Lookup,
+                "lookup",
                 0,   // available
                 1,   // unavailable
                 false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::GetAttr,
+                "getattr",
                 1,   // available
                 0,   // unavailable
                 true);   // last interval available
@@ -712,9 +727,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             // open and create both map to CreateHandle
             TEnv env;
-            auto bad = env.Start(EFileStoreAvailabilityRequestType::Open);
+            auto bad = env.Start("open");
             env.CompleteWithErrno(bad, EIO);
-            auto good = env.Start(EFileStoreAvailabilityRequestType::Create);
+            auto good = env.Start("create");
             env.CompleteOk(good);
 
             env.FinishInterval();
@@ -724,12 +739,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 1,   // unavailable
                 false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::Open,
+                "open",
                 0,   // available
                 1,   // unavailable
                 false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::Create,
+                "create",
                 1,   // available
                 0,   // unavailable
                 true);   // last interval available
@@ -738,9 +753,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             // mkdir and symlink both map to CreateNode
             TEnv env;
-            auto bad = env.Start(EFileStoreAvailabilityRequestType::MkDir);
+            auto bad = env.Start("mkdir");
             env.CompleteWithErrno(bad, EIO);
-            auto good = env.Start(EFileStoreAvailabilityRequestType::SymLink);
+            auto good = env.Start("symlink");
             env.CompleteOk(good);
 
             env.FinishInterval();
@@ -750,12 +765,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 1,   // unavailable
                 false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::MkDir,
+                "mkdir",
                 0,   // available
                 1,   // unavailable
                 false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::SymLink,
+                "symlink",
                 1,   // available
                 0,   // unavailable
                 true);   // last interval available
@@ -764,10 +779,9 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             // write and write_buf both map to WriteData
             TEnv env;
-            auto bad = env.Start(EFileStoreAvailabilityRequestType::Write);
+            auto bad = env.Start("write");
             env.CompleteWithErrno(bad, EIO);
-            auto good =
-                env.Start(EFileStoreAvailabilityRequestType::WriteBuf);
+            auto good = env.Start("write_buf");
             env.CompleteOk(good);
 
             env.FinishInterval();
@@ -777,12 +791,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 1,   // unavailable
                 false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::Write,
+                "write",
                 0,   // available
                 1,   // unavailable
                 false);   // last interval available
             env.AssertRequestIntervals(
-                EFileStoreAvailabilityRequestType::WriteBuf,
+                "write_buf",
                 1,   // available
                 0,   // unavailable
                 true);   // last interval available
@@ -799,7 +813,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // the request starts in (wall-clock) interval 2; the start event
         // itself rolls the accounting past the boundary first
-        env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.Start("read");
 
         // the late updater closes interval 1, in which the request did not
         // exist
@@ -823,7 +837,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         // the request is fresh-pending in the first interval => neutral
-        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        auto callContext = env.Start("read");
         env.FinishInterval();
         env.AssertIntervals(
             1,   // total
@@ -865,13 +879,13 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         env.Now += IntervalDuration + TDuration::Seconds(1);
         // interval 2: a starts (interval 1 elapsed empty => available)
-        auto a = env.Start(EFileStoreAvailabilityRequestType::Read);
+        auto a = env.Start("read");
 
         env.Now += IntervalDuration;
         // interval 3: a completes successfully; a was fresh-pending in
         // interval 2 => neutral there => interval 2 is available; b starts
         env.CompleteOk(a);
-        auto b = env.Start(EFileStoreAvailabilityRequestType::Write);
+        auto b = env.Start("write");
 
         env.Now += IntervalDuration;
         // interval 4: b completes with EIO; interval 3 saw a's success and
@@ -894,12 +908,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             1,   // unavailable
             false);   // last interval available
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Write,
+            "write",
             3,   // available
             1,   // unavailable
             false);   // last interval available
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Read,
+            "read",
             4,   // available
             0,   // unavailable
             true);   // last interval available
@@ -913,31 +927,35 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // a request started before the tracking is enabled gets no stamp
         auto preEnable = MakeIntrusive<TCallContext>();
-        preEnable->AvailabilityRequestType =
-            EFileStoreAvailabilityRequestType::Read;
+        preEnable->AvailabilityRequestType = ERequestType::Read;
         counters.RequestStarted(*preEnable, start);
         UNIT_ASSERT_VALUES_EQUAL(0, preEnable->AvailabilityIntervalSeqNo);
 
         // Request processing and the stats updater run concurrently with
-        // two racing EnableAndRegister() calls; the gates below guarantee
-        // full iterations both before and after enabling. Run under TSAN to
-        // verify the publication.
+        // two racing EnableAndRegister() calls. The updater advances the
+        // shared clock, so interval boundaries are crossed while requests
+        // are processed: the on-demand rollover in the request hooks races
+        // the updater rollover. The gates guarantee full iterations both
+        // before and after enabling and several boundaries crossed after
+        // enabling; run under TSAN to verify the publication.
+        std::atomic<ui64> nowUs = start.MicroSeconds();
         std::atomic<ui64> iterations = 0;
         std::atomic<bool> stop = false;
 
         std::thread requester([&] {
             while (!stop.load()) {
                 auto context = MakeIntrusive<TCallContext>();
-                context->AvailabilityRequestType =
-                    EFileStoreAvailabilityRequestType::Read;
-                counters.RequestStarted(*context, start);
-                counters.RequestCompleted(*context, start);
+                context->AvailabilityRequestType = ERequestType::Read;
+                const auto now = TInstant::MicroSeconds(nowUs.load());
+                counters.RequestStarted(*context, now);
+                counters.RequestCompleted(*context, now);
                 ++iterations;
             }
         });
         std::thread updater([&] {
             while (!stop.load()) {
-                counters.UpdateStats(start);
+                counters.UpdateStats(TInstant::MicroSeconds(nowUs.fetch_add(
+                    TDuration::Seconds(1).MicroSeconds())));
             }
         });
 
@@ -957,9 +975,14 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         enabler1.join();
         enabler2.join();
 
-        // at least 100 full iterations with the tracking enabled
+        // at least 100 full iterations and three elapsed intervals with
+        // the tracking enabled
         const ui64 enabledFrom = iterations.load();
-        while (iterations.load() < enabledFrom + 100) {}
+        const ui64 enabledNowUs = nowUs.load();
+        while (iterations.load() < enabledFrom + 100 ||
+               nowUs.load() <
+                   enabledNowUs + 3 * IntervalDuration.MicroSeconds())
+        {}
 
         stop = true;
         requester.join();
@@ -968,27 +991,31 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // The pre-enable request completes after enabling: it carries no
         // stamp and is ignored. A repeated completion of a tracked request
         // is ignored the same way; neither may disturb the accounting.
-        counters.RequestCompleted(*preEnable, start);
+        const auto end = TInstant::MicroSeconds(nowUs.load());
+        counters.RequestCompleted(*preEnable, end);
         auto repeated = MakeIntrusive<TCallContext>();
-        repeated->AvailabilityRequestType =
-            EFileStoreAvailabilityRequestType::Read;
-        counters.RequestStarted(*repeated, start);
-        counters.RequestCompleted(*repeated, start);
-        counters.RequestCompleted(*repeated, start);
+        repeated->AvailabilityRequestType = ERequestType::Read;
+        counters.RequestStarted(*repeated, end);
+        counters.RequestCompleted(*repeated, end);
+        counters.RequestCompleted(*repeated, end);
 
-        // the classification works after the race and the ignored events:
-        // the enabled-phase successes make the first interval available
-        counters.UpdateStats(start + IntervalDuration);
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            counterGroup->GetCounter(
-                "Availability_TotalIntervals",
-                true)->Val());
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            counterGroup->GetCounter(
-                "Availability_AvailableIntervals",
-                true)->Val());
+        // The accounting stays consistent across the concurrent rollovers:
+        // every closed interval is classified exactly once. Which intervals
+        // a racing request lands in is timing-dependent, so per-interval
+        // classification is not asserted here - the deterministic tests
+        // above cover it.
+        counters.UpdateStats(end + IntervalDuration);
+        const i64 total = counterGroup->GetCounter(
+            "Availability_TotalIntervals",
+            true)->Val();
+        const i64 available = counterGroup->GetCounter(
+            "Availability_AvailableIntervals",
+            true)->Val();
+        const i64 unavailable = counterGroup->GetCounter(
+            "Availability_UnavailableIntervals",
+            true)->Val();
+        UNIT_ASSERT(total >= 2);
+        UNIT_ASSERT_VALUES_EQUAL(total, available + unavailable);
     }
 
     Y_UNIT_TEST(ShouldSkipPartiallyObservedFirstInterval)
@@ -997,26 +1024,34 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TAvailabilityCounters counters;
         counters.EnableAndRegister(IntervalDuration, *counterGroup);
 
-        // the measurement begins two minutes into a wall-clock interval
+        // The measurement begins with the first observed activity after
+        // enabling - here the request event itself, with no updater tick
+        // before it - two minutes into a wall-clock interval.
         const TInstant alignedStart = TInstant::Hours(100);
-        const TInstant enableTime = alignedStart + TDuration::Minutes(2);
-        counters.UpdateStats(enableTime);
+        const TInstant firstEventTime = alignedStart + TDuration::Minutes(2);
 
         // an EIO completion within the partially observed interval
         auto context = MakeIntrusive<TCallContext>();
-        context->AvailabilityRequestType =
-            EFileStoreAvailabilityRequestType::Read;
-        counters.RequestStarted(*context, enableTime);
+        context->AvailabilityRequestType = ERequestType::Read;
+        counters.RequestStarted(*context, firstEventTime);
         context->GuestReplyErrno = EIO;
-        counters.RequestCompleted(*context, enableTime);
+        counters.RequestCompleted(*context, firstEventTime);
 
-        // The partial interval rolls over without classification: it never
-        // reaches the published counters even though it saw an EIO, because
-        // its first two minutes were not observed at all.
+        // The partial interval rolls over without classification even
+        // though it saw an EIO, because its first two minutes were not
+        // observed at all: neither the aggregated nor the per-type
+        // counters are published for it.
         counters.UpdateStats(alignedStart + IntervalDuration);
         auto total =
             counterGroup->GetCounter("Availability_TotalIntervals", true);
         UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
+        auto readGroup = counterGroup->FindSubgroup("request", "read");
+        UNIT_ASSERT(readGroup);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            readGroup->GetCounter(
+                "Availability_UnavailableIntervals",
+                true)->Val());
 
         // the first fully observed interval is classified normally
         counters.UpdateStats(alignedStart + IntervalDuration * 2);
@@ -1037,26 +1072,26 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         UNIT_ASSERT_VALUES_EQUAL(
             "write",
             TString(GetAvailabilityRequestTypeName(
-                EFileStoreAvailabilityRequestType::Write)));
+                ERequestType::Write)));
         UNIT_ASSERT_VALUES_EQUAL(
             "write_buf",
             TString(GetAvailabilityRequestTypeName(
-                EFileStoreAvailabilityRequestType::WriteBuf)));
+                ERequestType::WriteBuf)));
 
-        auto badContext = env.Start(EFileStoreAvailabilityRequestType::Write);
+        auto badContext = env.Start("write");
         env.CompleteWithErrno(badContext, EIO);
 
         env.FinishInterval();
 
         // the failing request type is unavailable in its own counters...
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Write,
+            "write",
             0,   // available
             1,   // unavailable
             false);   // last interval available
         // ...while an idle request type is available in the same interval...
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Read,
+            "read",
             1,   // available
             0,   // unavailable
             true);   // last interval available
@@ -1067,18 +1102,17 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             1,   // unavailable
             false);   // last interval available
 
-        auto goodContext =
-            env.Start(EFileStoreAvailabilityRequestType::Write);
+        auto goodContext = env.Start("write");
         env.CompleteOk(goodContext);
         env.FinishInterval();
 
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Write,
+            "write",
             1,   // available
             1,   // unavailable
             true);   // last interval available
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Read,
+            "read",
             2,   // available
             0,   // unavailable
             true);   // last interval available
@@ -1101,7 +1135,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             0,   // unavailable
             true);   // last interval available
         env.AssertRequestIntervals(
-            EFileStoreAvailabilityRequestType::Lookup,
+            "lookup",
             0,   // available
             0,   // unavailable
             true);   // last interval available

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -12,13 +12,13 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr TDuration Interval = TAvailabilityCounters::DefaultIntervalDuration;
+constexpr TDuration IntervalDuration = TDuration::Minutes(5);
 
 struct TEnv
 {
     NMonitoring::TDynamicCountersPtr CounterGroup =
         MakeIntrusive<NMonitoring::TDynamicCounters>();
-    TAvailabilityCounters Counters;
+    TAvailabilityCounters Counters{IntervalDuration};
     TInstant Now;
 
     NMonitoring::TDynamicCounters::TCounterPtr TotalIntervals;
@@ -51,14 +51,14 @@ struct TEnv
     // Advances time to the end of the current interval and rolls it over.
     void FinishInterval()
     {
-        Now += Interval;
+        Now += IntervalDuration;
         Counters.UpdateStats(Now);
     }
 
     void AdvanceWithinInterval(TDuration duration)
     {
         Now += duration;
-        UNIT_ASSERT(duration < Interval);
+        UNIT_ASSERT(duration < IntervalDuration);
         Counters.UpdateStats(Now);
     }
 
@@ -394,7 +394,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // exactly at the catch-up limit every elapsed interval is evaluated
         {
             TEnv env;
-            env.Now += Interval * 12;
+            env.Now += IntervalDuration * 12;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(12, 12, 0, true);
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
@@ -403,7 +403,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // one interval beyond the limit is reported as missing, not dropped
         {
             TEnv env;
-            env.Now += Interval * 13;
+            env.Now += IntervalDuration * 13;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(12, 12, 0, true);
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
@@ -412,7 +412,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         // a two-hour gap: half evaluated, half reported as missing
         {
             TEnv env;
-            env.Now += Interval * 24;
+            env.Now += IntervalDuration * 24;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(12, 12, 0, true);
             UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
@@ -433,7 +433,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             TEnv env;
             env.Start(EFileStoreAvailabilityRequestType::Read);
-            env.Now += Interval * 12;
+            env.Now += IntervalDuration * 12;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(12, 1, 11, false);
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
@@ -442,7 +442,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             TEnv env;
             env.Start(EFileStoreAvailabilityRequestType::Read);
-            env.Now += Interval * 13;
+            env.Now += IntervalDuration * 13;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(12, 1, 11, false);
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
@@ -451,7 +451,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         {
             TEnv env;
             env.Start(EFileStoreAvailabilityRequestType::Read);
-            env.Now += Interval * 24;
+            env.Now += IntervalDuration * 24;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(12, 1, 11, false);
             UNIT_ASSERT_VALUES_EQUAL(12, env.MissingIntervals->Val());
@@ -468,7 +468,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.FinishInterval();
         env.AssertIntervals(1, 1, 0, true);
 
-        env.Now += Interval * 3;
+        env.Now += IntervalDuration * 3;
         env.Counters.UpdateStats(env.Now);
 
         // the request remained outstanding throughout all 3 intervals

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <cerrno>
 #include <thread>
+#include <utility>
 
 namespace NCloud::NFileStore {
 
@@ -68,7 +69,7 @@ struct TEnv
     {
         auto callContext = MakeIntrusive<TCallContext>();
         callContext->AvailabilityRequestType = requestType;
-        Counters.RequestStarted(*callContext);
+        Counters.RequestStarted(*callContext, Now);
         return callContext;
     }
 
@@ -76,7 +77,7 @@ struct TEnv
     {
         // production success replies do not write GuestReplyErrno: they rely
         // on it being 0 for the current attempt
-        Counters.RequestCompleted(*callContext);
+        Counters.RequestCompleted(*callContext, Now);
     }
 
     void CompleteWithErrno(
@@ -84,7 +85,7 @@ struct TEnv
         int guestReplyErrno)
     {
         callContext->GuestReplyErrno = guestReplyErrno;
-        Counters.RequestCompleted(*callContext);
+        Counters.RequestCompleted(*callContext, Now);
     }
 
     // Asserts against the per-request-type published counters on the
@@ -788,68 +789,69 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldSupportCallContextReuse)
+    Y_UNIT_TEST(ShouldNotMarkPostBoundaryStartHung)
     {
         TEnv env;
 
-        // Pins the contract for a call context that is completed and then
-        // re-registered - the shape a vfs-layer retry would take. The hooks
-        // are driven directly; no dispatch-level retry path is exercised
-        // here.
-        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Read);
-        env.CompleteWithErrno(callContext, EIO);
-
-        env.Counters.RequestStarted(*callContext);
-
-        // the EIO completion of the first attempt is failure evidence, and
-        // the pending restarted attempt is neutral => unavailable
-        env.FinishInterval();
-        env.AssertIntervals(
-            1,   // total
-            0,   // available
-            1,   // unavailable
-            false);   // last interval available
-
-        // the successful completion of the restarted attempt is classified
-        // as a success: the re-registration cleared the stale EIO of the
-        // first attempt, and the success reply itself - as in production -
-        // does not write GuestReplyErrno
-        env.CompleteOk(callContext);
-        env.FinishInterval();
-        env.AssertIntervals(
-            2,   // total
-            1,   // available
-            1,   // unavailable
-            true);   // last interval available
-    }
-
-    Y_UNIT_TEST(ShouldNotCountRequestStartedAfterBoundaryAsHung)
-    {
-        TEnv env;
-
-        // the wall clock crosses the interval boundary while the stats
-        // updater stalls...
+        // move one second into the next wall-clock interval without any
+        // updater tick
         env.Now += IntervalDuration + TDuration::Seconds(1);
 
-        // ...and a request starts in the gap between the boundary and the
-        // late updater tick
-        auto context = env.Start(EFileStoreAvailabilityRequestType::Read);
+        // the request starts in (wall-clock) interval 2; the start event
+        // itself rolls the accounting past the boundary first
+        env.Start(EFileStoreAvailabilityRequestType::Read);
 
-        // the late tick closes the first interval: the request counts as
-        // fresh-pending (neutral) there, not hung
+        // the late updater closes interval 1, in which the request did not
+        // exist
         env.Counters.UpdateStats(env.Now);
-        env.AssertIntervals(
-            1,   // total
-            1,   // available
-            0,   // unavailable
-            true);   // last interval available
 
-        env.CompleteOk(context);
-        env.FinishInterval();
+        // Reach the end of the interval in which the request actually
+        // started: it was fresh-pending there => neutral, not hung. Both
+        // intervals must be available.
+        env.Now += IntervalDuration - TDuration::Seconds(1);
+        env.Counters.UpdateStats(env.Now);
+
         env.AssertIntervals(
             2,   // total
             2,   // available
             0,   // unavailable
+            true);   // last interval available
+    }
+
+    Y_UNIT_TEST(ShouldKeepHungIntervalUnavailableOnPostBoundaryCompletion)
+    {
+        TEnv env;
+
+        // the request is fresh-pending in the first interval => neutral
+        auto callContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.FinishInterval();
+        env.AssertIntervals(
+            1,   // total
+            1,   // available
+            0,   // unavailable
+            true);   // last interval available
+
+        // It stays outstanding through the entire second interval and
+        // completes successfully one second after the boundary, before any
+        // updater tick. The completion event rolls the accounting first, so
+        // the second interval is still classified with the request hung
+        // through it, and the success lands in the third interval.
+        env.Now += IntervalDuration + TDuration::Seconds(1);
+        env.CompleteOk(callContext);
+        env.Counters.UpdateStats(env.Now);
+        env.AssertIntervals(
+            2,   // total
+            1,   // available
+            1,   // unavailable
+            false);   // last interval available
+
+        // the third interval carries the successful completion
+        env.Now += IntervalDuration - TDuration::Seconds(1);
+        env.Counters.UpdateStats(env.Now);
+        env.AssertIntervals(
+            3,   // total
+            2,   // available
+            1,   // unavailable
             true);   // last interval available
     }
 
@@ -857,80 +859,173 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        // a request outstanding from before the stall
-        auto hungContext = env.Start(EFileStoreAvailabilityRequestType::Read);
-        env.FinishInterval();
+        // No updater ticks happen between the events below: every event is
+        // still assigned to its actual wall-clock interval because the
+        // request hooks roll the accounting on demand.
+
+        env.Now += IntervalDuration + TDuration::Seconds(1);
+        // interval 2: a starts (interval 1 elapsed empty => available)
+        auto a = env.Start(EFileStoreAvailabilityRequestType::Read);
+
+        env.Now += IntervalDuration;
+        // interval 3: a completes successfully; a was fresh-pending in
+        // interval 2 => neutral there => interval 2 is available; b starts
+        env.CompleteOk(a);
+        auto b = env.Start(EFileStoreAvailabilityRequestType::Write);
+
+        env.Now += IntervalDuration;
+        // interval 4: b completes with EIO; interval 3 saw a's success and
+        // the fresh-pending b => available
+        env.CompleteWithErrno(b, EIO);
+
+        env.Counters.UpdateStats(env.Now);
         env.AssertIntervals(
-            1,   // total
-            1,   // available
+            3,   // total
+            3,   // available
             0,   // unavailable
             true);   // last interval available
 
-        // the updater stalls for three intervals; requests keep starting
-        // and completing meanwhile
-        auto eioContext = env.Start(EFileStoreAvailabilityRequestType::Read);
-        env.CompleteWithErrno(eioContext, EIO);
-        auto okContext = env.Start(EFileStoreAvailabilityRequestType::Read);
-        env.CompleteOk(okContext);
-
-        env.Now += IntervalDuration * 3;
+        // interval 4 carries only b's EIO completion => unavailable
+        env.Now += IntervalDuration - TDuration::Seconds(1);
         env.Counters.UpdateStats(env.Now);
-
-        // Catch-up: the first stalled interval sees all the evidence
-        // accumulated during the stall, and the successful completion makes
-        // it available despite the EIO completion and the old hung request
-        // (any success => available). The remaining two stalled intervals
-        // see only the still-outstanding old request => hung =>
-        // unavailable.
         env.AssertIntervals(
             4,   // total
-            2,   // available
-            2,   // unavailable
-            false);   // last interval available
-
-        env.CompleteOk(hungContext);
-        env.FinishInterval();
-        env.AssertIntervals(
-            5,   // total
             3,   // available
-            2,   // unavailable
+            1,   // unavailable
+            false);   // last interval available
+        env.AssertRequestIntervals(
+            EFileStoreAvailabilityRequestType::Write,
+            3,   // available
+            1,   // unavailable
+            false);   // last interval available
+        env.AssertRequestIntervals(
+            EFileStoreAvailabilityRequestType::Read,
+            4,   // available
+            0,   // unavailable
             true);   // last interval available
     }
 
     Y_UNIT_TEST(ShouldEnableConcurrentlyWithRequestProcessing)
     {
-        // A sanitizer-oriented test: request processing and the stats
-        // updater run while the tracking is being enabled. The hooks must
-        // be no-ops until the tracker is published and must never observe
-        // a partially initialized one; run under TSAN to verify.
         auto counterGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
         TAvailabilityCounters counters;
+        const TInstant start = TInstant::Hours(100);
 
+        // a request started before the tracking is enabled gets no stamp
+        auto preEnable = MakeIntrusive<TCallContext>();
+        preEnable->AvailabilityRequestType =
+            EFileStoreAvailabilityRequestType::Read;
+        counters.RequestStarted(*preEnable, start);
+        UNIT_ASSERT_VALUES_EQUAL(0, preEnable->AvailabilityIntervalSeqNo);
+
+        // Request processing and the stats updater run concurrently with
+        // two racing EnableAndRegister() calls; the gates below guarantee
+        // full iterations both before and after enabling. Run under TSAN to
+        // verify the publication.
+        std::atomic<ui64> iterations = 0;
         std::atomic<bool> stop = false;
-
-        std::thread updater([&] {
-            TInstant now = TInstant::Hours(100);
-            while (!stop.load()) {
-                counters.UpdateStats(now);
-                now += TDuration::Seconds(1);
-            }
-        });
 
         std::thread requester([&] {
             while (!stop.load()) {
                 auto context = MakeIntrusive<TCallContext>();
                 context->AvailabilityRequestType =
                     EFileStoreAvailabilityRequestType::Read;
-                counters.RequestStarted(*context);
-                counters.RequestCompleted(*context);
+                counters.RequestStarted(*context, start);
+                counters.RequestCompleted(*context, start);
+                ++iterations;
+            }
+        });
+        std::thread updater([&] {
+            while (!stop.load()) {
+                counters.UpdateStats(start);
             }
         });
 
-        counters.EnableAndRegister(IntervalDuration, *counterGroup);
+        // at least one full iteration with the tracking disabled
+        while (iterations.load() == 0) {}
+
+        std::atomic<bool> go = false;
+        std::thread enabler1([&] {
+            while (!go.load()) {}
+            counters.EnableAndRegister(IntervalDuration, *counterGroup);
+        });
+        std::thread enabler2([&] {
+            while (!go.load()) {}
+            counters.EnableAndRegister(IntervalDuration, *counterGroup);
+        });
+        go = true;
+        enabler1.join();
+        enabler2.join();
+
+        // at least 100 full iterations with the tracking enabled
+        const ui64 enabledFrom = iterations.load();
+        while (iterations.load() < enabledFrom + 100) {}
 
         stop = true;
-        updater.join();
         requester.join();
+        updater.join();
+
+        // The pre-enable request completes after enabling: it carries no
+        // stamp and is ignored. A repeated completion of a tracked request
+        // is ignored the same way; neither may disturb the accounting.
+        counters.RequestCompleted(*preEnable, start);
+        auto repeated = MakeIntrusive<TCallContext>();
+        repeated->AvailabilityRequestType =
+            EFileStoreAvailabilityRequestType::Read;
+        counters.RequestStarted(*repeated, start);
+        counters.RequestCompleted(*repeated, start);
+        counters.RequestCompleted(*repeated, start);
+
+        // the classification works after the race and the ignored events:
+        // the enabled-phase successes make the first interval available
+        counters.UpdateStats(start + IntervalDuration);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counterGroup->GetCounter(
+                "Availability_TotalIntervals",
+                true)->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counterGroup->GetCounter(
+                "Availability_AvailableIntervals",
+                true)->Val());
+    }
+
+    Y_UNIT_TEST(ShouldSkipPartiallyObservedFirstInterval)
+    {
+        auto counterGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        TAvailabilityCounters counters;
+        counters.EnableAndRegister(IntervalDuration, *counterGroup);
+
+        // the measurement begins two minutes into a wall-clock interval
+        const TInstant alignedStart = TInstant::Hours(100);
+        const TInstant enableTime = alignedStart + TDuration::Minutes(2);
+        counters.UpdateStats(enableTime);
+
+        // an EIO completion within the partially observed interval
+        auto context = MakeIntrusive<TCallContext>();
+        context->AvailabilityRequestType =
+            EFileStoreAvailabilityRequestType::Read;
+        counters.RequestStarted(*context, enableTime);
+        context->GuestReplyErrno = EIO;
+        counters.RequestCompleted(*context, enableTime);
+
+        // The partial interval rolls over without classification: it never
+        // reaches the published counters even though it saw an EIO, because
+        // its first two minutes were not observed at all.
+        counters.UpdateStats(alignedStart + IntervalDuration);
+        auto total =
+            counterGroup->GetCounter("Availability_TotalIntervals", true);
+        UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
+
+        // the first fully observed interval is classified normally
+        counters.UpdateStats(alignedStart + IntervalDuration * 2);
+        UNIT_ASSERT_VALUES_EQUAL(1, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counterGroup->GetCounter(
+                "Availability_AvailableIntervals",
+                true)->Val());
     }
 
     Y_UNIT_TEST(ShouldPublishPerRequestTypeCounters)

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -4,7 +4,9 @@
 
 #include <util/generic/ptr.h>
 
+#include <atomic>
 #include <cerrno>
+#include <thread>
 
 namespace NCloud::NFileStore {
 
@@ -312,24 +314,31 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        // An old hung request together with a fresh EIO completion: every
-        // outstanding request is either hung or completed with EIO =>
-        // unavailable. This requires correctly attributing the completion to
-        // the fresh request via the interval sequence number.
-        auto hungContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        // a pending request started within the interval is neutral
+        auto oldContext = env.Start(EFileStoreAvailabilityRequestType::Read);
         env.FinishInterval();
         env.AssertIntervals(1, 1, 0, true);
 
+        // The old request completes while a fresh one is also outstanding.
+        // The completion must consume the old registration via the interval
+        // sequence number: the fresh request then stays fresh-pending
+        // (neutral) and the successful completion is the only evidence =>
+        // available. Decrementing the fresh request's accounting instead
+        // would classify it as hung and flip the interval to unavailable.
         auto freshContext =
             env.Start(EFileStoreAvailabilityRequestType::Read);
-        env.CompleteWithErrno(freshContext, EIO);
+        env.CompleteOk(oldContext);
 
         env.FinishInterval();
-        env.AssertIntervals(2, 1, 1, false);
+        env.AssertIntervals(2, 2, 0, true);
 
-        env.CompleteOk(hungContext);
+        // the fresh request is old by now and hangs the third interval
         env.FinishInterval();
-        env.AssertIntervals(3, 2, 1, true);
+        env.AssertIntervals(3, 2, 1, false);
+
+        env.CompleteOk(freshContext);
+        env.FinishInterval();
+        env.AssertIntervals(4, 3, 1, true);
     }
 
     Y_UNIT_TEST(ShouldClassifyRequestTypesIndependently)
@@ -356,10 +365,12 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        // requests outside the availability SLA - e.g. mknod, access, xattr
-        // and lock requests - get no availability request type at the FUSE
-        // dispatch and do not affect the metric even if they fail with EIO
-        // or hang
+        // Requests with EFileStoreAvailabilityRequestType::None do not
+        // affect the metric even if they fail with EIO or hang. (The FUSE
+        // dispatch assigns None to the requests outside the availability
+        // SLA - e.g. mknod, access, xattr and lock requests; that
+        // assignment lives in the CALL table in loop.cpp and is not covered
+        // here.)
         auto eioContext =
             env.Start(EFileStoreAvailabilityRequestType::None);
         env.CompleteWithErrno(eioContext, EIO);
@@ -494,12 +505,14 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.AssertIntervals(1, 0, 1, false);
     }
 
-    Y_UNIT_TEST(ShouldAccountFuseRequestTypesIndependently)
+    Y_UNIT_TEST(ShouldAccountRequestTypesIndependently)
     {
-        // EFileStoreRequest maps each of these FUSE request pairs onto one
+        // EFileStoreRequest maps each of these request pairs onto one
         // backend request type; the SLA accounts them independently, so a
-        // FUSE request type failing with EIO makes the interval unavailable
-        // even when its backend sibling succeeds in the same interval
+        // request type failing with EIO makes the interval unavailable even
+        // when its backend sibling succeeds in the same interval. (That the
+        // FUSE callbacks assign these enums is a property of the CALL table
+        // in loop.cpp and is not covered here.)
 
         {
             // lookup and getattr both map to GetNodeAttr
@@ -527,6 +540,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
             env.FinishInterval();
             env.AssertIntervals(1, 0, 1, false);
+            env.AssertRequestIntervals(
+                EFileStoreAvailabilityRequestType::Open, 0, 1, false);
+            env.AssertRequestIntervals(
+                EFileStoreAvailabilityRequestType::Create, 1, 0, true);
         }
 
         {
@@ -539,6 +556,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
             env.FinishInterval();
             env.AssertIntervals(1, 0, 1, false);
+            env.AssertRequestIntervals(
+                EFileStoreAvailabilityRequestType::MkDir, 0, 1, false);
+            env.AssertRequestIntervals(
+                EFileStoreAvailabilityRequestType::SymLink, 1, 0, true);
         }
 
         {
@@ -552,15 +573,21 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
             env.FinishInterval();
             env.AssertIntervals(1, 0, 1, false);
+            env.AssertRequestIntervals(
+                EFileStoreAvailabilityRequestType::Write, 0, 1, false);
+            env.AssertRequestIntervals(
+                EFileStoreAvailabilityRequestType::WriteBuf, 1, 0, true);
         }
     }
 
-    Y_UNIT_TEST(ShouldSupportRestartedRequests)
+    Y_UNIT_TEST(ShouldSupportCallContextReuse)
     {
         TEnv env;
 
-        // some request types are retried by the vfs layer by completing and
-        // re-starting the same call context
+        // Pins the contract for a call context that is completed and then
+        // re-registered - the shape a vfs-layer retry would take. The hooks
+        // are driven directly; no dispatch-level retry path is exercised
+        // here.
         auto callContext = env.Start(EFileStoreAvailabilityRequestType::Read);
         env.CompleteWithErrno(callContext, EIO);
 
@@ -578,6 +605,96 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         env.CompleteOk(callContext);
         env.FinishInterval();
         env.AssertIntervals(2, 1, 1, true);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountRequestStartedAfterBoundaryAsHung)
+    {
+        TEnv env;
+
+        // the wall clock crosses the interval boundary while the stats
+        // updater stalls...
+        env.Now += IntervalDuration + TDuration::Seconds(1);
+
+        // ...and a request starts in the gap between the boundary and the
+        // late updater tick
+        auto context = env.Start(EFileStoreAvailabilityRequestType::Read);
+
+        // the late tick closes the first interval: the request counts as
+        // fresh-pending (neutral) there, not hung
+        env.Counters.UpdateStats(env.Now);
+        env.AssertIntervals(1, 1, 0, true);
+
+        env.CompleteOk(context);
+        env.FinishInterval();
+        env.AssertIntervals(2, 2, 0, true);
+    }
+
+    Y_UNIT_TEST(ShouldAccountActivityDuringUpdaterStall)
+    {
+        TEnv env;
+
+        // a request outstanding from before the stall
+        auto hungContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.FinishInterval();
+        env.AssertIntervals(1, 1, 0, true);
+
+        // the updater stalls for three intervals; requests keep starting
+        // and completing meanwhile
+        auto eioContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.CompleteWithErrno(eioContext, EIO);
+        auto okContext = env.Start(EFileStoreAvailabilityRequestType::Read);
+        env.CompleteOk(okContext);
+
+        env.Now += IntervalDuration * 3;
+        env.Counters.UpdateStats(env.Now);
+
+        // Catch-up: the first stalled interval sees all the evidence
+        // accumulated during the stall, and the successful completion makes
+        // it available despite the EIO completion and the old hung request
+        // (any success => available). The remaining two stalled intervals
+        // see only the still-outstanding old request => hung =>
+        // unavailable.
+        env.AssertIntervals(4, 2, 2, false);
+
+        env.CompleteOk(hungContext);
+        env.FinishInterval();
+        env.AssertIntervals(5, 3, 2, true);
+    }
+
+    Y_UNIT_TEST(ShouldEnableConcurrentlyWithRequestProcessing)
+    {
+        // A sanitizer-oriented test: request processing and the stats
+        // updater run while the tracking is being enabled. The hooks must
+        // be no-ops until the tracker is published and must never observe
+        // a partially initialized one; run under TSAN to verify.
+        auto counterGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        TAvailabilityCounters counters;
+
+        std::atomic<bool> stop = false;
+
+        std::thread updater([&] {
+            TInstant now = TInstant::Hours(100);
+            while (!stop.load()) {
+                counters.UpdateStats(now);
+                now += TDuration::Seconds(1);
+            }
+        });
+
+        std::thread requester([&] {
+            while (!stop.load()) {
+                auto context = MakeIntrusive<TCallContext>();
+                context->AvailabilityRequestType =
+                    EFileStoreAvailabilityRequestType::Read;
+                counters.RequestStarted(*context);
+                counters.RequestCompleted(*context);
+            }
+        });
+
+        counters.EnableAndRegister(IntervalDuration, *counterGroup);
+
+        stop = true;
+        updater.join();
+        requester.join();
     }
 
     Y_UNIT_TEST(ShouldPublishPerRequestTypeCounters)

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -104,6 +104,8 @@ namespace NCloud::NFileStore{
     xxx(InMemoryIndexStateNotInitialized)                                      \
     xxx(WriteDataRequestWithBufferAndPayload)                                  \
     xxx(DiagnosticStatsInsertFailed)                                           \
+    xxx(AvailabilityCountersDoubleRegistration)                                \
+    xxx(AvailabilityCountersUnpairedCompletion)                                \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -105,7 +105,6 @@ namespace NCloud::NFileStore{
     xxx(WriteDataRequestWithBufferAndPayload)                                  \
     xxx(DiagnosticStatsInsertFailed)                                           \
     xxx(AvailabilityCountersDoubleRegistration)                                \
-    xxx(AvailabilityCountersUnpairedCompletion)                                \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -1,5 +1,6 @@
 #include "request_stats.h"
 
+#include "availability_counters.h"
 #include "config.h"
 #include "critical_events.h"
 #include "filesystem_counters.h"
@@ -427,9 +428,13 @@ private:
     const TString CloudId;
     const TString FolderId;
 
+    const ITimerPtr Timer;
+
     TRequestCountersPtr Counters;
     IPostponeTimePredictorPtr Predictor;
     TPostponeTimePredictorStats PredictorStats;
+
+    TAvailabilityCounters AvailabilityCounters;
 
     TMutex Lock;
     TVector<IIncompleteRequestProviderPtr> IncompleteRequestProviders;
@@ -454,6 +459,7 @@ public:
         , ClientId{std::move(clientId)}
         , CloudId{std::move(cloudId)}
         , FolderId{std::move(folderId)}
+        , Timer{timer}
         , Counters{MakeRequestCounters(
             timer,
             *counters,
@@ -461,7 +467,9 @@ public:
             histogramCounterOptions)}
         , Predictor{std::move(predictor)}
         , PredictorStats{counters, std::move(timer)}
-    {}
+    {
+        AvailabilityCounters.Register(*counters);
+    }
 
     void SetUserMetadata(TUserMetadata userMetadata)
     {
@@ -484,6 +492,8 @@ public:
             GetRequestType(callContext),
             callContext.RequestSize));
 
+        AvailabilityCounters.RequestStarted(callContext);
+
         PredictionStarted(callContext);
     }
 
@@ -494,6 +504,8 @@ public:
         RequestCompleted(
             callContext,
             GetDiagnosticsErrorKind(error));
+
+        AvailabilityCounters.RequestCompleted(callContext);
 
         PredictionCompleted(callContext);
     }
@@ -516,6 +528,8 @@ public:
         const auto requestTime = RequestCompleted(callContext, errorKind);
         LogCompleted(log, callContext, requestTime, errorKind, error);
 
+        AvailabilityCounters.RequestCompleted(callContext);
+
         PredictionCompleted(callContext);
     }
 
@@ -534,6 +548,7 @@ public:
 
         Counters->UpdateStats(updatePercentiles);
         PredictorStats.UpdateStats();
+        AvailabilityCounters.UpdateStats(Timer->Now());
     }
 
     void RegisterIncompleteRequestProvider(

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -9,6 +9,8 @@
 #include <cloud/filestore/libs/diagnostics/user_counter.h>
 #include <cloud/filestore/libs/service/context.h>
 
+#include <optional>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/timer.h>
@@ -434,7 +436,11 @@ private:
     IPostponeTimePredictorPtr Predictor;
     TPostponeTimePredictorStats PredictorStats;
 
-    TAvailabilityCounters AvailabilityCounters;
+    TDynamicCountersPtr StatsCounters;
+
+    // Present when the availability tracking is enabled for this filesystem
+    // via TFileStoreFeatures (see EnableAvailabilityTracking).
+    std::optional<TAvailabilityCounters> AvailabilityCounters;
 
     TMutex Lock;
     TVector<IIncompleteRequestProviderPtr> IncompleteRequestProviders;
@@ -467,8 +473,19 @@ public:
             histogramCounterOptions)}
         , Predictor{std::move(predictor)}
         , PredictorStats{counters, std::move(timer)}
+        , StatsCounters{std::move(counters)}
+    {}
+
+    void EnableAvailabilityTracking(TDuration interval) override
     {
-        AvailabilityCounters.Register(*counters);
+        if (AvailabilityCounters) {
+            // already enabled (e.g. the session was re-established)
+            return;
+        }
+
+        // a zero interval selects the default one
+        AvailabilityCounters.emplace(interval);
+        AvailabilityCounters->Register(*StatsCounters);
     }
 
     void SetUserMetadata(TUserMetadata userMetadata)
@@ -492,7 +509,9 @@ public:
             GetRequestType(callContext),
             callContext.RequestSize));
 
-        AvailabilityCounters.RequestStarted(callContext);
+        if (AvailabilityCounters) {
+            AvailabilityCounters->RequestStarted(callContext);
+        }
 
         PredictionStarted(callContext);
     }
@@ -505,7 +524,9 @@ public:
             callContext,
             GetDiagnosticsErrorKind(error));
 
-        AvailabilityCounters.RequestCompleted(callContext);
+        if (AvailabilityCounters) {
+            AvailabilityCounters->RequestCompleted(callContext);
+        }
 
         PredictionCompleted(callContext);
     }
@@ -528,7 +549,9 @@ public:
         const auto requestTime = RequestCompleted(callContext, errorKind);
         LogCompleted(log, callContext, requestTime, errorKind, error);
 
-        AvailabilityCounters.RequestCompleted(callContext);
+        if (AvailabilityCounters) {
+            AvailabilityCounters->RequestCompleted(callContext);
+        }
 
         PredictionCompleted(callContext);
     }
@@ -548,7 +571,9 @@ public:
 
         Counters->UpdateStats(updatePercentiles);
         PredictorStats.UpdateStats();
-        AvailabilityCounters.UpdateStats(Timer->Now());
+        if (AvailabilityCounters) {
+            AvailabilityCounters->UpdateStats(Timer->Now());
+        }
     }
 
     void RegisterIncompleteRequestProvider(

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -479,7 +479,7 @@ public:
     void EnableAvailabilityTracking(TDuration interval) override
     {
         if (AvailabilityCounters) {
-            // already enabled (e.g. the session was re-established)
+            // already enabled
             return;
         }
 

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -9,8 +9,6 @@
 #include <cloud/filestore/libs/diagnostics/user_counter.h>
 #include <cloud/filestore/libs/service/context.h>
 
-#include <optional>
-
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/timer.h>
@@ -438,9 +436,9 @@ private:
 
     TDynamicCountersPtr StatsCounters;
 
-    // Present when the availability tracking is enabled for this filesystem
-    // via TFileStoreFeatures (see EnableAvailabilityTracking).
-    std::optional<TAvailabilityCounters> AvailabilityCounters;
+    // The tracking is enabled for this filesystem via TFileStoreFeatures
+    // (see EnableAvailabilityTracking); until then the tracker is inert.
+    TAvailabilityCounters AvailabilityCounters;
 
     TMutex Lock;
     TVector<IIncompleteRequestProviderPtr> IncompleteRequestProviders;
@@ -478,14 +476,8 @@ public:
 
     void EnableAvailabilityTracking(TDuration interval) override
     {
-        if (AvailabilityCounters) {
-            // already enabled
-            return;
-        }
-
         // a zero interval selects the default one
-        AvailabilityCounters.emplace(interval);
-        AvailabilityCounters->Register(*StatsCounters);
+        AvailabilityCounters.EnableAndRegister(interval, *StatsCounters);
     }
 
     void SetUserMetadata(TUserMetadata userMetadata)
@@ -509,9 +501,7 @@ public:
             GetRequestType(callContext),
             callContext.RequestSize));
 
-        if (AvailabilityCounters) {
-            AvailabilityCounters->RequestStarted(callContext);
-        }
+        AvailabilityCounters.RequestStarted(callContext);
 
         PredictionStarted(callContext);
     }
@@ -524,9 +514,7 @@ public:
             callContext,
             GetDiagnosticsErrorKind(error));
 
-        if (AvailabilityCounters) {
-            AvailabilityCounters->RequestCompleted(callContext);
-        }
+        AvailabilityCounters.RequestCompleted(callContext);
 
         PredictionCompleted(callContext);
     }
@@ -549,9 +537,7 @@ public:
         const auto requestTime = RequestCompleted(callContext, errorKind);
         LogCompleted(log, callContext, requestTime, errorKind, error);
 
-        if (AvailabilityCounters) {
-            AvailabilityCounters->RequestCompleted(callContext);
-        }
+        AvailabilityCounters.RequestCompleted(callContext);
 
         PredictionCompleted(callContext);
     }
@@ -571,9 +557,7 @@ public:
 
         Counters->UpdateStats(updatePercentiles);
         PredictorStats.UpdateStats();
-        if (AvailabilityCounters) {
-            AvailabilityCounters->UpdateStats(Timer->Now());
-        }
+        AvailabilityCounters.UpdateStats(Timer->Now());
     }
 
     void RegisterIncompleteRequestProvider(

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -501,7 +501,7 @@ public:
             GetRequestType(callContext),
             callContext.RequestSize));
 
-        AvailabilityCounters.RequestStarted(callContext);
+        AvailabilityCounters.RequestStarted(callContext, Timer->Now());
 
         PredictionStarted(callContext);
     }
@@ -514,7 +514,7 @@ public:
             callContext,
             GetDiagnosticsErrorKind(error));
 
-        AvailabilityCounters.RequestCompleted(callContext);
+        AvailabilityCounters.RequestCompleted(callContext, Timer->Now());
 
         PredictionCompleted(callContext);
     }
@@ -537,7 +537,7 @@ public:
         const auto requestTime = RequestCompleted(callContext, errorKind);
         LogCompleted(log, callContext, requestTime, errorKind, error);
 
-        AvailabilityCounters.RequestCompleted(callContext);
+        AvailabilityCounters.RequestCompleted(callContext, Timer->Now());
 
         PredictionCompleted(callContext);
     }

--- a/cloud/filestore/libs/diagnostics/request_stats.h
+++ b/cloud/filestore/libs/diagnostics/request_stats.h
@@ -45,13 +45,8 @@ struct IRequestStats
     virtual void UpdateStats(bool updatePercentiles) = 0;
 
     // Enables the per-client filesystem availability tracking with the given
-    // interval duration (zero selects the default one) when the
-    // TFileStoreFeatures of the filesystem request it. Repeated calls are
-    // no-ops and the feature is never disabled in runtime. Must be invoked
-    // before guest requests start flowing (i.e. before the fuse loop is
-    // started). Only meaningful for per-filesystem stats: the default
-    // implementation ignores the call.
-    virtual void EnableAvailabilityTracking(TDuration /*interval*/)
+    // interval duration (zero selects the default one).
+    virtual void EnableAvailabilityTracking(TDuration /* interval */)
     {}
 
     virtual void RegisterIncompleteRequestProvider(IIncompleteRequestProviderPtr provider) = 0;

--- a/cloud/filestore/libs/diagnostics/request_stats.h
+++ b/cloud/filestore/libs/diagnostics/request_stats.h
@@ -44,6 +44,16 @@ struct IRequestStats
 
     virtual void UpdateStats(bool updatePercentiles) = 0;
 
+    // Enables the per-client filesystem availability tracking with the given
+    // interval duration (zero selects the default one) when the
+    // TFileStoreFeatures of the filesystem request it. Repeated calls are
+    // no-ops and the feature is never disabled in runtime. Must be invoked
+    // before guest requests start flowing (i.e. before the fuse loop is
+    // started). Only meaningful for per-filesystem stats: the default
+    // implementation ignores the call.
+    virtual void EnableAvailabilityTracking(TDuration /*interval*/)
+    {}
+
     virtual void RegisterIncompleteRequestProvider(IIncompleteRequestProviderPtr provider) = 0;
 
     virtual void Reset() = 0;

--- a/cloud/filestore/libs/diagnostics/ut/ya.make
+++ b/cloud/filestore/libs/diagnostics/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(cloud/filestore/libs/diagnostics)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/small.inc)
 
 SRCS(
+    availability_counters_ut.cpp
     module_stats_ut.cpp
     profile_log_events_ut.cpp
     profile_log_ut.cpp

--- a/cloud/filestore/libs/diagnostics/ya.make
+++ b/cloud/filestore/libs/diagnostics/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    availability_counters.cpp
     config.cpp
     critical_events.cpp
     filesystem_counters.cpp

--- a/cloud/filestore/libs/service/context.h
+++ b/cloud/filestore/libs/service/context.h
@@ -20,9 +20,8 @@ public:
 
     EFileStoreRequest RequestType = EFileStoreRequest::MAX;
 
-    // The FUSE request type as accounted by the per-client availability
-    // metric (None for requests outside the availability SLA). Assigned at
-    // the FUSE dispatch together with RequestType.
+    // The request type as accounted by the per-client availability
+    // metric (None for requests outside the availability SLA).
     EFileStoreAvailabilityRequestType AvailabilityRequestType =
         EFileStoreAvailabilityRequestType::None;
 
@@ -34,20 +33,13 @@ public:
     int CancellationCode = 0;
     std::atomic<bool> Cancelled = false;
 
-    // The errno sent to the guest in the response: the error code passed to
-    // fuse_reply_err() or 0 for successful replies and cancelled requests.
-    // Set by the vfs_fuse layer right before reporting request completion
-    // and reset by TAvailabilityCounters when the request is (re)registered.
-    // Used by the per-client availability metric to classify terminal request
-    // outcomes (EIO vs any other outcome), because the internal request error
-    // does not always match the guest-visible outcome.
+    // The errno sent to the guest in the response.
+    // Should be set by right before reporting request completion.
     int GuestReplyErrno = 0;
 
     // Availability registration stamp, maintained by TAvailabilityCounters
     // (see request stats): 0 means the request is not registered with the
-    // availability metric; otherwise the sequence number of the availability
-    // interval the request started in, plus one. Consumed (reset to 0) when
-    // the completion is reported.
+    // availability metric.
     ui64 AvailabilityIntervalSeqNo = 0;
 
     explicit TCallContext(ui64 requestId = 0);

--- a/cloud/filestore/libs/service/context.h
+++ b/cloud/filestore/libs/service/context.h
@@ -19,6 +19,13 @@ public:
     TString FileSystemId;
 
     EFileStoreRequest RequestType = EFileStoreRequest::MAX;
+
+    // The FUSE request type as accounted by the per-client availability
+    // metric (None for requests outside the availability SLA). Assigned at
+    // the FUSE dispatch together with RequestType.
+    EFileStoreAvailabilityRequestType AvailabilityRequestType =
+        EFileStoreAvailabilityRequestType::None;
+
     ui64 RequestSize = 0;
     bool Unaligned = false;
 
@@ -26,6 +33,22 @@ public:
 
     int CancellationCode = 0;
     std::atomic<bool> Cancelled = false;
+
+    // The errno sent to the guest in the response: the error code passed to
+    // fuse_reply_err() or 0 for successful replies and cancelled requests.
+    // Set by the vfs_fuse layer right before reporting request completion
+    // and reset by TAvailabilityCounters when the request is (re)registered.
+    // Used by the per-client availability metric to classify terminal request
+    // outcomes (EIO vs any other outcome), because the internal request error
+    // does not always match the guest-visible outcome.
+    int GuestReplyErrno = 0;
+
+    // Availability registration stamp, maintained by TAvailabilityCounters
+    // (see request stats): 0 means the request is not registered with the
+    // availability metric; otherwise the sequence number of the availability
+    // interval the request started in, plus one. Consumed (reset to 0) when
+    // the completion is reported.
+    ui64 AvailabilityIntervalSeqNo = 0;
 
     explicit TCallContext(ui64 requestId = 0);
     explicit TCallContext(TString fileSystemId, ui64 requestId = 0);

--- a/cloud/filestore/libs/service/request.h
+++ b/cloud/filestore/libs/service/request.h
@@ -223,6 +223,53 @@ enum class EFileStoreRequest
 
 constexpr size_t FileStoreRequestCount = static_cast<size_t>(EFileStoreRequest::MAX);
 
+////////////////////////////////////////////////////////////////////////////////
+
+// Guest (FUSE) request types for which the per-client filesystem availability
+// SLA is defined: readdir, readdirplus, opendir, releasedir, lookup, getattr,
+// setattr, write, write_buf, read, open, create, release, mkdir, rmdir,
+// unlink, rename, link, symlink, readlink, flush, fsync.
+//
+// A dedicated enum is required because EFileStoreRequest maps several
+// distinct FUSE request types onto one backend request type (e.g. lookup and
+// getattr both map to GetNodeAttr, and mkdir, symlink, link and even mknod
+// all map to CreateNode), while the SLA accounts each FUSE request type
+// independently - and some of the aliases (e.g. mknod) are not subject to
+// the SLA at all. Assigned at the FUSE dispatch (see TFileSystemLoop).
+enum class EFileStoreAvailabilityRequestType
+{
+    // the request is not subject to the availability SLA
+    None = 0,
+
+    Lookup = 1,
+    GetAttr = 2,
+    SetAttr = 3,
+    ReadLink = 4,
+    MkDir = 5,
+    RmDir = 6,
+    Unlink = 7,
+    SymLink = 8,
+    Link = 9,
+    Rename = 10,
+    Open = 11,
+    Create = 12,
+    Read = 13,
+    Write = 14,
+    WriteBuf = 15,
+    Flush = 16,
+    Fsync = 17,
+    Release = 18,
+    OpenDir = 19,
+    ReadDir = 20,
+    ReadDirPlus = 21,
+    ReleaseDir = 22,
+
+    MAX = 23,
+};
+
+constexpr size_t FileStoreAvailabilityRequestTypeCount =
+    static_cast<size_t>(EFileStoreAvailabilityRequestType::MAX);
+
 const TString& GetFileStoreRequestName(EFileStoreRequest requestType);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/service/request.h
+++ b/cloud/filestore/libs/service/request.h
@@ -233,9 +233,7 @@ constexpr size_t FileStoreRequestCount = static_cast<size_t>(EFileStoreRequest::
 // A dedicated enum is required because EFileStoreRequest maps several
 // distinct FUSE request types onto one backend request type (e.g. lookup and
 // getattr both map to GetNodeAttr, and mkdir, symlink, link and even mknod
-// all map to CreateNode), while the SLA accounts each FUSE request type
-// independently - and some of the aliases (e.g. mknod) are not subject to
-// the SLA at all. Assigned at the FUSE dispatch (see TFileSystemLoop).
+// all map to CreateNode).
 enum class EFileStoreAvailabilityRequestType
 {
     // the request is not subject to the availability SLA

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -293,6 +293,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(ServerWriteBackCacheFlushWritesInParallelEnabled, bool,     false     )\
                                                                                \
     xxx(GuestKeepCacheAllowed,                     bool,      false           )\
+    xxx(AvailabilityTrackingEnabled,   bool,       false                      )\
+    xxx(AvailabilityTrackingInterval,  TDuration,  TDuration::Zero()          )\
     xxx(GuestCachingType,                                                      \
         NProto::EGuestCachingType,                                             \
         NProto::GCT_NONE                                                      )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -353,6 +353,8 @@ public:
     bool GetServerWriteBackCacheFlushWritesInParallelEnabled() const;
 
     bool GetGuestKeepCacheAllowed() const;
+    bool GetAvailabilityTrackingEnabled() const;
+    TDuration GetAvailabilityTrackingInterval() const;
     NProto::EGuestCachingType GetGuestCachingType() const;
     ui64 GetSessionHandleOffloadedStatsCapacity() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -123,6 +123,11 @@ void FillFeatures(
     features->SetUseCustomReadDataResponseParser(
         config.GetUseCustomReadDataResponseParser());
 
+    features->SetAvailabilityTrackingEnabled(
+        config.GetAvailabilityTrackingEnabled());
+    features->SetAvailabilityTrackingInterval(
+        config.GetAvailabilityTrackingInterval().MilliSeconds());
+
     features->SetStatFileStoreCacheTTL(
         config.GetStatFileStoreCacheTTL().MilliSeconds());
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -1459,6 +1459,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetUseCustomReadDataResponseParser(true);
         config.SetExternalReadDataPayload(true);
         config.SetTabletDirectRdmaEnabled(true);
+        config.SetAvailabilityTrackingEnabled(true);
+        config.SetAvailabilityTrackingInterval(
+            TDuration::Seconds(15).MilliSeconds());
 
         features.SetTwoStageReadEnabled(true);
         features.SetTwoStageReadThreshold(64_KB);
@@ -1491,6 +1494,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         features.SetUseCustomReadDataResponseParser(true);
         features.SetExternalReadDataPayload(true);
         features.SetTabletDirectRdmaEnabled(true);
+        features.SetAvailabilityTrackingEnabled(true);
+        features.SetAvailabilityTrackingInterval(
+            TDuration::Seconds(15).MilliSeconds());
 
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
     }

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -59,6 +59,8 @@ namespace {
     xxx(GuestHandleKillPrivV2Enabled, bool,     false                         )\
     xxx(GuestPosixAclEnabled,         bool,     false                         )\
     xxx(ZeroCopyReadEnabled,          bool,     false                         )\
+    xxx(AvailabilityTrackingEnabled,  bool,     false                         )\
+    xxx(AvailabilityTrackingInterval, TDuration,  TDuration::Minutes(5)      )\
 // FILESTORE_FUSE_CONFIG
 
 #define FILESTORE_FILESYSTEM_DECLARE_CONFIG(name, type, value)                 \

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -60,7 +60,7 @@ namespace {
     xxx(GuestPosixAclEnabled,         bool,     false                         )\
     xxx(ZeroCopyReadEnabled,          bool,     false                         )\
     xxx(AvailabilityTrackingEnabled,  bool,     false                         )\
-    xxx(AvailabilityTrackingInterval, TDuration,  TDuration::Minutes(5)      )\
+    xxx(AvailabilityTrackingInterval, TDuration,  TDuration::Minutes(2)      )\
 // FILESTORE_FUSE_CONFIG
 
 #define FILESTORE_FILESYSTEM_DECLARE_CONFIG(name, type, value)                 \

--- a/cloud/filestore/libs/vfs_fuse/config.h
+++ b/cloud/filestore/libs/vfs_fuse/config.h
@@ -76,6 +76,9 @@ public:
 
     bool GetGuestPosixAclEnabled() const;
 
+    bool GetAvailabilityTrackingEnabled() const;
+    TDuration GetAvailabilityTrackingInterval() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/filestore/libs/vfs_fuse/fs.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs.cpp
@@ -57,6 +57,11 @@ int ReplyError(
             << " fuse_reply_err failed with code " << res);
     }
 
+    // Record the errno actually sent to the guest for the availability
+    // metric: the internal |error| does not always match the guest-visible
+    // outcome.
+    callContext.GuestReplyErrno = errorCode;
+
     requestStats.RequestCompleted(Log, callContext, error);
 
     const ui64 now = GetCycleCount();

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -223,8 +223,7 @@ struct TBootstrap
         Service = std::make_shared<TFileStoreTest>();
 
         NProto::TFileStoreFeatures features = featuresConfig;
-        // Exercise the per-client availability tracking in every test; the
-        // interval matches the one used by the newfeatures test configs.
+        // Exercise the per-client availability tracking in every test.
         features.SetAvailabilityTrackingEnabled(true);
         features.SetAvailabilityTrackingInterval(15000);   // in ms
 

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -7507,12 +7507,20 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             return MakeFuture(result);
         };
 
+        // start the first interval
+        timer->AdvanceTime(TDuration::MilliSeconds(15000));
+        bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
+
+        // The completed wait below guarantees the availability events were
+        // recorded before the clock advances, so the success is classified
+        // in the first interval - the assertions cover the request itself,
+        // not an idle interval.
         auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(
             "/file1",
             RootNodeId);
         UNIT_ASSERT(handle.Wait(WaitTimeout));
 
-        // cross the interval boundary and run the real registry updater
+        // roll the first interval
         timer->AdvanceTime(TDuration::MilliSeconds(15000));
         bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
 
@@ -7561,18 +7569,30 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                 NProto::TCreateHandleResponse(TErrorResponse(E_IO)));
         };
 
+        // start the first interval
+        timer->AdvanceTime(TDuration::MilliSeconds(15000));
+        bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
+
+        // roll the first interval and start the second interval
+        timer->AdvanceTime(TDuration::MilliSeconds(15000));
+        bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
+
+        // request is started in the second interval
         auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(
             "/file1",
             RootNodeId);
         UNIT_ASSERT(handle.Wait(WaitTimeout));
 
+        // roll the second interval
+        //
+        // request returned Eio => interval unvailable
         timer->AdvanceTime(TDuration::MilliSeconds(15000));
         bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
 
         auto counters = bootstrap.GetFileSystemStatsCounters();
         UNIT_ASSERT(counters);
         UNIT_ASSERT_VALUES_EQUAL(
-            1,
+            2,
             counters->GetCounter(
                 "Availability_TotalIntervals",
                 true)->Val());
@@ -7608,27 +7628,56 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         };
 
         auto hungPromise = NewPromise<NProto::TCreateHandleResponse>();
+        auto requestReceived = NewPromise<void>();
         bootstrap.Service->CreateHandleHandler =
             [&] (auto callContext, auto request)
         {
             Y_UNUSED(callContext);
             Y_UNUSED(request);
+            requestReceived.TrySetValue();
             return hungPromise.GetFuture();
         };
 
-        // the request is sent and stays outstanding
+        // start the first interval
+        timer->AdvanceTime(TDuration::MilliSeconds(15000));
+        bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
+
+        // request is started in the first interval
         auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(
             "/file1",
             RootNodeId);
 
-        // it is fresh-pending (neutral) in the interval it started in
+        // The request is processed on the fuse loop thread asynchronously:
+        // wait until it has actually reached the service - its availability
+        // registration happens earlier on the same path - before advancing
+        // the fake clock. Otherwise the registration races the advances and
+        // may see a later fake time, shifting the request into a later
+        // interval.
+        UNIT_ASSERT(requestReceived.GetFuture().Wait(WaitTimeout));
+
+        // it is fresh-pending (neutral) in the first interval
+        //
+        // roll the first interval and start the second interval
         timer->AdvanceTime(TDuration::MilliSeconds(15000));
         bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
 
-        // ...and hung through the next interval => unavailable
+        // request hung through the second interval => unavailable
         timer->AdvanceTime(TDuration::MilliSeconds(15000));
         bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
 
+        // Unblock the request before the assertions so that a failing
+        // assertion cannot unwind into Stop() with the request still
+        // outstanding.
+        NProto::TCreateHandleResponse result;
+        result.SetHandle(1);
+        result.MutableNodeAttr()->SetId(2);
+        result.MutableNodeAttr()->SetType(NProto::E_REGULAR_NODE);
+        hungPromise.SetValue(result);
+        UNIT_ASSERT(handle.Wait(WaitTimeout));
+
+        // Two intervals are classified: the first interval saw the request
+        // fresh-pending (neutral, no failure evidence) => available, the
+        // second interval saw it hung throughout => unavailable.
         auto counters = bootstrap.GetFileSystemStatsCounters();
         UNIT_ASSERT(counters);
         UNIT_ASSERT_VALUES_EQUAL(
@@ -7646,14 +7695,10 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             counters->GetCounter(
                 "Availability_UnavailableIntervals",
                 true)->Val());
-
-        // unblock the request before stopping
-        NProto::TCreateHandleResponse result;
-        result.SetHandle(1);
-        result.MutableNodeAttr()->SetId(2);
-        result.MutableNodeAttr()->SetType(NProto::E_REGULAR_NODE);
-        hungPromise.SetValue(result);
-        UNIT_ASSERT(handle.Wait(WaitTimeout));
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            counters->GetCounter(
+                "Availability_LastIntervalAvailable")->Val());
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -222,13 +222,8 @@ struct TBootstrap
 
         Service = std::make_shared<TFileStoreTest>();
 
-        NProto::TFileStoreFeatures features = featuresConfig;
-        // Exercise the per-client availability tracking in every test.
-        features.SetAvailabilityTrackingEnabled(true);
-        features.SetAvailabilityTrackingInterval(15000);   // in ms
-
         Service->CreateSessionHandler =
-            [features](auto callContext, auto request)
+            [featuresConfig](auto callContext, auto request)
         {
             Y_UNUSED(callContext);
 
@@ -236,7 +231,8 @@ struct TBootstrap
             NProto::TCreateSessionResponse result;
             result.MutableSession()->SetSessionId(SessionId);
             result.MutableFileStore()->SetBlockSize(4096);
-            result.MutableFileStore()->MutableFeatures()->CopyFrom(features);
+            result.MutableFileStore()->MutableFeatures()->CopyFrom(
+                featuresConfig);
             result.MutableFileStore()->SetFileSystemId(FileSystemId);
             return MakeFuture(result);
         };
@@ -303,6 +299,17 @@ struct TBootstrap
             CreateProfileLogStub(),
             Session,
             std::move(fileMapMemoryLimiter));
+    }
+
+    NMonitoring::TDynamicCountersPtr GetFileSystemStatsCounters() const
+    {
+        return Counters
+            ->FindSubgroup("component", TString{MetricsComponent} + "_fs")
+            ->FindSubgroup("host", "cluster")
+            ->FindSubgroup("filesystem", FileSystemId)
+            ->FindSubgroup("client", "")
+            ->FindSubgroup("cloud", "")
+            ->FindSubgroup("folder", "");
     }
 
     NMonitoring::TDynamicCountersPtr GetDirectoryHandleCounters() const
@@ -7466,6 +7473,187 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             }));
 
         restWriteDataPromise.SetValue({});
+    }
+
+    NProto::TFileStoreFeatures AvailabilityTrackingFeatures()
+    {
+        NProto::TFileStoreFeatures features;
+        features.SetAvailabilityTrackingEnabled(true);
+        features.SetAvailabilityTrackingInterval(15000);   // in ms
+        return features;
+    }
+
+    Y_UNIT_TEST(ShouldTrackAvailabilityOfSuccessfulRequests)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        TBootstrap bootstrap{
+            timer,
+            CreateScheduler(),
+            AvailabilityTrackingFeatures()};
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+
+        bootstrap.Service->CreateHandleHandler =
+            [] (auto callContext, auto request)
+        {
+            Y_UNUSED(callContext);
+            Y_UNUSED(request);
+            NProto::TCreateHandleResponse result;
+            result.SetHandle(1);
+            result.MutableNodeAttr()->SetId(2);
+            result.MutableNodeAttr()->SetType(NProto::E_REGULAR_NODE);
+            return MakeFuture(result);
+        };
+
+        auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(
+            "/file1",
+            RootNodeId);
+        UNIT_ASSERT(handle.Wait(WaitTimeout));
+
+        // cross the interval boundary and run the real registry updater
+        timer->AdvanceTime(TDuration::MilliSeconds(15000));
+        bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
+
+        auto counters = bootstrap.GetFileSystemStatsCounters();
+        UNIT_ASSERT(counters);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter(
+                "Availability_TotalIntervals",
+                true)->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter(
+                "Availability_AvailableIntervals",
+                true)->Val());
+
+        // the fuse create callback is published under request=create
+        auto createCounters = counters->FindSubgroup("request", "create");
+        UNIT_ASSERT(createCounters);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            createCounters->GetCounter(
+                "Availability_AvailableIntervals",
+                true)->Val());
+    }
+
+    Y_UNIT_TEST(ShouldTrackAvailabilityOfEioRequests)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        TBootstrap bootstrap{
+            timer,
+            CreateScheduler(),
+            AvailabilityTrackingFeatures()};
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+
+        bootstrap.Service->CreateHandleHandler =
+            [] (auto callContext, auto request)
+        {
+            Y_UNUSED(callContext);
+            Y_UNUSED(request);
+            // E_IO is delivered to the guest as errno EIO
+            return MakeFuture(
+                NProto::TCreateHandleResponse(TErrorResponse(E_IO)));
+        };
+
+        auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(
+            "/file1",
+            RootNodeId);
+        UNIT_ASSERT(handle.Wait(WaitTimeout));
+
+        timer->AdvanceTime(TDuration::MilliSeconds(15000));
+        bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
+
+        auto counters = bootstrap.GetFileSystemStatsCounters();
+        UNIT_ASSERT(counters);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter(
+                "Availability_TotalIntervals",
+                true)->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter(
+                "Availability_UnavailableIntervals",
+                true)->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            counters->GetCounter(
+                "Availability_LastIntervalAvailable")->Val());
+
+        auto createCounters = counters->FindSubgroup("request", "create");
+        UNIT_ASSERT(createCounters);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            createCounters->GetCounter(
+                "Availability_UnavailableIntervals",
+                true)->Val());
+    }
+
+    Y_UNIT_TEST(ShouldTrackAvailabilityOfHungRequests)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        TBootstrap bootstrap{
+            timer,
+            CreateScheduler(),
+            AvailabilityTrackingFeatures()};
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+
+        auto hungPromise = NewPromise<NProto::TCreateHandleResponse>();
+        bootstrap.Service->CreateHandleHandler =
+            [&] (auto callContext, auto request)
+        {
+            Y_UNUSED(callContext);
+            Y_UNUSED(request);
+            return hungPromise.GetFuture();
+        };
+
+        // the request is sent and stays outstanding
+        auto handle = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(
+            "/file1",
+            RootNodeId);
+
+        // it is fresh-pending (neutral) in the interval it started in
+        timer->AdvanceTime(TDuration::MilliSeconds(15000));
+        bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
+
+        // ...and hung through the next interval => unavailable
+        timer->AdvanceTime(TDuration::MilliSeconds(15000));
+        bootstrap.StatsRegistry->UpdateStats(false /* updatePercentiles */);
+
+        auto counters = bootstrap.GetFileSystemStatsCounters();
+        UNIT_ASSERT(counters);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            counters->GetCounter(
+                "Availability_TotalIntervals",
+                true)->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter(
+                "Availability_AvailableIntervals",
+                true)->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter(
+                "Availability_UnavailableIntervals",
+                true)->Val());
+
+        // unblock the request before stopping
+        NProto::TCreateHandleResponse result;
+        result.SetHandle(1);
+        result.MutableNodeAttr()->SetId(2);
+        result.MutableNodeAttr()->SetType(NProto::E_REGULAR_NODE);
+        hungPromise.SetValue(result);
+        UNIT_ASSERT(handle.Wait(WaitTimeout));
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -221,8 +221,15 @@ struct TBootstrap
         Fuse = std::make_shared<TFuseVirtioClient>(SocketPath, WaitTimeout);
 
         Service = std::make_shared<TFileStoreTest>();
+
+        NProto::TFileStoreFeatures features = featuresConfig;
+        // Exercise the per-client availability tracking in every test; the
+        // interval matches the one used by the newfeatures test configs.
+        features.SetAvailabilityTrackingEnabled(true);
+        features.SetAvailabilityTrackingInterval(15000);   // in ms
+
         Service->CreateSessionHandler =
-            [featuresConfig](auto callContext, auto request)
+            [features](auto callContext, auto request)
         {
             Y_UNUSED(callContext);
 
@@ -230,8 +237,7 @@ struct TBootstrap
             NProto::TCreateSessionResponse result;
             result.MutableSession()->SetSessionId(SessionId);
             result.MutableFileStore()->SetBlockSize(4096);
-            result.MutableFileStore()->MutableFeatures()->CopyFrom(
-                featuresConfig);
+            result.MutableFileStore()->MutableFeatures()->CopyFrom(features);
             result.MutableFileStore()->SetFileSystemId(FileSystemId);
             return MakeFuture(result);
         };

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -988,6 +988,10 @@ private:
                 StorageMediaKind,
                 CalcCompletionQueueRequestBucketCount(*Config));
             FileSystemConfig = MakeFileSystemConfig(filestore);
+            if (FileSystemConfig->GetAvailabilityTrackingEnabled()) {
+                RequestStats->EnableAvailabilityTracking(
+                    FileSystemConfig->GetAvailabilityTrackingInterval());
+            }
 
             SessionId = response.GetSession().GetSessionId();
 
@@ -1345,6 +1349,13 @@ private:
         config.SetGuestHandleKillPrivV2Enabled(
             features.GetGuestHandleKillPrivV2Enabled());
         config.SetGuestPosixAclEnabled(features.GetGuestPosixAclEnabled());
+
+        config.SetAvailabilityTrackingEnabled(
+            features.GetAvailabilityTrackingEnabled());
+        if (features.GetAvailabilityTrackingInterval()) {
+            config.SetAvailabilityTrackingInterval(
+                features.GetAvailabilityTrackingInterval());
+        }
 
         return std::make_shared<TFileSystemConfig>(config);
     }

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1604,6 +1604,7 @@ private:
         Method&& m,
         const char* name,
         EFileStoreRequest requestType,
+        EFileStoreAvailabilityRequestType availabilityRequestType,
         ui32 requestSize,
         fuse_req_t req,
         Args&&... args) noexcept
@@ -1615,6 +1616,7 @@ private:
             pThis->Config->GetFileSystemId(),
             fuse_req_unique(req));
         callContext->RequestType = requestType;
+        callContext->AvailabilityRequestType = availabilityRequestType;
         callContext->RequestSize = requestSize;
         callContext->LoopThreadId = TThread::CurrentThreadNumericId();
 
@@ -1665,15 +1667,20 @@ private:
 
     static void InitOps(fuse_lowlevel_ops& ops)
     {
-#define CALL(m, requestType, requestSize, req, ...)                            \
+#define CALL(m, requestType, availabilityRequestType, requestSize, req, ...)  \
     TFileSystemLoop::Call(                                                     \
         &IFileSystem::m,                                                       \
         #m,                                                                    \
         requestType,                                                           \
+        availabilityRequestType,                                               \
         requestSize,                                                           \
         req,                                                                   \
         __VA_ARGS__)                                                           \
 // CALL
+
+        using EAvailability = EFileStoreAvailabilityRequestType;
+
+        // clang-format off
 
         //
         // Initialization
@@ -1691,7 +1698,7 @@ private:
         //
 
         ops.statfs = [] (fuse_req_t req, fuse_ino_t ino) {
-            CALL(StatFs, EFileStoreRequest::StatFileStore, 0, req, ino);
+            CALL(StatFs, EFileStoreRequest::StatFileStore, EAvailability::None, 0, req, ino);
         };
 
         //
@@ -1699,43 +1706,43 @@ private:
         //
 
         ops.lookup = [] (fuse_req_t req, fuse_ino_t parent, const char* name) {
-            CALL(Lookup, EFileStoreRequest::GetNodeAttr, 0, req, parent, name);
+            CALL(Lookup, EFileStoreRequest::GetNodeAttr, EAvailability::Lookup, 0, req, parent, name);
         };
         ops.forget = [] (fuse_req_t req, fuse_ino_t ino, unsigned long nlookup) {
-            CALL(Forget, EFileStoreRequest::Forget, 0, req, ino, nlookup);
+            CALL(Forget, EFileStoreRequest::Forget, EAvailability::None, 0, req, ino, nlookup);
         };
         ops.forget_multi = [] (fuse_req_t req, size_t count, fuse_forget_data* forgets) {
-            CALL(ForgetMulti, EFileStoreRequest::ForgetMulti, 0, req, count, forgets);
+            CALL(ForgetMulti, EFileStoreRequest::ForgetMulti, EAvailability::None, 0, req, count, forgets);
         };
         ops.mkdir = [] (fuse_req_t req, fuse_ino_t parent, const char* name, mode_t mode) {
-            CALL(MkDir, EFileStoreRequest::CreateNode, 0, req, parent, name, mode);
+            CALL(MkDir, EFileStoreRequest::CreateNode, EAvailability::MkDir, 0, req, parent, name, mode);
         };
         ops.rmdir = [] (fuse_req_t req, fuse_ino_t parent, const char* name) {
-            CALL(RmDir, EFileStoreRequest::UnlinkNode, 0, req, parent, name);
+            CALL(RmDir, EFileStoreRequest::UnlinkNode, EAvailability::RmDir, 0, req, parent, name);
         };
         ops.mknod = [] (fuse_req_t req, fuse_ino_t parent, const char* name, mode_t mode, dev_t rdev) {
-            CALL(MkNode, EFileStoreRequest::CreateNode, 0, req, parent, name, mode, rdev);
+            CALL(MkNode, EFileStoreRequest::CreateNode, EAvailability::None, 0, req, parent, name, mode, rdev);
         };
         ops.unlink = [] (fuse_req_t req, fuse_ino_t parent, const char* name) {
-            CALL(Unlink, EFileStoreRequest::UnlinkNode, 0, req, parent, name);
+            CALL(Unlink, EFileStoreRequest::UnlinkNode, EAvailability::Unlink, 0, req, parent, name);
         };
 #if defined(FUSE_VIRTIO)
         ops.rename = [] (fuse_req_t req, fuse_ino_t parent, const char* name, fuse_ino_t newparent, const char* newname, uint32_t flags) {
-            CALL(Rename, EFileStoreRequest::RenameNode, 0, req, parent, name, newparent, newname, flags);
+            CALL(Rename, EFileStoreRequest::RenameNode, EAvailability::Rename, 0, req, parent, name, newparent, newname, flags);
         };
 #else
         ops.rename = [] (fuse_req_t req, fuse_ino_t parent, const char* name, fuse_ino_t newparent, const char* newname) {
-            CALL(Rename, EFileStoreRequest::RenameNode, 0, req, parent, name, newparent, newname, 0);
+            CALL(Rename, EFileStoreRequest::RenameNode, EAvailability::Rename, 0, req, parent, name, newparent, newname, 0);
         };
 #endif
         ops.symlink = [] (fuse_req_t req, const char* link, fuse_ino_t parent, const char* name) {
-            CALL(SymLink, EFileStoreRequest::CreateNode, 0, req, link, parent, name);
+            CALL(SymLink, EFileStoreRequest::CreateNode, EAvailability::SymLink, 0, req, link, parent, name);
         };
         ops.link = [] (fuse_req_t req, fuse_ino_t ino, fuse_ino_t newparent, const char* newname) {
-            CALL(Link, EFileStoreRequest::CreateNode, 0, req, ino, newparent, newname);
+            CALL(Link, EFileStoreRequest::CreateNode, EAvailability::Link, 0, req, ino, newparent, newname);
         };
         ops.readlink = [] (fuse_req_t req, fuse_ino_t ino) {
-            CALL(ReadLink, EFileStoreRequest::ReadLink, 0, req, ino);
+            CALL(ReadLink, EFileStoreRequest::ReadLink, EAvailability::ReadLink, 0, req, ino);
         };
 
         //
@@ -1743,13 +1750,13 @@ private:
         //
 
         ops.setattr = [] (fuse_req_t req, fuse_ino_t ino, struct stat* attr, int to_set, fuse_file_info* fi) {
-            CALL(SetAttr, EFileStoreRequest::SetNodeAttr, 0, req, ino, attr, to_set, fi);
+            CALL(SetAttr, EFileStoreRequest::SetNodeAttr, EAvailability::SetAttr, 0, req, ino, attr, to_set, fi);
         };
         ops.getattr = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(GetAttr, EFileStoreRequest::GetNodeAttr, 0, req, ino, fi);
+            CALL(GetAttr, EFileStoreRequest::GetNodeAttr, EAvailability::GetAttr, 0, req, ino, fi);
         };
         ops.access = [] (fuse_req_t req, fuse_ino_t ino, int mask) {
-            CALL(Access, EFileStoreRequest::AccessNode, 0, req, ino, mask);
+            CALL(Access, EFileStoreRequest::AccessNode, EAvailability::None, 0, req, ino, mask);
         };
 
         //
@@ -1757,16 +1764,16 @@ private:
         //
 
         ops.setxattr = [] (fuse_req_t req, fuse_ino_t ino, const char* name, const char* value, size_t size, int flags) {
-            CALL(SetXAttr, EFileStoreRequest::SetNodeXAttr, 0, req, ino, name, TString{value, size}, flags);
+            CALL(SetXAttr, EFileStoreRequest::SetNodeXAttr, EAvailability::None, 0, req, ino, name, TString{value, size}, flags);
         };
         ops.getxattr = [] (fuse_req_t req, fuse_ino_t ino, const char* name, size_t size) {
-            CALL(GetXAttr, EFileStoreRequest::GetNodeXAttr, 0, req, ino, name, size);
+            CALL(GetXAttr, EFileStoreRequest::GetNodeXAttr, EAvailability::None, 0, req, ino, name, size);
         };
         ops.listxattr = [] (fuse_req_t req, fuse_ino_t ino, size_t size) {
-            CALL(ListXAttr, EFileStoreRequest::ListNodeXAttr, 0, req, ino, size);
+            CALL(ListXAttr, EFileStoreRequest::ListNodeXAttr, EAvailability::None, 0, req, ino, size);
         };
         ops.removexattr = [] (fuse_req_t req, fuse_ino_t ino, const char* name) {
-            CALL(RemoveXAttr, EFileStoreRequest::RemoveNodeXAttr, 0, req, ino, name);
+            CALL(RemoveXAttr, EFileStoreRequest::RemoveNodeXAttr, EAvailability::None, 0, req, ino, name);
         };
 
         //
@@ -1774,19 +1781,19 @@ private:
         //
 
         ops.opendir = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(OpenDir, EFileStoreRequest::OpenDir, 0, req, ino, fi);
+            CALL(OpenDir, EFileStoreRequest::OpenDir, EAvailability::OpenDir, 0, req, ino, fi);
         };
 #if defined(FUSE_VIRTIO)
         ops.readdirplus = [] (fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, fuse_file_info* fi) {
-            CALL(ReadDir, EFileStoreRequest::ListNodes, 0, req, ino, size, offset, fi);
+            CALL(ReadDir, EFileStoreRequest::ListNodes, EAvailability::ReadDirPlus, 0, req, ino, size, offset, fi);
         };
 #else
         ops.readdir = [] (fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, fuse_file_info* fi) {
-            CALL(ReadDir, EFileStoreRequest::ListNodes, 0, req, ino, size, offset, fi);
+            CALL(ReadDir, EFileStoreRequest::ListNodes, EAvailability::ReadDir, 0, req, ino, size, offset, fi);
         };
 #endif
         ops.releasedir = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(ReleaseDir, EFileStoreRequest::ReleaseDir, 0, req, ino, fi);
+            CALL(ReleaseDir, EFileStoreRequest::ReleaseDir, EAvailability::ReleaseDir, 0, req, ino, fi);
         };
 
         //
@@ -1794,34 +1801,34 @@ private:
         //
 
         ops.create = [] (fuse_req_t req, fuse_ino_t parent, const char* name, mode_t mode, fuse_file_info* fi) {
-            CALL(Create, EFileStoreRequest::CreateHandle, 0, req, parent, name, mode, fi);
+            CALL(Create, EFileStoreRequest::CreateHandle, EAvailability::Create, 0, req, parent, name, mode, fi);
         };
         ops.open = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Open, EFileStoreRequest::CreateHandle, 0, req, ino, fi);
+            CALL(Open, EFileStoreRequest::CreateHandle, EAvailability::Open, 0, req, ino, fi);
         };
         ops.read = [] (fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, fuse_file_info* fi) {
-            CALL(Read, EFileStoreRequest::ReadData, size, req, ino, size, offset, fi);
+            CALL(Read, EFileStoreRequest::ReadData, EAvailability::Read, size, req, ino, size, offset, fi);
         };
         ops.write = [] (fuse_req_t req, fuse_ino_t ino, const char* buf, size_t size, off_t offset, fuse_file_info* fi) {
-            CALL(Write, EFileStoreRequest::WriteData, size, req, ino, TStringBuf{buf, size}, offset, fi);
+            CALL(Write, EFileStoreRequest::WriteData, EAvailability::Write, size, req, ino, TStringBuf{buf, size}, offset, fi);
         };
         ops.write_buf = [] (fuse_req_t req, fuse_ino_t ino, fuse_bufvec* bufv, off_t offset, fuse_file_info* fi) {
-            CALL(WriteBuf, EFileStoreRequest::WriteData, fuse_buf_size(bufv), req, ino, bufv, offset, fi);
+            CALL(WriteBuf, EFileStoreRequest::WriteData, EAvailability::WriteBuf, fuse_buf_size(bufv), req, ino, bufv, offset, fi);
         };
         ops.fallocate = [] (fuse_req_t req, fuse_ino_t ino, int mode, off_t offset, off_t length, fuse_file_info* fi) {
-            CALL(FAllocate, EFileStoreRequest::AllocateData, length, req, ino, mode, offset, length, fi);
+            CALL(FAllocate, EFileStoreRequest::AllocateData, EAvailability::None, length, req, ino, mode, offset, length, fi);
         };
         ops.flush = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Flush, EFileStoreRequest::FuseFlush, 0, req, ino, fi);
+            CALL(Flush, EFileStoreRequest::FuseFlush, EAvailability::Flush, 0, req, ino, fi);
         };
         ops.fsync = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
-            CALL(FSync, EFileStoreRequest::FuseFsync, 0, req, ino, datasync, fi);
+            CALL(FSync, EFileStoreRequest::FuseFsync, EAvailability::Fsync, 0, req, ino, datasync, fi);
         };
         ops.fsyncdir = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
-            CALL(FSyncDir, EFileStoreRequest::FuseFsyncDir, 0, req, ino, datasync, fi);
+            CALL(FSyncDir, EFileStoreRequest::FuseFsyncDir, EAvailability::None, 0, req, ino, datasync, fi);
         };
         ops.release = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Release, EFileStoreRequest::DestroyHandle, 0, req, ino, fi);
+            CALL(Release, EFileStoreRequest::DestroyHandle, EAvailability::Release, 0, req, ino, fi);
         };
 
         //
@@ -1829,15 +1836,17 @@ private:
         //
 
         ops.getlk = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi, struct flock* lock) {
-            CALL(GetLock, EFileStoreRequest::TestLock, lock->l_len, req, ino, fi, lock);
+            CALL(GetLock, EFileStoreRequest::TestLock, EAvailability::None, lock->l_len, req, ino, fi, lock);
         };
         ops.setlk = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi, struct flock* lock, int sleep) {
-            CALL(SetLock, GetLockRequestType(lock), lock->l_len, req, ino, fi, lock, sleep != 0);
+            CALL(SetLock, GetLockRequestType(lock), EAvailability::None, lock->l_len, req, ino, fi, lock, sleep != 0);
         };
         ops.flock = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi, int op) {
-            CALL(FLock, GetLockRequestType(op), 0, req, ino, fi, op);
+            CALL(FLock, GetLockRequestType(op), EAvailability::None, 0, req, ino, fi, op);
         };
 #undef CALL
+
+        // clang-format on
     }
 
 private:

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -67,7 +67,7 @@ message TFileStoreFeatures
 
     // Enables the per-client filesystem availability tracking on the guest.
     bool AvailabilityTrackingEnabled = 52;
-    // Availability interval duration (in ms); 0 means the default.
+    // Availability interval duration (in ms), 0 means the default.
     uint32 AvailabilityTrackingInterval = 53;
 }
 

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -64,6 +64,11 @@ message TFileStoreFeatures
     bool AsyncDestroyReadOnlyHandleEnabled = 49;
     bool ExternalWriteDataPayloadEnabled = 50;
     bool AsyncCreateHandleEnabled = 51;
+
+    // Enables the per-client filesystem availability tracking on the guest.
+    bool AvailabilityTrackingEnabled = 52;
+    // Availability interval duration (in ms); 0 means the default.
+    uint32 AvailabilityTrackingInterval = 53;
 }
 
 message TFileStore

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -35,3 +35,5 @@ UseCustomReadDataResponseParser: true
 MaxShardManagementRequestsInFlight: 3
 FakeTxPageFaultsProbability: 0.001
 FanoutStatsCollectionInShardsDisabled: true
+AvailabilityTrackingEnabled: true
+AvailabilityTrackingInterval: 15000


### PR DESCRIPTION
### Notes

A Shared Filesystem is considered **unavailable** during any `N-minute` interval in which, for at least one filesystem request type, at least one request was **outstanding** and every such request either failed with an **EIO** error, or **hung**.

**Note**: A request submitted during an interval and still outstanding when the interval ends is not classified for that interval. It does not contribute to determining whether the interval is available or unavailable

In all `N-minute` intervals in which the unavailability condition is not met, a Shared Filesystem is considered **available**.

Shared Filesystem availability for the measurement period shall be calculated as:
Number of `N-minute` intervals in which the Shared Filesystem was Available / Total number of `N-minute` intervals in the measurement period × 100%

### Definitions

A request is **outstanding** at a given point in time if it was submitted but had received no response, success or error, by that point.
A request is **hung** if it was **outstanding** for the entire duration of the `N-minute` interval.
Request type - a category of filesystem operation, Fuse request types:
```
readdir
readdirplus
opendir
releasedir
lookup
getattr
setattr
write
write_buf
read
open
create
release
mkdir
rmdir
unlink
rename
link
symlink
readlink
flush
fsync
```

EIO error - POSIX EIO error code (see https://man7.org/linux/man-pages/man3/errno.3.html)

### Issue
#6825 
