### PR TITLE
fix: revert back resources, fix mirror-yatool-resources to accommodate ydb 25-1 new mapping format, removed ./ya env var replacement

### DIFF
--- a/.github/scripts/mirror_yatool_resources.py
+++ b/.github/scripts/mirror_yatool_resources.py
@@ -35,6 +35,7 @@ REGISTRY_ENDPOINT_RE = re.compile(
 REGISTRY_URL_RE = re.compile(
     r"f(?P<quote>[\"'])\{REGISTRY_ENDPOINT\}(?P<path>/[0-9]+)(?P=quote)"
 )
+MAPPING_REGISTRY_ENDPOINT = "{registry_endpoint}"
 
 
 @dataclass(frozen=True)
@@ -45,10 +46,7 @@ class BootstrapResource:
 
 @dataclass(frozen=True)
 class BootstrapConfig:
-    source: str
     registry_endpoint: str
-    registry_endpoint_start: int
-    registry_endpoint_end: int
     resources: dict[str, BootstrapResource]
 
 
@@ -100,8 +98,6 @@ def extract_platform_map(source: str, registry_endpoint: str) -> dict[str, Any]:
 def load_bootstrap_config(path: Path) -> BootstrapConfig:
     source = path.read_text(encoding="utf-8")
 
-    # This narrow match also gives us the exact character range to replace when
-    # generating the patch that points ya at the local mirror.
     endpoint_matches = list(REGISTRY_ENDPOINT_RE.finditer(source))
     if len(endpoint_matches) != 1:
         raise ValueError("ya must contain exactly one REGISTRY_ENDPOINT default")
@@ -148,10 +144,7 @@ def load_bootstrap_config(path: Path) -> BootstrapConfig:
         resources[resource_id] = resource
 
     return BootstrapConfig(
-        source=source,
         registry_endpoint=registry_endpoint,
-        registry_endpoint_start=endpoint_match.start("endpoint"),
-        registry_endpoint_end=endpoint_match.end("endpoint"),
         resources=resources,
     )
 
@@ -290,30 +283,74 @@ def upload_resource(s3: Any, bucket: str, key: str, path: Path, md5: str) -> Non
     )
 
 
-def localize_mapping(mapping_path: Path, local_base_url: str) -> str:
-    data = load_json(mapping_path)
+def get_mapping_resources(data: dict[str, Any], mapping_path: Path) -> dict[str, Any]:
     resources = data.get("resources")
     if not isinstance(resources, dict):
         raise ValueError(f"{mapping_path} does not contain a resources object")
+    return resources
+
+
+def get_mapping_registry_endpoint(data: dict[str, Any], mapping_path: Path) -> str:
+    extensions = data.get("extensions")
+    if not isinstance(extensions, dict):
+        raise ValueError(f"{mapping_path} does not contain an extensions object")
+    registry_endpoint = extensions.get("registry_endpoint")
+    if not isinstance(registry_endpoint, str):
+        raise ValueError(
+            f"{mapping_path} does not contain a registry_endpoint extension"
+        )
+    return registry_endpoint.rstrip("/")
+
+
+def resolve_mapping_resources(
+    data: dict[str, Any], mapping_path: Path
+) -> dict[str, str]:
+    resources = get_mapping_resources(data, mapping_path)
+    registry_endpoint: str | None = None
+    resolved: dict[str, str] = {}
+    for resource_id, url in resources.items():
+        if not isinstance(resource_id, str) or not isinstance(url, str):
+            raise ValueError(f"{mapping_path} resource entries must be strings")
+
+        template_url = f"{MAPPING_REGISTRY_ENDPOINT}/{resource_id}"
+        if url == template_url:
+            if registry_endpoint is None:
+                registry_endpoint = get_mapping_registry_endpoint(data, mapping_path)
+            resolved[resource_id] = f"{registry_endpoint}/{resource_id}"
+        elif MAPPING_REGISTRY_ENDPOINT in url:
+            raise ValueError(
+                f"{mapping_path} resource {resource_id} has an invalid registry endpoint template"
+            )
+        else:
+            resolved[resource_id] = url
+    return resolved
+
+
+def localize_mapping(mapping_path: Path, local_base_url: str) -> str:
+    data = load_json(mapping_path)
+    resources = get_mapping_resources(data, mapping_path)
 
     base = validate_local_base_url(local_base_url)
-    for resource_id in list(resources):
-        resources[resource_id] = f"{base}/{resource_id}"
+    uses_registry_endpoint = False
+    for resource_id, url in resources.items():
+        if not isinstance(resource_id, str) or not isinstance(url, str):
+            raise ValueError(f"{mapping_path} resource entries must be strings")
+
+        template_url = f"{MAPPING_REGISTRY_ENDPOINT}/{resource_id}"
+        if url == template_url:
+            uses_registry_endpoint = True
+        elif MAPPING_REGISTRY_ENDPOINT in url:
+            raise ValueError(
+                f"{mapping_path} resource {resource_id} has an invalid registry endpoint template"
+            )
+        else:
+            resources[resource_id] = f"{base}/{resource_id}"
+
+    if uses_registry_endpoint:
+        get_mapping_registry_endpoint(data, mapping_path)
+        data["extensions"]["registry_endpoint"] = base
 
     return dump_json(data)
-
-
-def localize_bootstrap_script(config: BootstrapConfig, local_base_url: str) -> str:
-    base = validate_local_base_url(local_base_url)
-    endpoint_end = config.registry_endpoint_end
-
-    # Splice at the endpoint match positions. This avoids a broad replacement
-    # that could accidentally change the same URL elsewhere in ya.
-    return (
-        config.source[: config.registry_endpoint_start]
-        + base
-        + config.source[endpoint_end:]
-    )
 
 
 def file_patch(path: Path, localized_text: str) -> str:
@@ -401,28 +438,18 @@ def main() -> int:
     args = parse_args()
     local_base_url = validate_local_base_url(args.local_base_url)
     mapping = load_json(args.mapping)
-    resources = mapping.get("resources")
-    if not isinstance(resources, dict):
-        raise ValueError(f"{args.mapping} does not contain a resources object")
+    resources = get_mapping_resources(mapping, args.mapping)
 
     bootstrap = load_bootstrap_config(args.bootstrap_script)
     args.patch_out.parent.mkdir(parents=True, exist_ok=True)
     args.summary_out.parent.mkdir(parents=True, exist_ok=True)
 
     write_patch(
-        [
-            (args.mapping, localize_mapping(args.mapping, local_base_url)),
-            (
-                args.bootstrap_script,
-                localize_bootstrap_script(bootstrap, local_base_url),
-            ),
-        ],
+        [(args.mapping, localize_mapping(args.mapping, local_base_url))],
         args.patch_out,
     )
 
-    upload_sources = {
-        str(resource_id): str(url) for resource_id, url in resources.items()
-    }
+    upload_sources = resolve_mapping_resources(mapping, args.mapping)
     expected_md5: dict[str, str] = {}
     for resource_id, resource in bootstrap.resources.items():
         upload_sources[resource_id] = resource.source_url

--- a/.github/scripts/mirror_yatool_resources_test.py
+++ b/.github/scripts/mirror_yatool_resources_test.py
@@ -66,20 +66,6 @@ def test_load_bootstrap_config_extracts_all_platform_resources(
     }
 
 
-def test_localize_bootstrap_script_replaces_only_default_endpoint(
-    tmp_path: Path,
-) -> None:
-    bootstrap_script = write_bootstrap_script(tmp_path / "ya")
-    config = mirror.load_bootstrap_config(bootstrap_script)
-
-    localized = mirror.localize_bootstrap_script(
-        config, "https://mirror.example/resources/"
-    )
-
-    assert '"YA_REGISTRY_ENDPOINT", "https://mirror.example/resources"' in localized
-    assert 'f"{REGISTRY_ENDPOINT}/8580483288"' in localized
-
-
 def test_extract_platform_map_rejects_executable_python() -> None:
     source = """# Start of mapping
 PLATFORM_MAP = {
@@ -179,6 +165,42 @@ def test_is_localized_resource_url_rejects_non_matching_urls(url: str) -> None:
     )
 
 
+def test_resolve_mapping_resources_expands_registry_endpoint(tmp_path: Path) -> None:
+    mapping_path = tmp_path / "mapping.conf.json"
+    mapping = {
+        "extensions": {"registry_endpoint": "https://devtools-registry.s3.yandex.net"},
+        "resources": {"6277415836": "{registry_endpoint}/6277415836"},
+    }
+
+    assert mirror.resolve_mapping_resources(mapping, mapping_path) == {
+        "6277415836": "https://devtools-registry.s3.yandex.net/6277415836"
+    }
+
+
+def test_localize_mapping_replaces_registry_endpoint_only(tmp_path: Path) -> None:
+    mapping_path = tmp_path / "mapping.conf.json"
+    mapping_path.write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "registry_endpoint": "https://devtools-registry.s3.yandex.net"
+                },
+                "resources": {"6277415836": "{registry_endpoint}/6277415836"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    localized = json.loads(
+        mirror.localize_mapping(mapping_path, "https://mirror.example/resources/")
+    )
+
+    assert localized["extensions"]["registry_endpoint"] == (
+        "https://mirror.example/resources"
+    )
+    assert localized["resources"] == {"6277415836": "{registry_endpoint}/6277415836"}
+
+
 def test_main_skips_already_localized_resources(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -187,10 +209,13 @@ def test_main_skips_already_localized_resources(
     mapping.write_text(
         json.dumps(
             {
+                "extensions": {
+                    "registry_endpoint": "https://devtools-registry.s3.yandex.net"
+                },
                 "resources": {
                     "6277415836": f"{local_base_url}/6277415836",
-                    "6277415837": "https://devtools-registry.s3.yandex.net/6277415837",
-                }
+                    "6277415837": "{registry_endpoint}/6277415837",
+                },
             }
         ),
         encoding="utf-8",
@@ -257,7 +282,10 @@ def test_main_skips_already_localized_resources(
     assert "Uploaded or refreshed: `2`" in summary
     assert "Already up to date: `1`" in summary
     patch = patch_out.read_text(encoding="utf-8")
-    assert f'+    "YA_REGISTRY_ENDPOINT", "{local_base_url}"' in patch
+    assert "YA_REGISTRY_ENDPOINT" not in patch
+    assert str(bootstrap_script) not in patch
+    assert f'+        "registry_endpoint": "{local_base_url}"' in patch
+    assert '+        "6277415837": "{registry_endpoint}/6277415837"' in patch
 
 
 def test_main_rejects_bootstrap_resource_with_wrong_md5(

--- a/build/mapping.conf.json
+++ b/build/mapping.conf.json
@@ -1,7 +1,7 @@
 {
     "bottles": {},
     "extensions": {
-        "registry_endpoint": "https://devtools-registry.s3.yandex.net"
+        "registry_endpoint": "https://storage.eu-north2.nebius.cloud/nbs-yatool-resources"
     },
     "resources": {
         "6277415836": "{registry_endpoint}/6277415836",


### PR DESCRIPTION
ydb 25.1 introduced new mapping format that breaks mirror-yatool-resources. It was merged in ydb 25.1 commit with manually replaced url (and mapping itself was manually altered to fit mirror-yatool-resources and upload new resources there).

Also https://github.com/ydb-platform/nbs/commit/7c86bcc4ccb1509e0173d240495b3e3a7f281ceb reverted back mapping.conf.json endpoint url.