### PR TITLE
issue-5895: getaddrinfo shouldn't be called from fiber scheduler threads and from actor system threads

### DIFF
--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -22,6 +22,7 @@
 #include <cloud/filestore/libs/storage/core/probes.h>
 #include <cloud/filestore/libs/storage/fastshard/bootstrap/core.h>
 
+#include <cloud/storage/core/libs/common/hostname.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/diagnostics/stats_updater.h>
@@ -117,6 +118,18 @@ TConfigInitializerCommonPtr TBootstrapServer::InitConfigs(int argc, char** argv)
 void TBootstrapServer::InitActorSystemPrerequisites()
 {
     InitConfigs();
+
+    //
+    // The first FQDNHostName() call blocks in DNS and throws on
+    // failure - which must not happen on an actor thread or a silk
+    // fiber (e.g. BuildBackendInfo calls it on the response paths).
+    // Warm the cache here, with retries; failure fails the daemon.
+    //
+
+    GetFqdnHostNameWithRetries(
+        [this] (const yexception& e) {
+            STORAGE_WARN("FQDNHostName failed: " << e.what());
+        });
 
     const ui32 port = Configs->StorageConfig->GetFastShardServerPort();
     if (port) {

--- a/cloud/filestore/libs/storage/fastshard/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client.cpp
@@ -82,7 +82,17 @@ std::shared_ptr<IEndpoint> TClient::Connect(const TString& host, ui16 port)
     Y_ABORT_UNLESS(printed < sizeof(portStr), "printed=%u", printed);
 
     addrinfo* res = nullptr;
-    int gai = ::getaddrinfo(host.c_str(), portStr, &hints, &res);
+    int gai = 0;
+    {
+        //
+        // getaddrinfo blocks inside libc (DNS, nsswitch). Run it on the
+        // thread-mode worker pool: on a scheduler thread it would stall
+        // every fiber homed on this CPU for the whole resolution.
+        //
+
+        FiberScheduler::ThreadModeScope scope;
+        gai = ::getaddrinfo(host.c_str(), portStr, &hints, &res);
+    }
     if (gai != 0) {
         return nullptr;
     }

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client.cpp
@@ -55,7 +55,18 @@ int OpenTcp(const TString& host, ui16 port)
     }
 
     addrinfo* res = nullptr;
-    if (::getaddrinfo(host.c_str(), portStr, &hints, &res) != 0) {
+    int gai = 0;
+    {
+        //
+        // getaddrinfo blocks inside libc (DNS, nsswitch). Run it on the
+        // thread-mode worker pool: on a scheduler thread it would stall
+        // every fiber homed on this CPU for the whole resolution.
+        //
+
+        FiberScheduler::ThreadModeScope scope;
+        gai = ::getaddrinfo(host.c_str(), portStr, &hints, &res);
+    }
+    if (gai != 0) {
         return -1;
     }
     Y_DEFER


### PR DESCRIPTION
### Notes
* calling `getaddrinfo()` only in thread-mode fibers (in silk's thread-mode workers, not in fiber scheduler threads)
* fetching own hostname upon filestore-server startup to make sure that `FQDNHostName()` uses a cached hostname instead of calling `getaddrinfo()` from a fiber or an actor system thread

### Issue
https://github.com/ydb-platform/nbs/issues/5895
