### PR TITLE
issue-1751: [Filestore] Implement correct behavior for WriteBackCache when corruption is detected

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -41,6 +41,7 @@ namespace NCloud::NFileStore{
     xxx(WriteBackCacheCorruptionError)                                         \
     xxx(WriteBackCacheDataLossError)                                           \
     xxx(WriteBackCacheImpossibleState)                                         \
+    xxx(WriteBackCacheInvalidConfiguration)                                    \
     xxx(WriteBackCacheWritingNotAllowedInDrainingMode)                         \
     xxx(ErrorWasSentToTheGuest)                                                \
     xxx(DirectoryHandlesStorageError)                                          \

--- a/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
+++ b/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
@@ -37,7 +37,8 @@ THandleOpsQueue::EResult THandleOpsQueue::AddCreateRequest(
         return THandleOpsQueue::EResult::SerializationError;
     }
 
-    if (!RequestsToProcess.PushBack(result)) {
+    auto pushPackResult = RequestsToProcess.PushBack(result);
+    if (HasError(pushPackResult) || !pushPackResult.GetResult()) {
         Stats->IncrementOverflowErrorCount();
         return THandleOpsQueue::EResult::QueueOverflow;
     }
@@ -60,7 +61,8 @@ THandleOpsQueue::EResult THandleOpsQueue::AddDestroyRequest(
         return THandleOpsQueue::EResult::SerializationError;
     }
 
-    if (!RequestsToProcess.PushBack(result)) {
+    auto pushPackResult = RequestsToProcess.PushBack(result);
+    if (HasError(pushPackResult) || !pushPackResult.GetResult()) {
         Stats->IncrementOverflowErrorCount();
         return THandleOpsQueue::EResult::QueueOverflow;
     }
@@ -71,7 +73,13 @@ THandleOpsQueue::EResult THandleOpsQueue::AddDestroyRequest(
 
 std::optional<NProto::TQueueEntry> THandleOpsQueue::Front()
 {
-    const auto req = RequestsToProcess.Front();
+    const auto frontResult = RequestsToProcess.Front();
+    if (HasError(frontResult)) {
+        Stats->IncrementParseErrorCount();
+        return std::nullopt;
+    }
+
+    const auto req = frontResult.GetResult();
 
     NProto::TQueueEntry entry;
     if (!entry.ParseFromArray(req.data(), req.size())) {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -42,12 +42,10 @@ public:
         , LogTag(std::move(logTag))
     {
         SetCounters();
-    }
 
-    NProto::TError Init()
-    {
         if (Storage.IsCorrupted()) {
-            return MakeError(E_FAIL, "Data structure is corrupted");
+            // Reporting corrupted state is handled by TFileRingBuffer
+            return;
         }
 
         NJsonWriter::TBuf json;
@@ -65,9 +63,8 @@ public:
             .EndObject();
 
         STORAGE_INFO(
-            LogTag << " WriteBackCache has been initialized " << json.Str());
-
-        return {};
+            LogTag << " WriteBackCache storage has been initialized "
+                   << json.Str());
     }
 
     bool Empty() const override
@@ -75,9 +72,14 @@ public:
         return Storage.Empty();
     }
 
-    void Visit(const TVisitor& visitor) override
+    bool IsCorrupted() const override
     {
-        Storage.Visit(
+        return Storage.IsCorrupted();
+    }
+
+    NProto::TError Visit(const TVisitor& visitor) override
+    {
+        return Storage.Visit(
             [&visitor](ui32 checksum, ui32 tag, TStringBuf entry)
             {
                 Y_UNUSED(checksum);
@@ -97,23 +99,23 @@ public:
         return Storage.Alloc(size);
     }
 
-    void Commit() override
+    NProto::TError Commit() override
     {
-        bool success = Storage.Commit();
-        Y_ENSURE(success, "Failed to commit allocation");
+        auto res = Storage.Commit();
         SetCounters();
+        return res;
     }
 
-    void Free(const void* ptr) override
+    NProto::TError Free(const void* ptr) override
     {
-        bool success = Storage.Free(ptr);
-        Y_ENSURE(success, "Failed to free pointer " << ptr);
+        auto res = Storage.Free(ptr);
         SetCounters();
+        return res;
     }
 
-    void SetTag(const void* ptr, ui32 tag) override
+    NProto::TError SetTag(const void* ptr, ui32 tag) override
     {
-        Storage.SetTag(ptr, tag);
+        return Storage.SetTag(ptr, tag);
     }
 
     void UpdateStats() const override
@@ -140,24 +142,17 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TResultOrError<IPersistentStoragePtr> CreateFileRingBufferPersistentStorage(
+IPersistentStoragePtr CreateFileRingBufferPersistentStorage(
     IPersistentStorageStatsPtr stats,
     TPersistentStorageConfig config,
     TLog log,
     TString logTag)
 {
-    auto storage = std::make_shared<TFileRingBufferStorage>(
+    return std::make_shared<TFileRingBufferStorage>(
         std::move(stats),
         std::move(config),
         std::move(log),
         std::move(logTag));
-
-    auto error = storage->Init();
-    if (HasError(error)) {
-        return error;
-    }
-
-    return static_cast<IPersistentStoragePtr>(storage);
 }
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -22,14 +22,24 @@ struct IPersistentStorage
     virtual ~IPersistentStorage() = default;
 
     virtual bool Empty() const = 0;
-
-    // Enumerates the contents of the persistent storage in the allocation order
-    virtual void Visit(const TVisitor& visitor) = 0;
+    virtual bool IsCorrupted() const = 0;
 
     /**
-     * Gets the maximum possible buffer size that can be allocated.
-     * Alloc is guaranteed to succeed for any size <=
-     * MaxSupportedAllocationByteCount when the storage is empty.
+     * Enumerates the contents of the persistent storage in the allocation order
+     *
+     * Does not visit anything and returns an error if the buffer is corrupted.
+     */
+    virtual NProto::TError Visit(const TVisitor& visitor) = 0;
+
+    /**
+     * Returns the number of bytes that can be successfully allocated by
+     * PushBack and Alloc for an empty buffer without exceeding the capacity.
+     *
+     * Returns zero if the buffer is corrupted.
+     *
+     * Note: the purpose of this method is to provide a guarantee that an
+     * allocation of this size will eventually succeed. Allocations of higher
+     * sizes will fail with an error.
      */
     virtual ui64 GetMaxSupportedAllocationByteCount() const = 0;
 
@@ -39,29 +49,43 @@ struct IPersistentStorage
      * On successful allocation, returns a pointer to the buffer in persistent
      * storage. The caller should fill the buffer and call Commit.
      *
-     * Returns nullptr if there is not enough free space in the storage.
+     * On failure, returns nullptr if the buffer is full or an error if
+     * allocation is not possible due to corruption or invalid argument.
      *
-     * Returns an error if allocation is not possible due to other reasons.
+     * Note: only one allocation is possible at a time. Repeated Alloc will
+     * return an error.
      */
     [[nodiscard]] virtual TResultOrError<char*> Alloc(size_t size) = 0;
 
     /**
-     * Commits previous memory allocation
+     * Commits previously allocated memory buffer.
+     *
+     * Once committed, it is not allowed to modify the contents of the allocated
+     * entry. If there is a need to augment the allocation with additional data,
+     * SetTag can be used.
      *
      * Memory that was allocated but not committed will be lost at buffer
      * recreation.
      *
-     * Returns true if the commit was successful.
-     * Returns false if Alloc was not called.
+     * An error is returned if there is no incomplete allocation or the buffer
+     * is corrupted.
      */
-    virtual void Commit() = 0;
+    virtual NProto::TError Commit() = 0;
 
-    // Frees a previously allocated buffer.
-    virtual void Free(const void* ptr) = 0;
+    /**
+     * Frees a previously allocated and committed buffer.
+     *
+     * An error is returned if the pointer is invalid or the buffer is corrupted
+     */
+    virtual NProto::TError Free(const void* ptr) = 0;
 
-    // Once committed, entries should remain immutable.
-    // But it is possible to assign a small mutable tag to the entry.
-    virtual void SetTag(const void* ptr, ui32 tag) = 0;
+    /**
+     * Sets the tag value associated with the allocation.
+     *
+     * Returns an error if the pointer is invalid, the tag value exceeds the
+     * maximal supported value or if the buffer is corrupted.
+     */
+    virtual NProto::TError SetTag(const void* ptr, ui32 tag) = 0;
 
     virtual void UpdateStats() const = 0;
 };
@@ -79,7 +103,7 @@ struct TPersistentStorageConfig
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TResultOrError<IPersistentStoragePtr> CreateFileRingBufferPersistentStorage(
+IPersistentStoragePtr CreateFileRingBufferPersistentStorage(
     IPersistentStorageStatsPtr stats,
     TPersistentStorageConfig config,
     TLog log,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -41,7 +41,7 @@ struct TBootstrap
 
     NProto::TError Initialize()
     {
-        auto res = CreateFileRingBufferPersistentStorage(
+        Storage = CreateFileRingBufferPersistentStorage(
             Stats,
             {.FilePath = TempFile.GetName(),
              .DataCapacity = DefaultCapacity,
@@ -49,12 +49,7 @@ struct TBootstrap
             Log,
             "[tag]");
 
-        if (HasError(res)) {
-            return res.GetError();
-        }
-
-        Storage = res.ExtractResult();
-        return {};
+        return MakeError(Storage->IsCorrupted() ? E_FAIL : S_OK);
     }
 
     void Deinitialize()
@@ -89,9 +84,9 @@ struct TBootstrap
         return HasError(allocationResult);
     }
 
-    void Free(const void* ptr) const
+    NProto::TError Free(const void* ptr) const
     {
-        Storage->Free(ptr);
+        return Storage->Free(ptr);
     }
 
     TString Dump() const
@@ -157,7 +152,7 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         UNIT_ASSERT_VALUES_EQUAL(0, stats.EntryCount->Get());
     }
 
-    Y_UNIT_TEST(ShouldThrowOnDoubleFree)
+    Y_UNIT_TEST(ShouldReturnErrorOnDoubleFree)
     {
         TBootstrap b;
 
@@ -170,11 +165,11 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         const auto* ptr2 = b.Alloc("567890");
         UNIT_ASSERT(ptr2);
 
-        b.Free(ptr2);
-        UNIT_ASSERT_EXCEPTION(b.Free(ptr2), yexception);
+        UNIT_ASSERT(!HasError(b.Free(ptr2)));
+        UNIT_ASSERT(HasError(b.Free(ptr2)));
 
-        b.Free(ptr1);
-        UNIT_ASSERT_EXCEPTION(b.Free(ptr1), yexception);
+        UNIT_ASSERT(!HasError(b.Free(ptr1)));
+        UNIT_ASSERT(HasError(b.Free(ptr1)));
     }
 
     Y_UNIT_TEST(ShouldValidateAllocationSize)

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
@@ -37,6 +37,7 @@ public:
         : Stats(CreateWriteBackCacheStats())
         , State(
               *this,
+              CreateTestStorage(Stats),
               std::make_shared<TTestTimer>(),
               Stats->GetWriteBackCacheStateStats(),
               Stats->GetWriteDataRequestManagerStats(),
@@ -44,7 +45,7 @@ public:
               TFlushBatchLimits{},
               "[tag]")
     {
-        State.Init(CreateTestStorage(Stats));
+        State.Init();
 
         Write(2, "ABCD");
         Write(10, "IJKL");

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
@@ -13,11 +13,17 @@ bool TTestStorage::Empty() const
     return Data.empty();
 }
 
-void TTestStorage::Visit(const TVisitor& visitor)
+bool TTestStorage::IsCorrupted() const
+{
+    return false;
+}
+
+NProto::TError TTestStorage::Visit(const TVisitor& visitor)
 {
     for (const auto& it: List) {
         visitor(it.Tag, it.Data);
     }
+    return {};
 }
 
 ui64 TTestStorage::GetMaxSupportedAllocationByteCount() const
@@ -43,10 +49,12 @@ TResultOrError<char*> TTestStorage::Alloc(size_t size)
     return res;
 }
 
-void TTestStorage::Commit()
-{}
+NProto::TError TTestStorage::Commit()
+{
+    return {};
+}
 
-void TTestStorage::Free(const void* ptr)
+NProto::TError TTestStorage::Free(const void* ptr)
 {
     auto it = Data.find(ptr);
     Y_ENSURE(it != Data.end(), "Double free detected");
@@ -54,14 +62,16 @@ void TTestStorage::Free(const void* ptr)
     Data.erase(it);
 
     SetStats();
+    return {};
 }
 
-void TTestStorage::SetTag(const void* ptr, ui32 tag)
+NProto::TError TTestStorage::SetTag(const void* ptr, ui32 tag)
 {
     auto it = Data.find(ptr);
     Y_ENSURE(it != Data.end(), "Entry not found");
 
     it->second->Tag = tag;
+    return {};
 }
 
 void TTestStorage::UpdateStats() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
@@ -29,12 +29,13 @@ public:
     explicit TTestStorage(IPersistentStorageStatsPtr stats);
 
     bool Empty() const override;
-    void Visit(const TVisitor& visitor) override;
+    bool IsCorrupted() const override;
+    NProto::TError Visit(const TVisitor& visitor) override;
     ui64 GetMaxSupportedAllocationByteCount() const override;
     TResultOrError<char*> Alloc(size_t size) override;
-    void Commit() override;
-    void Free(const void* ptr) override;
-    void SetTag(const void* ptr, ui32 tag) override;
+    NProto::TError Commit() override;
+    NProto::TError Free(const void* ptr) override;
+    NProto::TError SetTag(const void* ptr, ui32 tag) override;
     void UpdateStats() const override;
 
     void SetCapacity(size_t capacity);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -83,6 +83,7 @@ private:
 
     IPersistentStoragePtr PersistentStorage;
     TWriteBackCacheState State;
+    bool IsInitialized = false;
 
     std::atomic<bool> DrainRequested = false;
     std::atomic<bool> DrainCompleted = false;
@@ -109,60 +110,68 @@ public:
               args.ClientId.c_str()))
         , FileSystemId(args.FileSystemId)
         , FilePath(args.FilePath)
+        , PersistentStorage(CreateFileRingBufferPersistentStorage(
+              args.Stats->GetPersistentStorageStats(),
+              {.FilePath = args.FilePath, .DataCapacity = args.CapacityBytes},
+              Log,
+              LogTag))
         , State(
               *this,
+              PersistentStorage,
               Timer,
               args.Stats->GetWriteBackCacheStateStats(),
               args.Stats->GetWriteDataRequestManagerStats(),
               args.Stats->GetNodeStateHolderStats(),
               BuildFlushBatchLimits(args),
               LogTag)
-    {
-        auto createPersistentStorageResult =
-            CreateFileRingBufferPersistentStorage(
-                args.Stats->GetPersistentStorageStats(),
-                {.FilePath = args.FilePath, .DataCapacity = args.CapacityBytes},
-                Log,
-                LogTag);
-
-        if (HasError(createPersistentStorageResult)) {
-            ReportWriteBackCacheCorruptionError(
-                TStringBuilder()
-                << LogTag
-                << " WriteBackCache persistent storage initialization failed: "
-                << createPersistentStorageResult.GetError()
-                << ", FilePath: " << args.FilePath.Quote());
-            return;
-        }
-
-        PersistentStorage = createPersistentStorageResult.ExtractResult();
-
-        // File ring buffer should be able to store any valid TWriteDataRequest.
-        // Inability to store it will cause this and future requests to remain
-        // in the pending queue forever (including requests with smaller size).
-        // Should fit 1 MiB of data plus some headers (assume 1 KiB is enough).
-        Y_ABORT_UNLESS(
-            PersistentStorage->GetMaxSupportedAllocationByteCount() >=
-            1024 * 1024 + 1016);
-    }
+    {}
 
     // This method should be called outside TImpl constructor because
     // it captures weak_from_this()
     void Init()
     {
-        if (!PersistentStorage) {
+        if (PersistentStorage->IsCorrupted()) {
+            ReportWriteBackCacheCorruptionError(
+                TStringBuilder()
+                << LogTag
+                << " WriteBackCache cannot be initialzed due to corrupted "
+                   "persistent storage, FilePath: "
+                << FilePath.Quote());
             return;
         }
 
-        if (!State.Init(PersistentStorage)) {
+        // File ring buffer should be able to store any valid TWriteDataRequest.
+        // Inability to store it will cause this and future requests to remain
+        // in the pending queue forever (including requests with smaller size).
+        // Should fit 1 MiB of data plus some headers (assume 1 KiB is enough).
+        const ui64 maxAllocationByteCount = 1024 * 1024 + 1016;
+
+        const ui64 maxSupportedAllocationByteCount =
+            PersistentStorage->GetMaxSupportedAllocationByteCount();
+
+        if (maxSupportedAllocationByteCount < maxAllocationByteCount) {
+            ReportWriteBackCacheInvalidConfiguration(
+                TStringBuilder() << LogTag
+                                 << " WriteBackCache cannot be initialzed "
+                                    "because MaxSupportedAllocationByteCount ("
+                                 << maxSupportedAllocationByteCount
+                                 << ") is less than the minimal allowed value ("
+                                 << maxAllocationByteCount
+                                 << "), FilePath: " << FilePath.Quote());
+            return;
+        }
+
+        if (!State.Init()) {
             ReportWriteBackCacheCorruptionError(
                 TStringBuilder()
                 << LogTag
                 << " WriteBackCache failed to deserialize requests from the "
                    "persistent storage due to corruption"
                 << ", FilePath: " << FilePath.Quote());
+            return;
         }
 
+        IsInitialized = true;
         ScheduleAutomaticFlushIfNeeded();
     }
 
@@ -206,6 +215,10 @@ public:
 
     NThreading::TFuture<NCloud::NProto::TError> Drain()
     {
+        if (!IsInitialized) {
+            return NewPromise<NCloud::NProto::TError>();
+        }
+
         if (!DrainRequested.exchange(true)) {
             STORAGE_INFO(LogTag << " Start WriteBackCache draining");
         }
@@ -236,6 +249,10 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadDataRequest> request)
     {
+        if (!IsInitialized) {
+            return NewPromise<NProto::TReadDataResponse>();
+        }
+
         if (request->GetFileSystemId().empty()) {
             request->SetFileSystemId(callContext->FileSystemId);
         }
@@ -296,6 +313,10 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TWriteDataRequest> request)
     {
+        if (!IsInitialized) {
+            return NewPromise<NProto::TWriteDataResponse>();
+        }
+
         if (request->GetFileSystemId().empty()) {
             request->SetFileSystemId(callContext->FileSystemId);
         }
@@ -313,16 +334,28 @@ public:
 
     TFuture<NProto::TError> FlushNodeData(ui64 nodeId)
     {
+        if (!IsInitialized) {
+            return NewPromise<NProto::TError>();
+        }
+
         return State.AddFlushRequest(nodeId);
     }
 
     TFuture<NProto::TError> FlushAllData()
     {
+        if (!IsInitialized) {
+            return NewPromise<NProto::TError>();
+        }
+
         return State.AddFlushAllRequest();
     }
 
     TFuture<NProto::TError> ReleaseHandle(ui64 nodeId, ui64 handle)
     {
+        if (!IsInitialized) {
+            return NewPromise<NProto::TError>();
+        }
+
         return State.AddReleaseHandleRequest(nodeId, handle);
     }
 
@@ -330,6 +363,10 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadDataRequest> request)
     {
+        if (!IsInitialized) {
+            return NewPromise<NProto::TReadDataResponse>();
+        }
+
         return ExecuteRequestUnderBarrier<NProto::TReadDataResponse>(
             request->GetNodeId(),
             [this,
@@ -346,6 +383,10 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TWriteDataRequest> request)
     {
+        if (!IsInitialized) {
+            return NewPromise<NProto::TWriteDataResponse>();
+        }
+
         return ExecuteRequestUnderBarrier<NProto::TWriteDataResponse>(
             request->GetNodeId(),
             [this,
@@ -362,6 +403,10 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TSetNodeAttrRequest> request)
     {
+        if (!IsInitialized) {
+            return NewPromise<NProto::TSetNodeAttrResponse>();
+        }
+
         const bool attrSizeNotAffected =
             (request->GetFlags() &
              ProtoFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE)) == 0;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -16,6 +16,7 @@ using ERequestType = IWriteBackCacheStateStats::ERequestType;
 
 TWriteBackCacheState::TWriteBackCacheState(
     IQueuedOperationsProcessor& processor,
+    IPersistentStoragePtr persistentStorage,
     ITimerPtr timer,
     IWriteBackCacheStateStatsPtr writeBackCacheStateStats,
     IWriteDataRequestManagerStatsPtr writeDataRequestManagerStats,
@@ -25,22 +26,20 @@ TWriteBackCacheState::TWriteBackCacheState(
     : SequenceIdGenerator(std::make_shared<TSequenceIdGenerator>())
     , Timer(std::move(timer))
     , Stats(std::move(writeBackCacheStateStats))
-    , RequestManagerStats(std::move(writeDataRequestManagerStats))
     , FlushBatchLimits(flushBatchLimits)
     , LogTag(std::move(logTag))
     , Nodes(Timer, std::move(nodeStateHolderStats))
+    , RequestManager(
+          SequenceIdGenerator,
+          std::move(persistentStorage),
+          Timer,
+          std::move(writeDataRequestManagerStats))
     , QueuedOperations(processor)
 {}
 
-bool TWriteBackCacheState::Init(IPersistentStoragePtr persistentStorage)
+bool TWriteBackCacheState::Init()
 {
     auto guard = LockStateAndPostponeQueuedOperations();
-
-    RequestManager = TWriteDataRequestManager(
-        SequenceIdGenerator,
-        std::move(persistentStorage),
-        Timer,
-        RequestManagerStats);
 
     return RequestManager.Init(
         [this](

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -54,7 +54,6 @@ private:
     const ISequenceIdGeneratorPtr SequenceIdGenerator;
     const ITimerPtr Timer;
     const IWriteBackCacheStateStatsPtr Stats;
-    const IWriteDataRequestManagerStatsPtr RequestManagerStats;
     const TFlushBatchLimits FlushBatchLimits;
     const TString LogTag;
 
@@ -86,6 +85,7 @@ public:
 
     TWriteBackCacheState(
         IQueuedOperationsProcessor& processor,
+        IPersistentStoragePtr persistentStorage,
         ITimerPtr timer,
         IWriteBackCacheStateStatsPtr writeBackCacheStateStats,
         IWriteDataRequestManagerStatsPtr writeDataRequestManagerStats,
@@ -94,7 +94,7 @@ public:
         TString logTag);
 
     // Read state from the persistent storage
-    bool Init(IPersistentStoragePtr persistentStorage);
+    bool Init();
 
     // Prevent new WriteData requests from being added to the cache - they
     // will fail with E_REJECTED error.

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -113,6 +113,7 @@ struct TBootstrap
     {
         State = std::make_unique<TWriteBackCacheState>(
             Processor,
+            Storage,
             Timer,
             Stats->GetWriteBackCacheStateStats(),
             Stats->GetWriteDataRequestManagerStats(),
@@ -120,7 +121,7 @@ struct TBootstrap
             FlushBatchLimits,
             "[test]");
 
-        return State->Init(Storage);
+        return State->Init();
     }
 
     void UpdateStats() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2767,6 +2767,73 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
             0,
             b.Metrics.WriteDataRequestDroppedCount->Get());
     }
+
+    Y_UNIT_TEST(ShouldReportStatsWhenFileRingBufferIsCorrupted)
+    {
+        TBootstrap b;
+
+        b.TempFileHandle.Pwrite("Corrupt cache", 13, 0);
+        b.TempFileHandle.Flush();
+
+        b.RecreateCache();
+
+        b.ModuleStats->UpdateStats(TInstant::Now());
+
+        UNIT_ASSERT_VALUES_EQUAL(1, b.Metrics.Storage.Corrupted->Get());
+    }
+
+    Y_UNIT_TEST(ShouldHangWhenFileRingBufferIsCorrupted)
+    {
+        TBootstrap b;
+
+        b.TempFileHandle.Pwrite("Corrupt cache", 13, 0);
+        b.TempFileHandle.Flush();
+
+        b.RecreateCache();
+
+        auto writeFuture = b.WriteToCache(1, 0, "abc");
+        auto readFuture = b.ReadFromCache(1, 0, 3);
+        auto flushFuture = b.Cache.FlushNodeData(1);
+        auto flushAllFuture = b.Cache.FlushAllData();
+        auto releaseHandleFuture = b.Cache.ReleaseHandle(1, 101);
+
+        auto writeRequest = std::make_shared<NProto::TWriteDataRequest>();
+        writeRequest->SetNodeId(1);
+        writeRequest->SetHandle(101);
+        writeRequest->SetOffset(0);
+        writeRequest->SetBuffer("abc");
+
+        auto directWriteFuture =
+            b.Cache.WriteDataDirect(b.CallContext, std::move(writeRequest));
+
+        auto readRequest = std::make_shared<NProto::TReadDataRequest>();
+        readRequest->SetNodeId(1);
+        readRequest->SetHandle(101);
+        readRequest->SetOffset(0);
+        readRequest->SetLength(3);
+
+        auto directReadFuture =
+            b.Cache.ReadDataDirect(b.CallContext, std::move(readRequest));
+
+        auto setNodeAttrRequest =
+            std::make_shared<NProto::TSetNodeAttrRequest>();
+
+        setNodeAttrRequest->SetNodeId(1);
+
+        auto setNodeAttrFuture =
+            b.Cache.SetNodeAttr(b.CallContext, std::move(setNodeAttrRequest));
+
+        Sleep(TDuration::Seconds(1));
+
+        UNIT_ASSERT(!writeFuture.HasValue());
+        UNIT_ASSERT(!readFuture.HasValue());
+        UNIT_ASSERT(!flushFuture.HasValue());
+        UNIT_ASSERT(!flushAllFuture.HasValue());
+        UNIT_ASSERT(!releaseHandleFuture.HasValue());
+        UNIT_ASSERT(!directWriteFuture.HasValue());
+        UNIT_ASSERT(!directReadFuture.HasValue());
+        UNIT_ASSERT(!setNodeAttrFuture.HasValue());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -15,8 +15,6 @@
 #include <util/system/compiler.h>
 #include <util/system/filemap.h>
 
-#include <span>
-
 namespace NCloud {
 
 namespace {
@@ -118,6 +116,16 @@ THeader InitHeader(const TFileRingBufferArgs& args)
         AlignUp(res.MetadataOffset + res.MetadataCapacity, sizeof(ui64));
     res.DataCapacity = args.DataCapacity;
     return res;
+}
+
+NProto::TError MakeBufferIsCorruptError()
+{
+    return MakeError(E_INVALID_STATE, "Buffer is corrupted");
+}
+
+NProto::TError MakeInvalidPointerError()
+{
+    return MakeError(E_ARGUMENT, "Invalid pointer");
 }
 
 }   // namespace
@@ -482,22 +490,31 @@ public:
         }
     }
 
-    bool PushBack(TStringBuf data)
+    TResultOrError<bool> PushBack(TStringBuf data)
     {
         if (!ValidateAccess("PushBack")) {
+            return MakeBufferIsCorruptError();
+        }
+
+        auto allocationResult = Alloc(data.size());
+
+        if (HasError(allocationResult)) {
+            return allocationResult.GetError();
+        }
+
+        if (allocationResult.GetResult() == nullptr) {
             return false;
         }
 
-        auto allocationStatus = Alloc(data.size());
-        if (HasError(allocationStatus) ||
-            allocationStatus.GetResult() == nullptr)
-        {
-            return false;
+        data.copy(allocationResult.GetResult(), data.size());
+
+        auto commitResult = Commit();
+
+        if (HasError(commitResult)) {
+            return commitResult;
         }
 
-        data.copy(allocationStatus.GetResult(), data.size());
-
-        return Commit();
+        return true;
     }
 
     TResultOrError<char*> Alloc(size_t size)
@@ -509,7 +526,7 @@ public:
         }
 
         if (!ValidateAccess("Alloc")) {
-            return MakeError(E_INVALID_STATE, "Buffer is corrupted");
+            return MakeBufferIsCorruptError();
         }
 
         if (size == 0) {
@@ -590,10 +607,14 @@ public:
         return ptr;
     }
 
-    bool Commit()
+    NProto::TError Commit()
     {
+        if (!ValidateAccess("Commit")) {
+            return MakeBufferIsCorruptError();
+        }
+
         if (!CurrentAllocation.HasValue()) {
-            return false;
+            return MakeError(E_ARGUMENT, "No allocation to commit");
         }
 
         CurrentAllocation.Header.DataChecksum =
@@ -617,18 +638,18 @@ public:
         EntryMap[CurrentAllocation.Data] = CurrentAllocation.ActualPos;
 
         CurrentAllocation = TEntryInfo::CreateInvalid();
-        return true;
+        return {};
     }
 
-    bool Free(const void* ptr)
+    NProto::TError Free(const void* ptr)
     {
         if (!ValidateAccess("Free")) {
-            return false;
+            return MakeBufferIsCorruptError();
         }
 
         auto it = EntryMap.find(ptr);
         if (it == EntryMap.end()) {
-            return false;
+            return MakeInvalidPointerError();
         }
 
         auto eh = Data()->ReadEntryHeader(it->second);
@@ -640,7 +661,7 @@ public:
 
         EraseFreeEntriesFromFront();
 
-        return true;
+        return {};
     }
 
     ui32 GetMaxTag() const
@@ -648,65 +669,78 @@ public:
         return Capabilities().MaxTag;
     }
 
-    ui32 GetTag(const void* ptr) const
+    TResultOrError<ui32> GetTag(const void* ptr) const
     {
         if (!ValidateAccess("GetTag")) {
-            return 0;
+            return MakeBufferIsCorruptError();
         }
 
         auto it = EntryMap.find(ptr);
         if (it == EntryMap.end()) {
-            return 0;
+            return MakeInvalidPointerError();
         }
 
         auto eh = Data()->ReadEntryHeader(it->second);
         return eh.Tag;
     }
 
-    void SetTag(const void* ptr, ui32 tag)
+    NProto::TError SetTag(const void* ptr, ui32 tag)
     {
         if (!ValidateAccess("SetTag")) {
-            return;
+            return MakeBufferIsCorruptError();
         }
 
         auto it = EntryMap.find(ptr);
         if (it == EntryMap.end()) {
-            return;
+            return MakeInvalidPointerError();
         }
 
         auto eh = Data()->ReadEntryHeader(it->second);
         eh.Tag = tag;
         Data()->WriteEntryHeader(it->second, eh);
+        return {};
     }
 
-    TStringBuf Front()
+    TResultOrError<TStringBuf> Front()
     {
         if (!ValidateAccess("Front")) {
-            return {};
+            return MakeBufferIsCorruptError();
         }
 
         auto e = GetFrontEntry();
 
         if (e.IsInvalid()) {
             SetCorrupted("Invalid front entry");
-            return {};
+            return MakeBufferIsCorruptError();
         }
 
         return e.GetData();
     }
 
-    void PopFront()
+    TResultOrError<bool> PopFront()
     {
         if (!ValidateAccess("PopFront")) {
-            return;
+            return MakeBufferIsCorruptError();
         }
 
-        auto cur = GetFrontEntry();
-        if (!cur.HasValue()) {
-            return;
+        auto e = GetFrontEntry();
+
+        if (e.IsInvalid()) {
+            SetCorrupted("Invalid front entry");
+            return MakeBufferIsCorruptError();
         }
 
-        Free(cur.Data);
+        if (!e.HasValue()) {
+            return false;
+        }
+
+        auto status = Free(e.Data);
+
+        if (HasError(status)) {
+            return status;
+        }
+
+        return true;
     }
 
     ui64 Size() const
@@ -735,10 +769,10 @@ public:
         return !IsCorrupted();
     }
 
-    void Visit(const TVisitor& visitor)
+    NProto::TError Visit(const TVisitor& visitor)
     {
         if (!ValidateAccess("Visit")) {
-            return;
+            return MakeBufferIsCorruptError();
         }
 
         VisitEntries(
@@ -748,6 +782,8 @@ public:
                     visitor(e.Header.DataChecksum, e.GetTag(), e.GetData());
                 }
             });
+
+        return {};
     }
 
     bool IsCorrupted() const
@@ -826,26 +862,26 @@ public:
         return Capabilities().MaxAllocationByteCount;
     }
 
-    TStringBuf GetMetadata()
+    TResultOrError<TStringBuf> GetMetadata()
     {
         if (!ValidateAccess("GetMetadata")) {
-            return {};
+            return MakeBufferIsCorruptError();
         }
 
         auto data = Accessor.GetRawMetadata();
 
         if (Header()->MetadataSize > data.size()) {
             SetCorrupted("Invalid MetadataSize");
-            return {};
+            return MakeBufferIsCorruptError();
         }
 
-        return {data.data(), Header()->MetadataSize};
+        return TStringBuf{data.data(), Header()->MetadataSize};
     }
 
-    bool SetMetadata(TStringBuf buf)
+    TResultOrError<bool> SetMetadata(TStringBuf buf)
     {
         if (!ValidateAccess("SetMetadata")) {
-            return false;
+            return MakeBufferIsCorruptError();
         }
 
         auto data = Accessor.GetRawMetadata();
@@ -877,7 +913,7 @@ TFileRingBuffer::TFileRingBuffer(
 
 TFileRingBuffer::~TFileRingBuffer() = default;
 
-bool TFileRingBuffer::PushBack(TStringBuf data)
+TResultOrError<bool> TFileRingBuffer::PushBack(TStringBuf data)
 {
     return Impl->PushBack(data);
 }
@@ -887,12 +923,12 @@ TResultOrError<char*> TFileRingBuffer::Alloc(size_t size)
     return Impl->Alloc(size);
 }
 
-bool TFileRingBuffer::Commit()
+NProto::TError TFileRingBuffer::Commit()
 {
     return Impl->Commit();
 }
 
-bool TFileRingBuffer::Free(const void* ptr)
+NProto::TError TFileRingBuffer::Free(const void* ptr)
 {
     return Impl->Free(ptr);
 }
@@ -902,24 +938,24 @@ ui32 TFileRingBuffer::GetMaxTag() const
     return Impl->GetMaxTag();
 }
 
-ui32 TFileRingBuffer::GetTag(const void* ptr) const
+TResultOrError<ui32> TFileRingBuffer::GetTag(const void* ptr) const
 {
     return Impl->GetTag(ptr);
 }
 
-void TFileRingBuffer::SetTag(const void* ptr, ui32 tag)
+NProto::TError TFileRingBuffer::SetTag(const void* ptr, ui32 tag)
 {
-    Impl->SetTag(ptr, tag);
+    return Impl->SetTag(ptr, tag);
 }
 
-TStringBuf TFileRingBuffer::Front()
+TResultOrError<TStringBuf> TFileRingBuffer::Front()
 {
     return Impl->Front();
 }
 
-void TFileRingBuffer::PopFront()
+TResultOrError<bool> TFileRingBuffer::PopFront()
 {
-    Impl->PopFront();
+    return Impl->PopFront();
 }
 
 ui64 TFileRingBuffer::Size() const
@@ -937,9 +973,9 @@ bool TFileRingBuffer::Validate()
     return Impl->Validate();
 }
 
-void TFileRingBuffer::Visit(const TVisitor& visitor)
+NProto::TError TFileRingBuffer::Visit(const TVisitor& visitor)
 {
-    Impl->Visit(visitor);
+    return Impl->Visit(visitor);
 }
 
 bool TFileRingBuffer::IsCorrupted() const
@@ -982,12 +1018,12 @@ ui64 TFileRingBuffer::GetMaxSupportedAllocationByteCount() const
     return Impl->GetMaxSupportedAllocationByteCount();
 }
 
-TStringBuf TFileRingBuffer::GetMetadata() const
+TResultOrError<TStringBuf> TFileRingBuffer::GetMetadata() const
 {
     return Impl->GetMetadata();
 }
 
-bool TFileRingBuffer::SetMetadata(TStringBuf data)
+TResultOrError<bool> TFileRingBuffer::SetMetadata(TStringBuf data)
 {
     return Impl->SetMetadata(data);
 }

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -48,65 +48,172 @@ public:
 
     ~TFileRingBuffer();
 
-public:
-    bool PushBack(TStringBuf data);
+    /**
+     * Allocates a new entry in the buffer and copies the data into it.
+     *
+     * On success, return true. The entry becomes visible immediately.
+     *
+     * On failure, return false if the buffer is full or an error if
+     * allocation is not possible due to corruption or invalid argument.
+     *
+     * Note: only one allocation is possible at a time. Calling PushBack while
+     * an allocation made by Alloc is not committed will return an error.
+     */
+    TResultOrError<bool> PushBack(TStringBuf data);
 
-    // Implement in-place allocation.
-    // Returns a pointer to the allocated memory or nullptr if storage is full.
-    // Returns an error if allocation is not possible due to corruption or
-    // invalid data.
+    /**
+     * In-place allocation of a memory block of the given size in the buffer.
+     *
+     * On success, returns a pointer to the allocated memory. The caller should
+     * fill the allocated memory with data and then commit it. Non-committed
+     * allocations are not visible and will be lost on buffer recreation.
+     *
+     * On failure, returns nullptr if the buffer is full or an error if
+     * allocation is not possible due to corruption or invalid argument.
+     *
+     * Note: only one allocation is possible at a time. Repeated Alloc will
+     * return an error.
+     */
     TResultOrError<char*> Alloc(size_t size);
 
-    // Calculate checksum for the previously allocated memory using Alloc
-    // and advance the write pointer.
-    // Once committed, allocated entries become immutable - it is not allowed
-    // to modify their contents via pointer returned by Alloc.
-    bool Commit();
+    /**
+     * Completes the previously made allocation by calculating checksum and
+     * making the allocation visible.
+     *
+     * Once committed, it is not allowed to modify the contents of the allocated
+     * entry. If there is a need to augment the allocation with additional data,
+     * GetTag/SetTag can be used.
+     *
+     * An error is returned if there is no incomplete allocation or the buffer
+     * is corrupted.
+     */
+    NProto::TError Commit();
 
-    // Free memory block previously allocated with Alloc.
-    // It is possible to free memory blocks in any order.
-    // Otherwise, it will be marked for deletion and removed later.
-    // Returns true if the pointer was correct and hasn't been freed yet.
-    bool Free(const void* ptr);
+    /**
+     * Frees a memory block that was previously allocated and committed.
+     * It is possible to free memory blocks in any order.
+     *
+     * An error is returned if the pointer is invalid or the buffer is corrupted
+     *
+     * Implementation details: if the allocation is in the front of the ring
+     * buffer, it is immediately freed. Otherwise, a FreeFlag is set for the
+     * allocation and it will be freed when it reaches the front of the buffer.
+     */
+    NProto::TError Free(const void* ptr);
 
-    // Each entry can be tagged with a small mutable integer value [0-7]
+    /**
+     * Gets the maximum tag value supported by the buffer.
+     * Version 5 and later support tags in the range [0-7].
+     * Earlier versions do not support tags.
+     */
     ui32 GetMaxTag() const;
-    ui32 GetTag(const void* ptr) const;
-    void SetTag(const void* ptr, ui32 tag);
 
-    TStringBuf Front();
-    void PopFront();
+    /**
+     * Gets the tag value associated with the allocation.
+     *
+     * Returns tag value on success.
+     * Returns an error if the pointer is invalid or if the buffer is corrupted.
+     */
+    TResultOrError<ui32> GetTag(const void* ptr) const;
+
+    /**
+     * Sets the tag value associated with the allocation.
+     *
+     * Returns an error if the pointer is invalid, the tag value exceeds the
+     * value returned by GetMaxTag() or if the buffer is corrupted.
+     */
+    NProto::TError SetTag(const void* ptr, ui32 tag);
+
+    /**
+     * Gets the front allocation of the buffer.
+     *
+     * Returns the contents of the front allocation on success.
+     * Returns empty string if the buffer is empty.
+     * Returns an error if storage is corrupted.
+     */
+    TResultOrError<TStringBuf> Front();
+
+    /**
+     * Frees the front allocation.
+     *
+     * Returns true on success.
+     * Returns false if the buffer is empty.
+     * Returns an error if the buffer is corrupted.
+     */
+    TResultOrError<bool> PopFront();
+
+    /**
+     * Returns the number of visible allocations in the buffer.
+     * The behavior is unspecified if the buffer is corrupted.
+     */
     ui64 Size() const;
+
+    /**
+     * Checks if the buffer is empty.
+     * The behavior is unspecified if the buffer is corrupted.
+     */
     bool Empty() const;
 
-    // Checks data and structure integrity including data checksum validation
-    // Sets IsCorrupted flag if any issues are found and returns false
-    // Returns true if everything is valid
-    // Fires a critical event and doesn't visit entries if a buffer is corrupted
+    /**
+     * Check data and structure integrity including data checksum validation.
+     * Set IsCorrupted flag if any issues are found and returns false.
+     * Return true if everything is valid.
+     * Fire a critical event and doesn't visit entries if a buffer is corrupted.
+     */
     bool Validate();
 
-    // Calls visitor for each entry in the buffer
-    // Fires a critical event doesn't visit entries if a buffer is corrupted
-    void Visit(const TVisitor& visitor);
+    /**
+     * Calls the visitor for each visible allocation in the buffer in the
+     * allocation order.
+     *
+     * Does not visit anything and returns an error if the buffer is corrupted.
+     */
+    NProto::TError Visit(const TVisitor& visitor);
+
     bool IsCorrupted() const;
     void SetCorrupted();
+
     ui64 GetRawCapacity() const;
     ui64 GetRawUsedBytesCount() const;
     ui32 GetVersion() const;
     ui64 GetMaxObservedEntryByteCount() const;
 
-    // Returns the number of bytes that can be allocated in the buffer without
-    // exceeding its capacity (PushBack will succeed).
-    // Returns zero if the buffer is full or corrupted.
+    /**
+     * Returns the number of bytes that can be successfully allocated by
+     * PushBack and Alloc right now without exceeding the capacity.
+     *
+     * Returns zero if the buffer is full or corrupted.
+     */
     ui64 GetAvailableByteCount() const;
 
-    // Returns the maximal number of bytes that can be allocated in the buffer
-    // (PushBack will succeed for an empty buffer).
-    // Returns zero if the buffer is corrupted.
+    /**
+     * Returns the number of bytes that can be successfully allocated by
+     * PushBack and Alloc for an empty buffer without exceeding the capacity.
+     *
+     * Returns zero if the buffer is corrupted.
+     *
+     * Note: the purpose of this method is to provide a guarantee that an
+     * allocation of this size will eventually succeed. Allocations of higher
+     * sizes will fail with an error.
+     */
     ui64 GetMaxSupportedAllocationByteCount() const;
 
-    TStringBuf GetMetadata() const;
-    bool SetMetadata(TStringBuf data);
+    /**
+     * Gets metadata
+     *
+     * Returns the metadata contents on success
+     * Returns an error if the buffer is corrupted
+     */
+    TResultOrError<TStringBuf> GetMetadata() const;
+
+    /**
+     * Sets metadata
+     *
+     * Returns true on success
+     * Returns false if the argument exceeds the metadata capacity
+     * Returns an error if the buffer is corrupted
+     */
+    TResultOrError<bool> SetMetadata(TStringBuf data);
 };
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor_ut.cpp
@@ -142,6 +142,11 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static bool operator==(bool lhs, const TResultOrError<bool>& rhs)
+{
+    return !HasError(rhs) && lhs == rhs.GetResult();
+}
+
 Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
 {
     Y_UNIT_TEST(ShouldValidateEmptyFile)
@@ -506,9 +511,9 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
         b.Execute(
             [](TFileRingBuffer& rb)
             {
-                UNIT_ASSERT(rb.PushBack("ABC"));
-                UNIT_ASSERT(rb.PushBack("123"));
-                UNIT_ASSERT(rb.SetMetadata("meta"));
+                UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABC"));
+                UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("123"));
+                UNIT_ASSERT_VALUES_EQUAL(true, rb.SetMetadata("meta"));
             },
             ver);
 
@@ -523,14 +528,14 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
         b.Execute(
             [](TFileRingBuffer& rb)
             {
-                while (rb.PushBack("ABCD")) {
+                while (rb.PushBack("ABCD").GetResult()) {
                     // Add elements until the buffer is full
                 }
 
                 rb.PopFront();
                 rb.PopFront();
 
-                UNIT_ASSERT(rb.PushBack("wrap"));
+                UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("wrap"));
             },
             ver);
 
@@ -543,7 +548,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
         b.Execute(
             [](TFileRingBuffer& rb)
             {
-                while (rb.PushBack("ABCD")) {
+                while (rb.PushBack("ABCD").GetResult()) {
                     // Add elements until the buffer is full
                 }
 
@@ -586,7 +591,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
     {
         TBootstrap b;
         b.Execute(
-            [](TFileRingBuffer& rb) { UNIT_ASSERT(rb.PushBack("ABC")); },
+            [](TFileRingBuffer& rb)
+            { UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABC")); },
             ver);
 
         b.AssertValidateSuccess();
@@ -602,7 +608,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
     {
         TBootstrap b;
         b.Execute(
-            [](TFileRingBuffer& rb) { UNIT_ASSERT(rb.PushBack("ABC")); },
+            [](TFileRingBuffer& rb)
+            { UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABC")); },
             ver);
 
         b.AssertValidateSuccess();
@@ -618,7 +625,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
     {
         TBootstrap b;
         b.Execute(
-            [](TFileRingBuffer& rb) { UNIT_ASSERT(rb.PushBack("ABC")); },
+            [](TFileRingBuffer& rb)
+            { UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABC")); },
             ver);
 
         b.AssertValidateSuccess();
@@ -632,7 +640,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
     {
         TBootstrap b;
         b.Execute(
-            [](TFileRingBuffer& rb) { UNIT_ASSERT(rb.PushBack("ABC")); },
+            [](TFileRingBuffer& rb)
+            { UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABC")); },
             ver);
 
         b.AssertValidateSuccess();
@@ -656,8 +665,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
         b.Execute(
             [](TFileRingBuffer& rb)
             {
-                UNIT_ASSERT(rb.PushBack("01234567"));
-                UNIT_ASSERT(rb.PushBack("ABC"));
+                UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("01234567"));
+                UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABC"));
             },
             ver);
 
@@ -703,8 +712,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
         b.Execute(
             [](TFileRingBuffer& rb)
             {
-                UNIT_ASSERT(rb.PushBack("ABC"));
-                UNIT_ASSERT(rb.SetMetadata("123"));
+                UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABC"));
+                UNIT_ASSERT_VALUES_EQUAL(true, rb.SetMetadata("123"));
             },
             ver);
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -14,6 +14,21 @@ namespace NCloud {
 
 using EVersion = EFileRingBufferVersion;
 
+static bool operator==(bool lhs, const TResultOrError<bool>& rhs)
+{
+    return !HasError(rhs) && lhs == rhs.GetResult();
+}
+
+static bool operator==(ui32 lhs, const TResultOrError<ui32>& rhs)
+{
+    return !HasError(rhs) && lhs == rhs.GetResult();
+}
+
+static bool operator==(TString lhs, const TResultOrError<TStringBuf>& rhs)
+{
+    return !HasError(rhs) && lhs == TString(rhs.GetResult());
+}
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -107,10 +122,10 @@ struct TReferenceImplementation
         , Version(version)
     {}
 
-    bool PushBack(TStringBuf data)
+    TResultOrError<bool> PushBack(TStringBuf data)
     {
         if (data.empty() || data.size() > MaxWeight) {
-            return false;
+            return MakeError(E_ARGUMENT);
         }
 
         ui32 sz = EntryOverhead + data.size();
@@ -148,19 +163,19 @@ struct TReferenceImplementation
         return true;
     }
 
-    TStringBuf Front() const
+    TResultOrError<TStringBuf> Front() const
     {
         if (!Q) {
-            return {};
+            return TStringBuf{};
         }
 
-        return Q.front();
+        return TStringBuf(Q.front());
     }
 
-    void PopFront()
+    TResultOrError<bool> PopFront()
     {
         if (!Q) {
-            return;
+            return false;
         }
 
         ui32 sz = Q.front().size() + EntryOverhead;
@@ -184,6 +199,8 @@ struct TReferenceImplementation
             ReadPos = 0;
             WritePos = 0;
         }
+
+        return true;
     }
 
     bool Empty() const
@@ -235,45 +252,50 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
         UNIT_ASSERT(rb.Empty());
 
-        UNIT_ASSERT(!rb.PushBack(GenerateData(rb.Size())));   // too long
-        UNIT_ASSERT(!rb.PushBack(""));              // empty
+        auto tooBigError = rb.PushBack(GenerateData(rb.Size()));
+        UNIT_ASSERT(HasError(tooBigError));
+        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, tooBigError.GetError().GetCode());
 
-        UNIT_ASSERT(rb.PushBack("vasya"));
-        UNIT_ASSERT(rb.PushBack("petya"));
-        UNIT_ASSERT(rb.PushBack("vasya2"));
-        UNIT_ASSERT(rb.PushBack("petya2"));
-        UNIT_ASSERT(!rb.PushBack("vasya3"));        // out of space
+        auto emptyError = rb.PushBack("");
+        UNIT_ASSERT(HasError(emptyError));
+        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, emptyError.GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("vasya"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("petya"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("vasya2"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("petya2"));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb.PushBack("vasya3")); // out of space
 
         UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(4, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya", rb.Front());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
 
         UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(3, rb.Size());
-        UNIT_ASSERT(!rb.PushBack("vasya3"));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb.PushBack("vasya3"));
 
         UNIT_ASSERT_VALUES_EQUAL("petya", rb.Front());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
 
         UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(2, rb.Size());
-        UNIT_ASSERT(rb.PushBack("vasya3"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("vasya3"));
 
         UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(3, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya2", rb.Front());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
 
         UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(2, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("petya2", rb.Front());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
 
         UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya3", rb.Front());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
 
         UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
@@ -303,14 +325,14 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = ver >= EVersion::V6 ? 80 : 64;
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, ver);
 
-        UNIT_ASSERT(rb->PushBack("vasya"));
-        UNIT_ASSERT(rb->PushBack("petya"));
-        UNIT_ASSERT(rb->PushBack("vasya2"));
-        UNIT_ASSERT(rb->PushBack("petya2"));
-        rb->PopFront();
-        rb->PopFront();
-        UNIT_ASSERT(rb->PushBack("vasya3"));
-        UNIT_ASSERT(rb->PushBack("xxx"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("vasya"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("petya"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("vasya2"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("petya2"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PopFront());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PopFront());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("vasya3"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("xxx"));
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, ver);
 
@@ -326,10 +348,10 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = 128;
         TFileRingBuffer rb(f.GetName(), len, 0, ver);
 
-        UNIT_ASSERT(rb.PushBack("vasya"));
-        UNIT_ASSERT(rb.PushBack("petya"));
-        UNIT_ASSERT(rb.PushBack("vasya2"));
-        UNIT_ASSERT(rb.PushBack("petya2"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("vasya"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("petya"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("vasya2"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("petya2"));
 
         UNIT_ASSERT(rb.Validate());
         TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
@@ -355,11 +377,11 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const TString data2(entryDataLen, 'b');
         const TString data3(entryDataLen, 'c');
 
-        UNIT_ASSERT(rb.PushBack(data));
-        UNIT_ASSERT(rb.PushBack(data2));
-        UNIT_ASSERT(!rb.PushBack(data3));
-        rb.PopFront();
-        UNIT_ASSERT(rb.PushBack(data3));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data2));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb.PushBack(data3));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data3));
 
         /*
          * Buffer data:
@@ -397,10 +419,10 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             const bool shouldPush = remainingBytes && RandomNumber<bool>();
             if (shouldPush) {
                 const ui32 entrySize =
-                    RandomNumber(Min(remainingBytes + 1, testUpToEntrySize));
+                    RandomNumber(Min(remainingBytes, testUpToEntrySize)) + 1;
                 const auto data = GenerateData(entrySize);
                 const auto maxAllocationSize = rb->GetAvailableByteCount();
-                const bool pushed = ri.PushBack(data);
+                const bool pushed = ri.PushBack(data).GetResult();
                 UNIT_ASSERT_VALUES_EQUAL(pushed, rb->PushBack(data));
                 if (pushed) {
                     UNIT_ASSERT_LE_C(
@@ -451,17 +473,17 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         TString data(36, 'a');
 
-        UNIT_ASSERT(rb.PushBack(data));
-        UNIT_ASSERT(ri.PushBack(data));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data));
+        UNIT_ASSERT_VALUES_EQUAL(true, ri.PushBack(data));
 
         rb.PopFront();
         ri.PopFront();
 
-        UNIT_ASSERT(rb.PushBack(data));
-        UNIT_ASSERT(ri.PushBack(data));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data));
+        UNIT_ASSERT_VALUES_EQUAL(true, ri.PushBack(data));
 
-        UNIT_ASSERT(!rb.PushBack(data));
-        UNIT_ASSERT(!ri.PushBack(data));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb.PushBack(data));
+        UNIT_ASSERT_VALUES_EQUAL(false, ri.PushBack(data));
     }
 
     FILE_RING_BUFFER_TEST(RandomizedPushPopRestore)
@@ -498,14 +520,14 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const TString data3(entryDataLen, 'c');
         const TString data4(entryDataLen, 'd');
 
-        UNIT_ASSERT(rb.PushBack(data));
-        UNIT_ASSERT(rb.PushBack(data2));
-        UNIT_ASSERT(!rb.PushBack(data3));
-        rb.PopFront();
-        UNIT_ASSERT(!rb.PushBack(data3));
-        rb.PopFront();
-        UNIT_ASSERT(rb.PushBack(data3));
-        UNIT_ASSERT(rb.PushBack(data4));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data2));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb.PushBack(data3));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
+        UNIT_ASSERT_VALUES_EQUAL(false, rb.PushBack(data3));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data3));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack(data4));
     }
 
     Y_UNIT_TEST(ShouldNotAccessMemoryOutsideMappedBuffer)
@@ -519,11 +541,11 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         char* data = static_cast<char*>(m.Ptr());
         data[len + 40] = 'A';
 
-        UNIT_ASSERT(rb.PushBack("01234567"));
-        UNIT_ASSERT(rb.PushBack("89abcde"));
-        rb.PopFront();
-        UNIT_ASSERT(rb.PushBack("01"));
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("01234567"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("89abcde"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("01"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
         UNIT_ASSERT_VALUES_EQUAL("01", rb.Front());
     }
 
@@ -536,14 +558,23 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         explicit TStateWithCorruptedEntryLength(int newLength)
             : RingBuffer(FileHandle.GetName(), Len, 0, EVersion::V5)
         {
-            UNIT_ASSERT(RingBuffer.PushBack("aaa"));
-            UNIT_ASSERT(RingBuffer.PushBack("bb"));
+            UNIT_ASSERT_VALUES_EQUAL(true, RingBuffer.PushBack("aaa"));
+            UNIT_ASSERT_VALUES_EQUAL(true, RingBuffer.PushBack("bb"));
 
             TFileMap m(FileHandle.GetName(), TMemoryMapCommon::oRdWr);
             m.Map(0, 256 + Len);
             char* data = static_cast<char*>(m.Ptr());
             UNIT_ASSERT_VALUES_EQUAL(2, data[267]);
             data[267] = newLength;
+        }
+
+        TString Dump()
+        {
+            TFileMap m(FileHandle.GetName(), TMemoryMapCommon::oRdWr);
+            m.Map(0, m.Length());
+            TString res(m.Length(), 0);
+            MemCopy(res.begin(), static_cast<const char*>(m.Ptr()), m.Length());
+            return res;
         }
     };
 
@@ -580,11 +611,11 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     {
         TStateWithCorruptedEntryLength good(2);
         TFileRingBuffer rb(good.FileHandle.GetName(), good.Len, 0, EVersion::V5);
-        UNIT_ASSERT(rb.PushBack("c"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("c"));
 
         TStateWithCorruptedEntryLength bad(1);
         TFileRingBuffer rb2(bad.FileHandle.GetName(), bad.Len, 0, EVersion::V5);
-        UNIT_ASSERT(!rb2.PushBack("c"));
+        UNIT_ASSERT(HasError(rb2.PushBack("c")));
     }
 
     FILE_RING_BUFFER_TEST(ShouldNotFailOnCapacityChange)
@@ -596,24 +627,38 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         TFileRingBuffer rb2(f.GetName(), len - 1, 0, ver);
 
         UNIT_ASSERT_EQUAL(f.GetLength(), len + 256);
-        UNIT_ASSERT(rb.PushBack("12345678"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("12345678"));
     }
 
     FILE_RING_BUFFER_TEST(ForbidModificationOfCorruptedBuffer)
     {
         TStateWithCorruptedEntryLength s(13);
         TFileRingBuffer rb(s.FileHandle.GetName(), s.Len, 0, ver);
-        auto state = Dump(rb);
 
-        const char* ptr = rb.Front().data();
-        UNIT_ASSERT(!rb.Free(ptr));
-        UNIT_ASSERT_VALUES_EQUAL(state, Dump(rb));
+        auto dump = s.Dump();
 
-        rb.PopFront();
-        UNIT_ASSERT_VALUES_EQUAL(state, Dump(rb));
+        UNIT_ASSERT(HasError(rb.Front()));
+        UNIT_ASSERT_STRINGS_EQUAL(dump, s.Dump());
 
-        UNIT_ASSERT(!rb.PushBack("1"));
-        UNIT_ASSERT_VALUES_EQUAL(state, Dump(rb));
+        int visitCount = 0;
+        auto visitor = [&visitCount](ui32, ui32, TStringBuf) {
+            visitCount++;
+        };
+        UNIT_ASSERT(HasError(rb.Visit(visitor)));
+        UNIT_ASSERT_VALUES_EQUAL(0, visitCount);
+        UNIT_ASSERT_STRINGS_EQUAL(dump, s.Dump());
+
+        UNIT_ASSERT(HasError(rb.PopFront()));
+        UNIT_ASSERT_STRINGS_EQUAL(dump, s.Dump());
+
+        UNIT_ASSERT(HasError(rb.PushBack("1")));
+        UNIT_ASSERT_STRINGS_EQUAL(dump, s.Dump());
+
+        UNIT_ASSERT(HasError(rb.Alloc(1)));
+        UNIT_ASSERT_STRINGS_EQUAL(dump, s.Dump());
+
+        UNIT_ASSERT(HasError(rb.Commit()));
+        UNIT_ASSERT_STRINGS_EQUAL(dump, s.Dump());
     }
 
     FILE_RING_BUFFER_TEST(ShouldGetRawCapacity)
@@ -633,17 +678,17 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         TFileRingBuffer rb(f.GetName(), len, 0, ver);
 
         UNIT_ASSERT_VALUES_EQUAL(0, rb.GetRawUsedBytesCount());
-        UNIT_ASSERT(rb.PushBack("abcd"));   // q bytes
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("abcd"));   // q bytes
         UNIT_ASSERT_VALUES_EQUAL(q, rb.GetRawUsedBytesCount());
-        UNIT_ASSERT(rb.PushBack("efgh"));   // q bytes
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("efgh"));   // q bytes
         UNIT_ASSERT_VALUES_EQUAL(q * 2, rb.GetRawUsedBytesCount());
-        UNIT_ASSERT(rb.PushBack("ijkl"));   // q bytes
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ijkl"));   // q bytes
         UNIT_ASSERT_VALUES_EQUAL(q * 3, rb.GetRawUsedBytesCount());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
         UNIT_ASSERT_VALUES_EQUAL(q * 2, rb.GetRawUsedBytesCount());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
         UNIT_ASSERT_VALUES_EQUAL(q, rb.GetRawUsedBytesCount());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
         UNIT_ASSERT_VALUES_EQUAL(0, rb.GetRawUsedBytesCount());
     }
 
@@ -658,17 +703,17 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         // 56 - header size (8)
         UNIT_ASSERT_VALUES_EQUAL(48, rb.GetAvailableByteCount());
-        UNIT_ASSERT(rb.PushBack("0123456789abcdef"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("0123456789abcdef"));
         UNIT_ASSERT_VALUES_EQUAL(24, rb.GetAvailableByteCount());
-        UNIT_ASSERT(rb.PushBack("ABCDEFGH"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABCDEFGH"));
         UNIT_ASSERT_VALUES_EQUAL(8, rb.GetAvailableByteCount());
-        UNIT_ASSERT(rb.PushBack("IJKLMNOP"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("IJKLMNOP"));
         UNIT_ASSERT_VALUES_EQUAL(0, rb.GetAvailableByteCount());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
         UNIT_ASSERT_VALUES_EQUAL(8 + adj, rb.GetAvailableByteCount());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
         UNIT_ASSERT_VALUES_EQUAL(24 + adj, rb.GetAvailableByteCount());
-        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(true, rb.PopFront());
         UNIT_ASSERT_VALUES_EQUAL(48, rb.GetAvailableByteCount());
     }
 
@@ -687,18 +732,18 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = 48;
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, ver);
 
-        UNIT_ASSERT_EQUAL(0, rb->GetMaxObservedEntryByteCount());
-        UNIT_ASSERT(rb->PushBack("abcd"));
-        UNIT_ASSERT_EQUAL(4, rb->GetMaxObservedEntryByteCount());
-        UNIT_ASSERT(rb->PushBack("ef"));
-        UNIT_ASSERT_EQUAL(4, rb->GetMaxObservedEntryByteCount());
-        UNIT_ASSERT(rb->PushBack("ghijk"));
-        UNIT_ASSERT_EQUAL(5, rb->GetMaxObservedEntryByteCount());
-        UNIT_ASSERT(!rb->PushBack("1234567890"));
-        UNIT_ASSERT_EQUAL(5, rb->GetMaxObservedEntryByteCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetMaxObservedEntryByteCount());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("abcd"));
+        UNIT_ASSERT_VALUES_EQUAL(4, rb->GetMaxObservedEntryByteCount());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("ef"));
+        UNIT_ASSERT_VALUES_EQUAL(4, rb->GetMaxObservedEntryByteCount());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("ghijk"));
+        UNIT_ASSERT_VALUES_EQUAL(5, rb->GetMaxObservedEntryByteCount());
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->PushBack("1234567890"));
+        UNIT_ASSERT_VALUES_EQUAL(5, rb->GetMaxObservedEntryByteCount());
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, ver);
-        UNIT_ASSERT_EQUAL(5, rb->GetMaxObservedEntryByteCount());
+        UNIT_ASSERT_VALUES_EQUAL(5, rb->GetMaxObservedEntryByteCount());
     }
 
     FILE_RING_BUFFER_TEST(ShouldGetAndSetMetadata_ZeroMetadataCapacity)
@@ -707,13 +752,13 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = 36;
 
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, ver);
-        UNIT_ASSERT(rb->PushBack("AAA"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("AAA"));
         UNIT_ASSERT_VALUES_EQUAL("", rb->GetMetadata());
-        UNIT_ASSERT(!rb->SetMetadata("1"));
-        UNIT_ASSERT(rb->SetMetadata(""));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->SetMetadata("1"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata(""));
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, ver);
-        UNIT_ASSERT(!rb->SetMetadata("1"));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->SetMetadata("1"));
         UNIT_ASSERT_VALUES_EQUAL("", rb->GetMetadata());
         UNIT_ASSERT_VALUES_EQUAL("AAA", rb->Front());
     }
@@ -724,18 +769,18 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = 36;
 
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
-        UNIT_ASSERT(rb->PushBack("AAA"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("AAA"));
         UNIT_ASSERT_VALUES_EQUAL("", rb->GetMetadata());
-        UNIT_ASSERT(rb->SetMetadata("1234"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata("1234"));
         UNIT_ASSERT_VALUES_EQUAL("1234", rb->GetMetadata());
-        UNIT_ASSERT(!rb->SetMetadata("abcdefghij"));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->SetMetadata("abcdefghij"));
         UNIT_ASSERT_VALUES_EQUAL("1234", rb->GetMetadata());
-        UNIT_ASSERT(rb->SetMetadata("abc"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata("abc"));
         UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
         UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
-        UNIT_ASSERT(rb->SetMetadata(""));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata(""));
         UNIT_ASSERT_VALUES_EQUAL("", rb->GetMetadata());
         UNIT_ASSERT_VALUES_EQUAL("AAA", rb->Front());
     }
@@ -746,12 +791,10 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = 36;
 
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
-        UNIT_ASSERT(rb->SetMetadata("1234"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata("1234"));
 
         {
             // Corrupt metadata contents
-            // Header validation will pass - it will be possible to change
-            // metadata
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
             m.Map(0, 256);
             char* data = static_cast<char*>(m.Ptr());
@@ -762,7 +805,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
         UNIT_ASSERT(rb->IsCorrupted());
-        UNIT_ASSERT(!rb->SetMetadata("1234"));
+        UNIT_ASSERT(HasError(rb->GetMetadata()));
+        UNIT_ASSERT(HasError(rb->SetMetadata("1234")));
     }
 
     FILE_RING_BUFFER_TEST(ShouldValidateMetadataWithCorruptedSize)
@@ -771,7 +815,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = 36;
 
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
-        UNIT_ASSERT(rb->SetMetadata("1234"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata("1234"));
 
         {
             // Corrupt metadata length (set length > capacity)
@@ -787,7 +831,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
         UNIT_ASSERT(rb->IsCorrupted());
-        UNIT_ASSERT(!rb->SetMetadata("1234"));
+        UNIT_ASSERT(HasError(rb->GetMetadata()));
+        UNIT_ASSERT(HasError(rb->SetMetadata("1234")));
     }
 
     FILE_RING_BUFFER_TEST(ShouldResizeMetadata)
@@ -796,42 +841,42 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = 19;
 
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 1, ver);
-        UNIT_ASSERT(rb->PushBack("ABCD"));
-        UNIT_ASSERT(rb->SetMetadata("1"));
-        UNIT_ASSERT(!rb->SetMetadata("12"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("ABCD"));
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata("1"));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->SetMetadata("12"));
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 4, ver);
-        UNIT_ASSERT_STRINGS_EQUAL("ABCD", rb->Front());
-        UNIT_ASSERT_STRINGS_EQUAL("1", rb->GetMetadata());
-        UNIT_ASSERT(rb->SetMetadata("123"));
-        UNIT_ASSERT(!rb->SetMetadata("12345"));
+        UNIT_ASSERT_VALUES_EQUAL("ABCD", rb->Front());
+        UNIT_ASSERT_VALUES_EQUAL("1", rb->GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata("123"));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->SetMetadata("12345"));
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 16, ver);
-        UNIT_ASSERT_STRINGS_EQUAL("ABCD", rb->Front());
-        UNIT_ASSERT_STRINGS_EQUAL("123", rb->GetMetadata());
-        UNIT_ASSERT(rb->SetMetadata("123456789"));
-        UNIT_ASSERT(!rb->SetMetadata("1234567890abcdef!"));
+        UNIT_ASSERT_VALUES_EQUAL("ABCD", rb->Front());
+        UNIT_ASSERT_VALUES_EQUAL("123", rb->GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata("123456789"));
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->SetMetadata("1234567890abcdef!"));
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 17, ver);
-        UNIT_ASSERT_STRINGS_EQUAL("ABCD", rb->Front());
-        UNIT_ASSERT_STRINGS_EQUAL("123456789", rb->GetMetadata());
-        UNIT_ASSERT(!rb->SetMetadata("1234567890abcdefg!"));
+        UNIT_ASSERT_VALUES_EQUAL("ABCD", rb->Front());
+        UNIT_ASSERT_VALUES_EQUAL("123456789", rb->GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->SetMetadata("1234567890abcdefg!"));
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 100, ver);
-        UNIT_ASSERT_STRINGS_EQUAL("ABCD", rb->Front());
-        UNIT_ASSERT_STRINGS_EQUAL("123456789", rb->GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL("ABCD", rb->Front());
+        UNIT_ASSERT_VALUES_EQUAL("123456789", rb->GetMetadata());
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 10, ver);
-        UNIT_ASSERT_STRINGS_EQUAL("ABCD", rb->Front());
-        UNIT_ASSERT_STRINGS_EQUAL("123456789", rb->GetMetadata());
-        UNIT_ASSERT(!rb->SetMetadata("1234567890!"));
+        UNIT_ASSERT_VALUES_EQUAL("ABCD", rb->Front());
+        UNIT_ASSERT_VALUES_EQUAL("123456789", rb->GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL(false, rb->SetMetadata("1234567890!"));
 
         // Cannot shrink metadata below current size
         // New metadata capacity = 9
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
-        UNIT_ASSERT_STRINGS_EQUAL("ABCD", rb->Front());
-        UNIT_ASSERT_STRINGS_EQUAL("123456789", rb->GetMetadata());
-        UNIT_ASSERT(rb->SetMetadata("abcdefghi"));
+        UNIT_ASSERT_VALUES_EQUAL("ABCD", rb->Front());
+        UNIT_ASSERT_VALUES_EQUAL("123456789", rb->GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->SetMetadata("abcdefghi"));
     }
 
     FILE_RING_BUFFER_TEST(ShouldResumeAbortedMetadataResize)
@@ -846,8 +891,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         // Collect expected file contents
         {
             TFileRingBuffer rb(f.GetName(), len, 1, ver);
-            UNIT_ASSERT(rb.PushBack("ABCD"));
-            UNIT_ASSERT(rb.SetMetadata("1"));
+            UNIT_ASSERT_VALUES_EQUAL(true, rb.PushBack("ABCD"));
+            UNIT_ASSERT_VALUES_EQUAL(true, rb.SetMetadata("1"));
         }
         {
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
@@ -991,10 +1036,10 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(!HasError(alloc3));
         auto alloc4 = rb.Alloc(1);
         UNIT_ASSERT(HasError(alloc4));
-        UNIT_ASSERT(rb.Commit());
+        UNIT_ASSERT(!HasError(rb.Commit()));
 
         // Commit without alloc
-        UNIT_ASSERT(!rb.Commit());
+        UNIT_ASSERT(HasError(rb.Commit()));
 
         rb.SetCorrupted();
 
@@ -1018,7 +1063,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             auto res = rb->Alloc(data.size());
             UNIT_ASSERT(!HasError(res));
             data.copy(res.GetResult(), data.size());
-            UNIT_ASSERT(rb->Commit());
+            UNIT_ASSERT(!HasError(rb->Commit()));
             return res.GetResult();
         };
 
@@ -1027,9 +1072,9 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const char* alloc3 = alloc(data3);
         const char* alloc4 = alloc(data4);
 
-        UNIT_ASSERT(rb->Free(alloc2));
-        UNIT_ASSERT(!rb->Free(alloc2));
-        UNIT_ASSERT(!rb->Free(nullptr));
+        UNIT_ASSERT(!HasError(rb->Free(alloc2)));
+        UNIT_ASSERT(HasError(rb->Free(alloc2)));
+        UNIT_ASSERT(HasError(rb->Free(nullptr)));
 
         UNIT_ASSERT_VALUES_EQUAL("hello, meow, ok", Dump(*rb));
         UNIT_ASSERT_VALUES_EQUAL(3, rb->Size());
@@ -1040,7 +1085,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT_VALUES_EQUAL("hello, meow, ok", Dump(*rb));
 
         alloc3 = Find(*rb, "meow").data();
-        UNIT_ASSERT(rb->Free(alloc3));
+        UNIT_ASSERT(!HasError(rb->Free(alloc3)));
 
         UNIT_ASSERT_VALUES_EQUAL("hello, ok", Dump(*rb));
         UNIT_ASSERT_VALUES_EQUAL(2, rb->Size());
@@ -1050,12 +1095,12 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         alloc1 = Find(*rb, "hello").data();
         alloc4 = Find(*rb, "ok").data();
 
-        UNIT_ASSERT(rb->Free(alloc1));
+        UNIT_ASSERT(!HasError(rb->Free(alloc1)));
 
         UNIT_ASSERT_VALUES_EQUAL("ok", Dump(*rb));
         UNIT_ASSERT_VALUES_EQUAL(1, rb->Size());
 
-        UNIT_ASSERT(rb->Free(alloc4));
+        UNIT_ASSERT(!HasError(rb->Free(alloc4)));
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(*rb));
         UNIT_ASSERT_VALUES_EQUAL(0, rb->Size());
@@ -1074,7 +1119,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         const TString data = "efgh";
 
-        UNIT_ASSERT(rb->PushBack("abcd"));   // 12 bytes
+        UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("abcd"));   // 12 bytes
 
         auto alloc = rb->Alloc(4);
         UNIT_ASSERT(!HasError(alloc));
@@ -1082,7 +1127,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         rb->PopFront();
 
-        UNIT_ASSERT(rb->Commit());
+        UNIT_ASSERT(!HasError(rb->Commit()));
 
         UNIT_ASSERT_VALUES_EQUAL(data, rb->Front());
 
@@ -1166,7 +1211,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(ptr1 != nullptr);
         ptr1[0] = 'a';
         ptr1[1] = 'b';
-        UNIT_ASSERT(rb.Commit());
+        UNIT_ASSERT(!HasError(rb.Commit()));
 
         auto ptr2 = rb.Alloc(1).GetResult();
         UNIT_ASSERT(ptr2 != nullptr);
@@ -1192,9 +1237,9 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
                 srcVersion);
 
             rb->SetMetadata("abc");
-            UNIT_ASSERT(rb->PushBack("123"));
-            UNIT_ASSERT(rb->PushBack("4"));
-            UNIT_ASSERT(rb->PushBack("xz"));
+            UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("123"));
+            UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("4"));
+            UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("xz"));
 
             UNIT_ASSERT_VALUES_EQUAL(
                 static_cast<ui32>(srcVersion),
@@ -1212,18 +1257,18 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             UNIT_ASSERT_VALUES_EQUAL("123, 4, xz", Dump(*rb));
 
             // New entries can be added only after the migration is completed
-            UNIT_ASSERT(!rb->PushBack("!"));
+            UNIT_ASSERT_VALUES_EQUAL(false, rb->PushBack("!"));
 
             // Migration didn't happen - need to empty the buffer first
             UNIT_ASSERT_VALUES_EQUAL(0, rb->GetAvailableByteCount());
 
-            rb->PopFront();
-            rb->PopFront();
-            rb->PopFront();
+            UNIT_ASSERT_VALUES_EQUAL(true, rb->PopFront());
+            UNIT_ASSERT_VALUES_EQUAL(true, rb->PopFront());
+            UNIT_ASSERT_VALUES_EQUAL(true, rb->PopFront());
 
             UNIT_ASSERT_LT(0, rb->GetAvailableByteCount());
 
-            UNIT_ASSERT(rb->PushBack("!"));
+            UNIT_ASSERT_VALUES_EQUAL(true, rb->PushBack("!"));
 
             UNIT_ASSERT_VALUES_EQUAL("!", Dump(*rb));
             UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
@@ -1280,3 +1325,41 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 }
 
 }   // namespace NCloud
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <>
+void Out<NCloud::TResultOrError<bool>>(
+    IOutputStream& os,
+    const NCloud::TResultOrError<bool>& value)
+{
+    if (HasError(value)) {
+        os << value.GetError();
+    } else {
+        os << value.GetResult();
+    }
+}
+
+template <>
+void Out<NCloud::TResultOrError<ui32>>(
+    IOutputStream& os,
+    const NCloud::TResultOrError<ui32>& value)
+{
+    if (HasError(value)) {
+        os << value.GetError();
+    } else {
+        os << value.GetResult();
+    }
+}
+
+template <>
+void Out<NCloud::TResultOrError<TStringBuf>>(
+    IOutputStream& os,
+    const NCloud::TResultOrError<TStringBuf>& value)
+{
+    if (HasError(value)) {
+        os << value.GetError();
+    } else {
+        os << value.GetResult();
+    }
+}


### PR DESCRIPTION
### Notes

Implement correct behavior for WriteBackCache when corruption is detected.

Previous behavior:
- Incomplete object creation causing null pointer access in various scenarios, for example, metrics collection.
Both resulted in entering pod into crash loop;
- Triggering `Y_ABORT_UNLESS` when trying to add a write request.
Both resulted in a crash loop.

Expected behavior:
- WriteBackCache is fully constructed;
- WriteBackCache doesn't serve requests and hangs;
- No errors are sent to the guest;
- A critical event is reported.

Manual resolution should be conducted in order to resolve the corrupted state.

Note: this PR covers only the case when corruption is detected at initialization. If corruption happens during the operation, `Y_ABORT_UNLESS` will cause a one-time crash. This is acceptable because the logic to handle all corruption paths would be complicated. The goal is to avoid entering a crash loop.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
