### PR TITLE
[Filestore] Move tablet state fields 1

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -759,7 +759,7 @@ bool TIndexTabletActor::CanUseUnconfirmedData() const
 
     const ui32 hardLimit = Config->GetUnconfirmedDataCountHardLimit();
     const size_t unconfirmedDataCount =
-        UnconfirmedData.size() +
+        GetUnconfirmedDataSize() +
         ConfirmedData.size() +
         GetUnconfirmedDataInProgressSize();
     if (hardLimit && unconfirmedDataCount >= hardLimit) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -761,7 +761,7 @@ bool TIndexTabletActor::CanUseUnconfirmedData() const
     const size_t unconfirmedDataCount =
         UnconfirmedData.size() +
         ConfirmedData.size() +
-        UnconfirmedDataInProgress.size();
+        GetUnconfirmedDataInProgressSize();
     if (hardLimit && unconfirmedDataCount >= hardLimit) {
         return false;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -470,13 +470,12 @@ void TIndexTabletActor::HandleGenerateBlobIds(
             unconfirmedData.GetLength(),
             GetBlockSize());
 
-        auto [inProgressIt, inserted] = UnconfirmedDataInProgress.emplace(
+        TABLET_VERIFY(UnconfirmedDataInProgressEmplace(
             commitId,
             TTrackedUnconfirmedData{
                 .Data = std::move(unconfirmedData),
                 .SessionId = GetSessionId(msg->Record),
-                .PipeServerId = ev->Recipient});
-        TABLET_VERIFY(inserted);
+                .PipeServerId = ev->Recipient}));
 
         NProto::TProfileLogRequestInfo profileLogRequest;
         InitTabletProfileLogRequestInfo(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -19,7 +19,7 @@ bool TIndexTabletActor::PrepareTx_AddDataUnconfirmed(
 {
     Y_UNUSED(ctx);
 
-    if (!UnconfirmedDataInProgress.contains(args.CommitId)) {
+    if (!UnconfirmedDataInProgressContains(args.CommitId)) {
         ReportUnconfirmedDataNotInProgress(
             TStringBuilder()
             << "tabletId: " << TabletID() << ", commitId: " << args.CommitId);
@@ -59,7 +59,7 @@ void TIndexTabletActor::ExecuteTx_AddDataUnconfirmed(
 
     auto db = CreateIndexTabletDatabase(tx.DB);
 
-    auto& data = UnconfirmedDataInProgress[args.CommitId].Data;
+    auto& data = UnconfirmedDataInProgressByCommitId(args.CommitId).Data;
 
     data.SetNodeId(args.NodeId);
 
@@ -80,16 +80,14 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
     const TActorContext& ctx,
     TTxIndexTablet::TAddDataUnconfirmed& args)
 {
-    auto inProgressIt = UnconfirmedDataInProgress.find(args.CommitId);
-    TABLET_VERIFY(inProgressIt != UnconfirmedDataInProgress.end());
-
-    const ui64 requestBytes = inProgressIt->second.Data.GetLength();
+    auto& data = FindAndVerifyUnconfirmedDataInProgress(args.CommitId);
+    const ui64 requestBytes = data.Data.GetLength();
     const bool deletionInProgress =
         args.RejectedByDeletion || DeletionQueue.contains(args.CommitId);
 
     Y_DEFER
     {
-        UnconfirmedDataInProgress.erase(inProgressIt);
+        EraseUnconfirmedDataInProgress(args.CommitId);
 
         FinalizeProfileLogRequestInfo(
             std::move(args.ProfileLogRequest),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -133,7 +133,7 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
         if (!deletionInProgress) {
             UnconfirmedData.emplace(
                 args.CommitId,
-                std::move(inProgressIt->second));
+                std::move(data));
 
             // Check if ConfirmAddData was received while we were executing.
             auto pendingIt = PendingConfirmation.find(args.CommitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -34,7 +34,7 @@ bool TIndexTabletActor::PrepareTx_AddDataUnconfirmed(
         return true;
     }
 
-    if (DeletionQueue.contains(args.CommitId)) {
+    if (DeletionQueueContains(args.CommitId)) {
         args.RejectedByDeletion = true;
         args.Error = MakeError(E_REJECTED, "Already deleted");
         LOG_WARN(
@@ -83,7 +83,7 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
     auto& data = FindAndVerifyUnconfirmedDataInProgress(args.CommitId);
     const ui64 requestBytes = data.Data.GetLength();
     const bool deletionInProgress =
-        args.RejectedByDeletion || DeletionQueue.contains(args.CommitId);
+        args.RejectedByDeletion || DeletionQueueContains(args.CommitId);
 
     Y_DEFER
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -131,7 +131,7 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
         // overtaken by later AddBlob TXs. The deferred reply will be triggered
         // in DeleteUnconfirmedData completion.
         if (!deletionInProgress) {
-            UnconfirmedData.emplace(
+            UnconfirmedDataEmplace(
                 args.CommitId,
                 std::move(data));
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -19,7 +19,7 @@ bool TIndexTabletActor::PrepareTx_AddDataUnconfirmed(
 {
     Y_UNUSED(ctx);
 
-    if (!GetUnconfirmedDataInProgressContains(args.CommitId)) {
+    if (!UnconfirmedDataInProgressContains(args.CommitId)) {
         ReportUnconfirmedDataNotInProgress(
             TStringBuilder()
             << "tabletId: " << TabletID() << ", commitId: " << args.CommitId);
@@ -34,7 +34,7 @@ bool TIndexTabletActor::PrepareTx_AddDataUnconfirmed(
         return true;
     }
 
-    if (GetDeletionQueueContains(args.CommitId)) {
+    if (DeletionQueueContains(args.CommitId)) {
         args.RejectedByDeletion = true;
         args.Error = MakeError(E_REJECTED, "Already deleted");
         LOG_WARN(
@@ -83,7 +83,7 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
     auto& data = AccessAndVerifyUnconfirmedDataInProgress(args.CommitId);
     const ui64 requestBytes = data.Data.GetLength();
     const bool deletionInProgress =
-        args.RejectedByDeletion || GetDeletionQueueContains(args.CommitId);
+        args.RejectedByDeletion || DeletionQueueContains(args.CommitId);
 
     Y_DEFER
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -19,7 +19,7 @@ bool TIndexTabletActor::PrepareTx_AddDataUnconfirmed(
 {
     Y_UNUSED(ctx);
 
-    if (!UnconfirmedDataInProgressContains(args.CommitId)) {
+    if (!GetUnconfirmedDataInProgressContains(args.CommitId)) {
         ReportUnconfirmedDataNotInProgress(
             TStringBuilder()
             << "tabletId: " << TabletID() << ", commitId: " << args.CommitId);
@@ -34,7 +34,7 @@ bool TIndexTabletActor::PrepareTx_AddDataUnconfirmed(
         return true;
     }
 
-    if (DeletionQueueContains(args.CommitId)) {
+    if (GetDeletionQueueContains(args.CommitId)) {
         args.RejectedByDeletion = true;
         args.Error = MakeError(E_REJECTED, "Already deleted");
         LOG_WARN(
@@ -59,7 +59,7 @@ void TIndexTabletActor::ExecuteTx_AddDataUnconfirmed(
 
     auto db = CreateIndexTabletDatabase(tx.DB);
 
-    auto& data = UnconfirmedDataInProgressByCommitId(args.CommitId).Data;
+    auto& data = AccessUnconfirmedDataInProgressByCommitId(args.CommitId).Data;
 
     data.SetNodeId(args.NodeId);
 
@@ -80,10 +80,10 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
     const TActorContext& ctx,
     TTxIndexTablet::TAddDataUnconfirmed& args)
 {
-    auto& data = FindAndVerifyUnconfirmedDataInProgress(args.CommitId);
+    auto& data = AccessAndVerifyUnconfirmedDataInProgress(args.CommitId);
     const ui64 requestBytes = data.Data.GetLength();
     const bool deletionInProgress =
-        args.RejectedByDeletion || DeletionQueueContains(args.CommitId);
+        args.RejectedByDeletion || GetDeletionQueueContains(args.CommitId);
 
     Y_DEFER
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -175,12 +175,11 @@ void TIndexTabletActor::HandleConfirmAddData(
         return;
     }
 
-    if (auto unconfirmedIt = UnconfirmedData.find(commitId);
-        unconfirmedIt != UnconfirmedData.end())
+    if (const auto* data = FindUnconfirmedData(commitId))
     {
         ProcessStorageStatusFlags(
             ctx,
-            unconfirmedIt->second.Data.GetBlobIds(),
+            data->Data.GetBlobIds(),
             msg->Record);
 
         deferReply();
@@ -261,7 +260,7 @@ void TIndexTabletActor::HandleCancelAddData(
 
     const ui64 commitId = msg->Record.GetCommitId();
 
-    if (!UnconfirmedData.contains(commitId) &&
+    if (!UnconfirmedDataContains(commitId) &&
         !UnconfirmedDataInProgressContains(commitId))
     {
         reply(ErrorUnconfirmedDataNotFound());
@@ -389,13 +388,12 @@ void TIndexTabletActor::AddBlobForUnconfirmedData(
 
 void TIndexTabletActor::ConfirmData(ui64 commitId, const TActorContext& ctx)
 {
-    auto unconfirmedIt = UnconfirmedData.find(commitId);
-    TABLET_VERIFY(unconfirmedIt != UnconfirmedData.end());
+    auto& data = FindAndVerifyUnconfirmedData(commitId);
 
     auto [pos, inserted] =
-        ConfirmedData.emplace(commitId, std::move(unconfirmedIt->second));
+        ConfirmedData.emplace(commitId, std::move(data));
     TABLET_VERIFY(inserted);
-    UnconfirmedData.erase(unconfirmedIt);
+    UnconfirmedDataErase(commitId);
 
     const auto& entry = pos->second;
 
@@ -425,23 +423,6 @@ void TIndexTabletActor::DeleteUnconfirmedData(
         shouldDelete)
 {
     TVector<ui64> commitIdsToDelete;
-
-    auto enqueueCommitIdsToDelete = [&](const auto& data)
-    {
-        for (const auto& [commitId, trackedData]: data) {
-            if (!shouldDelete(commitId, trackedData)) {
-                continue;
-            }
-
-            if (!DeletionQueueEmplace(commitId)) {
-                continue;
-            }
-
-            commitIdsToDelete.push_back(commitId);
-        }
-    };
-
-    enqueueCommitIdsToDelete(UnconfirmedData);
     EnqueueCommitIdsToDelete(shouldDelete, commitIdsToDelete);
 
     if (commitIdsToDelete.empty()) {
@@ -535,7 +516,7 @@ void TIndexTabletActor::ExecuteTx_DeleteUnconfirmedData(
 
     for (ui64 commitId: args.CommitIds) {
         db->DeleteUnconfirmedData(commitId);
-        UnconfirmedData.erase(commitId);
+        UnconfirmedDataErase(commitId);
         const bool released = TryReleaseCollectBarrier(commitId);
         TABLET_VERIFY(released);
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -184,7 +184,7 @@ void TIndexTabletActor::HandleConfirmAddData(
             msg->Record);
 
         deferReply();
-        if (!DeletionQueue.contains(commitId)) {
+        if (!DeletionQueueContains(commitId)) {
             ConfirmData(commitId, ctx);
         }
         return;
@@ -268,8 +268,8 @@ void TIndexTabletActor::HandleCancelAddData(
         return;
     }
 
-    if (!DeletionQueue.contains(commitId)) {
-        DeletionQueue.emplace(commitId);
+    if (!DeletionQueueContains(commitId)) {
+        DeletionQueueEmplace(commitId);
         // We reply to CancelAddData immediately, so from this point forward we
         // rely on DeleteUnconfirmedData being executed ahead of any later
         // AddBlob TX. Keep this execute before the reply path,
@@ -433,7 +433,7 @@ void TIndexTabletActor::DeleteUnconfirmedData(
                 continue;
             }
 
-            if (!DeletionQueue.emplace(commitId).second) {
+            if (!DeletionQueueEmplace(commitId)) {
                 continue;
             }
 
@@ -553,7 +553,7 @@ void TIndexTabletActor::CompleteTx_DeleteUnconfirmedData(
     TTxIndexTablet::TDeleteUnconfirmedData& args)
 {
     for (ui64 commitId: args.CommitIds) {
-        DeletionQueue.erase(commitId);
+        DeletionQueueErase(commitId);
         SendPendingConfirmAddDataResponse(
             ctx,
             commitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -190,8 +190,7 @@ void TIndexTabletActor::HandleConfirmAddData(
         return;
     }
 
-    if (UnconfirmedDataInProgress.find(commitId) !=
-        UnconfirmedDataInProgress.end())
+    if (UnconfirmedDataInProgressContains(commitId))
     {
         deferReply();
         Metrics->ConfirmAddDataExtra.DeferredCount.fetch_add(
@@ -263,7 +262,7 @@ void TIndexTabletActor::HandleCancelAddData(
     const ui64 commitId = msg->Record.GetCommitId();
 
     if (!UnconfirmedData.contains(commitId) &&
-        !UnconfirmedDataInProgress.contains(commitId))
+        !UnconfirmedDataInProgressContains(commitId))
     {
         reply(ErrorUnconfirmedDataNotFound());
         return;
@@ -443,7 +442,7 @@ void TIndexTabletActor::DeleteUnconfirmedData(
     };
 
     enqueueCommitIdsToDelete(UnconfirmedData);
-    enqueueCommitIdsToDelete(UnconfirmedDataInProgress);
+    EnqueueCommitIdsToDelete(shouldDelete, commitIdsToDelete);
 
     if (commitIdsToDelete.empty()) {
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -183,13 +183,13 @@ void TIndexTabletActor::HandleConfirmAddData(
             msg->Record);
 
         deferReply();
-        if (!DeletionQueueContains(commitId)) {
+        if (!GetDeletionQueueContains(commitId)) {
             ConfirmData(commitId, ctx);
         }
         return;
     }
 
-    if (UnconfirmedDataInProgressContains(commitId))
+    if (GetUnconfirmedDataInProgressContains(commitId))
     {
         deferReply();
         Metrics->ConfirmAddDataExtra.DeferredCount.fetch_add(
@@ -260,14 +260,14 @@ void TIndexTabletActor::HandleCancelAddData(
 
     const ui64 commitId = msg->Record.GetCommitId();
 
-    if (!UnconfirmedDataContains(commitId) &&
-        !UnconfirmedDataInProgressContains(commitId))
+    if (!GetUnconfirmedDataContains(commitId) &&
+        !GetUnconfirmedDataInProgressContains(commitId))
     {
         reply(ErrorUnconfirmedDataNotFound());
         return;
     }
 
-    if (!DeletionQueueContains(commitId)) {
+    if (!GetDeletionQueueContains(commitId)) {
         DeletionQueueEmplace(commitId);
         // We reply to CancelAddData immediately, so from this point forward we
         // rely on DeleteUnconfirmedData being executed ahead of any later
@@ -388,7 +388,7 @@ void TIndexTabletActor::AddBlobForUnconfirmedData(
 
 void TIndexTabletActor::ConfirmData(ui64 commitId, const TActorContext& ctx)
 {
-    auto& data = FindAndVerifyUnconfirmedData(commitId);
+    auto& data = AccessAndVerifyUnconfirmedData(commitId);
 
     auto [pos, inserted] =
         ConfirmedData.emplace(commitId, std::move(data));
@@ -419,11 +419,10 @@ void TIndexTabletActor::DeleteUnconfirmedData(
     const TActorContext& ctx,
     const char* entityLogTag,
     const TString& entityLogValue,
-    const std::function<bool(ui64, const TTrackedUnconfirmedData&)>&
-        shouldDelete)
+    const TDeletionDeterminer& shouldDelete)
 {
     TVector<ui64> commitIdsToDelete;
-    EnqueueCommitIdsToDelete(shouldDelete, commitIdsToDelete);
+    EnqueueCommitIdsToDelete(shouldDelete, &commitIdsToDelete);
 
     if (commitIdsToDelete.empty()) {
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -175,7 +175,7 @@ void TIndexTabletActor::HandleConfirmAddData(
         return;
     }
 
-    if (const auto* data = FindUnconfirmedData(commitId))
+    if (const auto* data = AccessUnconfirmedData(commitId))
     {
         ProcessStorageStatusFlags(
             ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -183,13 +183,13 @@ void TIndexTabletActor::HandleConfirmAddData(
             msg->Record);
 
         deferReply();
-        if (!GetDeletionQueueContains(commitId)) {
+        if (!DeletionQueueContains(commitId)) {
             ConfirmData(commitId, ctx);
         }
         return;
     }
 
-    if (GetUnconfirmedDataInProgressContains(commitId))
+    if (UnconfirmedDataInProgressContains(commitId))
     {
         deferReply();
         Metrics->ConfirmAddDataExtra.DeferredCount.fetch_add(
@@ -260,14 +260,14 @@ void TIndexTabletActor::HandleCancelAddData(
 
     const ui64 commitId = msg->Record.GetCommitId();
 
-    if (!GetUnconfirmedDataContains(commitId) &&
-        !GetUnconfirmedDataInProgressContains(commitId))
+    if (!UnconfirmedDataContains(commitId) &&
+        !UnconfirmedDataInProgressContains(commitId))
     {
         reply(ErrorUnconfirmedDataNotFound());
         return;
     }
 
-    if (!GetDeletionQueueContains(commitId)) {
+    if (!DeletionQueueContains(commitId)) {
         DeletionQueueEmplace(commitId);
         // We reply to CancelAddData immediately, so from this point forward we
         // rely on DeleteUnconfirmedData being executed ahead of any later

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
@@ -193,7 +193,7 @@ STFUNC(TConfirmBlobsActor::StateWork)
 
 void TIndexTabletActor::ConfirmBlobs(const TActorContext& ctx)
 {
-    if (UnconfirmedData.empty()) {
+    if (GetUnconfirmedDataSize() == 0) {
         BlobsConfirmed(ctx);
         return;
     }
@@ -203,11 +203,12 @@ void TIndexTabletActor::ConfirmBlobs(const TActorContext& ctx)
         TFileStoreComponents::TABLET,
         "%s ConfirmBlobs: starting confirmation for %zu entries",
         LogTag.c_str(),
-        UnconfirmedData.size());
+        GetUnconfirmedDataSize());
 
     TVector<TBlobRequest> requests;
 
-    for (const auto& [_, entry]: UnconfirmedData) {
+    auto makeBlobRequests = [&](const ui64, const auto& entry)
+    {
         for (const auto& blobIdProto: entry.Data.GetBlobIds()) {
             auto blobId = LogoBlobIDFromLogoBlobID(blobIdProto);
             auto partialBlobId = TPartialBlobId(
@@ -223,7 +224,9 @@ void TIndexTabletActor::ConfirmBlobs(const TActorContext& ctx)
                 partialBlobId.Generation());
             requests.emplace_back(partialBlobId, proxy);
         }
-    }
+    };
+
+    ForEachUnconfirmedData(makeBlobRequests);
 
     // Should not have records without blob ids
     if (requests.empty()) {
@@ -233,9 +236,9 @@ void TIndexTabletActor::ConfirmBlobs(const TActorContext& ctx)
             "%s ConfirmBlobs: request list is empty for %zu unconfirmed "
             "entries",
             LogTag.c_str(),
-            UnconfirmedData.size());
+            GetUnconfirmedDataSize());
 
-        UnconfirmedData.clear();
+        UnconfirmedDataClear();
         BlobsConfirmed(ctx);
         return;
     }
@@ -291,15 +294,17 @@ void TIndexTabletActor::HandleConfirmBlobsCompleted(
     TVector<ui64> unrecoverableCommitIds;
     TVector<ui64> recoverableCommitIds;
     unrecoverableCommitIds.reserve(unrecoverableCommitIdsSet.size());
-    recoverableCommitIds.reserve(UnconfirmedData.size());
+    recoverableCommitIds.reserve(GetUnconfirmedDataSize());
 
-    for (const auto& [commitId, _]: UnconfirmedData) {
+    auto getUnconfirmedCommitIds = [&] (ui64 commitId, const auto&) {
         if (unrecoverableCommitIdsSet.contains(commitId)) {
             unrecoverableCommitIds.push_back(commitId);
         } else {
             recoverableCommitIds.push_back(commitId);
         }
-    }
+    };
+
+    ForEachUnconfirmedData(getUnconfirmedCommitIds);
 
     if (!unrecoverableCommitIds.empty()) {
         // This Tx doesn't read from db and can't have page faults, so it's safe
@@ -334,9 +339,7 @@ void TIndexTabletActor::HandleConfirmBlobsCompleted(
     Sort(recoverableCommitIds);
 
     for (const ui64 commitId: recoverableCommitIds) {
-        auto it = UnconfirmedData.find(commitId);
-        TABLET_VERIFY(it != UnconfirmedData.end());
-        const auto& data = it->second.Data;
+        const auto& data = FindAndVerifyUnconfirmedData(commitId).Data;
         NProto::TProfileLogRequestInfo profileLogRequest;
         InitTabletProfileLogRequestInfo(
             profileLogRequest,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
@@ -339,7 +339,7 @@ void TIndexTabletActor::HandleConfirmBlobsCompleted(
     Sort(recoverableCommitIds);
 
     for (const ui64 commitId: recoverableCommitIds) {
-        const auto& data = FindAndVerifyUnconfirmedData(commitId).Data;
+        const auto& data = AccessAndVerifyUnconfirmedData(commitId).Data;
         NProto::TProfileLogRequestInfo profileLogRequest;
         InitTabletProfileLogRequestInfo(
             profileLogRequest,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -808,7 +808,7 @@ void TIndexTabletActor::FillSelfStorageStats(
     stats->SetSevenBytesHandlesCount(Metrics->SevenBytesHandlesCount);
 
     stats->SetUnconfirmedDataCount(
-        UnconfirmedData.size() + UnconfirmedDataInProgress.size());
+        UnconfirmedData.size() + GetUnconfirmedDataInProgressSize());
     stats->SetConfirmedDataCount(ConfirmedData.size());
 
     for (const auto& usage: GetQuotaUsages()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -808,7 +808,7 @@ void TIndexTabletActor::FillSelfStorageStats(
     stats->SetSevenBytesHandlesCount(Metrics->SevenBytesHandlesCount);
 
     stats->SetUnconfirmedDataCount(
-        UnconfirmedData.size() + GetUnconfirmedDataInProgressSize());
+        GetUnconfirmedDataSize() + GetUnconfirmedDataInProgressSize());
     stats->SetConfirmedDataCount(ConfirmedData.size());
 
     for (const auto& usage: GetQuotaUsages()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -74,43 +74,6 @@ TIndexTabletState::TIndexTabletState()
 
 TIndexTabletState::~TIndexTabletState() = default;
 
-bool TIndexTabletState::IsStateLoaded() const
-{
-    return Impl->StateLoaded;
-}
-
-void TIndexTabletState::CompleteStateLoad()
-{
-    Impl->StateLoaded = true;
-}
-
-bool TIndexTabletState::GetCompressNodeRef() const
-{
-    return Impl->CompressNodeRef || FileSystem.GetCompressNodeRef();
-}
-
-ui64 TIndexTabletState::GetMinDeletionMarkersCountSinceTabletStart() const
-{
-    return Impl->MinDeletionMarkersCountSinceTabletStart;
-}
-
-void TIndexTabletState::UpdateMinDeletionMarkersCountSinceTabletStart()
-{
-    Impl->MinDeletionMarkersCountSinceTabletStart = Min(
-        Impl->MinDeletionMarkersCountSinceTabletStart,
-        FileSystemStats.GetDeletionMarkersCount());
-}
-
-void TIndexTabletState::SetStartupGcExecuted()
-{
-    Impl->StartupGcExecuted = true;
-}
-
-bool TIndexTabletState::GetStartupGcExecuted() const
-{
-    return Impl->StartupGcExecuted;
-}
-
 void TIndexTabletState::UpdateLogTag(TString tag)
 {
     Impl->CacheReadBypass.UpdateLogTag(tag);
@@ -262,7 +225,7 @@ void TIndexTabletState::LoadState(
 
     MaxTabletStep = Max(config.GetMaxTabletStep(), LastStep);
 
-    Impl->CompressNodeRef = config.GetEnableNodeRefCompression();
+    CompressNodeRef = config.GetEnableNodeRefCompression();
 
     FileSystem.CopyFrom(fileSystem);
     FileSystemStats.CopyFrom(fileSystemStats);
@@ -275,7 +238,7 @@ void TIndexTabletState::LoadState(
     // reboot and throttle cleanup when the amount of deletion markers is
     // expected to drop below the minimal amount.
     // https://github.com/ydb-platform/nbs/pull/3268
-    Impl->MinDeletionMarkersCountSinceTabletStart =
+    MinDeletionMarkersCountSinceTabletStart =
         fileSystemStats.GetDeletionMarkersCount();
 
     if (FileSystemStats.GetLastNodeId() < RootNodeId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -371,6 +371,11 @@ void TIndexTabletState::DumpStats(IOutputStream& os) const
     );
 }
 
+const TNodeToSessionCounters& TIndexTabletState::GetNodeToSessionCounters() const
+{
+    return Impl->NodeToSessionCounters;
+}
+
 TMiscNodeStats TIndexTabletState::GetMiscNodeStats() const
 {
     return {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -74,6 +74,43 @@ TIndexTabletState::TIndexTabletState()
 
 TIndexTabletState::~TIndexTabletState() = default;
 
+bool TIndexTabletState::IsStateLoaded() const
+{
+    return Impl->StateLoaded;
+}
+
+void TIndexTabletState::CompleteStateLoad()
+{
+    Impl->StateLoaded = true;
+}
+
+bool TIndexTabletState::GetCompressNodeRef() const
+{
+    return Impl->CompressNodeRef || FileSystem.GetCompressNodeRef();
+}
+
+ui64 TIndexTabletState::GetMinDeletionMarkersCountSinceTabletStart() const
+{
+    return Impl->MinDeletionMarkersCountSinceTabletStart;
+}
+
+void TIndexTabletState::UpdateMinDeletionMarkersCountSinceTabletStart()
+{
+    Impl->MinDeletionMarkersCountSinceTabletStart = Min(
+        Impl->MinDeletionMarkersCountSinceTabletStart,
+        FileSystemStats.GetDeletionMarkersCount());
+}
+
+void TIndexTabletState::SetStartupGcExecuted()
+{
+    Impl->StartupGcExecuted = true;
+}
+
+bool TIndexTabletState::GetStartupGcExecuted() const
+{
+    return Impl->StartupGcExecuted;
+}
+
 void TIndexTabletState::UpdateLogTag(TString tag)
 {
     Impl->CacheReadBypass.UpdateLogTag(tag);
@@ -225,7 +262,7 @@ void TIndexTabletState::LoadState(
 
     MaxTabletStep = Max(config.GetMaxTabletStep(), LastStep);
 
-    CompressNodeRef = config.GetEnableNodeRefCompression();
+    Impl->CompressNodeRef = config.GetEnableNodeRefCompression();
 
     FileSystem.CopyFrom(fileSystem);
     FileSystemStats.CopyFrom(fileSystemStats);
@@ -238,7 +275,7 @@ void TIndexTabletState::LoadState(
     // reboot and throttle cleanup when the amount of deletion markers is
     // expected to drop below the minimal amount.
     // https://github.com/ydb-platform/nbs/pull/3268
-    MinDeletionMarkersCountSinceTabletStart =
+    Impl->MinDeletionMarkersCountSinceTabletStart =
         fileSystemStats.GetDeletionMarkersCount();
 
     if (FileSystemStats.GetLastNodeId() < RootNodeId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -264,9 +264,6 @@ protected:
     // is ever in flight up to SafePoint and page faults cannot reorder TXes
     TDeque<ui64> RecoveredDataToConfirm;
 
-    // CommitIds scheduled for unconfirmed-data deletion and waiting for
-    // completion.
-    THashSet<ui64> DeletionQueue;
     // ConfirmAddData requests that arrived before internal AddData completed.
     // Used for all requests until (#5353)
     THashMap<ui64, TVector<TPendingConfirmAddData>> PendingConfirmation;
@@ -277,8 +274,7 @@ protected:
 
 protected:
     void SetUnconfirmedRecoveryReady(bool value);
-    using TUnconfirmedDataMap =
-      THashMap<ui64, TTrackedUnconfirmedData>;
+
     bool UnconfirmedDataInProgressContains(ui64 commitId);
     TTrackedUnconfirmedData& UnconfirmedDataInProgressByCommitId(ui64 commitId);
     TTrackedUnconfirmedData& FindAndVerifyUnconfirmedDataInProgress(ui64 commitId);
@@ -288,6 +284,10 @@ protected:
         const std::function<bool(ui64, const TTrackedUnconfirmedData&)>& shouldDelete,
         TVector<ui64>& commitIdsToDelete);
     size_t GetUnconfirmedDataInProgressSize() const;
+
+    bool DeletionQueueContains(ui64 commitId);
+    bool DeletionQueueEmplace(ui64 commitId);
+    void DeletionQueueErase(ui64 commitId);
 
 
 public:

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -233,7 +233,6 @@ private:
     NProto::TFileSystem FileSystem;
     NProto::TFileSystemStats FileSystemStats;
     NCloud::NProto::TTabletStorageInfo TabletStorageInfo;
-    TNodeToSessionCounters NodeToSessionCounters;
     ui64 MinDeletionMarkersCountSinceTabletStart = 0;
 
     /*const*/ ui32 TruncateBlocksThreshold = 0;
@@ -429,10 +428,7 @@ public:
         );
     }
 
-    const TNodeToSessionCounters& GetNodeToSessionCounters() const
-    {
-        return NodeToSessionCounters;
-    }
+    const TNodeToSessionCounters& GetNodeToSessionCounters() const;
 
     bool UpdateLatencyStats(
         ui64 nodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -254,8 +254,6 @@ private:
 protected:
     TString LogTag;
 
-    // Data written to local db but not yet confirmed/indexed
-    THashMap<ui64, TTrackedUnconfirmedData> UnconfirmedData;
     // Data confirmed but not yet added to index
     THashMap<ui64, TTrackedUnconfirmedData> ConfirmedData;
 
@@ -275,20 +273,34 @@ protected:
 protected:
     void SetUnconfirmedRecoveryReady(bool value);
 
-    bool UnconfirmedDataInProgressContains(ui64 commitId);
+    bool UnconfirmedDataInProgressContains(ui64 commitId) const;
     TTrackedUnconfirmedData& UnconfirmedDataInProgressByCommitId(ui64 commitId);
-    TTrackedUnconfirmedData& FindAndVerifyUnconfirmedDataInProgress(ui64 commitId);
+    TTrackedUnconfirmedData& FindAndVerifyUnconfirmedDataInProgress(
+        ui64 commitId);
     void EraseUnconfirmedDataInProgress(ui64 commitId);
-    bool UnconfirmedDataInProgressEmplace(ui64 commitId, TTrackedUnconfirmedData data);
+    bool UnconfirmedDataInProgressEmplace(
+        ui64 commitId,
+        TTrackedUnconfirmedData data);
     void EnqueueCommitIdsToDelete(
-        const std::function<bool(ui64, const TTrackedUnconfirmedData&)>& shouldDelete,
+        const std::function<bool(ui64, const TTrackedUnconfirmedData&)>&
+            shouldDelete,
         TVector<ui64>& commitIdsToDelete);
     size_t GetUnconfirmedDataInProgressSize() const;
 
-    bool DeletionQueueContains(ui64 commitId);
+    bool DeletionQueueContains(ui64 commitId) const;
     bool DeletionQueueEmplace(ui64 commitId);
     void DeletionQueueErase(ui64 commitId);
 
+    bool UnconfirmedDataEmplace(ui64 commitId, TTrackedUnconfirmedData data);
+    void UnconfirmedDataErase(ui64 commitId);
+    bool UnconfirmedDataContains(ui64 commitId) const;
+    void UnconfirmedDataClear();
+    size_t GetUnconfirmedDataSize() const;
+    const TTrackedUnconfirmedData* FindUnconfirmedData(ui64 commitId) const;
+    TTrackedUnconfirmedData& FindAndVerifyUnconfirmedData(ui64 commitId);
+    void ForEachUnconfirmedData(
+        const std::function<void(const ui64, const TTrackedUnconfirmedData&)>&
+            visitor) const;
 
 public:
     TIndexTabletState();

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -254,8 +254,6 @@ private:
 protected:
     TString LogTag;
 
-    // Data for which internal AddDataUnconfirmed tx is still executing.
-    THashMap<ui64, TTrackedUnconfirmedData> UnconfirmedDataInProgress;
     // Data written to local db but not yet confirmed/indexed
     THashMap<ui64, TTrackedUnconfirmedData> UnconfirmedData;
     // Data confirmed but not yet added to index
@@ -279,6 +277,18 @@ protected:
 
 protected:
     void SetUnconfirmedRecoveryReady(bool value);
+    using TUnconfirmedDataMap =
+      THashMap<ui64, TTrackedUnconfirmedData>;
+    bool UnconfirmedDataInProgressContains(ui64 commitId);
+    TTrackedUnconfirmedData& UnconfirmedDataInProgressByCommitId(ui64 commitId);
+    TTrackedUnconfirmedData& FindAndVerifyUnconfirmedDataInProgress(ui64 commitId);
+    void EraseUnconfirmedDataInProgress(ui64 commitId);
+    bool UnconfirmedDataInProgressEmplace(ui64 commitId, TTrackedUnconfirmedData data);
+    void EnqueueCommitIdsToDelete(
+        const std::function<bool(ui64, const TTrackedUnconfirmedData&)>& shouldDelete,
+        TVector<ui64>& commitIdsToDelete);
+    size_t GetUnconfirmedDataInProgressSize() const;
+
 
 public:
     TIndexTabletState();

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -273,31 +273,32 @@ protected:
 protected:
     void SetUnconfirmedRecoveryReady(bool value);
 
-    bool UnconfirmedDataInProgressContains(ui64 commitId) const;
-    TTrackedUnconfirmedData& UnconfirmedDataInProgressByCommitId(ui64 commitId);
-    TTrackedUnconfirmedData& FindAndVerifyUnconfirmedDataInProgress(
+    bool GetUnconfirmedDataInProgressContains(ui64 commitId) const;
+    TTrackedUnconfirmedData& AccessUnconfirmedDataInProgressByCommitId(ui64 commitId);
+    TTrackedUnconfirmedData& AccessAndVerifyUnconfirmedDataInProgress(
         ui64 commitId);
     void EraseUnconfirmedDataInProgress(ui64 commitId);
     bool UnconfirmedDataInProgressEmplace(
         ui64 commitId,
         TTrackedUnconfirmedData data);
+    using TDeletionDeterminer = std::function<bool(ui64, const TTrackedUnconfirmedData&)>;
     void EnqueueCommitIdsToDelete(
-        const std::function<bool(ui64, const TTrackedUnconfirmedData&)>&
+        const TDeletionDeterminer&
             shouldDelete,
-        TVector<ui64>& commitIdsToDelete);
+        TVector<ui64>* commitIdsToDelete);
     size_t GetUnconfirmedDataInProgressSize() const;
 
-    bool DeletionQueueContains(ui64 commitId) const;
+    bool GetDeletionQueueContains(ui64 commitId) const;
     bool DeletionQueueEmplace(ui64 commitId);
     void DeletionQueueErase(ui64 commitId);
 
     bool UnconfirmedDataEmplace(ui64 commitId, TTrackedUnconfirmedData data);
     void UnconfirmedDataErase(ui64 commitId);
-    bool UnconfirmedDataContains(ui64 commitId) const;
+    bool GetUnconfirmedDataContains(ui64 commitId) const;
     void UnconfirmedDataClear();
     size_t GetUnconfirmedDataSize() const;
     const TTrackedUnconfirmedData* FindUnconfirmedData(ui64 commitId) const;
-    TTrackedUnconfirmedData& FindAndVerifyUnconfirmedData(ui64 commitId);
+    TTrackedUnconfirmedData& AccessAndVerifyUnconfirmedData(ui64 commitId);
     void ForEachUnconfirmedData(
         const std::function<void(const ui64, const TTrackedUnconfirmedData&)>&
             visitor) const;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -228,12 +228,10 @@ private:
     ui32 Generation = 0;
     ui32 LastStep = 0;
     ui32 LastCollectPerGenerationCounter = 0;
-    bool StartupGcExecuted = false;
 
     NProto::TFileSystem FileSystem;
     NProto::TFileSystemStats FileSystemStats;
     NCloud::NProto::TTabletStorageInfo TabletStorageInfo;
-    ui64 MinDeletionMarkersCountSinceTabletStart = 0;
 
     /*const*/ ui32 TruncateBlocksThreshold = 0;
     /*const*/ ui32 SessionHistoryEntryCount = 0;
@@ -246,10 +244,6 @@ private:
     /*const*/ ui64 LargeDeletionMarkersThresholdForBackpressure = 0;
 
     /*const*/ ui32 MaxTabletStep = Max<ui32>();
-
-    bool CompressNodeRef = false;
-
-    bool StateLoaded = false;
 
 protected:
     TString LogTag;
@@ -299,15 +293,9 @@ public:
         const TVector<NProtoPrivate::TResponseLogEntry>& responseLog,
         const TThrottlerConfig& throttlerConfig);
 
-    bool IsStateLoaded() const
-    {
-        return StateLoaded;
-    }
+    bool IsStateLoaded() const;
 
-    void CompleteStateLoad()
-    {
-        StateLoaded = true;
-    }
+    void CompleteStateLoad();
 
     bool UpdateAccessStats(ui64 nodeId, TInstant now);
 
@@ -386,10 +374,7 @@ public:
         return FileSystem.GetNodesCount();
     }
 
-    bool GetCompressNodeRef() const
-    {
-        return CompressNodeRef || FileSystem.GetCompressNodeRef();
-    }
+    bool GetCompressNodeRef() const;
 
     ui64 GetCurrentCommitId() const
     {
@@ -415,18 +400,9 @@ public:
         return FileSystemStats;
     }
 
-    ui64 GetMinDeletionMarkersCountSinceTabletStart() const
-    {
-        return MinDeletionMarkersCountSinceTabletStart;
-    }
+    ui64 GetMinDeletionMarkersCountSinceTabletStart() const;
 
-    void UpdateMinDeletionMarkersCountSinceTabletStart()
-    {
-        MinDeletionMarkersCountSinceTabletStart = Min(
-            MinDeletionMarkersCountSinceTabletStart,
-            FileSystemStats.GetDeletionMarkersCount()
-        );
-    }
+    void UpdateMinDeletionMarkersCountSinceTabletStart();
 
     const TNodeToSessionCounters& GetNodeToSessionCounters() const;
 
@@ -1282,15 +1258,9 @@ public:
         return ++LastCollectPerGenerationCounter;
     }
 
-    void SetStartupGcExecuted()
-    {
-        StartupGcExecuted = true;
-    }
+    void SetStartupGcExecuted();
 
-    bool GetStartupGcExecuted() const
-    {
-        return StartupGcExecuted;
-    }
+    bool GetStartupGcExecuted() const;
 
     void AcquireCollectBarrier(ui64 commitId);
     bool TryReleaseCollectBarrier(ui64 commitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -297,7 +297,7 @@ protected:
     bool GetUnconfirmedDataContains(ui64 commitId) const;
     void UnconfirmedDataClear();
     size_t GetUnconfirmedDataSize() const;
-    const TTrackedUnconfirmedData* FindUnconfirmedData(ui64 commitId) const;
+    const TTrackedUnconfirmedData* AccessUnconfirmedData(ui64 commitId) const;
     TTrackedUnconfirmedData& AccessAndVerifyUnconfirmedData(ui64 commitId);
     void ForEachUnconfirmedData(
         const std::function<void(const ui64, const TTrackedUnconfirmedData&)>&

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -273,7 +273,7 @@ protected:
 protected:
     void SetUnconfirmedRecoveryReady(bool value);
 
-    bool GetUnconfirmedDataInProgressContains(ui64 commitId) const;
+    bool UnconfirmedDataInProgressContains(ui64 commitId) const;
     TTrackedUnconfirmedData& AccessUnconfirmedDataInProgressByCommitId(ui64 commitId);
     TTrackedUnconfirmedData& AccessAndVerifyUnconfirmedDataInProgress(
         ui64 commitId);
@@ -288,13 +288,13 @@ protected:
         TVector<ui64>* commitIdsToDelete);
     size_t GetUnconfirmedDataInProgressSize() const;
 
-    bool GetDeletionQueueContains(ui64 commitId) const;
+    bool DeletionQueueContains(ui64 commitId) const;
     bool DeletionQueueEmplace(ui64 commitId);
     void DeletionQueueErase(ui64 commitId);
 
     bool UnconfirmedDataEmplace(ui64 commitId, TTrackedUnconfirmedData data);
     void UnconfirmedDataErase(ui64 commitId);
-    bool GetUnconfirmedDataContains(ui64 commitId) const;
+    bool UnconfirmedDataContains(ui64 commitId) const;
     void UnconfirmedDataClear();
     size_t GetUnconfirmedDataSize() const;
     const TTrackedUnconfirmedData* AccessUnconfirmedData(ui64 commitId) const;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -228,10 +228,12 @@ private:
     ui32 Generation = 0;
     ui32 LastStep = 0;
     ui32 LastCollectPerGenerationCounter = 0;
+    bool StartupGcExecuted = false;
 
     NProto::TFileSystem FileSystem;
     NProto::TFileSystemStats FileSystemStats;
     NCloud::NProto::TTabletStorageInfo TabletStorageInfo;
+    ui64 MinDeletionMarkersCountSinceTabletStart = 0;
 
     /*const*/ ui32 TruncateBlocksThreshold = 0;
     /*const*/ ui32 SessionHistoryEntryCount = 0;
@@ -244,6 +246,10 @@ private:
     /*const*/ ui64 LargeDeletionMarkersThresholdForBackpressure = 0;
 
     /*const*/ ui32 MaxTabletStep = Max<ui32>();
+
+    bool CompressNodeRef = false;
+
+    bool StateLoaded = false;
 
 protected:
     TString LogTag;
@@ -293,9 +299,15 @@ public:
         const TVector<NProtoPrivate::TResponseLogEntry>& responseLog,
         const TThrottlerConfig& throttlerConfig);
 
-    bool IsStateLoaded() const;
+    bool IsStateLoaded() const
+    {
+        return StateLoaded;
+    }
 
-    void CompleteStateLoad();
+    void CompleteStateLoad()
+    {
+        StateLoaded = true;
+    }
 
     bool UpdateAccessStats(ui64 nodeId, TInstant now);
 
@@ -374,7 +386,10 @@ public:
         return FileSystem.GetNodesCount();
     }
 
-    bool GetCompressNodeRef() const;
+    bool GetCompressNodeRef() const
+    {
+        return CompressNodeRef || FileSystem.GetCompressNodeRef();
+    }
 
     ui64 GetCurrentCommitId() const
     {
@@ -400,9 +415,18 @@ public:
         return FileSystemStats;
     }
 
-    ui64 GetMinDeletionMarkersCountSinceTabletStart() const;
+    ui64 GetMinDeletionMarkersCountSinceTabletStart() const
+    {
+        return MinDeletionMarkersCountSinceTabletStart;
+    }
 
-    void UpdateMinDeletionMarkersCountSinceTabletStart();
+    void UpdateMinDeletionMarkersCountSinceTabletStart()
+    {
+        MinDeletionMarkersCountSinceTabletStart = Min(
+            MinDeletionMarkersCountSinceTabletStart,
+            FileSystemStats.GetDeletionMarkersCount()
+        );
+    }
 
     const TNodeToSessionCounters& GetNodeToSessionCounters() const;
 
@@ -1258,9 +1282,15 @@ public:
         return ++LastCollectPerGenerationCounter;
     }
 
-    void SetStartupGcExecuted();
+    void SetStartupGcExecuted()
+    {
+        StartupGcExecuted = true;
+    }
 
-    bool GetStartupGcExecuted() const;
+    bool GetStartupGcExecuted() const
+    {
+        return StartupGcExecuted;
+    }
 
     void AcquireCollectBarrier(ui64 commitId);
     bool TryReleaseCollectBarrier(ui64 commitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -437,6 +437,60 @@ void TIndexTabletState::SetUnconfirmedRecoveryReady(bool value)
     Impl->CacheReadBypass.SetUnconfirmedRecoveryReady(value);
 }
 
+bool TIndexTabletState::UnconfirmedDataInProgressContains(ui64 commitId)
+{
+    return Impl->UnconfirmedDataInProgress.contains(commitId);
+}
+
+TTrackedUnconfirmedData&
+TIndexTabletState::UnconfirmedDataInProgressByCommitId(ui64 commitId)
+{
+    return Impl->UnconfirmedDataInProgress[commitId];
+}
+
+TTrackedUnconfirmedData&
+TIndexTabletState::FindAndVerifyUnconfirmedDataInProgress(ui64 commitId)
+{
+    auto& map = Impl->UnconfirmedDataInProgress;
+    auto it = map.find(commitId);
+
+    TABLET_VERIFY(it != map.end());
+
+    return it->second;
+}
+
+void TIndexTabletState::EraseUnconfirmedDataInProgress(ui64 commitId)
+{
+    Impl->UnconfirmedDataInProgress.erase(commitId);
+}
+
+bool TIndexTabletState::UnconfirmedDataInProgressEmplace(ui64 commitId, TTrackedUnconfirmedData data)
+{
+    return Impl->UnconfirmedDataInProgress.emplace(commitId, data).second;
+}
+
+void TIndexTabletState::EnqueueCommitIdsToDelete(
+    const std::function<bool(ui64, const TTrackedUnconfirmedData&)>& shouldDelete,
+    TVector<ui64>& commitIdsToDelete)
+{
+    auto map = Impl->UnconfirmedDataInProgress;
+    for(const auto& [commitId, trackedData]: map){
+        if(!shouldDelete(commitId, trackedData)){
+            continue;
+        }
+        if (!DeletionQueue.emplace(commitId).second) {
+            continue;
+        }
+
+        commitIdsToDelete.push_back(commitId);
+    }
+}
+
+size_t TIndexTabletState::GetUnconfirmedDataInProgressSize() const
+{
+    return Impl->UnconfirmedDataInProgress.size();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // FreshBytes
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -442,8 +442,8 @@ bool TIndexTabletState::UnconfirmedDataInProgressContains(ui64 commitId)
     return Impl->UnconfirmedDataInProgress.contains(commitId);
 }
 
-TTrackedUnconfirmedData&
-TIndexTabletState::UnconfirmedDataInProgressByCommitId(ui64 commitId)
+TTrackedUnconfirmedData& TIndexTabletState::UnconfirmedDataInProgressByCommitId(
+    ui64 commitId)
 {
     return Impl->UnconfirmedDataInProgress[commitId];
 }
@@ -464,18 +464,22 @@ void TIndexTabletState::EraseUnconfirmedDataInProgress(ui64 commitId)
     Impl->UnconfirmedDataInProgress.erase(commitId);
 }
 
-bool TIndexTabletState::UnconfirmedDataInProgressEmplace(ui64 commitId, TTrackedUnconfirmedData data)
+bool TIndexTabletState::UnconfirmedDataInProgressEmplace(
+    ui64 commitId,
+    TTrackedUnconfirmedData data)
 {
-    return Impl->UnconfirmedDataInProgress.emplace(commitId, data).second;
+    return Impl->UnconfirmedDataInProgress.emplace(commitId, std::move(data))
+        .second;
 }
 
 void TIndexTabletState::EnqueueCommitIdsToDelete(
-    const std::function<bool(ui64, const TTrackedUnconfirmedData&)>& shouldDelete,
+    const std::function<bool(ui64, const TTrackedUnconfirmedData&)>&
+        shouldDelete,
     TVector<ui64>& commitIdsToDelete)
 {
-    auto map = Impl->UnconfirmedDataInProgress;
-    for(const auto& [commitId, trackedData]: map){
-        if(!shouldDelete(commitId, trackedData)){
+    const auto& map = Impl->UnconfirmedDataInProgress;
+    for (const auto& [commitId, trackedData]: map) {
+        if (!shouldDelete(commitId, trackedData)) {
             continue;
         }
         if (!DeletionQueue.emplace(commitId).second) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -482,7 +482,7 @@ void TIndexTabletState::EnqueueCommitIdsToDelete(
         if (!shouldDelete(commitId, trackedData)) {
             continue;
         }
-        if (!DeletionQueue.emplace(commitId).second) {
+        if (!DeletionQueueEmplace(commitId)) {
             continue;
         }
 
@@ -493,6 +493,21 @@ void TIndexTabletState::EnqueueCommitIdsToDelete(
 size_t TIndexTabletState::GetUnconfirmedDataInProgressSize() const
 {
     return Impl->UnconfirmedDataInProgress.size();
+}
+
+bool TIndexTabletState::DeletionQueueContains(ui64 commitId)
+{
+    return Impl->DeletionQueue.contains(commitId);
+}
+
+bool TIndexTabletState::DeletionQueueEmplace(ui64 commitId)
+{
+    return Impl->DeletionQueue.emplace(commitId).second;
+}
+
+void TIndexTabletState::DeletionQueueErase(ui64 commitId)
+{
+    Impl->DeletionQueue.erase(commitId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -477,29 +477,23 @@ void TIndexTabletState::EnqueueCommitIdsToDelete(
         shouldDelete,
     TVector<ui64>& commitIdsToDelete)
 {
-    const auto& unconfirmed = Impl->UnconfirmedData;
-    for (const auto& [commitId, trackedData]: unconfirmed) {
-        if (!shouldDelete(commitId, trackedData)) {
-            continue;
-        }
-        if (!DeletionQueueEmplace(commitId)) {
-            continue;
-        }
+    auto process = [&](const auto& data)
+    {
+        for (const auto& [commitId, trackedData]: data) {
+            if (!shouldDelete(commitId, trackedData)) {
+                continue;
+            }
 
-        commitIdsToDelete.push_back(commitId);
-    }
+            if (!DeletionQueueEmplace(commitId)) {
+                continue;
+            }
 
-    const auto& unconfirmedInProgress = Impl->UnconfirmedDataInProgress;
-    for (const auto& [commitId, trackedData]: unconfirmedInProgress) {
-        if (!shouldDelete(commitId, trackedData)) {
-            continue;
+            commitIdsToDelete.push_back(commitId);
         }
-        if (!DeletionQueueEmplace(commitId)) {
-            continue;
-        }
+    };
 
-        commitIdsToDelete.push_back(commitId);
-    }
+    process(Impl->UnconfirmedData);
+    process(Impl->UnconfirmedDataInProgress);
 }
 
 size_t TIndexTabletState::GetUnconfirmedDataInProgressSize() const

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -373,7 +373,7 @@ void TIndexTabletState::LoadUnconfirmedData(
         AcquireCollectBarrier(entry.CommitId);
 
         // Skip session id. After restart we add all records to the index
-        UnconfirmedData[entry.CommitId] = {
+        Impl->UnconfirmedData[entry.CommitId] = {
             .Data = std::move(entry.Data)};
     }
 }
@@ -405,7 +405,7 @@ bool TIndexTabletState::HasDataOverlapWithUnconfirmed(
 
     // Intentionally without DataInProgress as we need it currently only for
     // recovery phase.
-    return hasDataOverlap(UnconfirmedData) || hasDataOverlap(ConfirmedData);
+    return hasDataOverlap(Impl->UnconfirmedData) || hasDataOverlap(ConfirmedData);
 }
 
 void TIndexTabletState::ActivateCacheReadBypass(
@@ -437,7 +437,7 @@ void TIndexTabletState::SetUnconfirmedRecoveryReady(bool value)
     Impl->CacheReadBypass.SetUnconfirmedRecoveryReady(value);
 }
 
-bool TIndexTabletState::UnconfirmedDataInProgressContains(ui64 commitId)
+bool TIndexTabletState::UnconfirmedDataInProgressContains(ui64 commitId) const
 {
     return Impl->UnconfirmedDataInProgress.contains(commitId);
 }
@@ -477,8 +477,20 @@ void TIndexTabletState::EnqueueCommitIdsToDelete(
         shouldDelete,
     TVector<ui64>& commitIdsToDelete)
 {
-    const auto& map = Impl->UnconfirmedDataInProgress;
-    for (const auto& [commitId, trackedData]: map) {
+    const auto& unconfirmed = Impl->UnconfirmedData;
+    for (const auto& [commitId, trackedData]: unconfirmed) {
+        if (!shouldDelete(commitId, trackedData)) {
+            continue;
+        }
+        if (!DeletionQueueEmplace(commitId)) {
+            continue;
+        }
+
+        commitIdsToDelete.push_back(commitId);
+    }
+
+    const auto& unconfirmedInProgress = Impl->UnconfirmedDataInProgress;
+    for (const auto& [commitId, trackedData]: unconfirmedInProgress) {
         if (!shouldDelete(commitId, trackedData)) {
             continue;
         }
@@ -495,7 +507,7 @@ size_t TIndexTabletState::GetUnconfirmedDataInProgressSize() const
     return Impl->UnconfirmedDataInProgress.size();
 }
 
-bool TIndexTabletState::DeletionQueueContains(ui64 commitId)
+bool TIndexTabletState::DeletionQueueContains(ui64 commitId) const
 {
     return Impl->DeletionQueue.contains(commitId);
 }
@@ -508,6 +520,62 @@ bool TIndexTabletState::DeletionQueueEmplace(ui64 commitId)
 void TIndexTabletState::DeletionQueueErase(ui64 commitId)
 {
     Impl->DeletionQueue.erase(commitId);
+}
+
+bool TIndexTabletState::UnconfirmedDataEmplace(
+    ui64 commitId,
+    TTrackedUnconfirmedData data)
+{
+    return Impl->UnconfirmedData.emplace(commitId, std::move(data)).second;
+}
+
+bool TIndexTabletState::UnconfirmedDataContains(ui64 commitId) const
+{
+    return Impl->UnconfirmedData.contains(commitId);
+}
+
+const TTrackedUnconfirmedData* TIndexTabletState::FindUnconfirmedData(
+    ui64 commitId) const
+{
+    const auto& map = Impl->UnconfirmedData;
+
+    auto it = map.find(commitId);
+    return it == map.end() ? nullptr : &it->second;
+}
+
+TTrackedUnconfirmedData& TIndexTabletState::FindAndVerifyUnconfirmedData(
+    ui64 commitId)
+{
+    auto& map = Impl->UnconfirmedData;
+    auto it = map.find(commitId);
+
+    TABLET_VERIFY(it != map.end());
+
+    return it->second;
+}
+
+void TIndexTabletState::UnconfirmedDataErase(ui64 commitId)
+{
+    Impl->UnconfirmedData.erase(commitId);
+}
+
+size_t TIndexTabletState::GetUnconfirmedDataSize() const
+{
+    return Impl->UnconfirmedData.size();
+}
+
+void TIndexTabletState::ForEachUnconfirmedData(
+    const std::function<void(const ui64, const TTrackedUnconfirmedData&)>&
+        visitor) const
+{
+    for (const auto& [key, entry]: Impl->UnconfirmedData) {
+        visitor(key, entry);
+    }
+}
+
+void TIndexTabletState::UnconfirmedDataClear()
+{
+    Impl->UnconfirmedData.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -437,19 +437,20 @@ void TIndexTabletState::SetUnconfirmedRecoveryReady(bool value)
     Impl->CacheReadBypass.SetUnconfirmedRecoveryReady(value);
 }
 
-bool TIndexTabletState::UnconfirmedDataInProgressContains(ui64 commitId) const
+bool TIndexTabletState::GetUnconfirmedDataInProgressContains(
+    ui64 commitId) const
 {
     return Impl->UnconfirmedDataInProgress.contains(commitId);
 }
 
-TTrackedUnconfirmedData& TIndexTabletState::UnconfirmedDataInProgressByCommitId(
-    ui64 commitId)
+TTrackedUnconfirmedData&
+TIndexTabletState::AccessUnconfirmedDataInProgressByCommitId(ui64 commitId)
 {
     return Impl->UnconfirmedDataInProgress[commitId];
 }
 
 TTrackedUnconfirmedData&
-TIndexTabletState::FindAndVerifyUnconfirmedDataInProgress(ui64 commitId)
+TIndexTabletState::AccessAndVerifyUnconfirmedDataInProgress(ui64 commitId)
 {
     auto& map = Impl->UnconfirmedDataInProgress;
     auto it = map.find(commitId);
@@ -473,9 +474,9 @@ bool TIndexTabletState::UnconfirmedDataInProgressEmplace(
 }
 
 void TIndexTabletState::EnqueueCommitIdsToDelete(
-    const std::function<bool(ui64, const TTrackedUnconfirmedData&)>&
+    const TDeletionDeterminer&
         shouldDelete,
-    TVector<ui64>& commitIdsToDelete)
+    TVector<ui64>* commitIdsToDelete)
 {
     auto process = [&](const auto& data)
     {
@@ -488,7 +489,7 @@ void TIndexTabletState::EnqueueCommitIdsToDelete(
                 continue;
             }
 
-            commitIdsToDelete.push_back(commitId);
+            commitIdsToDelete->push_back(commitId);
         }
     };
 
@@ -501,7 +502,7 @@ size_t TIndexTabletState::GetUnconfirmedDataInProgressSize() const
     return Impl->UnconfirmedDataInProgress.size();
 }
 
-bool TIndexTabletState::DeletionQueueContains(ui64 commitId) const
+bool TIndexTabletState::GetDeletionQueueContains(ui64 commitId) const
 {
     return Impl->DeletionQueue.contains(commitId);
 }
@@ -523,7 +524,7 @@ bool TIndexTabletState::UnconfirmedDataEmplace(
     return Impl->UnconfirmedData.emplace(commitId, std::move(data)).second;
 }
 
-bool TIndexTabletState::UnconfirmedDataContains(ui64 commitId) const
+bool TIndexTabletState::GetUnconfirmedDataContains(ui64 commitId) const
 {
     return Impl->UnconfirmedData.contains(commitId);
 }
@@ -534,10 +535,10 @@ const TTrackedUnconfirmedData* TIndexTabletState::FindUnconfirmedData(
     const auto& map = Impl->UnconfirmedData;
 
     auto it = map.find(commitId);
-    return it == map.end() ? nullptr : &it->second;
+    return Impl->UnconfirmedData.FindPtr(commitId)
 }
 
-TTrackedUnconfirmedData& TIndexTabletState::FindAndVerifyUnconfirmedData(
+TTrackedUnconfirmedData& TIndexTabletState::AccessAndVerifyUnconfirmedData(
     ui64 commitId)
 {
     auto& map = Impl->UnconfirmedData;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -452,12 +452,9 @@ TIndexTabletState::AccessUnconfirmedDataInProgressByCommitId(ui64 commitId)
 TTrackedUnconfirmedData&
 TIndexTabletState::AccessAndVerifyUnconfirmedDataInProgress(ui64 commitId)
 {
-    auto& map = Impl->UnconfirmedDataInProgress;
-    auto it = map.find(commitId);
-
-    TABLET_VERIFY(it != map.end());
-
-    return it->second;
+    auto* dataInProgress = Impl->UnconfirmedDataInProgress.FindPtr(commitId);
+    TABLET_VERIFY(dataInProgress != nullptr);
+    return *dataInProgress;
 }
 
 void TIndexTabletState::EraseUnconfirmedDataInProgress(ui64 commitId)
@@ -538,12 +535,9 @@ const TTrackedUnconfirmedData* TIndexTabletState::AccessUnconfirmedData(
 TTrackedUnconfirmedData& TIndexTabletState::AccessAndVerifyUnconfirmedData(
     ui64 commitId)
 {
-    auto& map = Impl->UnconfirmedData;
-    auto it = map.find(commitId);
-
-    TABLET_VERIFY(it != map.end());
-
-    return it->second;
+    auto* data = Impl->UnconfirmedData.FindPtr(commitId);
+    TABLET_VERIFY(data != nullptr);
+    return *data;
 }
 
 void TIndexTabletState::UnconfirmedDataErase(ui64 commitId)

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -529,13 +529,10 @@ bool TIndexTabletState::GetUnconfirmedDataContains(ui64 commitId) const
     return Impl->UnconfirmedData.contains(commitId);
 }
 
-const TTrackedUnconfirmedData* TIndexTabletState::FindUnconfirmedData(
+const TTrackedUnconfirmedData* TIndexTabletState::AccessUnconfirmedData(
     ui64 commitId) const
 {
-    const auto& map = Impl->UnconfirmedData;
-
-    auto it = map.find(commitId);
-    return Impl->UnconfirmedData.FindPtr(commitId)
+    return Impl->UnconfirmedData.FindPtr(commitId);
 }
 
 TTrackedUnconfirmedData& TIndexTabletState::AccessAndVerifyUnconfirmedData(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -437,7 +437,7 @@ void TIndexTabletState::SetUnconfirmedRecoveryReady(bool value)
     Impl->CacheReadBypass.SetUnconfirmedRecoveryReady(value);
 }
 
-bool TIndexTabletState::GetUnconfirmedDataInProgressContains(
+bool TIndexTabletState::UnconfirmedDataInProgressContains(
     ui64 commitId) const
 {
     return Impl->UnconfirmedDataInProgress.contains(commitId);
@@ -502,7 +502,7 @@ size_t TIndexTabletState::GetUnconfirmedDataInProgressSize() const
     return Impl->UnconfirmedDataInProgress.size();
 }
 
-bool TIndexTabletState::GetDeletionQueueContains(ui64 commitId) const
+bool TIndexTabletState::DeletionQueueContains(ui64 commitId) const
 {
     return Impl->DeletionQueue.contains(commitId);
 }
@@ -524,7 +524,7 @@ bool TIndexTabletState::UnconfirmedDataEmplace(
     return Impl->UnconfirmedData.emplace(commitId, std::move(data)).second;
 }
 
-bool TIndexTabletState::GetUnconfirmedDataContains(ui64 commitId) const
+bool TIndexTabletState::UnconfirmedDataContains(ui64 commitId) const
 {
     return Impl->UnconfirmedData.contains(commitId);
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -65,6 +65,8 @@ struct TIndexTabletState::TImpl
     TNodeLatencyStatsTracker LatencyTracker;
 
     TNodeToSessionCounters NodeToSessionCounters;
+    // Data for which internal AddDataUnconfirmed tx is still executing.
+    THashMap<ui64, TTrackedUnconfirmedData> UnconfirmedDataInProgress;
 
     TRangeLocks RangeLocks;
     TFreshBytes FreshBytes;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -65,10 +65,6 @@ struct TIndexTabletState::TImpl
     TNodeLatencyStatsTracker LatencyTracker;
 
     TNodeToSessionCounters NodeToSessionCounters;
-    bool StartupGcExecuted = false;
-    ui64 MinDeletionMarkersCountSinceTabletStart = 0;
-    bool CompressNodeRef = false;
-    bool StateLoaded = false;
 
     TRangeLocks RangeLocks;
     TFreshBytes FreshBytes;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -65,8 +65,12 @@ struct TIndexTabletState::TImpl
     TNodeLatencyStatsTracker LatencyTracker;
 
     TNodeToSessionCounters NodeToSessionCounters;
+
     // Data for which internal AddDataUnconfirmed tx is still executing.
     THashMap<ui64, TTrackedUnconfirmedData> UnconfirmedDataInProgress;
+    // CommitIds scheduled for unconfirmed-data deletion and waiting for
+    // completion.
+    THashSet<ui64> DeletionQueue;
 
     TRangeLocks RangeLocks;
     TFreshBytes FreshBytes;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -65,7 +65,8 @@ struct TIndexTabletState::TImpl
     TNodeLatencyStatsTracker LatencyTracker;
 
     TNodeToSessionCounters NodeToSessionCounters;
-
+    // Data written to local db but not yet confirmed/indexed
+    THashMap<ui64, TTrackedUnconfirmedData> UnconfirmedData;
     // Data for which internal AddDataUnconfirmed tx is still executing.
     THashMap<ui64, TTrackedUnconfirmedData> UnconfirmedDataInProgress;
     // CommitIds scheduled for unconfirmed-data deletion and waiting for

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -65,6 +65,10 @@ struct TIndexTabletState::TImpl
     TNodeLatencyStatsTracker LatencyTracker;
 
     TNodeToSessionCounters NodeToSessionCounters;
+    bool StartupGcExecuted = false;
+    ui64 MinDeletionMarkersCountSinceTabletStart = 0;
+    bool CompressNodeRef = false;
+    bool StateLoaded = false;
 
     TRangeLocks RangeLocks;
     TFreshBytes FreshBytes;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -64,6 +64,8 @@ struct TIndexTabletState::TImpl
     TNodeAccessStatsTracker AccessTracker;
     TNodeLatencyStatsTracker LatencyTracker;
 
+    TNodeToSessionCounters NodeToSessionCounters;
+
     TRangeLocks RangeLocks;
     TFreshBytes FreshBytes;
     TFreshBlocks FreshBlocks;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -765,17 +765,17 @@ void TIndexTabletState::ChangeNodeCounters(
         case TNodeToSessionStat::EKind::None:
             break;
         case TNodeToSessionStat::EKind::NodesOpenForWritingBySingleSession:
-            NodeToSessionCounters.NodesOpenForWritingBySingleSession += amount;
+            Impl->NodeToSessionCounters.NodesOpenForWritingBySingleSession += amount;
             break;
         case TNodeToSessionStat::EKind::NodesOpenForWritingByMultipleSessions:
-            NodeToSessionCounters.NodesOpenForWritingByMultipleSessions +=
+            Impl->NodeToSessionCounters.NodesOpenForWritingByMultipleSessions +=
                 amount;
             break;
         case TNodeToSessionStat::EKind::NodesOpenForReadingBySingleSession:
-            NodeToSessionCounters.NodesOpenForReadingBySingleSession += amount;
+            Impl->NodeToSessionCounters.NodesOpenForReadingBySingleSession += amount;
             break;
         case TNodeToSessionStat::EKind::NodesOpenForReadingByMultipleSessions:
-            NodeToSessionCounters.NodesOpenForReadingByMultipleSessions +=
+            Impl->NodeToSessionCounters.NodesOpenForReadingByMultipleSessions +=
                 amount;
             break;
     }


### PR DESCRIPTION
### Notes
This is a refactor suggested in https://github.com/ydb-platform/nbs/pull/6670
As part of this PR, I moved fields : `NodeToSessionCounters`, `UnconfirmedData`, `UnconfirmedDataInProgress`, `DeletionQueue`.

The remaining will be moved in another PR.

### Comment
https://github.com/ydb-platform/nbs/pull/6670#discussion_r3797657112
