### PR TITLE
issue-5895: fastshard page deallocation upon UnlinkNode

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -353,11 +353,13 @@ public:
         return Slots->Put(writeContext.Lsn, slot, writeContext.PageGroups);
     }
 
-    NProto::TError DeleteNode(ui64 nodeId, TWriteContext& writeContext)
+    NProto::TError DeleteNode(
+        ui64 nodeId,
+        TWriteContext& writeContext,
+        TNodeTableSlot* slot)
     {
-        TNodeTableSlot slot{};
         return Slots
-            ->Delete(writeContext.Lsn, nodeId, &slot, writeContext.PageGroups);
+            ->Delete(writeContext.Lsn, nodeId, slot, writeContext.PageGroups);
     }
 
     NProto::TError GetNode(ui64 nodeId, NProto::TNodeAttr* attr) const
@@ -665,11 +667,11 @@ public:
 
     NProto::TError Delete(
         const TNodePageClusterKey& k,
-        TWriteContext& writeContext)
+        TWriteContext& writeContext,
+        TNodePageClusterSlot* slot)
     {
-        TNodePageClusterSlot slot{};
         return Slots
-            ->Delete(writeContext.Lsn, k, &slot, writeContext.PageGroups);
+            ->Delete(writeContext.Lsn, k, slot, writeContext.PageGroups);
     }
 
     NProto::TError Get(
@@ -1205,7 +1207,8 @@ public:
                 return response;
             }
 
-            error = Nodes.DeleteNode(nodeId, writeContext);
+            TNodeTableSlot slot{};
+            error = Nodes.DeleteNode(nodeId, writeContext, &slot);
             if (HasError(error)) {
                 SILK_DEBUG(
                     "UnlinkNode::Nodes.DeleteNode error=%s",
@@ -1214,9 +1217,47 @@ public:
                 return response;
             }
 
-            //
-            // TODO(#5894): deallocate pages and delete them from page index.
-            //
+            TVector<ui64> storagePageClusterIds;
+            for (ui64 offset = 0; offset < slot.Size;
+                    offset += PageClusterSize)
+            {
+                TNodePageClusterSlot slot{};
+                error = PageIndex.Delete(
+                    {
+                        .NodeId = nodeId,
+                        .PageClusterId = offset / PageClusterSize
+                    },
+                    writeContext,
+                    &slot);
+
+                if (error.GetCode() == E_FS_NOENT) {
+                    //
+                    // This page cluster is not allocated.
+                    //
+
+                    continue;
+                }
+
+                if (HasError(error)) {
+                    SILK_DEBUG(
+                        "UnlinkNode::PageIndex.Delete error=%s",
+                        FormatError(error).c_str());
+                    *response.MutableError() = std::move(error);
+                    return response;
+                }
+
+                storagePageClusterIds.push_back(slot.StoragePageClusterId);
+            }
+
+            error =
+                PageAllocator.Deallocate(storagePageClusterIds, writeContext);
+            if (HasError(error)) {
+                SILK_DEBUG(
+                    "UnlinkNode::PageAllocator.Deallocate error=%s",
+                    FormatError(error).c_str());
+                *response.MutableError() = std::move(error);
+                return response;
+            }
         }
 
         auto pages = CollectPages(writeContext);

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
@@ -852,7 +852,7 @@ TEST(NaiveMirroredShardTest, DeallocatesPagesUponUnlink)
     const auto expectedData = GenerateValidateData(4_KB);
 
     //
-    // 3 pages, 2 clusters.
+    // 4 pages, 3 clusters, 1 skipped cluster.
     // Actual page usage - 2 x 8 = 16.
     //
 
@@ -889,6 +889,17 @@ TEST(NaiveMirroredShardTest, DeallocatesPagesUponUnlink)
             << FormatError(response.GetError());
     }
 
+    {
+        TWriteDataRequest request;
+        request.SetHandle(handle);
+        request.SetOffset(96_KB);
+        *request.MutableBuffer() = expectedData;
+        auto f = shard->WriteData(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
     //
     // Destroying the handle to let UnlinkNode release the pages.
     //
@@ -910,7 +921,7 @@ TEST(NaiveMirroredShardTest, DeallocatesPagesUponUnlink)
         EXPECT_EQ(1ULL, stats.UsedNodeCount);
         EXPECT_EQ(1ULL, stats.UsedNameCount);
         EXPECT_EQ(0ULL, stats.UsedHandleCount);
-        EXPECT_EQ(16ULL, stats.UsedPageCount);
+        EXPECT_EQ(24ULL, stats.UsedPageCount);
     }
 
     //

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
@@ -811,3 +811,130 @@ TEST(NaiveMirroredShardTest, UnalignedAppend)
             << FormatError(response.GetError());
     }
 }
+
+TEST(NaiveMirroredShardTest, DeallocatesPagesUponUnlink)
+{
+    silk::Logger::setLevel(silk::LogLevel::DEBUG);
+
+    TStorageFixture fx;
+
+    auto shard = CreateNaiveMirroredFileSystemShard(ShardNo, fx.Config);
+
+    const TString file1 = "file1";
+    const ui32 mode = 0644;
+    const ui64 uid = 111;
+    const ui64 gid = 222;
+
+    const ui32 createHandleFlags = ProtoFlag(TCreateHandleRequest::E_CREATE) |
+                                   ProtoFlag(TCreateHandleRequest::E_READ) |
+                                   ProtoFlag(TCreateHandleRequest::E_WRITE);
+
+    ui64 nodeId = 0;
+    ui64 handle = 0;
+    {
+        TCreateHandleRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        request.SetFlags(createHandleFlags);
+        request.SetMode(mode);
+        request.SetUid(uid);
+        request.SetGid(gid);
+        auto f = shard->CreateHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        handle = response.GetHandle();
+        EXPECT_TRUE(handle != 0);
+        nodeId = response.GetNodeAttr().GetId();
+        EXPECT_TRUE(nodeId != 0);
+    }
+
+    const auto expectedData = GenerateValidateData(4_KB);
+
+    //
+    // 3 pages, 2 clusters.
+    // Actual page usage - 2 x 8 = 16.
+    //
+
+    {
+        TWriteDataRequest request;
+        request.SetHandle(handle);
+        request.SetOffset(0);
+        *request.MutableBuffer() = expectedData;
+        auto f = shard->WriteData(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        TWriteDataRequest request;
+        request.SetHandle(handle);
+        request.SetOffset(32_KB);
+        *request.MutableBuffer() = expectedData;
+        auto f = shard->WriteData(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        TWriteDataRequest request;
+        request.SetHandle(handle);
+        request.SetOffset(40_KB);
+        *request.MutableBuffer() = expectedData;
+        auto f = shard->WriteData(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    //
+    // Destroying the handle to let UnlinkNode release the pages.
+    //
+
+    {
+        TDestroyHandleRequest request;
+        request.SetHandle(handle);
+        auto f = shard->DestroyHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        TFileSystemShardStats stats;
+        auto f = shard->CollectStats(&stats);
+        auto e = f.GetValueSync();
+        EXPECT_EQ(S_OK, e.GetCode()) << FormatError(e);
+        EXPECT_EQ(1ULL, stats.UsedNodeCount);
+        EXPECT_EQ(1ULL, stats.UsedNameCount);
+        EXPECT_EQ(0ULL, stats.UsedHandleCount);
+        EXPECT_EQ(16ULL, stats.UsedPageCount);
+    }
+
+    //
+    // Unlinking the node and verifying that the pages get released.
+    //
+
+    {
+        TUnlinkNodeRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        auto f = shard->UnlinkNode(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        TFileSystemShardStats stats;
+        auto f = shard->CollectStats(&stats);
+        auto e = f.GetValueSync();
+        EXPECT_EQ(S_OK, e.GetCode()) << FormatError(e);
+        EXPECT_EQ(0ULL, stats.UsedNodeCount);
+        EXPECT_EQ(0ULL, stats.UsedNameCount);
+        EXPECT_EQ(0ULL, stats.UsedHandleCount);
+        EXPECT_EQ(0ULL, stats.UsedPageCount);
+    }
+}


### PR DESCRIPTION
### Notes
Implemented a TODO item - deleting file pages from index and deallocating them upon `UnlinkNode`.

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895
