### PR TITLE
[NBS] Local NVMe service: ensure lockdown

### DIFF
--- a/cloud/blockstore/config/local_nvme.proto
+++ b/cloud/blockstore/config/local_nvme.proto
@@ -19,4 +19,25 @@ message TLocalNVMeConfig {
 
     // Update counters interval (in milliseconds).
     optional uint32 UpdateCountersInterval = 4;
+
+    // Configures NVMe Command and Feature Lockdown policy.
+    // The policy is applied only to NVMe devices that support the Lockdown command.
+    message TLockdownConfig {
+        // Admin command opcodes that must remain allowed.
+        // Supported opcodes not present in this list are prohibited when possible.
+        repeated uint32 AllowedAdminOpcodes = 1;
+
+        // Set Features identifiers that must remain allowed.
+        // Supported feature IDs not present in this list are prohibited when possible.
+        repeated uint32 AllowedSetFeatureIds = 2;
+
+        // Whether to prohibit the Lockdown command itself.
+        // The Lockdown command is prohibited only after all other requested
+        // lockdown operations have been applied.
+        optional bool BlockLockdownCommand = 3;
+    }
+
+    // Optional NVMe Lockdown configuration.
+    // If not specified, Lockdown is not applied.
+    optional TLockdownConfig LockdownConfig = 5;
 }

--- a/cloud/blockstore/libs/local_nvme/config.cpp
+++ b/cloud/blockstore/libs/local_nvme/config.cpp
@@ -3,6 +3,8 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 
 #include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/stream/format.h>
 
 #include <chrono>
 
@@ -14,16 +16,25 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Plain scalar fields: always present via Get##name(), fall back to
+// Default##name when not set in the proto.
 #define BLOCKSTORE_LOCAL_NVME_CONFIG(xxx)                                      \
-    xxx(DevicesSourceUri,                TString,          ""                 )\
-    xxx(StateCacheFilePath,              TString,          ""                 )\
-    xxx(UpdateDevicesInterval,           TDuration,        1min               )\
-    xxx(UpdateCountersInterval,           TDuration,        15s               )\
-// BLOCKSTORE_LOCAL_NVME_CONFIG
+    xxx(DevicesSourceUri, TString, "")                                         \
+    xxx(StateCacheFilePath, TString, "")                                       \
+    xxx(UpdateDevicesInterval, TDuration, 1min)                                \
+    xxx(UpdateCountersInterval, TDuration, 15s)                                \
+    // BLOCKSTORE_LOCAL_NVME_CONFIG
+
+// Fields wrapped into their own config-object type: no sensible default,
+// so Get##name() returns std::optional<type> and is std::nullopt when the
+// submessage is not set in the proto.
+#define BLOCKSTORE_LOCAL_NVME_CONFIG_OPT(xxx)                                  \
+    xxx(LockdownConfig, TNVMeLockdownConfig)                                   \
+    // BLOCKSTORE_LOCAL_NVME_CONFIG_OPT
 
 #define BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG(name, type, value)                \
     Y_DECLARE_UNUSED static const type Default##name = value;                  \
-// BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG
+    // BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG
 
 BLOCKSTORE_LOCAL_NVME_CONFIG(BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG)
 
@@ -43,7 +54,125 @@ TDuration ConvertValue<TDuration, ui32>(const ui32& value)
     return TDuration::MilliSeconds(value);
 }
 
+void DumpValue(IOutputStream& out, const TVector<ui8>& opcodes)
+{
+    out << "[ ";
+    for (ui8 opcode: opcodes) {
+        out << Hex(opcode, HF_ADDX) << " ";
+    }
+    out << "]";
+}
+
+template <typename T>
+void DumpValue(IOutputStream& out, const T& value)
+{
+    out << value;
+}
+
+template <typename T>
+void DumpValueHtml(IOutputStream& out, const T& value)
+{
+    DumpValue(out, value);
+}
+
+template <typename T>
+void DumpValue(IOutputStream& out, const std::optional<T>& value)
+{
+    if (value) {
+        DumpValue(out, *value);
+    } else {
+        out << "(not set)";
+    }
+}
+
+template <typename T>
+void DumpValueHtml(IOutputStream& out, const std::optional<T>& value)
+{
+    if (value) {
+        DumpValueHtml(out, *value);
+    } else {
+        out << "(not set)";
+    }
+}
+
 }   //  namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TNVMeLockdownConfig::TNVMeLockdownConfig(
+    const NProto::TLocalNVMeConfig::TLockdownConfig& proto)
+    : Proto(proto)
+{}
+
+TNVMeLockdownConfig::~TNVMeLockdownConfig() = default;
+
+TVector<ui8> TNVMeLockdownConfig::GetAllowedAdminOpcodes() const
+{
+    const auto& value = Proto.GetAllowedAdminOpcodes();
+    return {value.begin(), value.end()};
+}
+
+TVector<ui8> TNVMeLockdownConfig::GetAllowedSetFeatureIds() const
+{
+    const auto& value = Proto.GetAllowedSetFeatureIds();
+    return {value.begin(), value.end()};
+}
+
+bool TNVMeLockdownConfig::GetBlockLockdownCommand() const
+{
+    return Proto.GetBlockLockdownCommand();
+}
+
+void DumpValue(IOutputStream& out, const TNVMeLockdownConfig& config)
+{
+    out << Endl;
+
+    out << "  AllowedAdminOpcodes: ";
+    DumpValue(out, config.GetAllowedAdminOpcodes());
+    out << Endl;
+
+    out << "  AllowedSetFeatureIds: ";
+    DumpValue(out, config.GetAllowedSetFeatureIds());
+    out << Endl;
+
+    out << "  BlockLockdownCommand: " << config.GetBlockLockdownCommand();
+}
+
+void DumpValueHtml(IOutputStream& out, const TNVMeLockdownConfig& config)
+{
+    HTML (out) {
+        TABLE_CLASS ("table table-condensed") {
+            TABLEBODY () {
+                TABLER () {
+                    TABLED () {
+                        out << "AllowedAdminOpcodes";
+                    }
+                    TABLED () {
+                        DumpValueHtml(out, config.GetAllowedAdminOpcodes());
+                    }
+                }
+
+                TABLER () {
+                    TABLED () {
+                        out << "AllowedSetFeatureIds";
+                    }
+                    TABLED () {
+                        DumpValueHtml(out, config.GetAllowedSetFeatureIds());
+                    }
+                }
+
+                TABLER () {
+                    TABLED () {
+                        out << "BlockLockdownCommand";
+                    }
+                    TABLED () {
+                        out << config.GetBlockLockdownCommand();
+                    }
+                }
+            }
+        }
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -53,27 +182,46 @@ TLocalNVMeConfig::TLocalNVMeConfig(NProto::TLocalNVMeConfig proto)
 
 TLocalNVMeConfig::~TLocalNVMeConfig() = default;
 
+////////////////////////////////////////////////////////////////////////////////
+
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
-type TLocalNVMeConfig::Get##name() const                                       \
-{                                                                              \
-    const auto value = Proto.Get##name();                                      \
-    return !value ? Default##name : ConvertValue<type>(value);                 \
-}                                                                              \
-// BLOCKSTORE_CONFIG_GETTER
+    type TLocalNVMeConfig::Get##name() const                                   \
+    {                                                                          \
+        if (Proto.Has##name()) {                                               \
+            return ConvertValue<type>(Proto.Get##name());                      \
+        }                                                                      \
+        return Default##name;                                                  \
+    }                                                                          \
+    // BLOCKSTORE_CONFIG_GETTER
 
 BLOCKSTORE_LOCAL_NVME_CONFIG(BLOCKSTORE_CONFIG_GETTER)
 
 #undef BLOCKSTORE_CONFIG_GETTER
 
+#define BLOCKSTORE_CONFIG_GETTER_OPT(name, type)                               \
+    std::optional<type> TLocalNVMeConfig::Get##name() const                    \
+    {                                                                          \
+        if (!Proto.Has##name()) {                                              \
+            return std::nullopt;                                               \
+        }                                                                      \
+        return type(Proto.Get##name());                                        \
+    }                                                                          \
+    // BLOCKSTORE_CONFIG_GETTER_OPT
+
+BLOCKSTORE_LOCAL_NVME_CONFIG_OPT(BLOCKSTORE_CONFIG_GETTER_OPT)
+
+#undef BLOCKSTORE_CONFIG_GETTER_OPT
+
 void TLocalNVMeConfig::Dump(IOutputStream& out) const
 {
 #define BLOCKSTORE_CONFIG_DUMP(name, ...)                                      \
     out << #name << ": ";                                                      \
-    out << Get##name();                                                        \
+    DumpValue(out, Get##name());                                               \
     out << Endl;                                                               \
-// BLOCKSTORE_CONFIG_DUMP
+    // BLOCKSTORE_CONFIG_DUMP
 
     BLOCKSTORE_LOCAL_NVME_CONFIG(BLOCKSTORE_CONFIG_DUMP);
+    BLOCKSTORE_LOCAL_NVME_CONFIG_OPT(BLOCKSTORE_CONFIG_DUMP);
 
 #undef BLOCKSTORE_CONFIG_DUMP
 }
@@ -81,16 +229,21 @@ void TLocalNVMeConfig::Dump(IOutputStream& out) const
 void TLocalNVMeConfig::DumpHtml(IOutputStream& out) const
 {
 #define BLOCKSTORE_CONFIG_DUMP(name, ...)                                      \
-    TABLER() {                                                                 \
-        TABLED() { out << #name; }                                             \
-        TABLED() { out << Get##name(); }                                       \
+    TABLER () {                                                                \
+        TABLED () {                                                            \
+            out << #name;                                                      \
+        }                                                                      \
+        TABLED () {                                                            \
+            DumpValueHtml(out, Get##name());                                   \
+        }                                                                      \
     }                                                                          \
-// BLOCKSTORE_CONFIG_DUMP
+    // BLOCKSTORE_CONFIG_DUMP
 
-    HTML(out) {
-        TABLE_CLASS("table table-condensed") {
-            TABLEBODY() {
+    HTML (out) {
+        TABLE_CLASS ("table table-condensed") {
+            TABLEBODY () {
                 BLOCKSTORE_LOCAL_NVME_CONFIG(BLOCKSTORE_CONFIG_DUMP);
+                BLOCKSTORE_LOCAL_NVME_CONFIG_OPT(BLOCKSTORE_CONFIG_DUMP);
             }
         }
     }

--- a/cloud/blockstore/libs/local_nvme/config.h
+++ b/cloud/blockstore/libs/local_nvme/config.h
@@ -7,11 +7,28 @@
 #include <util/datetime/base.h>
 #include <util/generic/fwd.h>
 
-#include <variant>
+#include <optional>
 
 class IOutputStream;
 
 namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TNVMeLockdownConfig
+{
+private:
+    const NProto::TLocalNVMeConfig::TLockdownConfig Proto;
+
+public:
+    explicit TNVMeLockdownConfig(
+        const NProto::TLocalNVMeConfig::TLockdownConfig& proto);
+    ~TNVMeLockdownConfig();
+
+    [[nodiscard]] TVector<ui8> GetAllowedAdminOpcodes() const;
+    [[nodiscard]] TVector<ui8> GetAllowedSetFeatureIds() const;
+    [[nodiscard]] bool GetBlockLockdownCommand() const;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -28,6 +45,7 @@ public:
     [[nodiscard]] TString GetStateCacheFilePath() const;
     [[nodiscard]] TDuration GetUpdateDevicesInterval() const;
     [[nodiscard]] TDuration GetUpdateCountersInterval() const;
+    [[nodiscard]] std::optional<TNVMeLockdownConfig> GetLockdownConfig() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/blockstore/libs/local_nvme/config_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/config_ut.cpp
@@ -15,10 +15,50 @@ Y_UNIT_TEST_SUITE(TLocalNVMeConfigTest)
         NProto::TLocalNVMeConfig proto;
         proto.SetDevicesSourceUri("file:///etc/service/devices.txt");
 
-        TLocalNVMeConfigPtr config = std::make_shared<TLocalNVMeConfig>(proto);
-        UNIT_ASSERT_VALUES_EQUAL(
-            proto.GetDevicesSourceUri(),
-            config->GetDevicesSourceUri());
+        {
+            TLocalNVMeConfigPtr config =
+                std::make_shared<TLocalNVMeConfig>(proto);
+            UNIT_ASSERT_VALUES_EQUAL(
+                proto.GetDevicesSourceUri(),
+                config->GetDevicesSourceUri());
+
+            UNIT_ASSERT(!config->GetLockdownConfig());
+        }
+
+        const TVector<ui8> allowedAdminOpcodes{1, 2, 3};
+        const TVector<ui8> allowedSetFeatureIds{10, 20, 30};
+
+        {
+            auto& lockdownProto = *proto.MutableLockdownConfig();
+            lockdownProto.SetBlockLockdownCommand(true);
+            lockdownProto.MutableAllowedAdminOpcodes()->Assign(
+                allowedAdminOpcodes.begin(),
+                allowedAdminOpcodes.end());
+            lockdownProto.MutableAllowedSetFeatureIds()->Assign(
+                allowedSetFeatureIds.begin(),
+                allowedSetFeatureIds.end());
+        }
+
+        {
+            TLocalNVMeConfigPtr config =
+                std::make_shared<TLocalNVMeConfig>(proto);
+            UNIT_ASSERT_VALUES_EQUAL(
+                proto.GetDevicesSourceUri(),
+                config->GetDevicesSourceUri());
+
+            auto lockdown = config->GetLockdownConfig();
+
+            UNIT_ASSERT(lockdown);
+
+            UNIT_ASSERT(lockdown->GetBlockLockdownCommand());
+            UNIT_ASSERT_EQUAL(
+                allowedAdminOpcodes,
+                lockdown->GetAllowedAdminOpcodes());
+
+            UNIT_ASSERT_EQUAL(
+                allowedSetFeatureIds,
+                lockdown->GetAllowedSetFeatureIds());
+        }
     }
 }
 

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -20,6 +20,7 @@
 #include <util/generic/algorithm.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/scope.h>
+#include <util/stream/format.h>
 #include <util/stream/str.h>
 #include <util/string/builder.h>
 #include <util/system/fs.h>
@@ -64,6 +65,42 @@ TString Join(TStringBuf delim, const R& range)
     }
 
     return ss.Str();
+}
+
+TString FormatLockdownIds(const TVector<ui8>& ids)
+{
+    TStringBuilder out;
+    out << "[";
+
+    for (size_t i = 0; i < ids.size(); ++i) {
+        if (i) {
+            out << ", ";
+        }
+        out << Hex(ids[i], HF_ADDX);
+    }
+
+    out << "]";
+    return out;
+}
+
+TString FormatLockdownScopeState(const NNvme::TLockdownScopeState& state)
+{
+    return TStringBuilder()
+           << "{supported: " << FormatLockdownIds(state.Supported)
+           << ", prohibited: " << FormatLockdownIds(state.Prohibited) << "}";
+}
+
+TString FormatLockdownState(const NNvme::TLockdownState& state)
+{
+    if (!state.Supported) {
+        return "{supported: false}";
+    }
+
+    return TStringBuilder()
+           << "{supported: true"
+           << ", adminCmd: " << FormatLockdownScopeState(state.AdminCmd)
+           << ", featureId: " << FormatLockdownScopeState(state.FeatureId)
+           << "}";
 }
 
 // // xx:xx.x -> 0000:xx:xx.x
@@ -233,6 +270,12 @@ private:
         -> TResultOrError<TString>;
     auto GetDevice(const TSerialNumber& serialNumber)
         -> std::optional<NProto::TNVMeDevice>;
+
+    auto EnsureLockdown(const NProto::TNVMeDevice& device) const
+        -> NProto::TError;
+
+    auto GetLockdownState(const NProto::TNVMeDevice& device) const
+        -> TResultOrError<NNvme::TLockdownState>;
 
     auto StopImpl() -> TFuture<void>;
 
@@ -935,6 +978,13 @@ auto TLocalNVMeService::AcquireDeviceImpl(const TSerialNumber& serialNumber)
 
     UpdateStateCache();
 
+    if (auto error = EnsureLockdown(*device); HasError(error)) {
+        STORAGE_ERROR(
+            "Failed to ensure lockdown on NVMe device "
+            << serialNumber.Quote() << ": " << FormatError(error))
+        return error;
+    }
+
     if (auto error = BindDeviceToDriver(*device, "vfio-pci"); HasError(error)) {
         return error;
     }
@@ -1111,6 +1161,98 @@ auto TLocalNVMeService::GetDevice(const TSerialNumber& serialNumber)
     return *device;
 }
 
+auto TLocalNVMeService::GetLockdownState(
+    const NProto::TNVMeDevice& device) const
+    -> TResultOrError<NNvme::TLockdownState>
+{
+    auto r = SafeExecute<TResultOrError<NNvme::TLockdownState>>(
+        [&]
+        {
+            const auto ctrlPath = GetNVMeCtrlPath(device);
+
+            return NVMeManager->GetLockdownState(ctrlPath);
+        });
+
+    if (HasError(r)) {
+        return MakeError(
+            r.GetError().GetCode(),
+            TStringBuilder() << "Failed to get NVMe lockdown state for device "
+                             << device.GetSerialNumber().Quote() << ": "
+                             << FormatError(r.GetError()));
+    }
+
+    return r;
+}
+
+auto TLocalNVMeService::EnsureLockdown(const NProto::TNVMeDevice& device) const
+    -> NProto::TError
+{
+    const auto lockdownConfig = Config->GetLockdownConfig();
+
+    if (!lockdownConfig) {
+        return MakeError(S_FALSE, "Lockdown is not configured");
+    }
+
+    const auto& serialNumber = device.GetSerialNumber();
+
+    {
+        auto [state, error] = GetLockdownState(device);
+        if (HasError(error)) {
+            return error;
+        }
+
+        if (!state.Supported) {
+            STORAGE_INFO(
+                "Skip NVMe lockdown on device "
+                << serialNumber.Quote() << ": lockdown is not supported");
+
+            return MakeError(S_FALSE, "Lockdown is not supported");
+        }
+
+        STORAGE_INFO(
+            "Ensuring lockdown on NVMe device "
+            << serialNumber.Quote()
+            << ", state before: " << FormatLockdownState(state));
+    }
+
+    {
+        auto error = SafeExecute<NProto::TError>(
+            [&]
+            {
+                const auto ctrlPath = GetNVMeCtrlPath(device);
+
+                return NVMeManager->EnsureLockdown(
+                    ctrlPath,
+                    {
+                        .AllowedAdminOpcodes =
+                            lockdownConfig->GetAllowedAdminOpcodes(),
+                        .AllowedSetFeatureIds =
+                            lockdownConfig->GetAllowedSetFeatureIds(),
+                        .BlockLockdownCommand =
+                            lockdownConfig->GetBlockLockdownCommand(),
+                    });
+            });
+
+        if (HasError(error)) {
+            return error;
+        }
+    }
+
+    {
+        auto [state, error] = GetLockdownState(device);
+        if (HasError(error)) {
+            return error;
+        }
+
+        STORAGE_INFO(
+            "Lockdown ensured on NVMe device "
+            << serialNumber.Quote()
+            << ", state after: " << FormatLockdownState(state));
+    }
+
+    return {};
+}
+
 auto TLocalNVMeService::ReleaseDeviceImpl(const TSerialNumber& serialNumber)
     -> NProto::TError
 {
@@ -1131,8 +1273,16 @@ auto TLocalNVMeService::ReleaseDeviceImpl(const TSerialNumber& serialNumber)
         if (HasError(error)) {
             return error;
         }
-
         device = newDevice;
+    }
+
+    if (auto [state, error] = GetLockdownState(*device); HasError(error)) {
+        STORAGE_ERROR(FormatError(error));
+    } else {
+        STORAGE_INFO(
+            "NVMe lockdown state for device "
+            << device->GetSerialNumber().Quote() << ": "
+            << FormatLockdownState(state));
     }
 
     if (auto error = SanitizeNVMeDevice(*device); HasError(error)) {

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -43,6 +43,8 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 const TDuration DefaultTimeout = 5s;
+const ui8 AllowedAdminOpcodes[] = {0x1, 0x2, 0x3, 0xB};
+const ui8 AllowedSetFeatureIds[] = {0x1, 0x4, 0x5};
 
 struct TTestLocalNVMeDeviceProvider final: ILocalNVMeDeviceProvider
 {
@@ -77,15 +79,38 @@ struct TSanitizeInfo: TSanitizeStatus
     ui32 Count = 0;
 };
 
+struct TLockdownImpl
+{
+    std::function<TResultOrError<TLockdownState>(const TString& ctrlPath)>
+        GetLockdownState = [](const TString&)
+    {
+        return TLockdownState{.Supported = false};
+    };
+
+    std::function<
+        NProto::TError(const TString& ctrlPath, const TLockdownConfig& config)>
+        EnsureLockdown = [](const TString&, const NNvme::TLockdownConfig&)
+    {
+        return MakeError(
+            MAKE_SYSTEM_ERROR(ENOTSUP),
+            "Lockdown command is not supported");
+    };
+};
+
 class TTestNVMeManager: public INvmeManager
 {
 private:
     std::mutex Mutex;
     THashMap<TString, TSanitizeInfo> SanitizeInfo;
+    std::shared_ptr<TLockdownImpl> LockdownImpl;
 
     TAutoEvent SanitizeRequested;
 
 public:
+    explicit TTestNVMeManager(std::shared_ptr<TLockdownImpl> lockdownImpl)
+        : LockdownImpl(std::move(lockdownImpl))
+    {}
+
     void Start() final
     {}
 
@@ -167,18 +192,16 @@ public:
     TResultOrError<TLockdownState> GetLockdownState(
         const TString& ctrlPath) final
     {
-        Y_UNUSED(ctrlPath);
-
-        return TLockdownState{};
+        std::unique_lock lock{Mutex};
+        return LockdownImpl->GetLockdownState(ctrlPath);
     }
 
     NProto::TError EnsureLockdown(
         const TString& ctrlPath,
         const TLockdownConfig& config) final
     {
-        Y_UNUSED(ctrlPath, config);
-
-        return {};
+        std::unique_lock lock{Mutex};
+        return LockdownImpl->EnsureLockdown(ctrlPath, config);
     }
 
 public:
@@ -268,6 +291,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
     TLocalNVMeConfigPtr Config;
     ILoggingServicePtr Logging;
     IMonitoringServicePtr Monitoring;
+    std::shared_ptr<TLockdownImpl> LockdownImpl;
     std::shared_ptr<TTestNVMeManager> NVMeManager;
     TExecutorPtr Executor;
     ITaskQueuePtr BackgroundThreadPool;
@@ -289,7 +313,8 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
         Monitoring = CreateMonitoringServiceStub();
         Monitoring->Start();
 
-        NVMeManager = std::make_shared<TTestNVMeManager>();
+        LockdownImpl = std::make_shared<TLockdownImpl>();
+        NVMeManager = std::make_shared<TTestNVMeManager>(LockdownImpl);
 
         BackgroundThreadPool = CreateLongRunningTaskExecutor("BG");
         BackgroundThreadPool->Start();
@@ -393,6 +418,18 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
         proto.SetStateCacheFilePath(StateCacheFile);
         proto.SetUpdateDevicesInterval(TDuration(1s).MilliSeconds());
         proto.SetUpdateCountersInterval(TDuration(100ms).MilliSeconds());
+
+        auto& lockdownConfig = *proto.MutableLockdownConfig();
+
+        lockdownConfig.MutableAllowedAdminOpcodes()->Assign(
+            std::begin(AllowedAdminOpcodes),
+            std::end(AllowedAdminOpcodes));
+
+        lockdownConfig.MutableAllowedSetFeatureIds()->Assign(
+            std::begin(AllowedSetFeatureIds),
+            std::end(AllowedSetFeatureIds));
+
+        lockdownConfig.SetBlockLockdownCommand(true);
 
         Config = std::make_shared<TLocalNVMeConfig>(proto);
     }
@@ -1754,6 +1791,159 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 UNIT_ASSERT(revisionCounter);
                 UNIT_ASSERT_VALUES_EQUAL(1, revisionCounter->Val());
             }
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldLockdownDevices, TFixture)
+    {
+        const TString vfioDev = "vfio0";
+        const TString ctrlPath = "/dev/nvme0";
+        const auto& device = Devices[0];
+
+        const TVector<ui8>
+            supportedAdminOpcodes{0x1, 0x2, 0x3, 0x4, 0x5, 0xA, 0xB};
+        const TVector<ui8>
+            supportedSetFeatureIds{0x1, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8};
+
+        const TVector<ui8> prohibitedAdminOpcodesBeforeLockdown{0x4};
+        const TVector<ui8> prohibitedSetFeatureIdsBeforeLockdown{0x7};
+
+        const TVector<ui8> prohibitedAdminOpcodesAfterLockdown{0x4, 0x5, 0xA};
+        const TVector<ui8> prohibitedSetFeatureIdsAfterLockdown{
+            0x3,
+            0x6,
+            0x7,
+            0x8};
+
+        SysFs->GetVfioDeviceForPCIDeviceImpl =
+            [&](const TString& pciAddr) -> TString
+        {
+            if (pciAddr == device.GetPCIAddress()) {
+                return vfioDev;
+            }
+            return {};
+        };
+
+        TLockdownState lockdownState{
+            .Supported = true,
+            .AdminCmd =
+                {
+                    .Supported = supportedAdminOpcodes,
+                    .Prohibited = prohibitedAdminOpcodesBeforeLockdown,
+                },
+            .FeatureId =
+                {
+                    .Supported = supportedSetFeatureIds,
+                    .Prohibited = prohibitedSetFeatureIdsBeforeLockdown,
+                },
+        };
+
+        LockdownImpl->GetLockdownState =
+            [&](const auto& path) -> TResultOrError<TLockdownState>
+        {
+            if (path != ctrlPath) {
+                return MakeError(E_ARGUMENT, "Unexpected path");
+            }
+
+            return lockdownState;
+        };
+
+        LockdownImpl->EnsureLockdown =
+            [&](const auto& path, const TLockdownConfig& config)
+        {
+            if (!std::ranges::equal(
+                    AllowedAdminOpcodes,
+                    config.AllowedAdminOpcodes))
+            {
+                return MakeError(E_ARGUMENT, "Unexpected AllowedAdminOpcodes");
+            }
+
+            if (!std::ranges::equal(
+                    AllowedSetFeatureIds,
+                    config.AllowedSetFeatureIds))
+            {
+                return MakeError(E_ARGUMENT, "Unexpected AllowedSetFeatureIds");
+            }
+
+            if (!config.BlockLockdownCommand) {
+                return MakeError(E_ARGUMENT, "Unexpected BlockLockdownCommand");
+            }
+
+            if (path != ctrlPath) {
+                return MakeError(E_ARGUMENT, "Unexpected path");
+            }
+
+            lockdownState.AdminCmd.Prohibited =
+                prohibitedAdminOpcodesAfterLockdown;
+            lockdownState.FeatureId.Prohibited =
+                prohibitedSetFeatureIdsAfterLockdown;
+
+            return MakeError(S_OK);
+        };
+
+        SetProviderReady();
+
+        {
+            auto future = Service->AcquireNVMeDevice(
+                device.GetSerialNumber(),
+                EmptyIdempotenceId);
+            const auto& [_, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldFailAcquireWhenLockdownFails, TFixture)
+    {
+        const TString vfioDev = "vfio0";
+        const TString ctrlPath = "/dev/nvme0";
+        const auto& device = Devices[0];
+
+        SysFs->GetVfioDeviceForPCIDeviceImpl =
+            [&](const TString& pciAddr) -> TString
+        {
+            if (pciAddr == device.GetPCIAddress()) {
+                return vfioDev;
+            }
+            return {};
+        };
+
+        const TLockdownState lockdownState{
+            .Supported = true,
+            .AdminCmd = {.Supported = {0x1, 0x2, 0x3, 0x4, 0x5, 0xA, 0xB}},
+            .FeatureId = {.Supported = {0x1, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}},
+        };
+
+        LockdownImpl->GetLockdownState =
+            [&](const auto& path) -> TResultOrError<TLockdownState>
+        {
+            if (path == ctrlPath) {
+                return lockdownState;
+            }
+
+            return TLockdownState{};
+        };
+
+        const auto lockdownError = MakeError(E_INVALID_STATE, "test");
+
+        LockdownImpl->EnsureLockdown = [&](const auto&, const TLockdownConfig&)
+        {
+            return lockdownError;
+        };
+
+        SetProviderReady();
+
+        {
+            auto future = Service->AcquireNVMeDevice(
+                device.GetSerialNumber(),
+                EmptyIdempotenceId);
+            const auto& [_, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                lockdownError.GetCode(),
+                error.GetCode(),
+                FormatError(error));
         }
     }
 

--- a/cloud/blockstore/libs/nvme/nvme.h
+++ b/cloud/blockstore/libs/nvme/nvme.h
@@ -20,6 +20,31 @@ struct TSanitizeStatus
     double Progress = 0;
 };
 
+struct TLockdownConfig
+{
+    TVector<ui8> AllowedAdminOpcodes;
+    TVector<ui8> AllowedSetFeatureIds;
+    bool BlockLockdownCommand = false;
+};
+
+struct TLockdownScopeState
+{
+    // Identifier may be prohibited using Command and Feature Lockdown.
+    TVector<ui8> Supported;
+
+    // Identifier is currently prohibited.
+    TVector<ui8> Prohibited;
+};
+
+struct TLockdownState
+{
+    // Command and Feature Lockdown is supported by the controller.
+    bool Supported = false;
+
+    TLockdownScopeState AdminCmd;
+    TLockdownScopeState FeatureId;
+};
+
 struct INvmeManager: public IStartable
 {
     virtual NThreading::TFuture<NProto::TError> Format(
@@ -41,31 +66,6 @@ struct INvmeManager: public IStartable
     virtual NProto::TError ResetToSingleNamespace(const TString& ctrlPath) = 0;
 
     virtual TResultOrError<TString> GetDeviceModel(const TString& path) = 0;
-
-    struct TLockdownConfig
-    {
-        TVector<ui8> AllowedAdminOpcodes;
-        TVector<ui8> AllowedSetFeatureIds;
-        bool BlockLockdownCommand = false;
-    };
-
-    struct TLockdownScopeState
-    {
-        // Identifier may be prohibited using Command and Feature Lockdown.
-        TVector<ui8> Supported;
-
-        // Identifier is currently prohibited.
-        TVector<ui8> Prohibited;
-    };
-
-    struct TLockdownState
-    {
-        // Command and Feature Lockdown is supported by the controller.
-        bool Supported = false;
-
-        TLockdownScopeState AdminCmd;
-        TLockdownScopeState FeatureId;
-    };
 
     virtual TResultOrError<TLockdownState> GetLockdownState(
         const TString& ctrlPath) = 0;

--- a/cloud/blockstore/libs/nvme/utils_ut.cpp
+++ b/cloud/blockstore/libs/nvme/utils_ut.cpp
@@ -3,6 +3,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/random/shuffle.h>
+#include <util/stream/format.h>
 #include <util/string/join.h>
 
 #include <array>

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -199,17 +199,17 @@ struct TTestNvmeManager: NNvme::INvmeManager
         return {};
     }
 
-    TResultOrError<TLockdownState> GetLockdownState(
+    TResultOrError<NNvme::TLockdownState> GetLockdownState(
         const TString& ctrlPath) final
     {
         Y_UNUSED(ctrlPath);
 
-        return TLockdownState{};
+        return NNvme::TLockdownState{};
     }
 
     NProto::TError EnsureLockdown(
         const TString& ctrlPath,
-        const TLockdownConfig& config) final
+        const NNvme::TLockdownConfig& config) final
     {
         Y_UNUSED(ctrlPath, config);
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -129,17 +129,17 @@ struct TTestNvmeManager
         return {};
     }
 
-    TResultOrError<TLockdownState> GetLockdownState(
+    TResultOrError<NNvme::TLockdownState> GetLockdownState(
         const TString& ctrlPath) final
     {
         Y_UNUSED(ctrlPath);
 
-        return TLockdownState{};
+        return NNvme::TLockdownState{};
     }
 
     NProto::TError EnsureLockdown(
         const TString& ctrlPath,
-        const TLockdownConfig& config) final
+        const NNvme::TLockdownConfig& config) final
     {
         Y_UNUSED(ctrlPath, config);
 

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -116,17 +116,17 @@ struct TTestNvmeManager
         return {};
     }
 
-    TResultOrError<TLockdownState> GetLockdownState(
+    TResultOrError<NNvme::TLockdownState> GetLockdownState(
         const TString& ctrlPath) final
     {
         Y_UNUSED(ctrlPath);
 
-        return TLockdownState{};
+        return NNvme::TLockdownState{};
     }
 
     NProto::TError EnsureLockdown(
         const TString& ctrlPath,
-        const TLockdownConfig& config) final
+        const NNvme::TLockdownConfig& config) final
     {
         Y_UNUSED(ctrlPath, config);
 


### PR DESCRIPTION
Adds configurable NVMe Command and Feature Lockdown enforcement to the Local NVMe service.

* Adds optional `LockdownConfig` with allowlists for Admin Command opcodes and `Set Features` identifiers.
* Applies the policy only to NVMe devices that support the Lockdown command.
* Prohibits supported commands/features that are not explicitly allowed by the configuration.
* Optionally prohibits the Lockdown command itself after the rest of the policy has been applied.
* Keeps the existing behavior unchanged when `LockdownConfig` is not specified.
* Adds configuration handling and unit test coverage for the new lockdown policy.