### PR TITLE
Update YA_REGISTRY_ENDPOINT to new storage URL

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -48,10 +48,6 @@ inputs:
     required: false
     default: ""
     description: "ya make target platform"
-  ya_registry_endpoint:
-    required: false
-    default: "https://devtools-registry.s3.yandex.net"
-    description: "Ya tool mirror endpoint"
 outputs:
   build_error_log_url:
     description: "URL to Markdown summary of ya build errors"
@@ -100,7 +96,6 @@ runs:
       id: build
       shell: bash --noprofile --norc -eo pipefail -x {0}
       env:
-        YA_REGISTRY_ENDPOINT: ${{ inputs.ya_registry_endpoint }}
         NETWORK_RETRY_ATTEMPTS: ${{ inputs.network_retry_attempts }}
         BUILD_PRESET: ${{ inputs.build_preset }}
         BUILD_TARGET: ${{ inputs.build_target }}

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -83,10 +83,6 @@ inputs:
     required: false
     default: "/mnt/ya_make_tmpfs"
     description: "Mount point path for the tmpfs filesystem"
-  ya_registry_endpoint:
-    required: false
-    default: "https://devtools-registry.s3.yandex.net"
-    description: "Ya tool mirror endpoint"
 outputs:
   failed_tests:
     description: "List of failed tests"
@@ -163,7 +159,6 @@ runs:
       id: check_test_results
       shell: bash --noprofile --norc -eo pipefail -x {0}
       env:
-        YA_REGISTRY_ENDPOINT: ${{ inputs.ya_registry_endpoint }}
         NUMBER_OF_RETRIES: ${{ inputs.number_of_retries }}
         TEST_TIMEOUT_MINUTES: ${{ inputs.test_timeout_minutes }}
         TEST_BUDGET_MINUTES: ${{ inputs.test_budget_minutes }}

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -205,7 +205,6 @@ jobs:
         clean_ya_dir: ${{ inputs.clean_ya_dir }}
         use_network_cache: ${{ inputs.use_network_cache }}
         target_platform: ${{ inputs.target_platform }}
-        ya_registry_endpoint: ${{ vars.NEBIUS_YA_TOOL_MIRROR || 'https://devtools-registry.s3.yandex.net' }}
 
     - name: Run tests
       uses: ./.github/actions/test
@@ -231,7 +230,6 @@ jobs:
         test_timeout_minutes: ${{ inputs.test_timeout_minutes || '390' }}
         build_duration_seconds: ${{ steps.build.outputs.build_duration_seconds || '0' }}
         truncate_enabled: ${{ inputs.truncate_enabled }}
-        ya_registry_endpoint: ${{ vars.NEBIUS_YA_TOOL_MIRROR || 'https://devtools-registry.s3.yandex.net' }}
 
     - name: mark workload build failed
       if: ${{ failure() && steps.build.outcome == 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -205,7 +205,6 @@ jobs:
         clean_ya_dir: ${{ inputs.clean_ya_dir }}
         use_network_cache: ${{ inputs.use_network_cache }}
         target_platform: ${{ inputs.target_platform }}
-        ya_registry_endpoint: ${{ vars.NEBIUS_YA_TOOL_MIRROR || 'https://devtools-registry.s3.yandex.net' }}
 
     - name: Run tests
       uses: ./.github/actions/test
@@ -231,7 +230,6 @@ jobs:
         test_timeout_minutes: ${{ inputs.test_timeout_minutes || '390' }}
         build_duration_seconds: ${{ steps.build.outputs.build_duration_seconds || '0' }}
         truncate_enabled: ${{ inputs.truncate_enabled }}
-        ya_registry_endpoint: ${{ vars.NEBIUS_YA_TOOL_MIRROR || 'https://devtools-registry.s3.yandex.net' }}
 
     - name: mark workload build failed
       if: ${{ failure() && steps.build.outcome == 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -230,7 +230,6 @@ jobs:
         clean_ya_dir: ${{ inputs.clean_ya_dir }}
         use_network_cache: ${{ inputs.use_network_cache }}
         target_platform: ${{ inputs.target_platform }}
-        ya_registry_endpoint: ${{ vars.NEBIUS_YA_TOOL_MIRROR || 'https://devtools-registry.s3.yandex.net' }}
 
     - name: Run tests
       uses: ./.github/actions/test
@@ -256,7 +255,6 @@ jobs:
         test_timeout_minutes: ${{ inputs.test_timeout_minutes || '390' }}
         build_duration_seconds: ${{ steps.build.outputs.build_duration_seconds || '0' }}
         truncate_enabled: ${{ inputs.truncate_enabled }}
-        ya_registry_endpoint: ${{ vars.NEBIUS_YA_TOOL_MIRROR || 'https://devtools-registry.s3.yandex.net' }}
 
     - name: mark workload build failed
       if: ${{ failure() && steps.build.outcome == 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
@@ -457,7 +455,6 @@ jobs:
           use_network_cache: ${{ inputs.use_network_cache }}
           number_of_retries: ${{ inputs.number_of_retries }}
           test_timeout_minutes: ${{ inputs.test_timeout_minutes || '390' }}
-          ya_registry_endpoint: ${{ vars.NEBIUS_YA_TOOL_MIRROR || 'https://devtools-registry.s3.yandex.net' }}
 
       - name: mark workload retry as cancelled
         if: ${{ cancelled() && steps.test.outputs.report_generated != 'yes' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}

--- a/ya
+++ b/ya
@@ -32,7 +32,7 @@ def add_stage_start_to_environ(stage_name):
 RETRIES = 5
 HASH_PREFIX = 10
 
-REGISTRY_ENDPOINT = os.environ.get("YA_REGISTRY_ENDPOINT", "https://devtools-registry.s3.yandex.net")
+REGISTRY_ENDPOINT = os.environ.get("YA_REGISTRY_ENDPOINT", "https://storage.eu-north2.nebius.cloud/nbs-yatool-resources")
 
 # Please do not change this dict, it is updated automatically
 # Start of mapping


### PR DESCRIPTION
Currently it is overriden by env variable in github runners workflows. It makes sense to just replace it here simply from usability standpoint