### PR TITLE
[NBS, Filestore] Fix vhost logger destruction order

### DIFF
--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -16,7 +16,11 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TLog VhostLog;
+TLog& GetVhostLog()
+{
+    // Destroy the log before the global log backend registry.
+    return *Singleton<TLog>();
+}
 
 ELogPriority GetLogPriority(LogLevel level)
 {
@@ -33,9 +37,10 @@ void vhd_log(LogLevel level, const char* format, ...)
     va_list params;
     va_start(params, format);
 
+    auto& log = GetVhostLog();
     ELogPriority priority = GetLogPriority(level);
-    if (priority <= VhostLog.FiltrationLevel()) {
-        Printf(VhostLog << priority << ": ", format, params);
+    if (priority <= log.FiltrationLevel()) {
+        Printf(log << priority << ": ", format, params);
     }
 
     va_end(params);
@@ -196,10 +201,10 @@ public:
 
         auto result = NewPromise<NProto::TError>();
 
-        auto& Log = VhostLog;
+        auto& Log = GetVhostLog();
         STORAGE_INFO("vhd_unregister_blockdev starting: " << SocketPath);
         result.GetFuture().Apply([socketPath = SocketPath] (const auto& future) {
-            auto& Log = VhostLog;
+            auto& Log = GetVhostLog();
             STORAGE_INFO("vhd_unregister_blockdev completed: " << socketPath);
             return future;
         });
@@ -239,7 +244,7 @@ private:
 
 public:
     TVhostQueue()
-        : Log(VhostLog)
+        : Log(GetVhostLog())
     {
         VhdRequestQueue = vhd_create_request_queue();
     }
@@ -384,7 +389,7 @@ public:
 
 void InitVhostLog(ILoggingServicePtr logging)
 {
-    VhostLog = logging->CreateLog("BLOCKSTORE_VHOST");
+    GetVhostLog() = logging->CreateLog("BLOCKSTORE_VHOST");
 }
 
 IVhostQueueFactoryPtr CreateVhostQueueFactory()

--- a/cloud/filestore/libs/vhost/server.cpp
+++ b/cloud/filestore/libs/vhost/server.cpp
@@ -6,13 +6,19 @@
 
 #include <library/cpp/logger/log.h>
 
+#include <util/generic/singleton.h>
+
 namespace NCloud::NFileStore::NVhost {
 
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TLog VhostLog;
+TLog& GetVhostLog()
+{
+    // Destroy the log before the global log backend registry.
+    return *Singleton<TLog>();
+}
 
 ELogPriority GetLogPriority(LogLevel level)
 {
@@ -29,9 +35,10 @@ void vhd_log(LogLevel level, const char* format, ...)
     va_list params;
     va_start(params, format);
 
+    auto& log = GetVhostLog();
     ELogPriority priority = GetLogPriority(level);
-    if (priority <= VhostLog.FiltrationLevel()) {
-        Printf(VhostLog << priority << ": ", format, params);
+    if (priority <= log.FiltrationLevel()) {
+        Printf(log << priority << ": ", format, params);
     }
 
     va_end(params);
@@ -43,7 +50,7 @@ void vhd_log(LogLevel level, const char* format, ...)
 
 void InitLog(ILoggingServicePtr logging)
 {
-    VhostLog = logging->CreateLog("NFS_VHOST");
+    GetVhostLog() = logging->CreateLog("NFS_VHOST");
 }
 
 void StartServer()


### PR DESCRIPTION
### Motivation
Global `TLog` objects could be destroyed after `TGlobalLogsStorage`. In that case, `TLogBackend::~TLogBackend()` attempted to unregister the backend using an already destroyed mutex, causing `mutex lock failure (Invalid argument)`

### Notes

Replace global vhost `TLog` instances with singleton-backed accessors in Blockstore and Filestore. Using the singleton destruction mechanism ensures that vhost log backends are destroyed before the global log backend registry. 
* `TLog` now is created as `Singleton` with default `Priority = 65536`
* `TGlobalLogsStorage` has `Priority = 50`

### Issue

#6838 