### PR TITLE
issue-5895: fastshard layout tablet monpage

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -679,6 +679,10 @@ private:
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
+    void HandleHttpInfo_FastShardLayout(
+        const NActors::TActorContext& ctx,
+        const TCgiParameters& params,
+        TRequestInfoPtr requestInfo);
 
     //
     // Custom event handlers.

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -992,6 +992,7 @@ void TIndexTabletActor::HandleHttpInfo(
         {"dumpRange",       &TIndexTabletActor::HandleHttpInfo_DumpCompactionRange },
         {"dirViewer",       &TIndexTabletActor::HandleHttpInfo_DirViewer },
         {"locks",           &TIndexTabletActor::HandleHttpInfo_Locks },
+        {"fastShardLayout", &TIndexTabletActor::HandleHttpInfo_FastShardLayout },
     }};
 
     const auto* msg = ev->Get();
@@ -1077,6 +1078,13 @@ void TIndexTabletActor::RenderHttpInfo_OverviewTab(
         TAG(TH3) {
             out << "<a href='?TabletID=" << TabletID()
                 << "&action=locks'>Locks</a>";
+        }
+
+        if (GetFileSystem().GetIsFastShard()) {
+            TAG(TH3) {
+                out << "<a href='?TabletID=" << TabletID()
+                    << "&action=fastShardLayout'>Fast Shard Layout</a>";
+            }
         }
 
         const auto& shardIds = GetFileSystem().GetShardFileSystemIds();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_fastshard_layout.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_fastshard_layout.cpp
@@ -1,0 +1,53 @@
+#include "tablet_actor.h"
+
+#include <util/stream/str.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+using namespace NActors::NMon;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleHttpInfo_FastShardLayout(
+    const NActors::TActorContext& ctx,
+    const TCgiParameters& params,
+    TRequestInfoPtr requestInfo)
+{
+    Y_UNUSED(params);
+
+    //
+    // The layout page exists only for fast shards (Adapter mode). The
+    // FastShard check protects against a race with state loading: the
+    // shard instance appears only after CompleteAdapterLoadState.
+    //
+
+    if (!GetFileSystem().GetIsFastShard() || !FastShard) {
+        const TString message = "tablet is not a fast shard";
+        LOG_ERROR_S(
+            ctx,
+            TFileStoreComponents::TABLET,
+            LogTag << " " << message);
+        NCloud::Reply(
+            ctx,
+            *requestInfo,
+            std::make_unique<TEvRemoteHttpInfoRes>(message));
+        return;
+    }
+
+    //
+    // DumpLayoutHtml is synchronous and does no IO - the layout is
+    // fixed after the shard construction - so no worker actor is
+    // needed here, unlike in the Directory Viewer.
+    //
+
+    TStringStream out;
+    FastShard->DumpLayoutHtml(out);
+
+    NCloud::Reply(
+        ctx,
+        *requestInfo,
+        std::make_unique<TEvRemoteHttpInfoRes>(std::move(out.Str())));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_monitoring.cpp
@@ -31,6 +31,60 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Monitoring)
         auto response = tablet.GetRemoteHttpInfo();
         // check that it was served by user part of the tablet
         UNIT_ASSERT(response->Html.Contains("Filesystem Id:"));
+
+        //
+        // A regular tablet neither shows the fast shard layout link nor
+        // serves the page.
+        //
+
+        UNIT_ASSERT(!response->Html.Contains("action=fastShardLayout"));
+
+        response = tablet.GetRemoteHttpInfo("action=fastShardLayout");
+        UNIT_ASSERT_C(
+            response->Html.Contains("not a fast shard"),
+            response->Html);
+    }
+
+    Y_UNIT_TEST(ShouldHandleHttpInfo_FastShardLayout)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        tablet.ConfigureAsShard(
+            1 /* shardNo */,
+            "main_fs",
+            "main_fs_s1",
+            false /* directoryCreationInShardsEnabled */,
+            TVector<TString>() /* shardIds */,
+            NProtoPrivate::TFastShardConfig(),
+            true /* isFastShard */);
+
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+
+        auto response = tablet.GetRemoteHttpInfo();
+        UNIT_ASSERT_C(
+            response->Html.Contains("action=fastShardLayout"),
+            response->Html);
+
+        //
+        // The tablet is configured with the mem shard, whose layout
+        // dump is empty by design - the page contents are covered by
+        // the naive mirrored shard's own tests. Here we only check
+        // that the action is served and not rejected.
+        //
+
+        response = tablet.GetRemoteHttpInfo("action=fastShardLayout");
+        UNIT_ASSERT_C(
+            !response->Html.Contains("not a fast shard"),
+            response->Html);
+        UNIT_ASSERT_C(
+            !response->Html.Contains("alert-danger"),
+            response->Html);
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -56,6 +56,7 @@ SRCS(
     tablet_actor_loadstate_nodes.cpp
     tablet_actor_monitoring.cpp
     tablet_actor_monitoring_directory_viewer.cpp
+    tablet_actor_monitoring_fastshard_layout.cpp
     tablet_actor_monitoring_locks.cpp
     tablet_actor_oplog.cpp
     tablet_actor_quota.cpp

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -1133,10 +1133,13 @@ public:
     // Monitoring Http Info
     //
 
-    void SendRemoteHttpInfoRequest(const TString& query = {})
+    void SendRemoteHttpInfoRequest(
+        const TString& query = {},
+        HTTP_METHOD method = HTTP_METHOD_GET)
     {
         auto request = std::make_unique<NImpl::TEvRemoteHttpInfoRequest>(
-            "/app?" + query);
+            "/app?" + query,
+            method);
         SendRequest(std::move(request));
     }
 
@@ -1145,9 +1148,11 @@ public:
         return RecvResponse<NImpl::TEvRemoteHttpInfoResponse>();
     }
 
-    std::unique_ptr<NImpl::TEvRemoteHttpInfoResponse> GetRemoteHttpInfo(TString query = {})
+    std::unique_ptr<NImpl::TEvRemoteHttpInfoResponse> GetRemoteHttpInfo(
+        TString query = {},
+        HTTP_METHOD method = HTTP_METHOD_GET)
     {
-        SendRemoteHttpInfoRequest(std::move(query));
+        SendRemoteHttpInfoRequest(std::move(query), method);
         return RecvRemoteHttpInfoResponse();
     }
 


### PR DESCRIPTION
### Notes
Adding fastshard layout monpage. Layout html/json was implemented here: https://github.com/ydb-platform/nbs/pull/6800

<img width="749" height="361" alt="image" src="https://github.com/user-attachments/assets/747bce1d-209e-44f0-b44c-3301400a8725" />

### Issue
https://github.com/ydb-platform/nbs/issues/5895
