### PR TITLE
issue-5895: fastshard local setup scripts and manual

### DIFF
--- a/cloud/filestore/FASTSHARD.md
+++ b/cloud/filestore/FASTSHARD.md
@@ -1,0 +1,77 @@
+# Persistent fastshards in the local setup
+
+Fastshard is the YDB-BlobStorage-free storage backend for file shards (see
+[doc/filestore/design/storage/fastshard](../../doc/filestore/design/storage/fastshard/README.md)).
+This document lists the extra steps needed to run the local filestore setup
+([README.md](README.md)) with persistent fastshards, whose devices are hosted
+by blockstore-disk-agent from the [example](../../example) NBS setup.
+
+## Prerequisites
+
+* the local filestore setup is up and running as described in
+  [README.md](README.md) - its ydbd will also serve as the storage node for
+  NBS, do not start a second one
+* NBS binaries are built:
+
+```bash
+./ya make --build=profile -- cloud/blockstore/buildall
+```
+
+## 1. Enable the fastshard runtime
+
+Add to `cloud/filestore/bin/nfs/nfs-storage.txt`:
+
+```
+FastShardRuntimeEnabled: true
+```
+
+and restart filestore-server. Without this flag persistent fastshard configs
+silently degrade to stub shards.
+
+## 2. Launch the NBS example on the shared ydbd
+
+```bash
+cd example
+
+# prepare dirs, certs, device files and configs; the generated disk agent
+# configs include JournalledDeviceTcpServerListenAddress - the journalled
+# device servers fastshard talks to
+./0-setup.sh
+
+# do NOT run 1-start_storage.sh - the filestore ydbd on grpc://localhost:9001
+# is the storage node
+
+# create the /Root/NBS tenant on the running storage node
+./2-init_nbs_storage_tenant.sh
+
+# start nbsd (keep the tab open)
+./3-start_nbs.sh
+
+# start the disk agents (keep the tab open); the port override is needed
+# because agent 0 would otherwise collide with filestore-vhost on 29012
+IC_PORT=29600 ./4-start_disk_agent.sh
+```
+
+## 3. Create the filesystem and configure fastshards
+
+```bash
+cd cloud/filestore/bin
+
+./initctl.sh create
+./configurefastshards.py
+./initctl.sh mount
+```
+
+`configurefastshards.py` creates one mirrored NBS volume (`fastshard0`) as an
+allocation holder, reads its device layout from the DiskRegistry and turns
+the trailing shards of the filesystem into persistent fastshards - shard k
+mirrors across the k-th device of every replica of the volume. Run it with
+`--help` for the knobs (shard counts, ports, volume geometry).
+
+## Notes
+
+* the `fastshard0` volume must never be mounted - fastshards write to its
+  devices directly over the journalled device protocol
+* monitoring: filestore-server http://localhost:8767, nbsd
+  http://localhost:8766/blockstore/service, disk agents
+  http://localhost:9100..9104/blockstore/disk_agent

--- a/cloud/filestore/bin/configurefastshards.py
+++ b/cloud/filestore/bin/configurefastshards.py
@@ -190,9 +190,11 @@ def configure_shards(args, groups):
         shard_no = i + 1
         is_fast = shard_id in file_shard_ids
         if is_fast:
+            # The pair index is the shard position counted from the tail,
+            # so reconfiguring with a different file-shard-count never
+            # reassigns devices of the shards that stay file shards.
             fast_config = {"PersistentConfig": {
-                "StorageGroups":
-                    groups[i - (args.shard_count - args.file_shard_count)],
+                "StorageGroups": groups[args.shard_count - shard_no],
                 "NodesPerGroup": args.nodes_per_group,
                 "ExpectedGroupCapacity": args.group_capacity,
             }}

--- a/cloud/filestore/bin/configurefastshards.py
+++ b/cloud/filestore/bin/configurefastshards.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+#
+# Reconfigures the last FILE_SHARD_COUNT of the SHARD_COUNT shards created by
+# 'initctl.sh create' as file shards backed by persistent fastshard, same
+# scheme as cloud/filestore/tests/python/lib/fastshard.py.
+#
+# Device provisioning: creates one mirrored NBS volume (the example/ NBS setup
+# must be running: nbsd + disk agents with
+# JournalledDeviceTcpServerListenAddress configured), reads its device layout
+# from the DiskRegistry and pairs the k-th device of every replica into the
+# k-th fastshard storage group - so each file shard mirrors across the same
+# devices NBS allocated for the volume. The volume itself is only an
+# allocation holder and must not be mounted.
+#
+# Requires FastShardRuntimeEnabled: true in nfs/nfs-storage.txt.
+#
+# All options can be set via the same environment variables the other bin/
+# scripts use (FS, SHARD_COUNT, SERVER_PORT, ...) or via command line flags.
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+BIN_DIR = os.path.dirname(os.path.realpath(__file__))
+
+DEFAULT_BLOCKSTORE_CLIENT = \
+    os.path.normpath(os.path.join(BIN_DIR, "blockstore-client"))
+
+
+def parse_args():
+    def env(name, default):
+        return os.environ.get(name, default)
+
+    p = argparse.ArgumentParser(
+        description="configure persistent fastshard file shards on top of "
+                    "devices of a mirrored NBS volume")
+    p.add_argument(
+        "--fs", default=env("FS", "nfs"),
+        help="main filesystem id")
+    p.add_argument(
+        "--shard-count", type=int, default=int(env("SHARD_COUNT", "8")),
+        help="total shard count of the filesystem")
+    p.add_argument(
+        "--file-shard-count", type=int,
+        default=int(env("FILE_SHARD_COUNT", "0")),
+        help="number of trailing shards to turn into fastshard file shards"
+             " (default: shard-count - 1, the maximum the tablet allows)")
+    p.add_argument(
+        "--server-port", default=env("SERVER_PORT", "9021"),
+        help="filestore-server port")
+    p.add_argument(
+        "--nbs-server-port", default=env("NBS_SERVER_PORT", "9766"),
+        help="nbsd server port")
+    p.add_argument(
+        "--blockstore-client",
+        default=env("BLOCKSTORE_CLIENT", DEFAULT_BLOCKSTORE_CLIENT),
+        help="path to the blockstore-client binary")
+    p.add_argument(
+        "--disk-id", default=env("FASTSHARD_DISK_ID", "fastshard0"),
+        help="disk id of the allocation-holder volume")
+    p.add_argument(
+        "--media-kind", default=env("FASTSHARD_MEDIA_KIND", "mirror2"),
+        help="storage media kind of the volume (mirror2|mirror3)")
+    p.add_argument(
+        "--blocks-per-shard", type=int,
+        default=int(env("FASTSHARD_BLOCKS_PER_SHARD", "262144")),
+        help="volume blocks (4KiB) per file shard; the default is 1GiB -"
+             " one allocation unit of the example/ setup")
+    p.add_argument(
+        "--nodes-per-group", type=int,
+        default=int(env("FASTSHARD_NODES_PER_GROUP", "10000")),
+        help="NodesPerGroup for the fastshard config")
+    p.add_argument(
+        "--group-capacity", type=int,
+        default=int(env("FASTSHARD_GROUP_CAPACITY", str(512 * 1024**2))),
+        help="ExpectedGroupCapacity in bytes for the fastshard config")
+    p.add_argument(
+        "--jd-port-base", type=int, default=int(env("JD_PORT_BASE", "29900")),
+        help="journalled device server port convention: agent 'remoteN.*'"
+             " listens on base+N, the local agent on base"
+             " (see example/0-setup.sh)")
+
+    args = p.parse_args()
+    if args.file_shard_count == 0:
+        args.file_shard_count = args.shard_count - 1
+    return args
+
+
+def run(cmd, **kwargs):
+    print("+ " + " ".join(cmd))
+    return subprocess.run(cmd, **kwargs)
+
+
+def warn_if_fastshard_runtime_disabled():
+    storage_config = os.path.join(BIN_DIR, "nfs", "nfs-storage.txt")
+    try:
+        with open(storage_config) as f:
+            if "FastShardRuntimeEnabled" in f.read():
+                return
+    except OSError:
+        pass
+
+    print("WARNING: FastShardRuntimeEnabled is not set in %s;"
+          % storage_config)
+    print("         persistent fastshards will fall back to stubs. Add")
+    print("         'FastShardRuntimeEnabled: true' and restart"
+          " filestore-server.")
+
+
+def create_volume(args):
+    print("creating mirrored volume %s" % args.disk_id)
+    res = run([
+        args.blockstore_client, "createvolume",
+        "--port", args.nbs_server_port,
+        "--disk-id", args.disk_id,
+        "--storage-media-kind", args.media_kind,
+        "--blocks-count", str(args.file_shard_count * args.blocks_per_shard),
+        "--block-size", "4096",
+        "--cloud-id", "cloud",
+        "--folder-id", "folder",
+    ])
+    if res.returncode != 0:
+        print("volume creation failed (already exists?)"
+              " - using the existing one")
+
+
+def describe_disk(args):
+    res = run([
+        args.blockstore_client, "executeaction",
+        "--port", args.nbs_server_port,
+        "--verbose", "error",
+        "--action", "diskregistrydescribedisk",
+        "--input-bytes", json.dumps({"DiskId": args.disk_id}),
+    ], stdout=subprocess.PIPE, check=True, text=True)
+    return json.loads(res.stdout)
+
+
+def agent_port(agent_id, port_base):
+    m = re.match(r"remote(\d+)\.", agent_id)
+    return port_base + int(m.group(1)) if m else port_base
+
+
+def build_storage_groups(args, describe_response):
+    def get(d, *names):
+        for n in names:
+            if n in d:
+                return d[n]
+        return []
+
+    replicas = [get(describe_response, "Devices", "devices")]
+    for r in get(describe_response, "Replicas", "replicas"):
+        replicas.append(get(r, "Devices", "devices"))
+
+    groups = []
+    for k in range(args.file_shard_count):
+        devices = []
+        for replica in replicas:
+            if k >= len(replica):
+                sys.exit("replica has no device for shard %d" % k)
+            d = replica[k]
+            devices.append({
+                "Host": "localhost",
+                "Port": agent_port(
+                    d.get("AgentId") or d.get("agentId") or "",
+                    args.jd_port_base),
+                "DeviceId": d.get("DeviceUUID") or d.get("deviceUUID"),
+            })
+        groups.append([{"Devices": devices, "Type": "E_SG_MIRROR"}])
+    return groups
+
+
+def filestore_execute_action(args, action, request):
+    run([
+        os.path.join(BIN_DIR, "filestore-client"), "executeaction",
+        "--server-port", args.server_port,
+        "--action", action,
+        "--input-json", json.dumps(request),
+    ], check=True)
+
+
+def configure_shards(args, groups):
+    shard_ids = [
+        "%s_s%d" % (args.fs, i) for i in range(1, args.shard_count + 1)]
+    file_shard_ids = shard_ids[args.shard_count - args.file_shard_count:]
+
+    for i, shard_id in enumerate(shard_ids):
+        shard_no = i + 1
+        is_fast = shard_id in file_shard_ids
+        if is_fast:
+            fast_config = {"PersistentConfig": {
+                "StorageGroups":
+                    groups[i - (args.shard_count - args.file_shard_count)],
+                "NodesPerGroup": args.nodes_per_group,
+                "ExpectedGroupCapacity": args.group_capacity,
+            }}
+        else:
+            fast_config = {"MemConfig": {}}
+
+        filestore_execute_action(args, "configureasshard", {
+            "FileSystemId": shard_id,
+            "ShardNo": shard_no,
+            "MainFileSystemId": args.fs,
+            "ShardFileSystemIds": shard_ids,
+            "FileShardFileSystemIds": file_shard_ids,
+            "IsFastShard": is_fast,
+            "FastShardConfig": fast_config,
+            "DirectoryCreationInShardsEnabled": True,
+        })
+        print("configured shard %s (fastshard: %s)" % (shard_id, is_fast))
+
+    filestore_execute_action(args, "configureshards", {
+        "FileSystemId": args.fs,
+        "ShardFileSystemIds": shard_ids,
+        "FileShardFileSystemIds": file_shard_ids,
+        "DirectoryCreationInShardsEnabled": True,
+    })
+    print("configured %s: %d shards, last %d are fastshard file shards"
+          % (args.fs, args.shard_count, args.file_shard_count))
+
+
+def main():
+    args = parse_args()
+
+    if args.file_shard_count >= args.shard_count:
+        sys.exit(
+            "ERROR: FILE_SHARD_COUNT (%d) must be less than SHARD_COUNT (%d):"
+            " the filesystem needs at least one non-file shard"
+            % (args.file_shard_count, args.shard_count))
+
+    warn_if_fastshard_runtime_disabled()
+    create_volume(args)
+    groups = build_storage_groups(args, describe_disk(args))
+    configure_shards(args, groups)
+
+
+if __name__ == "__main__":
+    main()

--- a/example/0-setup.sh
+++ b/example/0-setup.sh
@@ -51,6 +51,7 @@ setup_remote_disk_agent() {
     truncate -s  1G "$BIN_DIR/data/remote$1-1024-1.bin"
     truncate -s  1G "$BIN_DIR/data/remote$1-1024-2.bin"
     truncate -s  1G "$BIN_DIR/data/remote$1-1024-3.bin"
+    truncate -s  1G "$BIN_DIR/data/remote$1-1024-4.bin"
 
     cat > $BIN_DIR/nbs/nbs-disk-agent-$1.txt <<EOF
 AgentId: "remote$1.cloud-example.net"
@@ -58,6 +59,7 @@ Enabled: true
 DedicatedDiskAgent: true
 Backend: DISK_AGENT_BACKEND_AIO
 AcquireRequired: true
+JournalledDeviceTcpServerListenAddress: "localhost:$(( 29900 + $1 ))"
 
 FileDevices: {
     Path: "$BIN_DIR/data/remote$1-1024-1.bin"
@@ -74,6 +76,12 @@ FileDevices: {
 FileDevices: {
     Path: "$BIN_DIR/data/remote$1-1024-3.bin"
     DeviceId: "remote$1-1024-3"
+    BlockSize: 4096
+}
+
+FileDevices: {
+    Path: "$BIN_DIR/data/remote$1-1024-4.bin"
+    DeviceId: "remote$1-1024-4"
     BlockSize: 4096
 }
 
@@ -112,6 +120,7 @@ Enabled: true
 DedicatedDiskAgent: true
 Backend: DISK_AGENT_BACKEND_AIO
 AcquireRequired: true
+JournalledDeviceTcpServerListenAddress: "localhost:29900"
 
 FileDevices: {
     Path: "$BIN_DIR/data/local-1024-1.bin"
@@ -159,11 +168,14 @@ setup_nonrepl_disk_registry() {
     setup_remote_disk_agent 4
 
     cat > "$BIN_DIR"/nbs/nbs-disk-registry.txt <<EOF
+IgnoreVersion: true
+
 KnownAgents {
     AgentId: "remote1.cloud-example.net"
     Devices: "remote1-1024-1"
     Devices: "remote1-1024-2"
     Devices: "remote1-1024-3"
+    Devices: "remote1-1024-4"
 }
 
 KnownAgents {
@@ -171,6 +183,7 @@ KnownAgents {
     Devices: "remote2-1024-1"
     Devices: "remote2-1024-2"
     Devices: "remote2-1024-3"
+    Devices: "remote2-1024-4"
 }
 
 KnownAgents {
@@ -178,6 +191,7 @@ KnownAgents {
     Devices: "remote3-1024-1"
     Devices: "remote3-1024-2"
     Devices: "remote3-1024-3"
+    Devices: "remote3-1024-4"
 }
 
 KnownAgents {
@@ -185,6 +199,7 @@ KnownAgents {
     Devices: "remote4-1024-1"
     Devices: "remote4-1024-2"
     Devices: "remote4-1024-3"
+    Devices: "remote4-1024-4"
 }
 
 KnownAgents {

--- a/example/2-init_nbs_storage_tenant.sh
+++ b/example/2-init_nbs_storage_tenant.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Initializes only the NBS tenant on an already-initialized ydbd storage node
+# (e.g. the one from cloud/filestore/bin running on the same host). Use this
+# instead of 2-init_storage.sh when the storage node is shared with another
+# setup: DefineBox / DefineStoragePools / BindRootStorage / Configure-Root are
+# deliberately not executed here - they describe this example's own ydbd
+# instance (pdisk paths, static group) and have already been applied by the
+# owner of the running storage node.
+#
+# Requirements for the running storage node:
+#   - grpc on localhost:$GRPC_PORT, domain Root, ClusterUUID "local"
+#   - storage pools of kinds "ssd" and "rot" defined (the filestore setup
+#     defines the same pools as this example)
+
+DATA_DIR="data"
+source ./prepare_binaries.sh || exit 1
+
+GRPC_PORT=${GRPC_PORT:-9001}
+
+set -e
+
+# CreateTenant is asynchronous: the console immediately replies with an
+# unfinished operation, which the ydbd CLI prints as
+# "ERROR: STATUS_CODE_UNSPECIFIED ()" even though the tenant is being
+# created. Tolerate that reply (and ALREADY_EXISTS on reruns), then poll
+# until the tenant path appears.
+echo "CreateTenant"
+ydbd -s grpc://localhost:$GRPC_PORT admin console execute --domain=Root --retry=10 dynamic/CreateTenant.txt || true
+
+echo "Waiting for /Root/NBS"
+created=0
+for _ in $(seq 1 30); do
+    if ydbd -s grpc://localhost:$GRPC_PORT db schema ls /Root 2>/dev/null | grep -qw NBS; then
+        created=1
+        break
+    fi
+    sleep 1
+done
+if [[ "$created" != "1" ]]; then
+    echo "ERROR: /Root/NBS did not appear in 30s"
+    exit 1
+fi
+
+ALLOW_NAMED_CONFIGS_REQ="
+ConfigsConfig {
+    UsageScopeRestrictions {
+        AllowedTenantUsageScopeKinds: 100
+        AllowedHostUsageScopeKinds:   100
+        AllowedNodeTypeUsageScopeKinds: 100
+    }
+}
+"
+
+echo "AllowNamedConfigs"
+ydbd -s grpc://localhost:$GRPC_PORT admin console config set --merge "$ALLOW_NAMED_CONFIGS_REQ"
+echo "SetUserAttributes(set unlimited for nonrepl disks)"
+ydbd -s grpc://localhost:$GRPC_PORT db schema user-attribute set /Root/NBS __volume_space_limit_ssd_nonrepl=$(( 999 * 1024**5 ))
+#
+# Optional: the yaml console config only sets
+# blockstore_config.volume_preemption_type=PREEMPTION_NONE for nbs
+# nodes, which matters when several nbs nodes balance volumes. Since
+# ydb 25.1 "admin config replace" validates the yaml as a complete
+# cluster config (requires domains_config etc), so this minimal file
+# is rejected - skip with a warning in that case.
+#
+echo "Set Console Config (optional)"
+if ! ydb -e grpc://localhost:$GRPC_PORT -d /Root admin config replace -f ydb/config.yaml --allow-unknown-fields; then
+    echo "WARNING: yaml console config rejected by this cluster; continuing" \
+        "without it (volume preemption stays at its default)"
+fi

--- a/example/README.md
+++ b/example/README.md
@@ -23,9 +23,18 @@ Run the following command in a new tab:
 ./1-start_storage.sh
 ```
 
+OR skip this step if you already have a configured ydbd instance - e.g. after
+going through the filestore manual.
+
 ## Initialize storage node configuration
 ```bash
 ./2-init_storage.sh
+```
+
+OR if you already have a configured ydbd instance you should run another command
+which omits some of the initialization steps:
+```bash
+./2-init_nbs_storage_tenant.sh
 ```
 
 ## Start nbsd
@@ -70,7 +79,7 @@ sudo dd iflag=direct if=/dev/nbd0 of=./result.bin count=5 bs=4096
 ## See what's happening inside
 Go to http://localhost:8766/blockstore/service and check a particular volume (eg ```vol0```)
 
-If the blockstore server is running on a virtual machine, you must first configure port forwarding: 
+If the blockstore server is running on a virtual machine, you must first configure port forwarding:
 ```bash
 ssh -L 8766:localhost:8766 <vm_ip>
 ```


### PR DESCRIPTION
### Notes
Persistent fastshard support in local filestore setup. To implement this I had to make some small changes in local nbs setup scripts:
* added more devices into remote agent configs to have enough devices for 7 fileshards x mirror2
* enabled  `JournalledDeviceTcpServerListenAddress` in diskagentd configs

### Issue
https://github.com/ydb-platform/nbs/issues/5895
