### PR TITLE
issue-5895: added devices into fastshard layout dump

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/resources/html/layout.html
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/resources/html/layout.html
@@ -26,3 +26,28 @@
         {{ endfor }}
     </tbody>
 </table>
+
+<h3>Storage Groups</h3>
+
+<table class="fsl-table">
+    <thead>
+        <tr>
+            <th>Group</th>
+            <th>Type</th>
+            <th>Host</th>
+            <th>Port</th>
+            <th>Device id</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{ for DEVICES }}
+        <tr>
+            <td>{{ GROUP_NO }}</td>
+            <td>{{ GROUP_TYPE }}</td>
+            <td>{{ HOST }}</td>
+            <td>{{ PORT }}</td>
+            <td>{{ DEVICE_ID }}</td>
+        </tr>
+        {{ endfor }}
+    </tbody>
+</table>

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -922,7 +922,8 @@ struct TComponentLayout
 
 void DumpLayoutComponentsJson(
     IOutputStream& out,
-    const TVector<TComponentLayout>& components)
+    const TVector<TComponentLayout>& components,
+    const NProtoPrivate::TPersistentFastShardConfig& config)
 {
     NJsonWriter::TBuf writer(NJsonWriter::HEM_DONT_ESCAPE_HTML, &out);
 
@@ -944,17 +945,43 @@ void DumpLayoutComponentsJson(
         writer.EndObject();
     }
     writer.EndList();
+
+    writer.WriteKey("storageGroups");
+    writer.BeginList();
+    for (const auto& group: config.GetStorageGroups()) {
+        writer.BeginObject();
+        writer.WriteKey("type");
+        writer.WriteString(
+            NProtoPrivate::TStorageGroup::EStorageGroupType_Name(
+                group.GetType()));
+        writer.WriteKey("devices");
+        writer.BeginList();
+        for (const auto& device: group.GetDevices()) {
+            writer.BeginObject();
+            writer.WriteKey("host");
+            writer.WriteString(device.GetHost());
+            writer.WriteKey("port");
+            writer.WriteULongLong(device.GetPort());
+            writer.WriteKey("deviceId");
+            writer.WriteString(device.GetDeviceId());
+            writer.EndObject();
+        }
+        writer.EndList();
+        writer.EndObject();
+    }
+    writer.EndList();
     writer.EndObject();
 }
 
 void DumpLayoutComponentsHtml(
     IOutputStream& out,
-    const TVector<TComponentLayout>& components)
+    const TVector<TComponentLayout>& components,
+    const NProtoPrivate::TPersistentFastShardConfig& config)
 {
-    TVector<TTemplateVars> rows;
-    rows.reserve(components.size());
+    TVector<TTemplateVars> componentRows;
+    componentRows.reserve(components.size());
     for (const auto& c: components) {
-        rows.push_back({
+        componentRows.push_back({
             {"NAME", c.Name},
             {"OFFSET_BYTES", ToString(c.OffsetBytes)},
             {"SIZE_BYTES", ToString(c.SizeBytes)},
@@ -963,10 +990,35 @@ void DumpLayoutComponentsHtml(
         });
     }
 
+    //
+    // The template engine's loop arrays are flat, so the group/device
+    // hierarchy is flattened into one row per device with its group's
+    // number and type repeated.
+    //
+
+    TVector<TTemplateVars> deviceRows;
+    for (size_t groupNo = 0; groupNo < config.StorageGroupsSize(); ++groupNo) {
+        const auto& group = config.GetStorageGroups(groupNo);
+        for (const auto& device: group.GetDevices()) {
+            deviceRows.push_back({
+                {"GROUP_NO", ToString(groupNo)},
+                {"GROUP_TYPE",
+                 NProtoPrivate::TStorageGroup::EStorageGroupType_Name(
+                     group.GetType())},
+                {"HOST", device.GetHost()},
+                {"PORT", ToString(device.GetPort())},
+                {"DEVICE_ID", device.GetDeviceId()},
+            });
+        }
+    }
+
     OutputTemplate(
         NResource::Find("fastshard/html/layout.html"),
         {{"STYLE", NResource::Find("fastshard/css/layout.css")}},
-        {{"COMPONENTS", std::move(rows)}},
+        {
+            {"COMPONENTS", std::move(componentRows)},
+            {"DEVICES", std::move(deviceRows)},
+        },
         out);
 }
 
@@ -1098,12 +1150,12 @@ public:
 public:
     void DumpLayoutHtml(IOutputStream& out) const
     {
-        DumpLayoutComponentsHtml(out, Layout);
+        DumpLayoutComponentsHtml(out, Layout, Config);
     }
 
     void DumpLayoutJson(IOutputStream& out) const
     {
-        DumpLayoutComponentsJson(out, Layout);
+        DumpLayoutComponentsJson(out, Layout, Config);
     }
 
 public:

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_layout.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_layout.cpp
@@ -9,6 +9,7 @@
 
 #include <util/generic/size_literals.h>
 #include <util/stream/str.h>
+#include <util/string/cast.h>
 
 #include <gtest/gtest.h>
 
@@ -82,6 +83,20 @@ struct TStorageFixture
     {
         Config.SetNodesPerGroup(NodesPerGroup);
         Config.SetExpectedGroupCapacity(64_MB);
+
+        //
+        // The null storage group factory ignores the devices; they are
+        // here so that the layout dump has something to display.
+        //
+
+        auto* group = Config.AddStorageGroups();
+        group->SetType(NProtoPrivate::TStorageGroup::E_SG_MIRROR);
+        for (ui32 i = 1; i <= 3; ++i) {
+            auto* device = group->AddDevices();
+            device->SetHost("host-" + ToString(i));
+            device->SetPort(29900 + i);
+            device->SetDeviceId("device-" + ToString(i));
+        }
     }
 };
 
@@ -162,6 +177,25 @@ TEST(NaiveMirroredShardLayoutTest, DumpsLayout)
     }
 
     //
+    // Storage groups mirror the config, with every device field.
+    //
+
+    {
+        const auto& groups = parsed["storageGroups"].GetArray();
+        ASSERT_EQ(1u, groups.size()) << json.Str();
+        EXPECT_EQ("E_SG_MIRROR", groups[0]["type"].GetString());
+
+        const auto& devices = groups[0]["devices"].GetArray();
+        ASSERT_EQ(3u, devices.size()) << json.Str();
+        for (ui32 i = 1; i <= 3; ++i) {
+            const auto& d = devices[i - 1];
+            EXPECT_EQ("host-" + ToString(i), d["host"].GetString());
+            EXPECT_EQ(29900 + i, d["port"].GetUInteger());
+            EXPECT_EQ("device-" + ToString(i), d["deviceId"].GetString());
+        }
+    }
+
+    //
     // Html test.
     //
 
@@ -180,6 +214,20 @@ TEST(NaiveMirroredShardLayoutTest, DumpsLayout)
     EXPECT_TRUE(html.Str().Contains("Fast Shard Layout")) << html.Str();
     for (const auto& name: expectedNames) {
         EXPECT_TRUE(html.Str().Contains("<td>" + name + "</td>"))
+            << html.Str();
+    }
+
+    EXPECT_TRUE(html.Str().Contains("Storage Groups")) << html.Str();
+    EXPECT_TRUE(html.Str().Contains("<td>E_SG_MIRROR</td>")) << html.Str();
+    for (ui32 i = 1; i <= 3; ++i) {
+        EXPECT_TRUE(
+            html.Str().Contains("<td>host-" + ToString(i) + "</td>"))
+            << html.Str();
+        EXPECT_TRUE(
+            html.Str().Contains("<td>" + ToString(29900 + i) + "</td>"))
+            << html.Str();
+        EXPECT_TRUE(
+            html.Str().Contains("<td>device-" + ToString(i) + "</td>"))
             << html.Str();
     }
 


### PR DESCRIPTION
### Notes
Added device lists into fastshard layout dumps. Previously only data structure offsets and sizes were present in the dumps.

### Issue
https://github.com/ydb-platform/nbs/issues/5895