### PR TITLE
issue-1559: [Disk Manager] Add filesystem snapshot barrier mechanism

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/create_snapshot_from_filesystem_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/create_snapshot_from_filesystem_task.go
@@ -176,13 +176,12 @@ func (t *createSnapshotFromFilesystemTask) Run(
 
 func (t *createSnapshotFromFilesystemTask) Cancel(
 	ctx context.Context,
-	execCtx tasks.ExecutionContext,
+	_ tasks.ExecutionContext,
 ) error {
 
 	_, err := t.storage.DeletingFilesystemSnapshot(
 		ctx,
 		t.request.GetSnapshotId(),
-		execCtx.GetTaskID(),
 	)
 	return err
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/delete_filesystem_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/delete_filesystem_snapshot_task.go
@@ -36,23 +36,21 @@ func (t *deleteFilesystemSnapshotTask) Load(request, state []byte) error {
 
 func (t *deleteFilesystemSnapshotTask) deleteFilesystemSnapshot(
 	ctx context.Context,
-	execCtx tasks.ExecutionContext,
 ) error {
 
 	_, err := t.storage.DeletingFilesystemSnapshot(
 		ctx,
 		t.request.SnapshotId,
-		execCtx.GetTaskID(),
 	)
 	return err
 }
 
 func (t *deleteFilesystemSnapshotTask) Run(
 	ctx context.Context,
-	execCtx tasks.ExecutionContext,
+	_ tasks.ExecutionContext,
 ) error {
 
-	err := t.deleteFilesystemSnapshot(ctx, execCtx)
+	err := t.deleteFilesystemSnapshot(ctx)
 	if err != nil {
 		return errors.NewRetriableErrorWithIgnoreRetryLimit(err)
 	}
@@ -62,10 +60,10 @@ func (t *deleteFilesystemSnapshotTask) Run(
 
 func (t *deleteFilesystemSnapshotTask) Cancel(
 	ctx context.Context,
-	execCtx tasks.ExecutionContext,
+	_ tasks.ExecutionContext,
 ) error {
 
-	return t.deleteFilesystemSnapshot(ctx, execCtx)
+	return t.deleteFilesystemSnapshot(ctx)
 }
 
 func (t *deleteFilesystemSnapshotTask) GetMetadata(

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/mocks/storage_mock.go
@@ -40,10 +40,9 @@ func (s *StorageMock) FilesystemSnapshotCreated(
 func (s *StorageMock) DeletingFilesystemSnapshot(
 	ctx context.Context,
 	snapshotID string,
-	taskID string,
 ) (*storage.FilesystemSnapshotMeta, error) {
 
-	args := s.Called(ctx, snapshotID, taskID)
+	args := s.Called(ctx, snapshotID)
 	return args.Get(0).(*storage.FilesystemSnapshotMeta), args.Error(1)
 }
 
@@ -99,23 +98,23 @@ func (s *StorageMock) GetTotalFilesystemSnapshotStorageSize(ctx context.Context)
 	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (s *StorageMock) LockFilesystemSnapshot(
+func (s *StorageMock) AcquireFilesystemSnapshotBarrier(
 	ctx context.Context,
 	snapshotID string,
-	lockTaskID string,
-) (locked bool, err error) {
-
-	args := s.Called(ctx, snapshotID, lockTaskID)
-	return args.Get(0).(bool), args.Error(1)
-}
-
-func (s *StorageMock) UnlockFilesystemSnapshot(
-	ctx context.Context,
-	snapshotID string,
-	lockTaskID string,
+	taskID string,
 ) error {
 
-	args := s.Called(ctx, snapshotID, lockTaskID)
+	args := s.Called(ctx, snapshotID, taskID)
+	return args.Error(0)
+}
+
+func (s *StorageMock) ReleaseFilesystemSnapshotBarrier(
+	ctx context.Context,
+	snapshotID string,
+	taskID string,
+) error {
+
+	args := s.Called(ctx, snapshotID, taskID)
 	return args.Error(0)
 }
 

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/mocks/storage_mock.go
@@ -98,7 +98,7 @@ func (s *StorageMock) GetTotalFilesystemSnapshotStorageSize(ctx context.Context)
 	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (s *StorageMock) AcquireFilesystemSnapshotBarrier(
+func (s *StorageMock) LockFilesystemSnapshot(
 	ctx context.Context,
 	snapshotID string,
 	taskID string,
@@ -108,7 +108,7 @@ func (s *StorageMock) AcquireFilesystemSnapshotBarrier(
 	return args.Error(0)
 }
 
-func (s *StorageMock) ReleaseFilesystemSnapshotBarrier(
+func (s *StorageMock) UnlockFilesystemSnapshot(
 	ctx context.Context,
 	snapshotID string,
 	taskID string,

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/schema/schema.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/schema/schema.go
@@ -35,6 +35,22 @@ func Create(
 	err = db.CreateOrAlterTable(
 		ctx,
 		storageFolder,
+		"filesystem_snapshot_lock_holders",
+		persistence.NewCreateTableDescription(
+			persistence.WithColumn("snapshot_id", persistence.Optional(persistence.TypeUTF8)),
+			persistence.WithColumn("lock_task_id", persistence.Optional(persistence.TypeUTF8)),
+			persistence.WithPrimaryKeyColumn("snapshot_id", "lock_task_id"),
+		),
+		dropUnusedColumns,
+	)
+	if err != nil {
+		return err
+	}
+	logging.Info(ctx, "Created filesystem_snapshot_lock_holders table")
+
+	err = db.CreateOrAlterTable(
+		ctx,
+		storageFolder,
 		"deleting",
 		persistence.NewCreateTableDescription(
 			persistence.WithColumn("deleting_at", persistence.Optional(persistence.TypeTimestamp)),
@@ -176,7 +192,13 @@ func Drop(
 
 	logging.Info(ctx, "Dropping schema for dataplane filesystem snapshot storage in %v", db.AbsolutePath(storageFolder))
 
-	err := db.DropTable(ctx, storageFolder, "filesystem_snapshots")
+	err := db.DropTable(ctx, storageFolder, "filesystem_snapshot_lock_holders")
+	if err != nil {
+		return err
+	}
+	logging.Info(ctx, "Dropped filesystem_snapshot_lock_holders table")
+
+	err = db.DropTable(ctx, storageFolder, "filesystem_snapshots")
 	if err != nil {
 		return err
 	}

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/schema/schema.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/schema/schema.go
@@ -35,7 +35,7 @@ func Create(
 	err = db.CreateOrAlterTable(
 		ctx,
 		storageFolder,
-		"filesystem_snapshot_lock_holders",
+		"filesystem_snapshot_locks",
 		persistence.NewCreateTableDescription(
 			persistence.WithColumn("snapshot_id", persistence.Optional(persistence.TypeUTF8)),
 			persistence.WithColumn("lock_task_id", persistence.Optional(persistence.TypeUTF8)),
@@ -46,7 +46,7 @@ func Create(
 	if err != nil {
 		return err
 	}
-	logging.Info(ctx, "Created filesystem_snapshot_lock_holders table")
+	logging.Info(ctx, "Created filesystem_snapshot_locks table")
 
 	err = db.CreateOrAlterTable(
 		ctx,
@@ -192,11 +192,11 @@ func Drop(
 
 	logging.Info(ctx, "Dropping schema for dataplane filesystem snapshot storage in %v", db.AbsolutePath(storageFolder))
 
-	err := db.DropTable(ctx, storageFolder, "filesystem_snapshot_lock_holders")
+	err := db.DropTable(ctx, storageFolder, "filesystem_snapshot_locks")
 	if err != nil {
 		return err
 	}
-	logging.Info(ctx, "Dropped filesystem_snapshot_lock_holders table")
+	logging.Info(ctx, "Dropped filesystem_snapshot_locks table")
 
 	err = db.DropTable(ctx, storageFolder, "filesystem_snapshots")
 	if err != nil {

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage.go
@@ -76,18 +76,19 @@ type Storage interface {
 		ctx context.Context,
 	) (storageSize uint64, err error)
 
-	// AcquireFilesystemSnapshotBarrier joins taskID to the snapshot's shared
-	// deletion barrier. Repeated calls with the same taskID are idempotent.
-	AcquireFilesystemSnapshotBarrier(
+	// LockFilesystemSnapshot prevents deletion while any lock remains. Multiple
+	// callers can lock the same snapshot successfully without waiting for existing
+	// locks to be released; repeated calls with the same taskID are idempotent.
+	LockFilesystemSnapshot(
 		ctx context.Context,
 		snapshotID string,
 		taskID string,
 	) error
 
-	// ReleaseFilesystemSnapshotBarrier removes taskID from the shared deletion
-	// barrier. It is idempotent, including for deleting or missing snapshots;
-	// deletion is unblocked after the last holder exits.
-	ReleaseFilesystemSnapshotBarrier(
+	// UnlockFilesystemSnapshot removes the lock owned by taskID. It is
+	// idempotent, including for deleting or missing snapshots; deletion is
+	// unblocked after the last lock is removed.
+	UnlockFilesystemSnapshot(
 		ctx context.Context,
 		snapshotID string,
 		taskID string,

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage.go
@@ -43,7 +43,6 @@ type Storage interface {
 	DeletingFilesystemSnapshot(
 		ctx context.Context,
 		snapshotID string,
-		taskID string,
 	) (*FilesystemSnapshotMeta, error)
 
 	GetFilesystemSnapshotsToDelete(
@@ -77,16 +76,21 @@ type Storage interface {
 		ctx context.Context,
 	) (storageSize uint64, err error)
 
-	LockFilesystemSnapshot(
+	// AcquireFilesystemSnapshotBarrier joins taskID to the snapshot's shared
+	// deletion barrier. Repeated calls with the same taskID are idempotent.
+	AcquireFilesystemSnapshotBarrier(
 		ctx context.Context,
 		snapshotID string,
-		lockTaskID string,
-	) (locked bool, err error)
+		taskID string,
+	) error
 
-	UnlockFilesystemSnapshot(
+	// ReleaseFilesystemSnapshotBarrier removes taskID from the shared deletion
+	// barrier. It is idempotent, including for deleting or missing snapshots;
+	// deletion is unblocked after the last holder exits.
+	ReleaseFilesystemSnapshotBarrier(
 		ctx context.Context,
 		snapshotID string,
-		lockTaskID string,
+		taskID string,
 	) error
 
 	GetFilesystemSnapshotMeta(

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb.go
@@ -58,7 +58,7 @@ func (s *storageYDB) fetchFilesystemSnapshotByID(
 	return scanFilesystemSnapshotStates(ctx, res)
 }
 
-func (s *storageYDB) upsertFilesystemSnapshotLockHolder(
+func (s *storageYDB) upsertFilesystemSnapshotLock(
 	ctx context.Context,
 	tx *persistence.Transaction,
 	snapshotID string,
@@ -71,7 +71,7 @@ func (s *storageYDB) upsertFilesystemSnapshotLockHolder(
 		declare $snapshot_id as Utf8;
 		declare $lock_task_id as Utf8;
 
-		upsert into filesystem_snapshot_lock_holders (snapshot_id, lock_task_id)
+		upsert into filesystem_snapshot_locks (snapshot_id, lock_task_id)
 		values ($snapshot_id, $lock_task_id)
 	`, s.tablesPath),
 		persistence.ValueParam("$snapshot_id", persistence.UTF8Value(snapshotID)),
@@ -80,7 +80,7 @@ func (s *storageYDB) upsertFilesystemSnapshotLockHolder(
 	return err
 }
 
-func (s *storageYDB) deleteFilesystemSnapshotLockHolder(
+func (s *storageYDB) deleteFilesystemSnapshotLock(
 	ctx context.Context,
 	tx *persistence.Transaction,
 	snapshotID string,
@@ -93,7 +93,7 @@ func (s *storageYDB) deleteFilesystemSnapshotLockHolder(
 		declare $snapshot_id as Utf8;
 		declare $lock_task_id as Utf8;
 
-		delete from filesystem_snapshot_lock_holders
+		delete from filesystem_snapshot_locks
 		where snapshot_id = $snapshot_id and lock_task_id = $lock_task_id
 	`, s.tablesPath),
 		persistence.ValueParam("$snapshot_id", persistence.UTF8Value(snapshotID)),
@@ -102,7 +102,7 @@ func (s *storageYDB) deleteFilesystemSnapshotLockHolder(
 	return err
 }
 
-func (s *storageYDB) getAnyFilesystemSnapshotLockHolder(
+func (s *storageYDB) getAnyFilesystemSnapshotLock(
 	ctx context.Context,
 	tx *persistence.Transaction,
 	snapshotID string,
@@ -114,7 +114,7 @@ func (s *storageYDB) getAnyFilesystemSnapshotLockHolder(
 		declare $snapshot_id as Utf8;
 
 		select lock_task_id
-		from filesystem_snapshot_lock_holders
+		from filesystem_snapshot_locks
 		where snapshot_id = $snapshot_id
 		limit 1
 	`, s.tablesPath),
@@ -293,7 +293,6 @@ func (s *storageYDB) deletingFilesystemSnapshot(
 ) (deleting *FilesystemSnapshotMeta, err error) {
 
 	deletingAt := time.Now()
-
 	tx, err := session.BeginRWTransaction(ctx)
 	if err != nil {
 		return nil, err
@@ -377,12 +376,13 @@ func (s *storageYDB) deletingFilesystemSnapshot(
 	return state.toFilesystemSnapshotMeta(), tx.Commit(ctx)
 }
 
-func (s *storageYDB) acquireFilesystemSnapshotBarrier(
+func (s *storageYDB) lockFilesystemSnapshot(
 	ctx context.Context,
 	session *persistence.Session,
 	snapshotID string,
 	lockTaskID string,
 ) error {
+
 	if lockTaskID == "" {
 		return task_errors.NewNonRetriableErrorf(
 			"lock task ID should not be empty",
@@ -420,7 +420,7 @@ func (s *storageYDB) acquireFilesystemSnapshotBarrier(
 		}
 
 		return task_errors.NewNonRetriableErrorf(
-			"can't acquire barrier for filesystem snapshot with id %v and status %v",
+			"can't lock filesystem snapshot with id %v and status %v",
 			snapshotID,
 			filesystemSnapshotStatusToString(state.status),
 		)
@@ -432,7 +432,7 @@ func (s *storageYDB) acquireFilesystemSnapshotBarrier(
 			return tx.Commit(ctx)
 		}
 
-		err = s.upsertFilesystemSnapshotLockHolder(
+		err = s.upsertFilesystemSnapshotLock(
 			ctx,
 			tx,
 			snapshotID,
@@ -479,16 +479,17 @@ func (s *storageYDB) acquireFilesystemSnapshotBarrier(
 		return err
 	}
 
-	logging.Info(ctx, "Acquired barrier for filesystem snapshot with id %v", snapshotID)
+	logging.Info(ctx, "Locked filesystem snapshot with id %v", snapshotID)
 	return nil
 }
 
-func (s *storageYDB) releaseFilesystemSnapshotBarrier(
+func (s *storageYDB) unlockFilesystemSnapshot(
 	ctx context.Context,
 	session *persistence.Session,
 	snapshotID string,
 	lockTaskID string,
 ) error {
+
 	if lockTaskID == "" {
 		return task_errors.NewNonRetriableErrorf(
 			"lock task ID should not be empty",
@@ -513,13 +514,14 @@ func (s *storageYDB) releaseFilesystemSnapshotBarrier(
 
 	state := states[0]
 	if state.status >= filesystemSnapshotStatusDeleting {
-		// The snapshot no longer has a barrier to release.
+		// Unlike locking, unlocking a deleting snapshot is a successful no-op,
+		// so callers can safely retry cleanup after deletion has started.
 		return tx.Commit(ctx)
 	}
 
 	if state.lockTaskID != lockTaskID {
-		// Remove an additional lock holder, if present.
-		err = s.deleteFilesystemSnapshotLockHolder(
+		// Remove an additional lock, if present.
+		err = s.deleteFilesystemSnapshotLock(
 			ctx,
 			tx,
 			snapshotID,
@@ -532,7 +534,7 @@ func (s *storageYDB) releaseFilesystemSnapshotBarrier(
 		return tx.Commit(ctx)
 	}
 
-	nextLockHolderTaskID, err := s.getAnyFilesystemSnapshotLockHolder(
+	nextLockTaskID, err := s.getAnyFilesystemSnapshotLock(
 		ctx,
 		tx,
 		snapshotID,
@@ -541,13 +543,13 @@ func (s *storageYDB) releaseFilesystemSnapshotBarrier(
 		return err
 	}
 
-	state.lockTaskID = nextLockHolderTaskID
-	if nextLockHolderTaskID != "" {
-		err = s.deleteFilesystemSnapshotLockHolder(
+	state.lockTaskID = nextLockTaskID
+	if nextLockTaskID != "" {
+		err = s.deleteFilesystemSnapshotLock(
 			ctx,
 			tx,
 			snapshotID,
-			nextLockHolderTaskID,
+			nextLockTaskID,
 		)
 		if err != nil {
 			return err
@@ -574,15 +576,15 @@ func (s *storageYDB) releaseFilesystemSnapshotBarrier(
 		return err
 	}
 
-	if nextLockHolderTaskID == "" {
-		logging.Info(ctx, "Released barrier for filesystem snapshot with id %v", snapshotID)
+	if nextLockTaskID == "" {
+		logging.Info(ctx, "Unlocked filesystem snapshot with id %v", snapshotID)
 	} else {
 		logging.Info(
 			ctx,
-			"Transferred filesystem snapshot barrier with id %v from %v to %v",
+			"Transferred representative filesystem snapshot lock with id %v from %v to %v",
 			snapshotID,
 			lockTaskID,
-			nextLockHolderTaskID,
+			nextLockTaskID,
 		)
 	}
 	return nil
@@ -816,6 +818,10 @@ func (s *storageYDB) ClearDeletingFilesystemSnapshots(
 	keys []*protos.DeletingFilesystemSnapshotKey,
 ) error {
 
+	// Do not clean up filesystem_snapshot_locks here. Locks must be explicitly
+	// released before deletion starts. A leaked lock leaves deletion interrupted
+	// and requires manual intervention, which is safer than a cleanup bug
+	// accidentally unlocking and deleting a protected snapshot.
 	for _, key := range keys {
 		_, err := s.db.ExecuteRW(ctx, fmt.Sprintf(`
 			--!syntax_v1
@@ -877,7 +883,7 @@ func (s *storageYDB) TablesEmpty(ctx context.Context) (bool, error) {
 	// Used by tests to verify collection cleanup.
 	for _, table := range []string{
 		"filesystem_snapshots",
-		"filesystem_snapshot_lock_holders",
+		"filesystem_snapshot_locks",
 		"deleting",
 		"node_refs",
 		"node_refs_by_shard",
@@ -953,7 +959,7 @@ func (s *storageYDB) CheckFilesystemSnapshotReady(
 	return nil
 }
 
-func (s *storageYDB) AcquireFilesystemSnapshotBarrier(
+func (s *storageYDB) LockFilesystemSnapshot(
 	ctx context.Context,
 	snapshotID string,
 	lockTaskID string,
@@ -962,7 +968,7 @@ func (s *storageYDB) AcquireFilesystemSnapshotBarrier(
 	return s.db.Execute(
 		ctx,
 		func(ctx context.Context, session *persistence.Session) error {
-			return s.acquireFilesystemSnapshotBarrier(
+			return s.lockFilesystemSnapshot(
 				ctx,
 				session,
 				snapshotID,
@@ -972,7 +978,7 @@ func (s *storageYDB) AcquireFilesystemSnapshotBarrier(
 	)
 }
 
-func (s *storageYDB) ReleaseFilesystemSnapshotBarrier(
+func (s *storageYDB) UnlockFilesystemSnapshot(
 	ctx context.Context,
 	snapshotID string,
 	lockTaskID string,
@@ -981,7 +987,7 @@ func (s *storageYDB) ReleaseFilesystemSnapshotBarrier(
 	return s.db.Execute(
 		ctx,
 		func(ctx context.Context, session *persistence.Session) error {
-			return s.releaseFilesystemSnapshotBarrier(
+			return s.unlockFilesystemSnapshot(
 				ctx,
 				session,
 				snapshotID,

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb.go
@@ -543,6 +543,10 @@ func (s *storageYDB) unlockFilesystemSnapshot(
 		return err
 	}
 
+	// Current owner lock is present only in the snapshot lockTaskID,
+	// filesystem_snapshot_locks table is used only for additional locks.
+	// So when the current owner is released, we promoted one of additional
+	// locks to the current owner, if any additional lock exist.
 	state.lockTaskID = nextLockTaskID
 	if nextLockTaskID != "" {
 		err = s.deleteFilesystemSnapshotLock(

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb.go
@@ -406,7 +406,7 @@ func (s *storageYDB) lockFilesystemSnapshot(
 			return err
 		}
 
-		return task_errors.NewNonRetriableErrorf(
+		return task_errors.NewSilentNonRetriableErrorf(
 			"filesystem snapshot with id %v is not found",
 			snapshotID,
 		)
@@ -419,7 +419,7 @@ func (s *storageYDB) lockFilesystemSnapshot(
 			return err
 		}
 
-		return task_errors.NewNonRetriableErrorf(
+		return task_errors.NewSilentNonRetriableErrorf(
 			"can't lock filesystem snapshot with id %v and status %v",
 			snapshotID,
 			filesystemSnapshotStatusToString(state.status),

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb.go
@@ -58,6 +58,96 @@ func (s *storageYDB) fetchFilesystemSnapshotByID(
 	return scanFilesystemSnapshotStates(ctx, res)
 }
 
+func (s *storageYDB) upsertFilesystemSnapshotLockHolder(
+	ctx context.Context,
+	tx *persistence.Transaction,
+	snapshotID string,
+	lockTaskID string,
+) error {
+
+	_, err := tx.Execute(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $snapshot_id as Utf8;
+		declare $lock_task_id as Utf8;
+
+		upsert into filesystem_snapshot_lock_holders (snapshot_id, lock_task_id)
+		values ($snapshot_id, $lock_task_id)
+	`, s.tablesPath),
+		persistence.ValueParam("$snapshot_id", persistence.UTF8Value(snapshotID)),
+		persistence.ValueParam("$lock_task_id", persistence.UTF8Value(lockTaskID)),
+	)
+	return err
+}
+
+func (s *storageYDB) deleteFilesystemSnapshotLockHolder(
+	ctx context.Context,
+	tx *persistence.Transaction,
+	snapshotID string,
+	lockTaskID string,
+) error {
+
+	_, err := tx.Execute(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $snapshot_id as Utf8;
+		declare $lock_task_id as Utf8;
+
+		delete from filesystem_snapshot_lock_holders
+		where snapshot_id = $snapshot_id and lock_task_id = $lock_task_id
+	`, s.tablesPath),
+		persistence.ValueParam("$snapshot_id", persistence.UTF8Value(snapshotID)),
+		persistence.ValueParam("$lock_task_id", persistence.UTF8Value(lockTaskID)),
+	)
+	return err
+}
+
+func (s *storageYDB) getAnyFilesystemSnapshotLockHolder(
+	ctx context.Context,
+	tx *persistence.Transaction,
+	snapshotID string,
+) (string, error) {
+
+	res, err := tx.Execute(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $snapshot_id as Utf8;
+
+		select lock_task_id
+		from filesystem_snapshot_lock_holders
+		where snapshot_id = $snapshot_id
+		limit 1
+	`, s.tablesPath),
+		persistence.ValueParam("$snapshot_id", persistence.UTF8Value(snapshotID)),
+	)
+	if err != nil {
+		return "", err
+	}
+	defer res.Close()
+
+	if !res.NextResultSet(ctx) || !res.NextRow() {
+		if res.Err() != nil {
+			return "", task_errors.NewRetriableError(res.Err())
+		}
+
+		if ctx.Err() != nil {
+			return "", task_errors.NewRetriableError(ctx.Err())
+		}
+
+		return "", nil
+	}
+
+	var lockTaskID string
+	err = res.ScanNamed(
+		persistence.OptionalWithDefault("lock_task_id", &lockTaskID),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return lockTaskID, nil
+}
+
 func (s *storageYDB) createFilesystemSnapshot(
 	ctx context.Context,
 	session *persistence.Session,
@@ -200,7 +290,6 @@ func (s *storageYDB) deletingFilesystemSnapshot(
 	ctx context.Context,
 	session *persistence.Session,
 	snapshotID string,
-	taskID string,
 ) (deleting *FilesystemSnapshotMeta, err error) {
 
 	deletingAt := time.Now()
@@ -234,7 +323,7 @@ func (s *storageYDB) deletingFilesystemSnapshot(
 			return state.toFilesystemSnapshotMeta(), err
 		}
 
-		if len(state.lockTaskID) != 0 && state.lockTaskID != taskID {
+		if len(state.lockTaskID) != 0 {
 			err = tx.Commit(ctx)
 			if err != nil {
 				return nil, err
@@ -288,46 +377,84 @@ func (s *storageYDB) deletingFilesystemSnapshot(
 	return state.toFilesystemSnapshotMeta(), tx.Commit(ctx)
 }
 
-func (s *storageYDB) lockFilesystemSnapshot(
+func (s *storageYDB) acquireFilesystemSnapshotBarrier(
 	ctx context.Context,
 	session *persistence.Session,
 	snapshotID string,
 	lockTaskID string,
-) (locked bool, err error) {
+) error {
+	if lockTaskID == "" {
+		return task_errors.NewNonRetriableErrorf(
+			"lock task ID should not be empty",
+		)
+	}
 
 	tx, err := session.BeginRWTransaction(ctx)
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer tx.Rollback(ctx)
 
 	states, err := s.fetchFilesystemSnapshotByID(ctx, tx, snapshotID)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if len(states) == 0 {
-		return false, tx.Commit(ctx)
+		err = tx.Commit(ctx)
+		if err != nil {
+			return err
+		}
+
+		return task_errors.NewNonRetriableErrorf(
+			"filesystem snapshot with id %v is not found",
+			snapshotID,
+		)
 	}
 
 	state := states[0]
 	if state.status >= filesystemSnapshotStatusDeleting {
-		return false, tx.Commit(ctx)
+		err = tx.Commit(ctx)
+		if err != nil {
+			return err
+		}
+
+		return task_errors.NewNonRetriableErrorf(
+			"can't acquire barrier for filesystem snapshot with id %v and status %v",
+			snapshotID,
+			filesystemSnapshotStatusToString(state.status),
+		)
 	}
 
 	if len(state.lockTaskID) != 0 {
-		err = tx.Commit(ctx)
-		if err != nil {
-			return false, err
-		}
-
 		if state.lockTaskID == lockTaskID {
 			// Should be idempotent.
-			return true, nil
+			return tx.Commit(ctx)
 		}
 
-		logging.Info(ctx, "Filesystem snapshot %v already has lock %v, cannot acquire lock %v", snapshotID, state.lockTaskID, lockTaskID)
-		return false, task_errors.NewInterruptExecutionError()
+		err = s.upsertFilesystemSnapshotLockHolder(
+			ctx,
+			tx,
+			snapshotID,
+			lockTaskID,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = tx.Commit(ctx)
+		if err != nil {
+			return err
+		}
+
+		logging.Info(
+			ctx,
+			"Filesystem snapshot %v has representative lock %v and acquired additional lock %v",
+			snapshotID,
+			state.lockTaskID,
+			lockTaskID,
+		)
+		return nil
 	}
 
 	state.lockTaskID = lockTaskID
@@ -344,24 +471,29 @@ func (s *storageYDB) lockFilesystemSnapshot(
 		persistence.ValueParam("$states", persistence.ListValue(state.structValue())),
 	)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	err = tx.Commit(ctx)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	logging.Info(ctx, "Locked filesystem snapshot with id %v", snapshotID)
-	return true, nil
+	logging.Info(ctx, "Acquired barrier for filesystem snapshot with id %v", snapshotID)
+	return nil
 }
 
-func (s *storageYDB) unlockFilesystemSnapshot(
+func (s *storageYDB) releaseFilesystemSnapshotBarrier(
 	ctx context.Context,
 	session *persistence.Session,
 	snapshotID string,
 	lockTaskID string,
 ) error {
+	if lockTaskID == "" {
+		return task_errors.NewNonRetriableErrorf(
+			"lock task ID should not be empty",
+		)
+	}
 
 	tx, err := session.BeginRWTransaction(ctx)
 	if err != nil {
@@ -381,21 +513,46 @@ func (s *storageYDB) unlockFilesystemSnapshot(
 
 	state := states[0]
 	if state.status >= filesystemSnapshotStatusDeleting {
-		// Should be idempotent.
-		return tx.Commit(ctx)
-	}
-
-	if len(state.lockTaskID) == 0 {
-		// Should be idempotent.
+		// The snapshot no longer has a barrier to release.
 		return tx.Commit(ctx)
 	}
 
 	if state.lockTaskID != lockTaskID {
-		// Our lock is not present, so it's a success.
+		// Remove an additional lock holder, if present.
+		err = s.deleteFilesystemSnapshotLockHolder(
+			ctx,
+			tx,
+			snapshotID,
+			lockTaskID,
+		)
+		if err != nil {
+			return err
+		}
+
 		return tx.Commit(ctx)
 	}
 
-	state.lockTaskID = ""
+	nextLockHolderTaskID, err := s.getAnyFilesystemSnapshotLockHolder(
+		ctx,
+		tx,
+		snapshotID,
+	)
+	if err != nil {
+		return err
+	}
+
+	state.lockTaskID = nextLockHolderTaskID
+	if nextLockHolderTaskID != "" {
+		err = s.deleteFilesystemSnapshotLockHolder(
+			ctx,
+			tx,
+			snapshotID,
+			nextLockHolderTaskID,
+		)
+		if err != nil {
+			return err
+		}
+	}
 
 	_, err = tx.Execute(ctx, fmt.Sprintf(`
 		--!syntax_v1
@@ -417,7 +574,17 @@ func (s *storageYDB) unlockFilesystemSnapshot(
 		return err
 	}
 
-	logging.Info(ctx, "Unlocked filesystem snapshot with id %v", snapshotID)
+	if nextLockHolderTaskID == "" {
+		logging.Info(ctx, "Released barrier for filesystem snapshot with id %v", snapshotID)
+	} else {
+		logging.Info(
+			ctx,
+			"Transferred filesystem snapshot barrier with id %v from %v to %v",
+			snapshotID,
+			lockTaskID,
+			nextLockHolderTaskID,
+		)
+	}
 	return nil
 }
 
@@ -580,7 +747,6 @@ func (s *storageYDB) FilesystemSnapshotCreated(
 func (s *storageYDB) DeletingFilesystemSnapshot(
 	ctx context.Context,
 	snapshotID string,
-	taskID string,
 ) (*FilesystemSnapshotMeta, error) {
 
 	var snapshotMeta *FilesystemSnapshotMeta
@@ -593,7 +759,6 @@ func (s *storageYDB) DeletingFilesystemSnapshot(
 				ctx,
 				session,
 				snapshotID,
-				taskID,
 			)
 			return err
 		},
@@ -712,6 +877,7 @@ func (s *storageYDB) TablesEmpty(ctx context.Context) (bool, error) {
 	// Used by tests to verify collection cleanup.
 	for _, table := range []string{
 		"filesystem_snapshots",
+		"filesystem_snapshot_lock_holders",
 		"deleting",
 		"node_refs",
 		"node_refs_by_shard",
@@ -787,23 +953,7 @@ func (s *storageYDB) CheckFilesystemSnapshotReady(
 	return nil
 }
 
-func (s *storageYDB) LockFilesystemSnapshot(
-	ctx context.Context,
-	snapshotID string,
-	lockTaskID string,
-) (locked bool, err error) {
-
-	err = s.db.Execute(
-		ctx,
-		func(ctx context.Context, session *persistence.Session) error {
-			locked, err = s.lockFilesystemSnapshot(ctx, session, snapshotID, lockTaskID)
-			return err
-		},
-	)
-	return locked, err
-}
-
-func (s *storageYDB) UnlockFilesystemSnapshot(
+func (s *storageYDB) AcquireFilesystemSnapshotBarrier(
 	ctx context.Context,
 	snapshotID string,
 	lockTaskID string,
@@ -812,7 +962,31 @@ func (s *storageYDB) UnlockFilesystemSnapshot(
 	return s.db.Execute(
 		ctx,
 		func(ctx context.Context, session *persistence.Session) error {
-			return s.unlockFilesystemSnapshot(ctx, session, snapshotID, lockTaskID)
+			return s.acquireFilesystemSnapshotBarrier(
+				ctx,
+				session,
+				snapshotID,
+				lockTaskID,
+			)
+		},
+	)
+}
+
+func (s *storageYDB) ReleaseFilesystemSnapshotBarrier(
+	ctx context.Context,
+	snapshotID string,
+	lockTaskID string,
+) error {
+
+	return s.db.Execute(
+		ctx,
+		func(ctx context.Context, session *persistence.Session) error {
+			return s.releaseFilesystemSnapshotBarrier(
+				ctx,
+				session,
+				snapshotID,
+				lockTaskID,
+			)
 		},
 	)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb_test.go
@@ -409,7 +409,7 @@ func TestCheckFilesystemSnapshotReadyWithCancellationDoesNotReturnNonRetriableEr
 	}
 }
 
-func TestFilesystemSnapshotBarrier(t *testing.T) {
+func TestLockUnlockFilesystemSnapshot(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
@@ -427,25 +427,25 @@ func TestFilesystemSnapshotBarrier(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier1")
+	err = f.storage.LockFilesystemSnapshot(f.ctx, snapshotID, "lock1")
 	require.NoError(t, err)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier2")
+	err = f.storage.LockFilesystemSnapshot(f.ctx, snapshotID, "lock2")
 	require.NoError(t, err)
 
 	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, snapshotID)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier2")
+	err = f.storage.UnlockFilesystemSnapshot(f.ctx, snapshotID, "lock2")
 	require.NoError(t, err)
 
-	// Releasing one participant does not release the barrier.
+	// Unlocking one task does not remove the other task's lock.
 	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, snapshotID)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier1")
+	err = f.storage.UnlockFilesystemSnapshot(f.ctx, snapshotID, "lock1")
 	require.NoError(t, err)
 
 	deleting, err := f.storage.DeletingFilesystemSnapshot(
@@ -455,19 +455,19 @@ func TestFilesystemSnapshotBarrier(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, deleting)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier3")
+	err = f.storage.LockFilesystemSnapshot(f.ctx, snapshotID, "lock3")
 	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier3")
+	err = f.storage.UnlockFilesystemSnapshot(f.ctx, snapshotID, "lock3")
 	require.NoError(t, err)
 }
 
-func TestFilesystemSnapshotBarrierAcquireAndReleaseAreIdempotent(t *testing.T) {
+func TestLockUnlockFilesystemSnapshotAreIdempotent(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
 	snapshotID := t.Name()
-	const barrierTaskID = "barrier"
+	const lockTaskID = "lock"
 	_, err := f.storage.CreateFilesystemSnapshot(
 		f.ctx,
 		FilesystemSnapshotMeta{
@@ -481,47 +481,47 @@ func TestFilesystemSnapshotBarrierAcquireAndReleaseAreIdempotent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(
+	err = f.storage.LockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		barrierTaskID,
+		lockTaskID,
 	)
 	require.NoError(t, err)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(
+	err = f.storage.LockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		barrierTaskID,
+		lockTaskID,
 	)
 	require.NoError(t, err)
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+	err = f.storage.UnlockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		barrierTaskID,
+		lockTaskID,
 	)
 	require.NoError(t, err)
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+	err = f.storage.UnlockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		barrierTaskID,
+		lockTaskID,
 	)
 	require.NoError(t, err)
 
-	// Repeated acquisition creates one barrier participant, and repeated release
+	// Repeated locking by the same task creates one lock, and repeated unlocking
 	// is a no-op, so deletion is allowed.
 	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, snapshotID)
 	require.NoError(t, err)
 }
 
-func TestFilesystemSnapshotBarrierParticipantAcquireIsIdempotent(t *testing.T) {
+func TestFilesystemSnapshotAdditionalLockIsIdempotent(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
 	snapshotID := t.Name()
-	const firstBarrierTaskID = "barrier-1"
-	const secondBarrierTaskID = "barrier-2"
+	const firstLockTaskID = "lock-1"
+	const secondLockTaskID = "lock-2"
 	_, err := f.storage.CreateFilesystemSnapshot(
 		f.ctx,
 		FilesystemSnapshotMeta{
@@ -535,26 +535,26 @@ func TestFilesystemSnapshotBarrierParticipantAcquireIsIdempotent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(
+	err = f.storage.LockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		firstBarrierTaskID,
+		firstLockTaskID,
 	)
 	require.NoError(t, err)
 
 	for i := 0; i < 2; i++ {
-		err = f.storage.AcquireFilesystemSnapshotBarrier(
+		err = f.storage.LockFilesystemSnapshot(
 			f.ctx,
 			snapshotID,
-			secondBarrierTaskID,
+			secondLockTaskID,
 		)
 		require.NoError(t, err)
 	}
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+	err = f.storage.UnlockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		firstBarrierTaskID,
+		firstLockTaskID,
 	)
 	require.NoError(t, err)
 
@@ -565,15 +565,15 @@ func TestFilesystemSnapshotBarrierParticipantAcquireIsIdempotent(t *testing.T) {
 	require.Nil(t, deleting)
 	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+	err = f.storage.UnlockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		secondBarrierTaskID,
+		secondLockTaskID,
 	)
 	require.NoError(t, err)
 
-	// Repeated acquisition of the second participant must require only one
-	// release before the barrier is empty.
+	// Repeated locking by the second task must require only one unlock before
+	// the snapshot is unlocked.
 	deleting, err = f.storage.DeletingFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
@@ -582,7 +582,7 @@ func TestFilesystemSnapshotBarrierParticipantAcquireIsIdempotent(t *testing.T) {
 	require.NotNil(t, deleting)
 }
 
-func TestEmptyFilesystemSnapshotBarrierTaskIDIsRejected(t *testing.T) {
+func TestEmptyFilesystemSnapshotLockTaskIDIsRejected(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
@@ -600,18 +600,18 @@ func TestEmptyFilesystemSnapshotBarrierTaskIDIsRejected(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(f.ctx, snapshotID, "")
+	err = f.storage.LockFilesystemSnapshot(f.ctx, snapshotID, "")
 	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(f.ctx, snapshotID, "")
+	err = f.storage.UnlockFilesystemSnapshot(f.ctx, snapshotID, "")
 	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
 
-	// Invalid barrier operations must not create a participant.
+	// Invalid lock operations must not create a lock.
 	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, snapshotID)
 	require.NoError(t, err)
 }
 
-func TestConcurrentFilesystemSnapshotBarrierPromotionAndIdempotentAcquire(
+func TestConcurrentFilesystemSnapshotLockPromotionAndIdempotentLock(
 	t *testing.T,
 ) {
 	f := createFixture(t)
@@ -620,8 +620,8 @@ func TestConcurrentFilesystemSnapshotBarrierPromotionAndIdempotentAcquire(
 	const attempts = 10
 	for i := 0; i < attempts; i++ {
 		snapshotID := fmt.Sprintf("%s-%d", t.Name(), i)
-		firstBarrierTaskID := fmt.Sprintf("barrier-1-%d", i)
-		secondBarrierTaskID := fmt.Sprintf("barrier-2-%d", i)
+		firstLockTaskID := fmt.Sprintf("lock-1-%d", i)
+		secondLockTaskID := fmt.Sprintf("lock-2-%d", i)
 
 		_, err := f.storage.CreateFilesystemSnapshot(
 			f.ctx,
@@ -636,44 +636,44 @@ func TestConcurrentFilesystemSnapshotBarrierPromotionAndIdempotentAcquire(
 		)
 		require.NoError(t, err, "attempt %v", i)
 
-		err = f.storage.AcquireFilesystemSnapshotBarrier(
+		err = f.storage.LockFilesystemSnapshot(
 			f.ctx,
 			snapshotID,
-			firstBarrierTaskID,
+			firstLockTaskID,
 		)
 		require.NoError(t, err, "attempt %v", i)
 
-		err = f.storage.AcquireFilesystemSnapshotBarrier(
+		err = f.storage.LockFilesystemSnapshot(
 			f.ctx,
 			snapshotID,
-			secondBarrierTaskID,
+			secondLockTaskID,
 		)
 		require.NoError(t, err, "attempt %v", i)
 
 		start := make(chan struct{})
-		releaseResultCh := make(chan error, 1)
-		acquireResultCh := make(chan error, 1)
+		unlockResultCh := make(chan error, 1)
+		lockResultCh := make(chan error, 1)
 
 		go func() {
 			<-start
-			releaseResultCh <- f.storage.ReleaseFilesystemSnapshotBarrier(
+			unlockResultCh <- f.storage.UnlockFilesystemSnapshot(
 				f.ctx,
 				snapshotID,
-				firstBarrierTaskID,
+				firstLockTaskID,
 			)
 		}()
 		go func() {
 			<-start
-			acquireResultCh <- f.storage.AcquireFilesystemSnapshotBarrier(
+			lockResultCh <- f.storage.LockFilesystemSnapshot(
 				f.ctx,
 				snapshotID,
-				secondBarrierTaskID,
+				secondLockTaskID,
 			)
 		}()
 
 		close(start)
-		require.NoError(t, <-releaseResultCh, "attempt %v", i)
-		require.NoError(t, <-acquireResultCh, "attempt %v", i)
+		require.NoError(t, <-unlockResultCh, "attempt %v", i)
+		require.NoError(t, <-lockResultCh, "attempt %v", i)
 
 		deleting, err := f.storage.DeletingFilesystemSnapshot(
 			f.ctx,
@@ -688,12 +688,12 @@ func TestConcurrentFilesystemSnapshotBarrierPromotionAndIdempotentAcquire(
 			i,
 		)
 
-		// A concurrent idempotent acquire must not duplicate the promoted
-		// participant. One release empties the barrier.
-		err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		// A concurrent idempotent lock must not duplicate the promoted lock. One
+		// unlock removes it.
+		err = f.storage.UnlockFilesystemSnapshot(
 			f.ctx,
 			snapshotID,
-			secondBarrierTaskID,
+			secondLockTaskID,
 		)
 		require.NoError(t, err, "attempt %v", i)
 
@@ -706,13 +706,13 @@ func TestConcurrentFilesystemSnapshotBarrierPromotionAndIdempotentAcquire(
 	}
 }
 
-func TestDeleteFilesystemSnapshotAfterLastBarrierRelease(t *testing.T) {
+func TestDeleteFilesystemSnapshotAfterLastUnlock(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
 	snapshotID := t.Name()
-	const firstBarrierTaskID = "barrier-1"
-	const secondBarrierTaskID = "barrier-2"
+	const firstLockTaskID = "lock-1"
+	const secondLockTaskID = "lock-2"
 	_, err := f.storage.CreateFilesystemSnapshot(
 		f.ctx,
 		FilesystemSnapshotMeta{
@@ -726,28 +726,28 @@ func TestDeleteFilesystemSnapshotAfterLastBarrierRelease(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(
+	err = f.storage.LockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		firstBarrierTaskID,
+		firstLockTaskID,
 	)
 	require.NoError(t, err)
 
-	err = f.storage.AcquireFilesystemSnapshotBarrier(
+	err = f.storage.LockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		secondBarrierTaskID,
+		secondLockTaskID,
 	)
 	require.NoError(t, err)
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+	err = f.storage.UnlockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		firstBarrierTaskID,
+		firstLockTaskID,
 	)
 	require.NoError(t, err)
 
-	// Deletion remains blocked until every barrier participant releases.
+	// Deletion remains blocked until every task unlocks the snapshot.
 	deleting, err := f.storage.DeletingFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
@@ -755,10 +755,10 @@ func TestDeleteFilesystemSnapshotAfterLastBarrierRelease(t *testing.T) {
 	require.Nil(t, deleting)
 	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+	err = f.storage.UnlockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		secondBarrierTaskID,
+		secondLockTaskID,
 	)
 	require.NoError(t, err)
 
@@ -770,7 +770,7 @@ func TestDeleteFilesystemSnapshotAfterLastBarrierRelease(t *testing.T) {
 	require.NotNil(t, deleting)
 }
 
-func TestConcurrentAcquireFilesystemSnapshotBarrierAndDelete(t *testing.T) {
+func TestConcurrentLockFilesystemSnapshotAndDelete(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
@@ -782,7 +782,7 @@ func TestConcurrentAcquireFilesystemSnapshotBarrierAndDelete(t *testing.T) {
 	const attempts = 10
 	for i := 0; i < attempts; i++ {
 		snapshotID := fmt.Sprintf("%s-%d", t.Name(), i)
-		barrierTaskID := fmt.Sprintf("barrier-%v", i)
+		lockTaskID := fmt.Sprintf("lock-%v", i)
 		_, err := f.storage.CreateFilesystemSnapshot(
 			f.ctx,
 			FilesystemSnapshotMeta{
@@ -797,15 +797,15 @@ func TestConcurrentAcquireFilesystemSnapshotBarrierAndDelete(t *testing.T) {
 		require.NoError(t, err, "attempt %v", i)
 
 		start := make(chan struct{})
-		acquireResultCh := make(chan error, 1)
+		lockResultCh := make(chan error, 1)
 		deleteResultCh := make(chan deleteResult, 1)
 
 		go func() {
 			<-start
-			acquireResultCh <- f.storage.AcquireFilesystemSnapshotBarrier(
+			lockResultCh <- f.storage.LockFilesystemSnapshot(
 				f.ctx,
 				snapshotID,
-				barrierTaskID,
+				lockTaskID,
 			)
 		}()
 		go func() {
@@ -818,32 +818,31 @@ func TestConcurrentAcquireFilesystemSnapshotBarrierAndDelete(t *testing.T) {
 		}()
 
 		close(start)
-		acquireErr := <-acquireResultCh
+		lockErr := <-lockResultCh
 		deleteResult := <-deleteResultCh
 
 		if deleteResult.err == nil {
-			// Deletion serialized first, so a barrier can no longer be acquired.
-			// Releasing it remains an idempotent no-op.
+			// Deletion serialized first, so the snapshot can no longer be locked.
+			// Unlocking it remains an idempotent no-op.
 			require.NotNil(t, deleteResult.meta, "attempt %v", i)
 			require.ErrorIs(
 				t,
-				acquireErr,
+				lockErr,
 				errors.NewEmptyNonRetriableError(),
 				"attempt %v",
 				i,
 			)
 
-			err = f.storage.ReleaseFilesystemSnapshotBarrier(
+			err = f.storage.UnlockFilesystemSnapshot(
 				f.ctx,
 				snapshotID,
-				barrierTaskID,
+				lockTaskID,
 			)
 			require.NoError(t, err, "attempt %v", i)
 			continue
 		}
 
-		// Acquisition serialized first, so deletion must wait for that barrier
-		// participant.
+		// Locking serialized first, so deletion must wait for that lock.
 		require.Nil(t, deleteResult.meta, "attempt %v", i)
 		require.ErrorIs(
 			t,
@@ -852,12 +851,12 @@ func TestConcurrentAcquireFilesystemSnapshotBarrierAndDelete(t *testing.T) {
 			"attempt %v",
 			i,
 		)
-		require.NoError(t, acquireErr, "attempt %v", i)
+		require.NoError(t, lockErr, "attempt %v", i)
 
-		err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		err = f.storage.UnlockFilesystemSnapshot(
 			f.ctx,
 			snapshotID,
-			barrierTaskID,
+			lockTaskID,
 		)
 		require.NoError(t, err, "attempt %v", i)
 
@@ -870,7 +869,7 @@ func TestConcurrentAcquireFilesystemSnapshotBarrierAndDelete(t *testing.T) {
 	}
 }
 
-func TestConcurrentReleaseAndDeleteFilesystemSnapshotWithSecondBarrierParticipant(
+func TestConcurrentUnlockAndDeleteFilesystemSnapshotWithSecondLockHolder(
 	t *testing.T,
 ) {
 	f := createFixture(t)
@@ -879,8 +878,8 @@ func TestConcurrentReleaseAndDeleteFilesystemSnapshotWithSecondBarrierParticipan
 	const attempts = 10
 	for i := 0; i < attempts; i++ {
 		snapshotID := fmt.Sprintf("%s-%d", t.Name(), i)
-		firstBarrierTaskID := fmt.Sprintf("barrier-1-%v", i)
-		secondBarrierTaskID := fmt.Sprintf("barrier-2-%v", i)
+		firstLockTaskID := fmt.Sprintf("lock-1-%v", i)
+		secondLockTaskID := fmt.Sprintf("lock-2-%v", i)
 		_, err := f.storage.CreateFilesystemSnapshot(
 			f.ctx,
 			FilesystemSnapshotMeta{
@@ -894,30 +893,30 @@ func TestConcurrentReleaseAndDeleteFilesystemSnapshotWithSecondBarrierParticipan
 		)
 		require.NoError(t, err, "attempt %v", i)
 
-		err = f.storage.AcquireFilesystemSnapshotBarrier(
+		err = f.storage.LockFilesystemSnapshot(
 			f.ctx,
 			snapshotID,
-			firstBarrierTaskID,
+			firstLockTaskID,
 		)
 		require.NoError(t, err)
 
-		err = f.storage.AcquireFilesystemSnapshotBarrier(
+		err = f.storage.LockFilesystemSnapshot(
 			f.ctx,
 			snapshotID,
-			secondBarrierTaskID,
+			secondLockTaskID,
 		)
 		require.NoError(t, err, "attempt %v", i)
 
 		start := make(chan struct{})
-		releaseResultCh := make(chan error, 1)
+		unlockResultCh := make(chan error, 1)
 		deleteResultCh := make(chan error, 1)
 
 		go func() {
 			<-start
-			releaseResultCh <- f.storage.ReleaseFilesystemSnapshotBarrier(
+			unlockResultCh <- f.storage.UnlockFilesystemSnapshot(
 				f.ctx,
 				snapshotID,
-				firstBarrierTaskID,
+				firstLockTaskID,
 			)
 		}()
 		go func() {
@@ -930,7 +929,7 @@ func TestConcurrentReleaseAndDeleteFilesystemSnapshotWithSecondBarrierParticipan
 		}()
 
 		close(start)
-		require.NoError(t, <-releaseResultCh, "attempt %v", i)
+		require.NoError(t, <-unlockResultCh, "attempt %v", i)
 		require.ErrorIs(
 			t,
 			<-deleteResultCh,
@@ -939,10 +938,10 @@ func TestConcurrentReleaseAndDeleteFilesystemSnapshotWithSecondBarrierParticipan
 			i,
 		)
 
-		err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		err = f.storage.UnlockFilesystemSnapshot(
 			f.ctx,
 			snapshotID,
-			secondBarrierTaskID,
+			secondLockTaskID,
 		)
 		require.NoError(t, err, "attempt %v", i)
 
@@ -955,23 +954,23 @@ func TestConcurrentReleaseAndDeleteFilesystemSnapshotWithSecondBarrierParticipan
 	}
 }
 
-func TestFilesystemSnapshotBarrierForNonexistingSnapshot(t *testing.T) {
+func TestLockUnlockNonexistingFilesystemSnapshot(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
 	snapshotID := t.Name()
 
-	err := f.storage.AcquireFilesystemSnapshotBarrier(
+	err := f.storage.LockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		"barrier",
+		"lock",
 	)
 	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
 
-	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+	err = f.storage.UnlockFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		"barrier",
+		"lock",
 	)
 	require.NoError(t, err)
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb_test.go
@@ -175,7 +175,6 @@ func TestDeleteFilesystemSnapshot(t *testing.T) {
 	deleting, err := f.storage.DeletingFilesystemSnapshot(
 		f.ctx,
 		snapshotMeta.ID,
-		"delete",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, deleting)
@@ -185,7 +184,6 @@ func TestDeleteFilesystemSnapshot(t *testing.T) {
 	deleting2, err := f.storage.DeletingFilesystemSnapshot(
 		f.ctx,
 		snapshotMeta.ID,
-		"delete",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, deleting2)
@@ -206,7 +204,6 @@ func TestDeleteNonexistingFilesystemSnapshot(t *testing.T) {
 	deleting, err := f.storage.DeletingFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		"delete",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, deleting)
@@ -244,10 +241,10 @@ func TestGetFilesystemSnapshotsToDelete(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot1", "delete1")
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot1")
 	require.NoError(t, err)
 
-	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot2", "delete2")
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot2")
 	require.NoError(t, err)
 
 	// Get snapshots to delete
@@ -301,7 +298,7 @@ func TestCheckFilesystemSnapshotAlive(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mark for deletion
-	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot", "delete")
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot")
 	require.NoError(t, err)
 
 	// Should not be alive
@@ -341,7 +338,7 @@ func TestCheckFilesystemSnapshotReady(t *testing.T) {
 	err = f.storage.CheckFilesystemSnapshotReady(f.ctx, "snapshot")
 	require.NoError(t, err)
 
-	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot", "delete")
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot")
 	require.NoError(t, err)
 
 	err = f.storage.CheckFilesystemSnapshotReady(f.ctx, "snapshot")
@@ -412,15 +409,15 @@ func TestCheckFilesystemSnapshotReadyWithCancellationDoesNotReturnNonRetriableEr
 	}
 }
 
-func TestLockUnlockFilesystemSnapshot(t *testing.T) {
+func TestFilesystemSnapshotBarrier(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
-	// Create snapshot
+	snapshotID := t.Name()
 	_, err := f.storage.CreateFilesystemSnapshot(
 		f.ctx,
 		FilesystemSnapshotMeta{
-			ID:           "snapshot",
+			ID:           snapshotID,
 			CreateTaskID: "create",
 			Filesystem: &types.Filesystem{
 				ZoneId:       "zone",
@@ -430,67 +427,553 @@ func TestLockUnlockFilesystemSnapshot(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Lock snapshot
-	locked, err := f.storage.LockFilesystemSnapshot(f.ctx, "snapshot", "lock1")
+	err = f.storage.AcquireFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier1")
 	require.NoError(t, err)
-	require.True(t, locked)
 
-	// Try to lock again with different task ID - should fail
-	locked, err = f.storage.LockFilesystemSnapshot(f.ctx, "snapshot", "lock2")
-	require.Error(t, err)
-	require.False(t, locked)
-	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
+	err = f.storage.AcquireFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier2")
+	require.NoError(t, err)
 
-	// Try to delete locked snapshot - should fail
-	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot", "delete1")
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, snapshotID)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
 
-	// Unlock with wrong task ID - should succeed (unlock is idempotent)
-	err = f.storage.UnlockFilesystemSnapshot(f.ctx, "snapshot", "lock2")
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier2")
 	require.NoError(t, err)
 
-	// Check still locked
-	meta, err := f.storage.GetFilesystemSnapshotMeta(f.ctx, "snapshot")
-	require.NoError(t, err)
-	require.Equal(t, "lock1", meta.LockTaskID)
+	// Releasing one participant does not release the barrier.
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, snapshotID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
 
-	// Unlock with correct task ID
-	err = f.storage.UnlockFilesystemSnapshot(f.ctx, "snapshot", "lock1")
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier1")
 	require.NoError(t, err)
 
-	// Check unlocked
-	meta, err = f.storage.GetFilesystemSnapshotMeta(f.ctx, "snapshot")
-	require.NoError(t, err)
-	require.Empty(t, meta.LockTaskID)
-
-	// Now deletion should succeed after unlock
 	deleting, err := f.storage.DeletingFilesystemSnapshot(
 		f.ctx,
-		"snapshot",
-		"delete1",
+		snapshotID,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, deleting)
 
-	// Try to lock snapshot that is deleting - should return false
-	locked, err = f.storage.LockFilesystemSnapshot(f.ctx, "snapshot", "lock3")
+	err = f.storage.AcquireFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier3")
+	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(f.ctx, snapshotID, "barrier3")
 	require.NoError(t, err)
-	require.False(t, locked)
 }
 
-func TestLockNonexistingFilesystemSnapshot(t *testing.T) {
+func TestFilesystemSnapshotBarrierAcquireAndReleaseAreIdempotent(t *testing.T) {
 	f := createFixture(t)
 	defer f.teardown()
 
-	// Lock non-existing snapshot - should succeed but return false
-	locked, err := f.storage.LockFilesystemSnapshot(
+	snapshotID := t.Name()
+	const barrierTaskID = "barrier"
+	_, err := f.storage.CreateFilesystemSnapshot(
 		f.ctx,
-		"nonexisting",
-		"lock",
+		FilesystemSnapshotMeta{
+			ID:           snapshotID,
+			CreateTaskID: "create",
+			Filesystem: &types.Filesystem{
+				ZoneId:       "zone",
+				FilesystemId: "fs",
+			},
+		},
 	)
 	require.NoError(t, err)
-	require.False(t, locked)
+
+	err = f.storage.AcquireFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		barrierTaskID,
+	)
+	require.NoError(t, err)
+
+	err = f.storage.AcquireFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		barrierTaskID,
+	)
+	require.NoError(t, err)
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		barrierTaskID,
+	)
+	require.NoError(t, err)
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		barrierTaskID,
+	)
+	require.NoError(t, err)
+
+	// Repeated acquisition creates one barrier participant, and repeated release
+	// is a no-op, so deletion is allowed.
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, snapshotID)
+	require.NoError(t, err)
+}
+
+func TestFilesystemSnapshotBarrierParticipantAcquireIsIdempotent(t *testing.T) {
+	f := createFixture(t)
+	defer f.teardown()
+
+	snapshotID := t.Name()
+	const firstBarrierTaskID = "barrier-1"
+	const secondBarrierTaskID = "barrier-2"
+	_, err := f.storage.CreateFilesystemSnapshot(
+		f.ctx,
+		FilesystemSnapshotMeta{
+			ID:           snapshotID,
+			CreateTaskID: "create",
+			Filesystem: &types.Filesystem{
+				ZoneId:       "zone",
+				FilesystemId: "fs",
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	err = f.storage.AcquireFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		firstBarrierTaskID,
+	)
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		err = f.storage.AcquireFilesystemSnapshotBarrier(
+			f.ctx,
+			snapshotID,
+			secondBarrierTaskID,
+		)
+		require.NoError(t, err)
+	}
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		firstBarrierTaskID,
+	)
+	require.NoError(t, err)
+
+	deleting, err := f.storage.DeletingFilesystemSnapshot(
+		f.ctx,
+		snapshotID,
+	)
+	require.Nil(t, deleting)
+	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		secondBarrierTaskID,
+	)
+	require.NoError(t, err)
+
+	// Repeated acquisition of the second participant must require only one
+	// release before the barrier is empty.
+	deleting, err = f.storage.DeletingFilesystemSnapshot(
+		f.ctx,
+		snapshotID,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, deleting)
+}
+
+func TestEmptyFilesystemSnapshotBarrierTaskIDIsRejected(t *testing.T) {
+	f := createFixture(t)
+	defer f.teardown()
+
+	snapshotID := t.Name()
+	_, err := f.storage.CreateFilesystemSnapshot(
+		f.ctx,
+		FilesystemSnapshotMeta{
+			ID:           snapshotID,
+			CreateTaskID: "create",
+			Filesystem: &types.Filesystem{
+				ZoneId:       "zone",
+				FilesystemId: "fs",
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	err = f.storage.AcquireFilesystemSnapshotBarrier(f.ctx, snapshotID, "")
+	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(f.ctx, snapshotID, "")
+	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
+
+	// Invalid barrier operations must not create a participant.
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, snapshotID)
+	require.NoError(t, err)
+}
+
+func TestConcurrentFilesystemSnapshotBarrierPromotionAndIdempotentAcquire(
+	t *testing.T,
+) {
+	f := createFixture(t)
+	defer f.teardown()
+
+	const attempts = 10
+	for i := 0; i < attempts; i++ {
+		snapshotID := fmt.Sprintf("%s-%d", t.Name(), i)
+		firstBarrierTaskID := fmt.Sprintf("barrier-1-%d", i)
+		secondBarrierTaskID := fmt.Sprintf("barrier-2-%d", i)
+
+		_, err := f.storage.CreateFilesystemSnapshot(
+			f.ctx,
+			FilesystemSnapshotMeta{
+				ID:           snapshotID,
+				CreateTaskID: "create",
+				Filesystem: &types.Filesystem{
+					ZoneId:       "zone",
+					FilesystemId: "fs",
+				},
+			},
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		err = f.storage.AcquireFilesystemSnapshotBarrier(
+			f.ctx,
+			snapshotID,
+			firstBarrierTaskID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		err = f.storage.AcquireFilesystemSnapshotBarrier(
+			f.ctx,
+			snapshotID,
+			secondBarrierTaskID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		start := make(chan struct{})
+		releaseResultCh := make(chan error, 1)
+		acquireResultCh := make(chan error, 1)
+
+		go func() {
+			<-start
+			releaseResultCh <- f.storage.ReleaseFilesystemSnapshotBarrier(
+				f.ctx,
+				snapshotID,
+				firstBarrierTaskID,
+			)
+		}()
+		go func() {
+			<-start
+			acquireResultCh <- f.storage.AcquireFilesystemSnapshotBarrier(
+				f.ctx,
+				snapshotID,
+				secondBarrierTaskID,
+			)
+		}()
+
+		close(start)
+		require.NoError(t, <-releaseResultCh, "attempt %v", i)
+		require.NoError(t, <-acquireResultCh, "attempt %v", i)
+
+		deleting, err := f.storage.DeletingFilesystemSnapshot(
+			f.ctx,
+			snapshotID,
+		)
+		require.Nil(t, deleting, "attempt %v", i)
+		require.ErrorIs(
+			t,
+			err,
+			errors.NewEmptyRetriableError(),
+			"attempt %v",
+			i,
+		)
+
+		// A concurrent idempotent acquire must not duplicate the promoted
+		// participant. One release empties the barrier.
+		err = f.storage.ReleaseFilesystemSnapshotBarrier(
+			f.ctx,
+			snapshotID,
+			secondBarrierTaskID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		deleting, err = f.storage.DeletingFilesystemSnapshot(
+			f.ctx,
+			snapshotID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+		require.NotNil(t, deleting, "attempt %v", i)
+	}
+}
+
+func TestDeleteFilesystemSnapshotAfterLastBarrierRelease(t *testing.T) {
+	f := createFixture(t)
+	defer f.teardown()
+
+	snapshotID := t.Name()
+	const firstBarrierTaskID = "barrier-1"
+	const secondBarrierTaskID = "barrier-2"
+	_, err := f.storage.CreateFilesystemSnapshot(
+		f.ctx,
+		FilesystemSnapshotMeta{
+			ID:           snapshotID,
+			CreateTaskID: "create",
+			Filesystem: &types.Filesystem{
+				ZoneId:       "zone",
+				FilesystemId: "fs",
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	err = f.storage.AcquireFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		firstBarrierTaskID,
+	)
+	require.NoError(t, err)
+
+	err = f.storage.AcquireFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		secondBarrierTaskID,
+	)
+	require.NoError(t, err)
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		firstBarrierTaskID,
+	)
+	require.NoError(t, err)
+
+	// Deletion remains blocked until every barrier participant releases.
+	deleting, err := f.storage.DeletingFilesystemSnapshot(
+		f.ctx,
+		snapshotID,
+	)
+	require.Nil(t, deleting)
+	require.ErrorIs(t, err, errors.NewEmptyRetriableError())
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		secondBarrierTaskID,
+	)
+	require.NoError(t, err)
+
+	deleting, err = f.storage.DeletingFilesystemSnapshot(
+		f.ctx,
+		snapshotID,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, deleting)
+}
+
+func TestConcurrentAcquireFilesystemSnapshotBarrierAndDelete(t *testing.T) {
+	f := createFixture(t)
+	defer f.teardown()
+
+	type deleteResult struct {
+		meta *FilesystemSnapshotMeta
+		err  error
+	}
+
+	const attempts = 10
+	for i := 0; i < attempts; i++ {
+		snapshotID := fmt.Sprintf("%s-%d", t.Name(), i)
+		barrierTaskID := fmt.Sprintf("barrier-%v", i)
+		_, err := f.storage.CreateFilesystemSnapshot(
+			f.ctx,
+			FilesystemSnapshotMeta{
+				ID:           snapshotID,
+				CreateTaskID: "create",
+				Filesystem: &types.Filesystem{
+					ZoneId:       "zone",
+					FilesystemId: "fs",
+				},
+			},
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		start := make(chan struct{})
+		acquireResultCh := make(chan error, 1)
+		deleteResultCh := make(chan deleteResult, 1)
+
+		go func() {
+			<-start
+			acquireResultCh <- f.storage.AcquireFilesystemSnapshotBarrier(
+				f.ctx,
+				snapshotID,
+				barrierTaskID,
+			)
+		}()
+		go func() {
+			<-start
+			meta, err := f.storage.DeletingFilesystemSnapshot(
+				f.ctx,
+				snapshotID,
+			)
+			deleteResultCh <- deleteResult{meta: meta, err: err}
+		}()
+
+		close(start)
+		acquireErr := <-acquireResultCh
+		deleteResult := <-deleteResultCh
+
+		if deleteResult.err == nil {
+			// Deletion serialized first, so a barrier can no longer be acquired.
+			// Releasing it remains an idempotent no-op.
+			require.NotNil(t, deleteResult.meta, "attempt %v", i)
+			require.ErrorIs(
+				t,
+				acquireErr,
+				errors.NewEmptyNonRetriableError(),
+				"attempt %v",
+				i,
+			)
+
+			err = f.storage.ReleaseFilesystemSnapshotBarrier(
+				f.ctx,
+				snapshotID,
+				barrierTaskID,
+			)
+			require.NoError(t, err, "attempt %v", i)
+			continue
+		}
+
+		// Acquisition serialized first, so deletion must wait for that barrier
+		// participant.
+		require.Nil(t, deleteResult.meta, "attempt %v", i)
+		require.ErrorIs(
+			t,
+			deleteResult.err,
+			errors.NewEmptyRetriableError(),
+			"attempt %v",
+			i,
+		)
+		require.NoError(t, acquireErr, "attempt %v", i)
+
+		err = f.storage.ReleaseFilesystemSnapshotBarrier(
+			f.ctx,
+			snapshotID,
+			barrierTaskID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		deleting, err := f.storage.DeletingFilesystemSnapshot(
+			f.ctx,
+			snapshotID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+		require.NotNil(t, deleting, "attempt %v", i)
+	}
+}
+
+func TestConcurrentReleaseAndDeleteFilesystemSnapshotWithSecondBarrierParticipant(
+	t *testing.T,
+) {
+	f := createFixture(t)
+	defer f.teardown()
+
+	const attempts = 10
+	for i := 0; i < attempts; i++ {
+		snapshotID := fmt.Sprintf("%s-%d", t.Name(), i)
+		firstBarrierTaskID := fmt.Sprintf("barrier-1-%v", i)
+		secondBarrierTaskID := fmt.Sprintf("barrier-2-%v", i)
+		_, err := f.storage.CreateFilesystemSnapshot(
+			f.ctx,
+			FilesystemSnapshotMeta{
+				ID:           snapshotID,
+				CreateTaskID: "create",
+				Filesystem: &types.Filesystem{
+					ZoneId:       "zone",
+					FilesystemId: "fs",
+				},
+			},
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		err = f.storage.AcquireFilesystemSnapshotBarrier(
+			f.ctx,
+			snapshotID,
+			firstBarrierTaskID,
+		)
+		require.NoError(t, err)
+
+		err = f.storage.AcquireFilesystemSnapshotBarrier(
+			f.ctx,
+			snapshotID,
+			secondBarrierTaskID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		start := make(chan struct{})
+		releaseResultCh := make(chan error, 1)
+		deleteResultCh := make(chan error, 1)
+
+		go func() {
+			<-start
+			releaseResultCh <- f.storage.ReleaseFilesystemSnapshotBarrier(
+				f.ctx,
+				snapshotID,
+				firstBarrierTaskID,
+			)
+		}()
+		go func() {
+			<-start
+			_, err := f.storage.DeletingFilesystemSnapshot(
+				f.ctx,
+				snapshotID,
+			)
+			deleteResultCh <- err
+		}()
+
+		close(start)
+		require.NoError(t, <-releaseResultCh, "attempt %v", i)
+		require.ErrorIs(
+			t,
+			<-deleteResultCh,
+			errors.NewEmptyRetriableError(),
+			"attempt %v",
+			i,
+		)
+
+		err = f.storage.ReleaseFilesystemSnapshotBarrier(
+			f.ctx,
+			snapshotID,
+			secondBarrierTaskID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+
+		deleting, err := f.storage.DeletingFilesystemSnapshot(
+			f.ctx,
+			snapshotID,
+		)
+		require.NoError(t, err, "attempt %v", i)
+		require.NotNil(t, deleting, "attempt %v", i)
+	}
+}
+
+func TestFilesystemSnapshotBarrierForNonexistingSnapshot(t *testing.T) {
+	f := createFixture(t)
+	defer f.teardown()
+
+	snapshotID := t.Name()
+
+	err := f.storage.AcquireFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		"barrier",
+	)
+	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
+
+	err = f.storage.ReleaseFilesystemSnapshotBarrier(
+		f.ctx,
+		snapshotID,
+		"barrier",
+	)
+	require.NoError(t, err)
 }
 
 func TestListFilesystemSnapshots(t *testing.T) {
@@ -549,7 +1032,7 @@ func TestListFilesystemSnapshots(t *testing.T) {
 	require.True(t, snapshots.Has("snapshot2"))
 
 	// Mark one for deletion
-	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot1", "delete")
+	_, err = f.storage.DeletingFilesystemSnapshot(f.ctx, "snapshot1")
 	require.NoError(t, err)
 
 	// Should only list the ready one

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb_test.go
@@ -457,6 +457,7 @@ func TestLockUnlockFilesystemSnapshot(t *testing.T) {
 
 	err = f.storage.LockFilesystemSnapshot(f.ctx, snapshotID, "lock3")
 	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
+	require.True(t, errors.IsSilent(err))
 
 	err = f.storage.UnlockFilesystemSnapshot(f.ctx, snapshotID, "lock3")
 	require.NoError(t, err)
@@ -966,6 +967,7 @@ func TestLockUnlockNonexistingFilesystemSnapshot(t *testing.T) {
 		"lock",
 	)
 	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
+	require.True(t, errors.IsSilent(err))
 
 	err = f.storage.UnlockFilesystemSnapshot(
 		f.ctx,

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/transfer_task_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/transfer_task_test.go
@@ -1175,7 +1175,6 @@ func TestCreateSnapshotFromFilesystemDoesNotRunWhenDeletedBeforeTransfer(t *test
 	_, err := f.snapshotStorage.DeletingFilesystemSnapshot(
 		f.ctx,
 		snapshotID,
-		"delete-task",
 	)
 	require.NoError(t, err)
 
@@ -1238,7 +1237,6 @@ func TestCreateSnapshotFromFilesystemStopsWhenDeletedDuringTransfer(t *testing.T
 			_, err := f.snapshotStorage.DeletingFilesystemSnapshot(
 				ctx,
 				snapshotID,
-				"delete-task",
 			)
 			return err
 		},


### PR DESCRIPTION
### Notes
Change Lock behavior to barrier with multiple acquirers behavior. LockFilesystemSnapshot() -> AcquireFilesystemSnapshotBarrier() UnlockFilesystemSnapshot() -> ReleaseFilesystemSnapshotBarrier().

When restoring a filesystem shard (which is exceptional situation caused by an incident), we need to be sure snapshot is not deleted. We want to be able to restore different shards simultaneously.

On the contrary to filesystem shard restoration, which is an incident mitigation method, filesystem from snapshot restoration should not require locking (we do not lock disk snapshots).
### Issue
#1559