### PR TITLE
[Disk Manager]  fix ydbd pg port collision

### DIFF
--- a/cloud/disk_manager/test/recipe/ydb_launcher.py
+++ b/cloud/disk_manager/test/recipe/ydb_launcher.py
@@ -28,6 +28,8 @@ class YDBLauncher:
         self.__dynamic_storage_pools = dynamic_storage_pools
 
     def start(self):
+        # Make ydbd use the harness-allocated PGWire port; otherwise its default
+        # port 5432 may collide with a dynamically allocated monitoring port.
         os.environ["YDB_ALLOCATE_PGWIRE_PORT"] = "true"
         self.__cluster.start()
         for kimimr_node in list(self.__cluster.nodes.values()):

--- a/cloud/disk_manager/test/recipe/ydb_launcher.py
+++ b/cloud/disk_manager/test/recipe/ydb_launcher.py
@@ -1,3 +1,5 @@
+import os
+
 from cloud.tasks.test.common.processes import register_process, kill_processes
 from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
@@ -26,6 +28,7 @@ class YDBLauncher:
         self.__dynamic_storage_pools = dynamic_storage_pools
 
     def start(self):
+        os.environ["YDB_ALLOCATE_PGWIRE_PORT"] = "true"
         self.__cluster.start()
         for kimimr_node in list(self.__cluster.nodes.values()):
             register_process(SERVICE_NAME, kimimr_node.pid)

--- a/cloud/tasks/acceptance_tests/ya.make
+++ b/cloud/tasks/acceptance_tests/ya.make
@@ -1,5 +1,7 @@
 GO_TEST()
 
+ENV(YDB_ALLOCATE_PGWIRE_PORT=true)
+
 INCLUDE(${ARCADIA_ROOT}/contrib/ydb/public/tools/ydb_recipe/recipe.inc)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/tasks/acceptance_tests/recipe/recipe.inc)

--- a/cloud/tasks/persistence/tests/ya.make
+++ b/cloud/tasks/persistence/tests/ya.make
@@ -1,5 +1,7 @@
 GO_TEST_FOR(cloud/tasks/persistence)
 
+ENV(YDB_ALLOCATE_PGWIRE_PORT=true)
+
 INCLUDE(${ARCADIA_ROOT}/contrib/ydb/public/tools/ydb_recipe/recipe.inc)
 
 SIZE(MEDIUM)

--- a/cloud/tasks/storage/tests/ya.make
+++ b/cloud/tasks/storage/tests/ya.make
@@ -1,5 +1,7 @@
 GO_TEST_FOR(cloud/tasks/storage)
 
+ENV(YDB_ALLOCATE_PGWIRE_PORT=true)
+
 INCLUDE(${ARCADIA_ROOT}/contrib/ydb/public/tools/ydb_recipe/recipe.inc)
 
 IF (RACE)

--- a/cloud/tasks/tasks_tests/ya.make
+++ b/cloud/tasks/tasks_tests/ya.make
@@ -1,5 +1,7 @@
 GO_TEST()
 
+ENV(YDB_ALLOCATE_PGWIRE_PORT=true)
+
 INCLUDE(${ARCADIA_ROOT}/contrib/ydb/public/tools/ydb_recipe/recipe.inc)
 
 GO_XTEST_SRCS(

--- a/contrib/ydb/public/tools/ydb_recipe/recipe.inc
+++ b/contrib/ydb/public/tools/ydb_recipe/recipe.inc
@@ -1,4 +1,5 @@
 ENV(YDB_DRIVER_BINARY="contrib/ydb/apps/ydbd/ydbd")
+ENV(YDB_ALLOCATE_PGWIRE_PORT=true)
 
 DEPENDS(
     contrib/ydb/apps/ydbd

--- a/contrib/ydb/public/tools/ydb_recipe/recipe.inc
+++ b/contrib/ydb/public/tools/ydb_recipe/recipe.inc
@@ -1,5 +1,4 @@
 ENV(YDB_DRIVER_BINARY="contrib/ydb/apps/ydbd/ydbd")
-ENV(YDB_ALLOCATE_PGWIRE_PORT=true)
 
 DEPENDS(
     contrib/ydb/apps/ydbd


### PR DESCRIPTION
### Notes
When ydbd mon port is selected as 5432 and pg port is set as 5432 there is a port collision. fix it by using port-manager for pgwire port selection by setting YDB_ALLOCATE_PGWIRE_PORT environment variable.