### PR TITLE
Fix TStorageServiceTest.ShouldReassignTablet by preserving EnableScheduleForActor propagation in TTabletScheduledEventsGuard

### DIFF
--- a/contrib/ydb/core/testlib/tablet_helpers.cpp
+++ b/contrib/ydb/core/testlib/tablet_helpers.cpp
@@ -1024,6 +1024,19 @@ namespace NKikimr {
             PrevRegistrationObserverFunc = Runtime.SetRegistrationObserverFunc(
                 [&](TTestActorRuntimeBase& runtime, const TActorId& parentId, const TActorId& actorId) {
                 TabletTracer.OnRegistration(AsKikimrRuntime(runtime), parentId, actorId);
+                // Chain to the previous observer (normally
+                // TTestActorRuntimeBase::DefaultRegistrationObserver) so that
+                // the EnableScheduleForActor whitelist keeps being propagated
+                // from parent actors to their children while the guard is
+                // active. A tablet rebooted under the guard is respawned by
+                // its (schedule-enabled) bootstrapper within the guard's
+                // lifetime; without this propagation the new tablet instance
+                // is never whitelisted, and once the guard is destroyed all
+                // the events the tablet schedules for itself are silently
+                // dropped by TTestActorRuntime::DefaultScheduledFilterFunc.
+                if (PrevRegistrationObserverFunc) {
+                    PrevRegistrationObserverFunc(runtime, parentId, actorId);
+                }
             });
 
             PrevScheduledFilterFunc = Runtime.SetScheduledEventFilter([&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event,


### PR DESCRIPTION
### Background: how timers work in the test runtime

Two mechanisms in TTestActorRuntime matter here:
* Scheduled events are dropped by default. In the simulated actor system, when an actor calls Schedule() ("send this to myself after N ms"), the event is only delivered if a scheduled-event filter approves it. The default filter, TTestActorRuntime::DefaultScheduledFilterFunc, drops everything except a small hardcoded set (pipe client retries, a few blobstorage/follower retries) and events whose recipient is on the schedule whitelist — actors registered via EnableScheduleForActor.
* The whitelist is inherited parent → child. The test env boots tablets through CreateTestBootstrapper and whitelists only the bootstrapper. The tablet's real actors get whitelisted transitively: TTestActorRuntimeBase::DefaultRegistrationObserver runs on every actor registration, and if the parent is whitelisted, the child is added too. So: bootstrapper → sys tablet actor → user actor (THive) → executor — the whole tree inherits, and that's the only reason the original hive's internal timers work at all.

### The bug, step by step

* TTestEnv::RebootHive() needs to restart hive (the test mutates the BSC SelectGroups reply to fake high group occupancy, and hive only re-reads occupancy on boot). It wraps NKikimr::RebootTablet in CreateTabletScheduledEventsGuard({hiveTabletId}, ...), whose job is to temporarily allow the rebooting tablet's scheduled events so the reboot completes in simulated time.
* The guard's constructor swaps out four runtime hooks, including the registration observer. Its replacement only feeds the guard's internal tablet tracer — it does not call the previous observer. So for as long as the guard is alive, the parent→child whitelist inheritance from step 2 above is switched off. That's the defect.
* RebootTablet poisons hive. The bootstrapper (still alive, still whitelisted) respawns it — but every actor of the new hive instance is registered inside the guard's window, so none of them enter the whitelist.
Nothing looks wrong yet: while the guard lives, its own filter admits events for traced tablet actors, so the reboot finishes.
* RebootHive() returns, the guard's destructor restores the default filter and observers. The restarted hive is now running without whitelist membership, and from this moment every Schedule() it makes is silently discarded. The hive has permanently lost its timers.
* The ydb 25.1 hive's post-restart flow actually needs those timers. After restart it reloads state: the FileStore tablet is known but VolatileState: Unknown (the "not ready for anything" warning in your log), hive pings node 40's Local, Local re-registers and syncs — and along the way the FileStore tablet gets restarted (the pipe disconnect at 12:20:50). Re-booting it trips hive's restart-penalty logic (restarts counted per TTxStartTablet, with TabletRestartsPeriod=1s, TabletRestartsMaxCount=2, PostponeStartPeriod=1s), so the boot is postponed — and a postponed boot resumes only via a scheduled ProcessBootQueue wakeup.
* That wakeup is exactly what step 5 destroys. The postpone deadline never fires, the boot queue is never reprocessed, and the tablet stays dead forever — silently, since postponing logs only at debug level, which matches your WARN-filtered log showing nothing from hive.

Visible fallout: the session worker retries pipe connects to the tablet with ERROR for 30 virtual seconds, then E_TIMEOUT. The test's ExecuteAction("reassigntablet") goes hive-proxy → TEvReassignTabletSpace → hive, and completes only when hive sends back TEvTabletCreationResult after finishing the group update — which never happens. GrabEdgeEvent keeps pumping retry traffic until the runtime's safety valve trips: TSchedulingLimitReachedException: Processed over 100000 events.

### The fix

One change in TTabletScheduledEventsGuard's constructor: after feeding the tracer, the registration observer now chains to the previous observer (PrevRegistrationObserverFunc, normally DefaultRegistrationObserver) instead of replacing its behavior. 

Test log:
```
2026-08-18T22:17:56.900364Z node 39 :BS_PROXY_DISCOVER WARN: [d3a1fc113ba9dc9e] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.900429Z node 39 :BS_PROXY_DISCOVER WARN: [0ba3dc80ac2e664d] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.900482Z node 39 :BS_PROXY_DISCOVER WARN: [1ff8c6bd1c773d5b] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.900520Z node 39 :BS_PROXY_DISCOVER WARN: [b6845e37898c7df3] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.900622Z node 39 :BS_PROXY_DISCOVER WARN: [74f3fe3eccc1e6e3] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.900798Z node 39 :BS_PROXY_DISCOVER WARN: [045be497128c87f5] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.901361Z node 39 :BS_PROXY_DISCOVER WARN: [2f6935a3b86b7aeb] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.901592Z node 39 :BS_PROXY_DISCOVER WARN: [228f3240d1677545] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.901992Z node 39 :BS_PROXY_DISCOVER WARN: [a68d86426db8d7c3] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.903991Z node 39 :BS_PROXY_DISCOVER WARN: [bdacece49e31ae42] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.904172Z node 39 :BS_PROXY_DISCOVER WARN: [6f8059a6d378e0eb] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.904302Z node 39 :BS_PROXY_DISCOVER WARN: [7b409e8af5c78a2e] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:56.914722Z node 39 :FLAT_TX_SCHEMESHARD WARN: Cannot subscribe to console configs
2026-08-18T22:17:56.914731Z node 39 :IMPORT WARN: Table profiles were not loaded
tablet_helpers.cpp: SetPath # /home/github/.ya/build/build_root/5m8i/00028e/r3tmp/tmpCsApgy/pdisk_1.dat
2026-08-18T22:17:57.016274Z node 39 :FLAT_TX_SCHEMESHARD WARN: Operation part proposed ok, but propose itself is undo unsafe, suboperation type: ESchemeOpAlterSubDomain, opId: 1:0, at schemeshard:  72075186232688896
2026-08-18T22:17:57.019283Z node 39 :FLAT_TX_SCHEMESHARD WARN: NotifyTxCompletion, unknown transaction, txId: 1, at schemeshard: 72075186232688896
2026-08-18T22:17:57.022164Z node 39 :FLAT_TX_SCHEMESHARD WARN: Operation part proposed ok, but propose itself is undo unsafe, suboperation type: ESchemeOpCreateSubDomain, opId: 281474976720656:0, at schemeshard:  72075186232688896
2026-08-18T22:17:57.107759Z node 40 :NFS_SS_PROXY DEBUG: FileStore "test": send create request (dir: "local/nfs/_12E", name: "test")
2026-08-18T22:17:57.109151Z node 39 :HIVE WARN: HIVE#72075186224013313 Node(40, (0,0,0,0)) VolatileState: Unknown -> Disconnected
2026-08-18T22:17:57.109168Z node 39 :HIVE WARN: HIVE#72075186224013313 Node(40, (0,0,0,0)) VolatileState: Disconnected -> Connecting
2026-08-18T22:17:57.109650Z node 39 :FLAT_TX_SCHEMESHARD WARN: Operation part proposed ok, but propose itself is undo unsafe, suboperation type: ESchemeOpCreateFileStore, opId: 281474976720658:1, at schemeshard:  72075186232688896
2026-08-18T22:17:57.110050Z node 40 :NFS_SS_PROXY DEBUG: Request ESchemeOpCreateFileStore with TxId# 281474976720658 in progress, waiting for completion
2026-08-18T22:17:57.110069Z node 40 :NFS_SS_PROXY DEBUG: Creating reply proxy actor for schemeshard 72075186232688896
2026-08-18T22:17:57.110076Z node 40 :NFS_SS_PROXY DEBUG: Sending NotifyTxCompletion to 72075186232688896 for txId# 281474976720658
2026-08-18T22:17:57.111898Z node 40 :NFS_SS_PROXY DEBUG: Received NotifyTxCompletionRegistered from 72075186232688896 for txId# 281474976720658
2026-08-18T22:17:57.623415Z node 39 :FLAT_TX_SCHEMESHARD WARN: Cannot get console configs
2026-08-18T22:17:57.623430Z node 39 :IMPORT WARN: Table profiles were not loaded
2026-08-18T22:17:58.292688Z node 39 :HIVE WARN: HIVE#72075186224013313 Handle TEvInterconnect::TEvNodeConnected, NodeId 40 Cookie 40
2026-08-18T22:17:58.293045Z node 39 :HIVE WARN: HIVE#72075186224013313 Node(40, (0,0,0,0)) VolatileState: Connecting -> Connected
2026-08-18T22:17:58.315361Z node 40 :BS_PROXY_DISCOVER WARN: [3bfeb2c07fc7d251] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:58.316894Z node 40 :BS_PROXY_DISCOVER WARN: [9622bae6c97deebb] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-08-18T22:17:58.317398Z node 40 :NFS_TABLET DEBUG: [t:72075186224037888] Switched to state Init (system: [40:894:2124], user: [40:910:2135], executor: [40:944:2135])
2026-08-18T22:17:58.317416Z node 40 :NFS_TABLET TRACE: [72075186224037888] PrepareTx InitSchema (gen: 1, step: 2)
2026-08-18T22:17:58.317420Z node 40 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx InitSchema (gen: 1, step: 2)
2026-08-18T22:17:58.321965Z node 40 :NFS_TABLET TRACE: [72075186224037888] CompleteTx InitSchema (gen: 1, step: 2)
2026-08-18T22:17:58.322004Z node 40 :NFS_TABLET TRACE: [72075186224037888] PrepareTx LoadState (gen: 1, step: 3)
2026-08-18T22:17:58.322007Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet state data
2026-08-18T22:17:58.322052Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet state data finished
2026-08-18T22:17:58.322054Z node 40 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx LoadState (gen: 1, step: 3)
2026-08-18T22:17:58.322056Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Preparing tablet state
2026-08-18T22:17:58.322066Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Initializing tablet storage info
2026-08-18T22:17:58.322562Z node 40 :NFS_TABLET TRACE: [72075186224037888] CompleteTx LoadState (gen: 1, step: 3)
2026-08-18T22:17:58.322573Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Setting CloudId=, FolderId=, EntityId= for the storage config features overrides
2026-08-18T22:17:58.322592Z node 40 :NFS_TABLET DEBUG: [t:72075186224037888] Switched to state Work (system: [40:894:2124], user: [40:910:2135], executor: [40:944:2135])
2026-08-18T22:17:58.322595Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Activating tablet
2026-08-18T22:17:58.322598Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Initializing tablet state
2026-08-18T22:17:58.322612Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet sessions
2026-08-18T22:17:58.322615Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Enqueueing truncate operations: 0
2026-08-18T22:17:58.322617Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet checkpoints: 0
2026-08-18T22:17:58.322619Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet quotas: 0
2026-08-18T22:17:58.322621Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading fresh bytes: 0
2026-08-18T22:17:58.322624Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading fresh blocks: 0
2026-08-18T22:17:58.322626Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading garbage blobs: 0
2026-08-18T22:17:58.322628Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading unconfirmed data entries: 0
2026-08-18T22:17:58.322631Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Scheduling startup events
2026-08-18T22:17:58.322638Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Scheduling OpLog ops
2026-08-18T22:17:58.322642Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Load state completed
2026-08-18T22:17:58.322658Z node 40 :NFS_TABLET INFO: [t:72075186224037888] LoadCompactionMapChunk started (first range: #0, count: 10485760)
2026-08-18T22:17:58.322663Z node 40 :NFS_TABLET TRACE: [72075186224037888] PrepareTx LoadCompactionMapChunk (gen: 1, step: 4)
2026-08-18T22:17:58.322665Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading compaction map chunk 0, 10485760
2026-08-18T22:17:58.322671Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Loading compaction map chunk finished
2026-08-18T22:17:58.322674Z node 40 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx LoadCompactionMapChunk (gen: 1, step: 4)
2026-08-18T22:17:58.322682Z node 40 :NFS_TABLET TRACE: [72075186224037888] CompleteTx LoadCompactionMapChunk (gen: 1, step: 4)
2026-08-18T22:17:58.322694Z node 40 :NFS_TABLET INFO: [t:72075186224037888] LoadCompactionMapChunk completed (S_OK)
2026-08-18T22:17:58.322697Z node 40 :NFS_TABLET INFO: [t:72075186224037888] ConfirmBlobs: recovery confirmation completed
2026-08-18T22:17:58.322702Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Compaction state loaded, MaxLoadedInOrderRangeId: 0, RangesWithEmptyScore: 0
2026-08-18T22:17:58.373746Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Starting tablet config initialization [txId: 10002], autosharding [0, 4398046511104]
2026-08-18T22:17:58.373763Z node 40 :NFS_TABLET TRACE: [72075186224037888] PrepareTx UpdateConfig (gen: 1, step: 4)
2026-08-18T22:17:58.373766Z node 40 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx UpdateConfig (gen: 1, step: 4)
2026-08-18T22:17:58.373773Z node 40 :NFS_TABLET INFO: [t:72075186224037888] Setting CloudId=test_cloud, FolderId=test_folder, EntityId=test for the storage config features overrides
2026-08-18T22:17:58.374188Z node 40 :NFS_TABLET TRACE: [72075186224037888] CompleteTx UpdateConfig (gen: 1, step: 4)
2026-08-18T22:17:58.375563Z node 40 :NFS_TABLET DEBUG: [f:test][t:72075186224037888] Sending OK response for UpdateConfig with version=1
2026-08-18T22:17:58.378217Z node 40 :NFS_SS_PROXY DEBUG: Received NotifyTxCompletionResult from 72075186232688896 for txId# 281474976720658
2026-08-18T22:17:58.378229Z node 40 :NFS_SS_PROXY DEBUG: TModifySchemeActor received TEvWaitSchemeTxResponse
2026-08-18T22:17:58.378242Z node 40 :NFS_SS_PROXY INFO: FileStore "test": created successfully
2026-08-18T22:17:58.378253Z node 40 :NFS_SERVICE INFO: [test] Created main filesystem
2026-08-18T22:17:58.378266Z node 40 :NFS_SERVICE DEBUG: #0 completed CreateFileStore (S_OK)
2026-08-18T22:17:58.378341Z node 40 :NFS_SERVICE INFO: [f:test][c:client][s:94566549-55c74100-413f0ff8-9a57e28a][n:0] create session [40:991:2175] self [40:737:2100]
2026-08-18T22:17:58.378741Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 0
2026-08-18T22:17:58.378816Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] pipe connected to 72075186224037888
2026-08-18T22:17:58.378833Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] do creating session: Headers { ClientId: "client" SessionId: "94566549-55c74100-413f0ff8-9a57e28a" OriginFqdn: "computeinstance-e02wnfkb9bn509d114" } FileSystemId: "test"
2026-08-18T22:17:58.378845Z node 40 :NFS_TABLET DEBUG: [f:test][t:72075186224037888] CreateSession: Headers { ClientId: "client" SessionId: "94566549-55c74100-413f0ff8-9a57e28a" OriginFqdn: "computeinstance-e02wnfkb9bn509d114" } FileSystemId: "test"
2026-08-18T22:17:58.378850Z node 40 :NFS_TABLET TRACE: [72075186224037888] PrepareTx CreateSession (gen: 1, step: 5)
2026-08-18T22:17:58.378853Z node 40 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx CreateSession (gen: 1, step: 5)
2026-08-18T22:17:58.378857Z node 40 :NFS_TABLET INFO: [f:test][t:72075186224037888] CreateSession c:client, s:94566549-55c74100-413f0ff8-9a57e28a, n:0 creating new session
2026-08-18T22:17:58.378860Z node 40 :NFS_TABLET INFO: [f:test][t:72075186224037888] creating session c: client, s: 94566549-55c74100-413f0ff8-9a57e28a
2026-08-18T22:17:58.378878Z node 40 :NFS_TABLET INFO: [f:test][t:72075186224037888] created session c: client, s: 94566549-55c74100-413f0ff8-9a57e28a, owner: [40:991:2175]
2026-08-18T22:17:58.379153Z node 40 :NFS_TABLET TRACE: [72075186224037888] CompleteTx CreateSession (gen: 1, step: 5)
2026-08-18T22:17:58.379172Z node 40 :NFS_TABLET DEBUG: [f:test][t:72075186224037888] New session TFileStoreFeatures 'ThreeStageWriteThreshold: 65536 PreferredBlockSize: 4096 AsyncHandleOperationPeriod: 50 HasXAttrs: true MaxFuseLoopThreads: 1 TabletDirectRdmaEnabled: false'
2026-08-18T22:17:58.379176Z node 40 :NFS_TABLET INFO: [f:test][t:72075186224037888] CreateSession completed (S_OK)
2026-08-18T22:17:58.379185Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] session established: S_OK, state(0)
2026-08-18T22:17:58.379190Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] session notify 0 (S_OK)
2026-08-18T22:17:58.379200Z node 40 :NFS_SERVICE INFO: [f:test][c:client][s:94566549-55c74100-413f0ff8-9a57e28a][n:0] session created (S_OK), state(0)
Leader for TabletID 72075186224013313 is [39:226:2180] sender: [39:1014:2058] recipient: [39:168:2145]
2026-08-18T22:17:58.380252Z node 40 :NFS_HIVE_PROXY ERROR: Pipe to hive 72075186224013313 has been reset 
Leader for TabletID 72075186224013313 is [39:226:2180] sender: [39:1018:2058] recipient: [39:15:2062]
Leader for TabletID 72075186224013313 is [39:226:2180] sender: [39:1019:2058] recipient: [39:1017:2711]
Leader for TabletID 72075186224013313 is [39:1021:2712] sender: [39:1022:2058] recipient: [39:1017:2711]
Leader for TabletID 72075186224013313 is [39:226:2180] sender: [40:1020:2049] recipient: [40:44:2053]
2026-08-18T22:17:58.607586Z node 39 :HIVE WARN: HIVE#72075186224013313 The tablet FileStore.72075186224037888.Leader.1 is not ready for anything State:ReadyToWork VolatileState:Unknown
2026-08-18T22:17:58.607748Z node 39 :HIVE WARN: HIVE#72075186224013313 Handle TEvInterconnect::TEvNodeConnected, NodeId 40 Cookie 40
2026-08-18T22:18:01.226921Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] pipe disconnected
2026-08-18T22:18:01.451566Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 0
2026-08-18T22:18:01.451658Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:01.808145Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:01.808298Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:06.099978Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:06.100146Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:06.621156Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:06.621342Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:07.068542Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:07.068693Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:07.526633Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:07.526803Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:07.974011Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:07.974258Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:08.432553Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:08.432701Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:12.197738Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:12.197900Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:12.645975Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:12.646223Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:13.104918Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:13.105151Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:13.553041Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:13.553243Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:14.001387Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:14.001629Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:14.593983Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:14.594190Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:18.135189Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:18.135363Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:18.572915Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:18.573155Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:19.010801Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:19.011001Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:19.448066Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:19.448240Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:19.916334Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:19.916527Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:20.505974Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:20.506242Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:24.200322Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:24.200525Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:24.810075Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:24.810274Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:25.409932Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:25.410109Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:26.175827Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:26.176086Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:26.785253Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:26.785428Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:27.415181Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:27.415410Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:30.209596Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:30.209848Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:30.840016Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:30.840200Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:31.500561Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:31.500745Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:32.130665Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:32.130848Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:32.780942Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] creating pipe for tablet 72075186224037888, last reset at 1787091484
2026-08-18T22:18:32.781121Z node 40 :NFS_SERVICE_WORKER ERROR: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] failed to connect to 72075186224037888: ERROR
2026-08-18T22:18:33.412353Z node 40 :NFS_SERVICE_WORKER WARN: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] create timeouted, couldn't connect from 2026-08-18T22:18:04Z
2026-08-18T22:18:33.412373Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] session notify 0 (E_TIMEOUT failed to connect to fs)
2026-08-18T22:18:33.412395Z node 40 :NFS_SERVICE WARN: [f:test][c:client][s:94566549-55c74100-413f0ff8-9a57e28a][n:0] session failed (E_TIMEOUT failed to connect to fs)
2026-08-18T22:18:33.412400Z node 40 :NFS_SERVICE INFO: [s:"94566549-55c74100-413f0ff8-9a57e28a"]remove session [40:991:2175] self [40:737:2100]
2026-08-18T22:18:33.412410Z node 40 :NFS_SERVICE_WORKER INFO: [f:"test"][c:"client"][s:"94566549-55c74100-413f0ff8-9a57e28a"][a:[40:991:2175]] session poisoned, dying [40:737:2100] -> [40:991:2175]
[[bad]](TWithBackTrace<yexception>) contrib/ydb/library/actors/testlib/test_runtime.h:580: Exception occured while waiting for NCloud::NFileStore::NStorage::TProtoResponseEvent<NCloud::NFileStore::NProto::TExecuteActionResponse, 275054790u>: (NActors::TSchedulingLimitReachedException) TestActorRuntime Processed over 100000 events.contrib/ydb/library/actors/testlib/test_runtime.cpp:718: [[rst]]
[[alt1]]TWithBackTrace<yexception>::TWithBackTrace<>()+51 (0xD0F2DB3)
NCloud::NFileStore::NStorage::TProtoResponseEvent<NCloud::NFileStore::NProto::TExecuteActionResponse, 275054790u>* NActors::TTestActorRuntimeBase::GrabEdgeEventRethrow<NCloud::NFileStore::NStorage::TProtoResponseEvent<NCloud::NFileStore::NProto::TExecuteActionResponse, 275054790u>>(TAutoPtr<NActors::IEventHandle, TDelete>&, TDuration)+325 (0xD101085)
auto NCloud::NFileStore::NStorage::TServiceClient::RecvResponse<NCloud::NFileStore::NStorage::TProtoResponseEvent<NCloud::NFileStore::NProto::TExecuteActionResponse, 275054790u>>()+41 (0xD100909)
std::__y1::unique_ptr<NCloud::NFileStore::NStorage::TProtoResponseEvent<NCloud::NFileStore::NProto::TExecuteActionResponse, 275054790u>, std::__y1::default_delete<NCloud::NFileStore::NStorage::TProtoResponseEvent<NCloud::NFileStore::NProto::TExecuteActionResponse, 275054790u>>> NCloud::NFileStore::NStorage::TServiceClient::ExecuteAction<char const (&) [15], TBasicString<char, std::__y1::char_traits<char>>&>(char const (&) [15], TBasicString<char, std::__y1::char_traits<char>>&)+224 (0xD0820D0)
NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceTest::TTestCaseShouldReassignTablet::Execute_(NUnitTest::TTestContext&)+6627 (0xD07D133)
NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceTest::TCurrentTest::Execute()::'lambda'()::operator()() const+71 (0xD0F2267)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+126 (0xD6047CE)
NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceTest::TCurrentTest::Execute()+409 (0xD0F1A89)
NUnitTest::TTestFactory::Execute()+803 (0xD604F63)
NUnitTest::RunMain(int, char**)+3037 (0xD612D0D)
??+0 (0x7F3864229D90)
__libc_start_main+128 (0x7F3864229E40)
_start+41 (0xC150029)
[[rst]]
```

https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/PR-check/32189998716/1/nebius-x86-64/logs/filestore/1/cloud/filestore/libs/storage/service/ut/test-results/unittest/chunk4/testing_out_stuff/TStorageServiceTest.ShouldReassignTablet.err
