### PR TITLE
RDMA service endpoint monitoring

### DIFF
--- a/cloud/blockstore/config/rdma.proto
+++ b/cloud/blockstore/config/rdma.proto
@@ -14,6 +14,10 @@ message TRdmaTarget
     TRdmaEndpoint Endpoint = 1;
     NCloud.NProto.TRdmaServer Server = 2;   // deprecated
     uint32 WorkerThreads = 3;
+
+    // Keep track of the client connections and of the volumes mounted over
+    // them, and show them on a monitoring page.
+    bool ConnectionMonitoringEnabled = 4;
 }
 
 message TRdmaConfig

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -264,6 +264,7 @@ void TBootstrapBase::Init()
                     Configs->RdmaConfig->GetBlockstoreServerTarget()),
                 Logging,
                 GetTraceSerializer(),
+                Monitoring,
                 RdmaRequestServer,
                 Service);
             STORAGE_INFO("RDMA Target initialized");

--- a/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
+++ b/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
@@ -81,34 +81,34 @@ public:
     }
 
     void HandleRequest(
-        void* context,
+        NRdma::IServerRequest* context,
         TCallContextBasePtr callContext,
         TStringBuf in,
         TStringBuf out) override;
 
 private:
     NProto::TError DoHandleRequest(
-        void* context,
+        NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         TStringBuf in,
         TStringBuf out);
 
     NProto::TError HandleReadBlocksRequest(
-        void* context,
+        NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TReadBlocksRequest& request,
         TStringBuf requestData,
         TStringBuf out);
 
     NProto::TError HandleWriteBlocksRequest(
-        void* context,
+        NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TWriteBlocksRequest& request,
         TStringBuf requestData,
         TStringBuf out);
 
     NProto::TError HandleZeroBlocksRequest(
-        void* context,
+        NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TZeroBlocksRequest* request,
         TStringBuf requestData,
@@ -120,7 +120,7 @@ using TRdmaEndpointPtr = std::shared_ptr<TRdmaEndpoint>;
 ////////////////////////////////////////////////////////////////////////////////
 
 void TRdmaEndpoint::HandleRequest(
-    void* context,
+    NRdma::IServerRequest* context,
     TCallContextBasePtr callContext,
     TStringBuf in,
     TStringBuf out)
@@ -161,7 +161,7 @@ void TRdmaEndpoint::HandleRequest(
 }
 
 NProto::TError TRdmaEndpoint::DoHandleRequest(
-    void* context,
+    NRdma::IServerRequest* context,
     TCallContextPtr callContext,
     TStringBuf in,
     TStringBuf out)
@@ -204,7 +204,7 @@ NProto::TError TRdmaEndpoint::DoHandleRequest(
 }
 
 NProto::TError TRdmaEndpoint::HandleReadBlocksRequest(
-    void* context,
+    NRdma::IServerRequest* context,
     TCallContextPtr callContext,
     NProto::TReadBlocksRequest& request,
     TStringBuf requestData,
@@ -261,7 +261,7 @@ NProto::TError TRdmaEndpoint::HandleReadBlocksRequest(
 }
 
 NProto::TError TRdmaEndpoint::HandleWriteBlocksRequest(
-    void* context,
+    NRdma::IServerRequest* context,
     TCallContextPtr callContext,
     NProto::TWriteBlocksRequest& request,
     TStringBuf requestData,
@@ -315,7 +315,7 @@ NProto::TError TRdmaEndpoint::HandleWriteBlocksRequest(
 }
 
 NProto::TError TRdmaEndpoint::HandleZeroBlocksRequest(
-    void* context,
+    NRdma::IServerRequest* context,
     TCallContextPtr callContext,
     NProto::TZeroBlocksRequest* request,
     TStringBuf requestData,

--- a/cloud/blockstore/libs/rdma_test/server_test_async.cpp
+++ b/cloud/blockstore/libs/rdma_test/server_test_async.cpp
@@ -29,12 +29,16 @@ TString MakeKey(const TString& host, ui32 port)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class IRequestWrapper
+class IRequestWrapper: public NCloud::NStorage::NRdma::IServerRequest
 {
 public:
-    virtual ~IRequestWrapper() = default;
     virtual void SendResponse(size_t responseBytes) = 0;
     virtual void SendError(ui32 error, TStringBuf message) = 0;
+
+    [[nodiscard]] ui64 GetSessionId() const override
+    {
+        return 0;
+    }
 };
 
 template <typename TRequestResponse>
@@ -99,14 +103,19 @@ public:
         : Handler(std::move(handler))
     {}
 
-    void SendResponse(void* context, size_t responseBytes) override
+    void SendResponse(
+        NCloud::NStorage::NRdma::IServerRequest* context,
+        size_t responseBytes) override
     {
         std::unique_ptr<IRequestWrapper> wrapper(
             static_cast<IRequestWrapper*>(context));
         wrapper->SendResponse(responseBytes);
     }
 
-    void SendError(void* context, ui32 error, TStringBuf message) override
+    void SendError(
+        NCloud::NStorage::NRdma::IServerRequest* context,
+        ui32 error,
+        TStringBuf message) override
     {
         std::unique_ptr<IRequestWrapper> wrapper(
             static_cast<IRequestWrapper*>(context));

--- a/cloud/blockstore/libs/service_rdma/mount_registry.cpp
+++ b/cloud/blockstore/libs/service_rdma/mount_registry.cpp
@@ -1,0 +1,199 @@
+#include "mount_registry.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/task_queue.h>
+#include <cloud/storage/core/libs/common/thread_pool.h>
+
+#include <util/generic/algorithm.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TMountRegistry::TMountRegistry(TLog log)
+    : Log(std::move(log))
+      // a single thread on purpose, see the comment on the class
+    , Queue(CreateThreadPool("RDMA_REG", 1))
+{}
+
+TMountRegistry::~TMountRegistry() = default;
+
+void TMountRegistry::Start()
+{
+    Queue->Start();
+}
+
+void TMountRegistry::Stop()
+{
+    Queue->Stop();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TMountRegistry::Enqueue(std::function<void()> update) noexcept
+{
+    auto task = [Log = Log, update = std::move(update)]
+    {
+        // the thread pool runs the task in a noexcept context
+        auto error = SafeExecute<NProto::TError>(
+            [&]
+            {
+                update();
+                return NProto::TError{};
+            });
+
+        if (HasError(error)) {
+            STORAGE_WARN(
+                "Can't update the mount registry: %s",
+                FormatError(error).c_str());
+        }
+    };
+
+    // called from the transport threads, nothing may escape into them
+    auto error = SafeExecute<NProto::TError>(
+        [&]
+        {
+            Queue->ExecuteSimple(std::move(task));
+            return NProto::TError{};
+        });
+
+    if (HasError(error)) {
+        STORAGE_WARN(
+            "Can't enqueue a mount registry update: %s",
+            FormatError(error).c_str());
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TMountRegistry::AddConnection(
+    ui64 sessionId,
+    TString peer,
+    TInstant startTs) noexcept
+{
+    Enqueue(
+        [this, sessionId, peer = std::move(peer), startTs]
+        { DoAddConnection(sessionId, peer, startTs); });
+}
+
+void TMountRegistry::RemoveConnection(ui64 sessionId) noexcept
+{
+    Enqueue([this, sessionId] { DoRemoveConnection(sessionId); });
+}
+
+void TMountRegistry::AddMount(ui64 sessionId, TMountInfo info) noexcept
+{
+    Enqueue(
+        [this, sessionId, info = std::move(info)]() mutable
+        { DoAddMount(sessionId, std::move(info)); });
+}
+
+void TMountRegistry::RemoveMount(
+    ui64 sessionId,
+    TString diskId,
+    TString clientId) noexcept
+{
+    Enqueue(
+        [this,
+         sessionId,
+         diskId = std::move(diskId),
+         clientId = std::move(clientId)]
+        { DoRemoveMount(sessionId, diskId, clientId); });
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TMountRegistry::DoAddConnection(
+    ui64 sessionId,
+    TString peer,
+    TInstant startTs)
+{
+    with_lock (Lock) {
+        auto& connection = Connections[sessionId];
+        connection.SessionId = sessionId;
+        connection.Peer = std::move(peer);
+        connection.StartTs = startTs;
+    }
+}
+
+void TMountRegistry::DoRemoveConnection(ui64 sessionId)
+{
+    with_lock (Lock) {
+        Connections.erase(sessionId);
+    }
+}
+
+void TMountRegistry::DoAddMount(ui64 sessionId, TMountInfo info)
+{
+    with_lock (Lock) {
+        auto* connection = Connections.FindPtr(sessionId);
+        if (!connection) {
+            // the connection is announced before it can serve anything and
+            // forgotten only after everything it delivered has been answered,
+            // so there is no mount to record here - and recording one would
+            // bring a closed connection back for good
+            return;
+        }
+
+        auto it = FindIf(
+            connection->Mounts,
+            [&](const auto& mount)
+            {
+                return mount.DiskId == info.DiskId &&
+                       mount.ClientId == info.ClientId;
+            });
+
+        if (it != connection->Mounts.end()) {
+            *it = std::move(info);
+        } else {
+            connection->Mounts.push_back(std::move(info));
+        }
+    }
+}
+
+void TMountRegistry::DoRemoveMount(
+    ui64 sessionId,
+    const TString& diskId,
+    const TString& clientId)
+{
+    with_lock (Lock) {
+        auto* connection = Connections.FindPtr(sessionId);
+        if (!connection) {
+            return;
+        }
+
+        EraseIf(
+            connection->Mounts,
+            [&](const auto& mount)
+            {
+                return mount.DiskId == diskId && mount.ClientId == clientId;
+            });
+    }
+}
+
+TVector<TConnectionInfo> TMountRegistry::GetConnections() const
+{
+    TVector<TConnectionInfo> result;
+
+    with_lock (Lock) {
+        result.reserve(Connections.size());
+
+        for (const auto& [sessionId, connection]: Connections) {
+            result.push_back(connection);
+        }
+    }
+
+    SortBy(result, [](const auto& connection) { return connection.StartTs; });
+
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TMountRegistryPtr CreateMountRegistry(ILoggingServicePtr logging)
+{
+    return std::make_shared<TMountRegistry>(
+        logging->CreateLog("BLOCKSTORE_SERVER"));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/service_rdma/mount_registry.h
+++ b/cloud/blockstore/libs/service_rdma/mount_registry.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cloud/blockstore/public/api/protos/mount.pb.h>
+
+#include <cloud/storage/core/libs/common/public.h>
+#include <cloud/storage/core/libs/common/startable.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/diagnostics/public.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/hash.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/system/spinlock.h>
+
+#include <functional>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Parameters of a single MountVolume request, kept for monitoring purposes.
+struct TMountInfo
+{
+    TString DiskId;
+    TString ClientId;
+
+    NProto::EVolumeAccessMode VolumeAccessMode =
+        NProto::VOLUME_ACCESS_READ_WRITE;
+    NProto::EVolumeMountMode VolumeMountMode = NProto::VOLUME_MOUNT_REMOTE;
+
+    ui64 MountSeqNumber = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// A client connection along with the volumes mounted over it.
+struct TConnectionInfo
+{
+    ui64 SessionId = 0;
+    TString Peer;
+    TInstant StartTs;
+
+    TVector<TMountInfo> Mounts;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Keeps track of the RDMA client connections and the volumes mounted over
+// each of them.
+//
+// Every update is applied on a thread of its own, so all of them return
+// before the change becomes visible. That single thread is what orders the
+// opening of a connection against its closing: the two are reported from
+// different transport threads and would otherwise race. Updates never block
+// and never throw, which is what the transport threads need from them.
+class TMountRegistry final:
+    public IStartable
+{
+private:
+    TLog Log;
+    ITaskQueuePtr Queue;
+
+    THashMap<ui64, TConnectionInfo> Connections;
+    mutable TAdaptiveLock Lock;
+
+public:
+    explicit TMountRegistry(TLog log);
+    ~TMountRegistry() override;
+
+    void Start() override;
+    void Stop() override;
+
+    void AddConnection(
+        ui64 sessionId,
+        TString peer,
+        TInstant startTs) noexcept;
+
+    void RemoveConnection(ui64 sessionId) noexcept;
+
+    void AddMount(ui64 sessionId, TMountInfo info) noexcept;
+
+    void RemoveMount(
+        ui64 sessionId,
+        TString diskId,
+        TString clientId) noexcept;
+
+    // Consistent snapshot of the connections, oldest first.
+    TVector<TConnectionInfo> GetConnections() const;
+
+private:
+    void Enqueue(std::function<void()> update) noexcept;
+
+    // applied on the registry thread. Announcing a connection is the only
+    // thing that creates an entry, and closing it is the only thing that
+    // drops one - together with everything mounted over it.
+    void DoAddConnection(ui64 sessionId, TString peer, TInstant startTs);
+    void DoRemoveConnection(ui64 sessionId);
+    void DoAddMount(ui64 sessionId, TMountInfo info);
+    void DoRemoveMount(
+        ui64 sessionId,
+        const TString& diskId,
+        const TString& clientId);
+};
+
+using TMountRegistryPtr = std::shared_ptr<TMountRegistry>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TMountRegistryPtr CreateMountRegistry(ILoggingServicePtr logging);
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/service_rdma/mount_registry_ut.cpp
+++ b/cloud/blockstore/libs/service_rdma/mount_registry_ut.cpp
@@ -1,0 +1,229 @@
+#include "mount_registry.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/datetime/base.h>
+
+#include <functional>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TMountInfo MakeMountInfo(const TString& diskId, const TString& clientId)
+{
+    TMountInfo info;
+    info.DiskId = diskId;
+    info.ClientId = clientId;
+    return info;
+}
+
+TString MakePeer(ui64 sessionId)
+{
+    return TStringBuilder() << "10.0.0.1:" << sessionId;
+}
+
+TInstant MakeStartTs(ui64 sessionId)
+{
+    return TInstant::Seconds(100 + sessionId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture
+    : public NUnitTest::TBaseFixture
+{
+    TMountRegistry Registry{TLog{}};
+
+    void SetUp(NUnitTest::TTestContext& /*context*/) override
+    {
+        Registry.Start();
+    }
+
+    void TearDown(NUnitTest::TTestContext& /*context*/) override
+    {
+        Registry.Stop();
+    }
+
+    void AddConnection(ui64 sessionId)
+    {
+        Registry.AddConnection(
+            sessionId,
+            MakePeer(sessionId),
+            MakeStartTs(sessionId));
+    }
+
+    // Updates are applied on the registry thread, so the result only shows up
+    // some time after the call returns.
+    TVector<TConnectionInfo> WaitForConnections(
+        const std::function<bool(const TVector<TConnectionInfo>&)>& ready)
+    {
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+
+        for (;;) {
+            auto connections = Registry.GetConnections();
+            if (ready(connections) || TInstant::Now() >= deadline) {
+                return connections;
+            }
+
+            Sleep(TDuration::MilliSeconds(10));
+        }
+    }
+
+    TVector<TConnectionInfo> WaitForMounts(size_t expectedCount)
+    {
+        return WaitForConnections(
+            [=](const auto& connections)
+            {
+                return connections.size() == 1 &&
+                       connections[0].Mounts.size() == expectedCount;
+            });
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TMountRegistryTest)
+{
+    Y_UNIT_TEST_F(ShouldTrackSeveralMountsOfOneSession, TFixture)
+    {
+        AddConnection(42);
+        Registry.AddMount(42, MakeMountInfo("vol-1", "client-a"));
+        Registry.AddMount(42, MakeMountInfo("vol-2", "client-a"));
+
+        auto connections = WaitForMounts(2);
+        UNIT_ASSERT_VALUES_EQUAL(1, connections.size());
+        UNIT_ASSERT_VALUES_EQUAL(42, connections[0].SessionId);
+        UNIT_ASSERT_VALUES_EQUAL("10.0.0.1:42", connections[0].Peer);
+        UNIT_ASSERT_VALUES_EQUAL(MakeStartTs(42), connections[0].StartTs);
+
+        const auto& mounts = connections[0].Mounts;
+        UNIT_ASSERT_VALUES_EQUAL(2, mounts.size());
+        UNIT_ASSERT_VALUES_EQUAL("vol-1", mounts[0].DiskId);
+        UNIT_ASSERT_VALUES_EQUAL("vol-2", mounts[1].DiskId);
+    }
+
+    Y_UNIT_TEST_F(ShouldReplaceRepeatedMountOfSameVolume, TFixture)
+    {
+        AddConnection(42);
+        Registry.AddMount(42, MakeMountInfo("vol-1", "client-a"));
+
+        auto remount = MakeMountInfo("vol-1", "client-a");
+        remount.MountSeqNumber = 7;
+        Registry.AddMount(42, std::move(remount));
+
+        auto connections = WaitForConnections(
+            [](const auto& connections)
+            {
+                return connections.size() == 1 &&
+                       connections[0].Mounts.size() == 1 &&
+                       connections[0].Mounts[0].MountSeqNumber == 7;
+            });
+
+        UNIT_ASSERT_VALUES_EQUAL(1, connections.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, connections[0].Mounts.size());
+        UNIT_ASSERT_VALUES_EQUAL(7, connections[0].Mounts[0].MountSeqNumber);
+    }
+
+    Y_UNIT_TEST_F(ShouldForgetUnmountedVolume, TFixture)
+    {
+        AddConnection(42);
+        Registry.AddMount(42, MakeMountInfo("vol-1", "client-a"));
+        Registry.AddMount(42, MakeMountInfo("vol-2", "client-a"));
+        Registry.RemoveMount(42, "vol-1", "client-a");
+
+        auto connections = WaitForMounts(1);
+        UNIT_ASSERT_VALUES_EQUAL(1, connections.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, connections[0].Mounts.size());
+        UNIT_ASSERT_VALUES_EQUAL("vol-2", connections[0].Mounts[0].DiskId);
+    }
+
+    Y_UNIT_TEST_F(ShouldKeepMountsOfDifferentSessionsApart, TFixture)
+    {
+        AddConnection(1);
+        AddConnection(2);
+        Registry.AddMount(1, MakeMountInfo("vol-1", "client-a"));
+        Registry.AddMount(2, MakeMountInfo("vol-2", "client-b"));
+
+        auto connections = WaitForConnections(
+            [](const auto& connections)
+            {
+                return connections.size() == 2 &&
+                       !connections[0].Mounts.empty() &&
+                       !connections[1].Mounts.empty();
+            });
+
+        UNIT_ASSERT_VALUES_EQUAL(2, connections.size());
+
+        // ordered by connection time, see MakeStartTs()
+        UNIT_ASSERT_VALUES_EQUAL(1, connections[0].SessionId);
+        UNIT_ASSERT_VALUES_EQUAL(1, connections[0].Mounts.size());
+        UNIT_ASSERT_VALUES_EQUAL("vol-1", connections[0].Mounts[0].DiskId);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, connections[1].SessionId);
+        UNIT_ASSERT_VALUES_EQUAL(1, connections[1].Mounts.size());
+        UNIT_ASSERT_VALUES_EQUAL("vol-2", connections[1].Mounts[0].DiskId);
+    }
+
+    Y_UNIT_TEST_F(ShouldForgetMountsOfClosedConnection, TFixture)
+    {
+        AddConnection(42);
+        Registry.AddMount(42, MakeMountInfo("vol-1", "client-a"));
+        Registry.RemoveConnection(42);
+
+        auto connections = WaitForConnections(
+            [](const auto& connections) { return connections.empty(); });
+
+        UNIT_ASSERT_VALUES_EQUAL(0, connections.size());
+    }
+
+    Y_UNIT_TEST_F(ShouldShowConnectionWithoutMounts, TFixture)
+    {
+        AddConnection(42);
+
+        auto connections = WaitForMounts(0);
+        UNIT_ASSERT_VALUES_EQUAL(1, connections.size());
+        UNIT_ASSERT_VALUES_EQUAL(42, connections[0].SessionId);
+        UNIT_ASSERT(connections[0].Mounts.empty());
+    }
+
+    Y_UNIT_TEST_F(ShouldIgnoreMountOfUnknownConnection, TFixture)
+    {
+        // a mount must never create a connection entry: that would resurrect
+        // a connection that has already been closed
+        Registry.AddMount(42, MakeMountInfo("vol-1", "client-a"));
+
+        // the announcement below is applied after the mount above, so seeing
+        // it means the mount has been processed too
+        AddConnection(1);
+
+        auto connections = WaitForConnections(
+            [](const auto& connections) { return !connections.empty(); });
+
+        UNIT_ASSERT_VALUES_EQUAL(1, connections.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, connections[0].SessionId);
+        UNIT_ASSERT(connections[0].Mounts.empty());
+    }
+
+    Y_UNIT_TEST_F(ShouldIgnoreMountOfClosedConnection, TFixture)
+    {
+        AddConnection(42);
+        Registry.RemoveConnection(42);
+        Registry.AddMount(42, MakeMountInfo("vol-1", "client-a"));
+
+        AddConnection(1);
+
+        auto connections = WaitForConnections(
+            [](const auto& connections) { return !connections.empty(); });
+
+        UNIT_ASSERT_VALUES_EQUAL(1, connections.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, connections[0].SessionId);
+    }
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -1,5 +1,6 @@
 #include "rdma_target.h"
 
+#include "mount_registry.h"
 #include "rdma_protocol.h"
 
 #include <cloud/blockstore/libs/common/iovector.h>
@@ -17,10 +18,14 @@
 #include <cloud/storage/core/libs/rdma/iface/protocol.h>
 #include <cloud/storage/core/libs/rdma/iface/server.h>
 
+#include <library/cpp/monlib/service/pages/html_mon_page.h>
+#include <library/cpp/monlib/service/pages/index_mon_page.h>
+#include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/protobuf/util/pb_io.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/list.h>
+#include <util/stream/format.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -57,15 +62,6 @@ constexpr size_t MaxRealProtoSize =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TRequestDetails
-{
-    void* Context = nullptr;
-    TStringBuf Out;
-    TStringBuf DataBuffer;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 template <typename TResponse>
 void FillResponse(const TCallContextPtr& callContext, TResponse& response)
 {
@@ -81,6 +77,19 @@ void FillResponse(const TCallContextPtr& callContext, TResponse& response)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TMountInfo MakeMountInfo(const NProto::TMountVolumeRequest& request)
+{
+    TMountInfo info;
+    info.DiskId = request.GetDiskId();
+    info.ClientId = request.GetHeaders().GetClientId();
+    info.VolumeAccessMode = request.GetVolumeAccessMode();
+    info.VolumeMountMode = request.GetVolumeMountMode();
+    info.MountSeqNumber = request.GetMountSeqNumber();
+    return info;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 // Thread-safe. After Init() public method HandleRequest() can be called
 // from any thread.
 class TRequestHandler final
@@ -90,6 +99,9 @@ class TRequestHandler final
     IBlockStorePtr Service;
     ITraceSerializerPtr TraceSerializer;
     ITaskQueuePtr TaskQueue;
+
+    // not set when nobody is going to look at the connections
+    TMountRegistryPtr MountRegistry;
 
     TLog Log;
     std::weak_ptr<NCloud::NStorage::NRdma::IServerEndpoint> Endpoint;
@@ -101,10 +113,12 @@ public:
     TRequestHandler(
         IBlockStorePtr service,
         ITraceSerializerPtr traceSerializer,
-        ITaskQueuePtr taskQueue)
+        ITaskQueuePtr taskQueue,
+        TMountRegistryPtr mountRegistry)
         : Service(std::move(service))
         , TraceSerializer(std::move(traceSerializer))
         , TaskQueue(std::move(taskQueue))
+        , MountRegistry(std::move(mountRegistry))
     {}
 
     void Init(
@@ -120,7 +134,32 @@ public:
         return NCloud::NBlockStore::CreateCallContext();
     }
 
+    void OnSessionCreated(
+        const NCloud::NStorage::NRdma::IServerSession& session) noexcept override
+    {
+        if (!MountRegistry) {
+            return;
+        }
+
+        // the session reference is only valid for the duration of this call,
+        // so everything the registry needs is copied out right here
+        MountRegistry->AddConnection(
+            session.GetId(),
+            session.GetPeer(),
+            session.GetStartTs());
+    }
+
+    void OnSessionClosed(ui64 sessionId) noexcept override
+    {
+        if (!MountRegistry) {
+            return;
+        }
+
+        MountRegistry->RemoveConnection(sessionId);
+    }
+
 private:
+
 #define BLOCKSTORE_HANDLE_REQUEST(name, ...)                             \
     case TBlockStoreServerProtocol::Ev##name##Request:                   \
         return Handle##name##Request(                                    \
@@ -133,7 +172,7 @@ private:
     // BLOCKSTORE_HANDLE_REQUEST
 
     NProto::TError DoHandleRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         TStringBuf in,
         TStringBuf out) const
@@ -168,7 +207,7 @@ private:
 #undef BLOCKSTORE_HANDLE_REQUEST
 
     void HandleRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextBasePtr callContext,
         TStringBuf in,
         TStringBuf out) override
@@ -192,6 +231,32 @@ private:
                     }
                 }
             });
+    }
+
+    void OnVolumeMounted(
+        NCloud::NStorage::NRdma::IServerRequest* context,
+        TMountInfo info) const
+    {
+        if (!context || !MountRegistry) {
+            return;
+        }
+
+        MountRegistry->AddMount(context->GetSessionId(), std::move(info));
+    }
+
+    void OnVolumeUnmounted(
+        NCloud::NStorage::NRdma::IServerRequest* context,
+        TString diskId,
+        TString clientId) const
+    {
+        if (!context || !MountRegistry) {
+            return;
+        }
+
+        MountRegistry->RemoveMount(
+            context->GetSessionId(),
+            std::move(diskId),
+            std::move(clientId));
     }
 
     size_t SerializeReadBlocksResponse(
@@ -227,7 +292,7 @@ private:
     }
 
     NProto::TError HandleReadBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TReadBlocksRequest* request,
         TStringBuf requestData,
@@ -337,7 +402,7 @@ private:
     }
 
     NProto::TError HandleWriteBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TWriteBlocksRequest* request,
         TStringBuf requestData,
@@ -438,7 +503,7 @@ private:
     }
 
     NProto::TError HandleZeroBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TZeroBlocksRequest* request,
         TStringBuf requestData,
@@ -519,7 +584,7 @@ private:
     }
 
     NProto::TError HandlePingRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TPingRequest* request,
         TStringBuf requestData,
@@ -551,7 +616,7 @@ private:
     }
 
     NProto::TError HandleMountVolumeRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TMountVolumeRequest* request,
         TStringBuf requestData,
@@ -571,6 +636,9 @@ private:
 
         request->SetForceRemoteBinding(true);
 
+        // has to be collected before the request is moved out
+        auto mountInfo = MakeMountInfo(*request);
+
         auto req =
             std::make_shared<NProto::TMountVolumeRequest>(std::move(*request));
 
@@ -580,10 +648,17 @@ private:
             [out = out,
              context = context,
              endpoint = Endpoint,
+             mountInfo = std::move(mountInfo),
              callContext = std::move(callContext),
-             weakSelf = weak_from_this()](auto future)
+             weakSelf = weak_from_this()](auto future) mutable
             {
                 auto response = ExtractResponse(future);
+
+                if (!HasError(response.GetError())) {
+                    if (auto self = weakSelf.lock()) {
+                        self->OnVolumeMounted(context, std::move(mountInfo));
+                    }
+                }
 
                 ui32 flags = 0;
                 size_t responseBytes = 0;
@@ -622,7 +697,7 @@ private:
     }
 
     NProto::TError HandleUnmountVolumeRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TUnmountVolumeRequest* request,
         TStringBuf requestData,
@@ -640,6 +715,10 @@ private:
 
         Y_ENSURE_RETURN(requestData.length() == 0, "invalid request");
 
+        // have to be collected before the request is moved out
+        auto diskId = request->GetDiskId();
+        auto clientId = request->GetHeaders().GetClientId();
+
         auto req = std::make_shared<NProto::TUnmountVolumeRequest>(
             std::move(*request));
 
@@ -649,10 +728,18 @@ private:
             [out = out,
              context = context,
              endpoint = Endpoint,
+             diskId = std::move(diskId),
+             clientId = std::move(clientId),
              callContext = std::move(callContext),
              weakSelf = weak_from_this()](auto future)
             {
                 auto response = ExtractResponse(future);
+
+                if (!HasError(response.GetError())) {
+                    if (auto self = weakSelf.lock()) {
+                        self->OnVolumeUnmounted(context, diskId, clientId);
+                    }
+                }
 
                 ui32 flags = 0;
                 size_t responseBytes = 0;
@@ -695,6 +782,9 @@ private:
 
 class TRdmaTarget final: public IStartable
 {
+    // number of mount related columns, see DumpHtml()
+    static constexpr size_t MountColumnCount = 5;
+
     const TBlockstoreServerRdmaTargetConfigPtr Config;
 
     ILoggingServicePtr Logging;
@@ -702,6 +792,8 @@ class TRdmaTarget final: public IStartable
     NCloud::NStorage::NRdma::IServerPtr Server;
     ITaskQueuePtr TaskQueue;
 
+    // not set when nobody is going to look at the connections
+    TMountRegistryPtr MountRegistry;
     std::shared_ptr<TRequestHandler> Handler;
 
     TLog Log;
@@ -713,21 +805,28 @@ public:
         ITraceSerializerPtr traceSerializer,
         NCloud::NStorage::NRdma::IServerPtr server,
         ITaskQueuePtr taskQueue,
+        TMountRegistryPtr mountRegistry,
         IBlockStorePtr service)
         : Config(std::move(rdmaTargetConfig))
         , Logging(std::move(logging))
         , TraceSerializer(std::move(traceSerializer))
         , Server(std::move(server))
         , TaskQueue(std::move(taskQueue))
+        , MountRegistry(std::move(mountRegistry))
     {
         Handler = std::make_shared<TRequestHandler>(
             std::move(service),
             TraceSerializer,
-            TaskQueue);
+            TaskQueue,
+            MountRegistry);
     }
 
     void Start() override
     {
+        if (MountRegistry) {
+            MountRegistry->Start();
+        }
+
         auto endpoint =
             Server->StartEndpoint(Config->Host, Config->Port, Handler);
 
@@ -744,6 +843,106 @@ public:
     {
         Server->Stop();
         TaskQueue->Stop();
+
+        if (MountRegistry) {
+            MountRegistry->Stop();
+        }
+    }
+
+    // Renders the client connections along with the volumes mounted over them.
+    void DumpHtml(IOutputStream& out) const
+    {
+        if (!MountRegistry) {
+            out << "Connection tracking is disabled";
+            return;
+        }
+
+        auto connections = MountRegistry->GetConnections();
+
+        HTML(out) {
+            TAG(TH3) {
+                out << "Connections"
+                    << " <font color=gray>" << connections.size() << "</font>";
+            }
+
+            TABLE_SORTABLE_CLASS("table table-bordered") {
+                TABLEHEAD() {
+                    TABLER() {
+                        TABLEH() { out << "SessionId"; }
+                        TABLEH() { out << "Peer"; }
+                        TABLEH() { out << "Connected"; }
+                        TABLEH() { out << "DiskId"; }
+                        TABLEH() { out << "ClientId"; }
+                        TABLEH() { out << "AccessMode"; }
+                        TABLEH() { out << "MountMode"; }
+                        TABLEH() { out << "MountSeqNumber"; }
+                    }
+                }
+
+                for (const auto& connection: connections) {
+                    if (connection.Mounts.empty()) {
+                        RenderConnection(out, connection, nullptr);
+                        continue;
+                    }
+
+                    for (const auto& mount: connection.Mounts) {
+                        RenderConnection(out, connection, &mount);
+                    }
+                }
+            }
+        }
+    }
+
+private:
+    static void RenderConnection(
+        IOutputStream& out,
+        const TConnectionInfo& connection,
+        const TMountInfo* mount)
+    {
+        HTML(out) {
+            TABLER() {
+                TABLED() { out << Hex(connection.SessionId, HF_FULL); }
+                TABLED() { out << connection.Peer; }
+                TABLED() { out << connection.StartTs; }
+
+                if (mount) {
+                    TABLED() { out << mount->DiskId; }
+                    TABLED() { out << mount->ClientId; }
+                    TABLED() {
+                        out << NProto::EVolumeAccessMode_Name(
+                            mount->VolumeAccessMode);
+                    }
+                    TABLED() {
+                        out << NProto::EVolumeMountMode_Name(
+                            mount->VolumeMountMode);
+                    }
+                    TABLED() { out << mount->MountSeqNumber; }
+                } else {
+                    // a connection that hasn't mounted anything (yet)
+                    for (size_t i = 0; i < MountColumnCount; ++i) {
+                        TABLED() { out << "-"; }
+                    }
+                }
+            }
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TRdmaTargetMonPage final: public THtmlMonPage
+{
+    const std::shared_ptr<TRdmaTarget> Target;
+
+public:
+    explicit TRdmaTargetMonPage(std::shared_ptr<TRdmaTarget> target)
+        : THtmlMonPage("RdmaTarget", "RdmaTarget", true)
+        , Target(std::move(target))
+    {}
+
+    void OutputContent(IMonHttpRequest& request) override
+    {
+        Target->DumpHtml(request.Output());
     }
 };
 
@@ -753,19 +952,33 @@ IStartablePtr CreateBlockstoreServerRdmaTarget(
     TBlockstoreServerRdmaTargetConfigPtr rdmaTargetConfig,
     ILoggingServicePtr logging,
     ITraceSerializerPtr traceSerializer,
+    IMonitoringServicePtr monitoring,
     NCloud::NStorage::NRdma::IServerPtr server,
     IBlockStorePtr service)
 {
     auto threadPool = CreateThreadPool("RDMA", rdmaTargetConfig->WorkerThreads);
     threadPool->Start();
 
-    return std::make_shared<TRdmaTarget>(
+    // without a monitoring page there is nobody to read the connections, so
+    // the handler is left with an observer that drops them
+    auto mountRegistry = monitoring ? CreateMountRegistry(logging) : nullptr;
+
+    auto target = std::make_shared<TRdmaTarget>(
         std::move(rdmaTargetConfig),
         std::move(logging),
         std::move(traceSerializer),
         std::move(server),
         std::move(threadPool),
+        std::move(mountRegistry),
         std::move(service));
+
+    if (monitoring) {
+        auto rootPage = monitoring->RegisterIndexPage("blockstore", "BlockStore");
+        static_cast<TIndexMonPage&>(*rootPage).Register(
+            new TRdmaTargetMonPage(target));
+    }
+
+    return target;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -959,9 +959,12 @@ IStartablePtr CreateBlockstoreServerRdmaTarget(
     auto threadPool = CreateThreadPool("RDMA", rdmaTargetConfig->WorkerThreads);
     threadPool->Start();
 
-    // without a monitoring page there is nobody to read the connections, so
-    // the handler is left with an observer that drops them
-    auto mountRegistry = monitoring ? CreateMountRegistry(logging) : nullptr;
+    // without a page there is nobody to read the connections, so they are not
+    // tracked at all and the handler is left with an empty registry pointer
+    auto mountRegistry =
+        monitoring && rdmaTargetConfig->ConnectionMonitoringEnabled
+            ? CreateMountRegistry(logging)
+            : nullptr;
 
     auto target = std::make_shared<TRdmaTarget>(
         std::move(rdmaTargetConfig),
@@ -969,10 +972,10 @@ IStartablePtr CreateBlockstoreServerRdmaTarget(
         std::move(traceSerializer),
         std::move(server),
         std::move(threadPool),
-        std::move(mountRegistry),
+        mountRegistry,
         std::move(service));
 
-    if (monitoring) {
+    if (mountRegistry) {
         auto rootPage = monitoring->RegisterIndexPage("blockstore", "BlockStore");
         static_cast<TIndexMonPage&>(*rootPage).Register(
             new TRdmaTargetMonPage(target));

--- a/cloud/blockstore/libs/service_rdma/rdma_target.h
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.h
@@ -3,11 +3,16 @@
 #include <cloud/blockstore/config/rdma.pb.h>
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/storage/core/libs/common/public.h>
+#include <cloud/storage/core/libs/common/startable.h>
 #include <cloud/storage/core/libs/coroutine/public.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
+#include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/rdma/iface/public.h>
 
+#include <util/generic/ptr.h>
 #include <util/system/hostname.h>
+
+#include <memory>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -41,10 +46,13 @@ struct TBlockstoreServerRdmaTargetConfig
 using TBlockstoreServerRdmaTargetConfigPtr =
     std::shared_ptr<TBlockstoreServerRdmaTargetConfig>;
 
+////////////////////////////////////////////////////////////////////////////////
+
 IStartablePtr CreateBlockstoreServerRdmaTarget(
     TBlockstoreServerRdmaTargetConfigPtr rdmaTargetConfig,
     ILoggingServicePtr logging,
     ITraceSerializerPtr traceSerializer,
+    IMonitoringServicePtr monitoring,
     NCloud::NStorage::NRdma::IServerPtr server,
     IBlockStorePtr service);
 

--- a/cloud/blockstore/libs/service_rdma/rdma_target.h
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.h
@@ -23,10 +23,13 @@ struct TBlockstoreServerRdmaTargetConfig
     TString Host = "localhost";
     ui32 Port = 10088;
     ui32 WorkerThreads = 1;
+    bool ConnectionMonitoringEnabled = false;
 
     explicit TBlockstoreServerRdmaTargetConfig(
         const NProto::TRdmaTarget& target)
     {
+        ConnectionMonitoringEnabled = target.GetConnectionMonitoringEnabled();
+
         const auto& endpoint = target.GetEndpoint();
 
         if (const auto& host = endpoint.GetHost()) {

--- a/cloud/blockstore/libs/service_rdma/rdma_target_ut.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target_ut.cpp
@@ -153,11 +153,15 @@ struct TTestEnv
     }
 };
 
-TTestEnv CreateTestEnv(IBlockStorePtr service)
+TTestEnv CreateTestEnv(
+    IBlockStorePtr service,
+    bool connectionMonitoringEnabled = true)
 {
     auto server = std::make_shared<TTestServer>();
 
     NProto::TRdmaTarget rdmaTargetProto;
+    rdmaTargetProto.SetConnectionMonitoringEnabled(connectionMonitoringEnabled);
+
     auto config =
         std::make_shared<TBlockstoreServerRdmaTargetConfig>(rdmaTargetProto);
 
@@ -181,22 +185,25 @@ TTestEnv CreateTestEnv(IBlockStorePtr service)
         std::move(target)};
 }
 
-NMonitoring::TIndexMonPage* FindRootPage(const IMonitoringServicePtr& monitoring)
+NMonitoring::IMonPage* FindRdmaTargetPage(
+    const IMonitoringServicePtr& monitoring)
 {
     auto rootPage = monitoring->GetMonPage("blockstore");
-    UNIT_ASSERT(rootPage);
+    if (!rootPage) {
+        return nullptr;
+    }
 
     auto* indexPage =
         dynamic_cast<NMonitoring::TIndexMonPage*>(rootPage.Get());
     UNIT_ASSERT(indexPage);
 
-    return indexPage;
+    return indexPage->FindPage("RdmaTarget");
 }
 
 TString RenderMonPage(const IMonitoringServicePtr& monitoring)
 {
     auto* page = dynamic_cast<NMonitoring::THtmlMonPage*>(
-        FindRootPage(monitoring)->FindPage("RdmaTarget"));
+        FindRdmaTargetPage(monitoring));
     UNIT_ASSERT(page);
 
     TStringStream out;
@@ -506,7 +513,23 @@ Y_UNIT_TEST_SUITE(TRequestHandlerTest)
         auto service = std::make_shared<TTestService>();
         auto env = CreateTestEnv(service);
 
-        UNIT_ASSERT(FindRootPage(env.Monitoring)->FindPage("RdmaTarget"));
+        UNIT_ASSERT(FindRdmaTargetPage(env.Monitoring));
+
+        env.Target->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldNotTrackConnectionsWhenMonitoringIsDisabled)
+    {
+        auto service = std::make_shared<TTestService>();
+        auto env = CreateTestEnv(service, false);
+        auto handler = env.GetHandler();
+
+        UNIT_ASSERT(!FindRdmaTargetPage(env.Monitoring));
+
+        // the handler still has to survive the connection events
+        TTestSession session(4242);
+        handler->OnSessionCreated(session);
+        handler->OnSessionClosed(session.GetId());
 
         env.Target->Stop();
     }

--- a/cloud/blockstore/libs/service_rdma/rdma_target_ut.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target_ut.cpp
@@ -5,12 +5,20 @@
 #include <cloud/blockstore/libs/service/service_test.h>
 
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/diagnostics/trace_serializer.h>
 #include <cloud/storage/core/libs/rdma/iface/protobuf.h>
 #include <cloud/storage/core/libs/rdma/iface/server.h>
 
+#include <library/cpp/monlib/service/mon_service_http_request.h>
+#include <library/cpp/monlib/service/pages/html_mon_page.h>
+#include <library/cpp/monlib/service/pages/index_mon_page.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/future.h>
+
+#include <util/datetime/base.h>
+
+#include <functional>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -23,14 +31,19 @@ class TTestEndpoint: public NCloud::NStorage::NRdma::IServerEndpoint
     NThreading::TPromise<void> Done{NThreading::NewPromise<void>()};
 
 public:
-    void SendResponse(void* context, size_t responseBytes) override
+    void SendResponse(
+        NCloud::NStorage::NRdma::IServerRequest* context,
+        size_t responseBytes) override
     {
         Y_UNUSED(context);
         Y_UNUSED(responseBytes);
         Done.SetValue();
     }
 
-    void SendError(void* context, ui32 error, TStringBuf message) override
+    void SendError(
+        NCloud::NStorage::NRdma::IServerRequest* context,
+        ui32 error,
+        TStringBuf message) override
     {
         Y_UNUSED(context);
         Y_UNUSED(error);
@@ -41,6 +54,48 @@ public:
     NThreading::TFuture<void> WaitDone()
     {
         return Done.GetFuture();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestSession final: public NCloud::NStorage::NRdma::IServerSession
+{
+    const ui64 Id;
+
+    explicit TTestSession(ui64 id)
+        : Id(id)
+    {}
+
+    ui64 GetId() const override
+    {
+        return Id;
+    }
+
+    TString GetPeer() const override
+    {
+        return "10.0.0.1:41234";
+    }
+
+    TInstant GetStartTs() const override
+    {
+        return TInstant::Seconds(100);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestRequest final: public NCloud::NStorage::NRdma::IServerRequest
+{
+    const ui64 SessionId;
+
+    explicit TTestRequest(ui64 sessionId)
+        : SessionId(sessionId)
+    {}
+
+    ui64 GetSessionId() const override
+    {
+        return SessionId;
     }
 };
 
@@ -84,6 +139,7 @@ public:
 struct TTestEnv
 {
     std::shared_ptr<TTestServer> Server;
+    IMonitoringServicePtr Monitoring;
     IStartablePtr Target;
 
     NCloud::NStorage::NRdma::IServerHandlerPtr GetHandler() const
@@ -107,17 +163,75 @@ TTestEnv CreateTestEnv(IBlockStorePtr service)
 
     auto logging = CreateLoggingService("console");
     auto traceSerializer = CreateTraceSerializerStub();
+    auto monitoring = CreateMonitoringServiceStub();
 
     auto target = CreateBlockstoreServerRdmaTarget(
         config,
         std::move(logging),
         std::move(traceSerializer),
+        monitoring,
         server,
         std::move(service));
 
     target->Start();
 
-    return TTestEnv{std::move(server), std::move(target)};
+    return TTestEnv{
+        std::move(server),
+        std::move(monitoring),
+        std::move(target)};
+}
+
+NMonitoring::TIndexMonPage* FindRootPage(const IMonitoringServicePtr& monitoring)
+{
+    auto rootPage = monitoring->GetMonPage("blockstore");
+    UNIT_ASSERT(rootPage);
+
+    auto* indexPage =
+        dynamic_cast<NMonitoring::TIndexMonPage*>(rootPage.Get());
+    UNIT_ASSERT(indexPage);
+
+    return indexPage;
+}
+
+TString RenderMonPage(const IMonitoringServicePtr& monitoring)
+{
+    auto* page = dynamic_cast<NMonitoring::THtmlMonPage*>(
+        FindRootPage(monitoring)->FindPage("RdmaTarget"));
+    UNIT_ASSERT(page);
+
+    TStringStream out;
+
+    // OutputContent() only ever reaches for the output stream, so the rest of
+    // the request can stay empty
+    NMonitoring::TMonService2HttpRequest request{
+        &out,
+        nullptr,   // httpRequest
+        nullptr,   // monService
+        page,
+        "",        // pathInfo
+        nullptr};  // parent
+
+    page->OutputContent(request);
+
+    return out.Str();
+}
+
+// The registry is updated asynchronously, so the page only catches up with a
+// mount some time after the response for it has been sent.
+TString WaitForRenderedPage(
+    const IMonitoringServicePtr& monitoring,
+    const std::function<bool(const TString&)>& ready)
+{
+    const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+
+    for (;;) {
+        auto html = RenderMonPage(monitoring);
+        if (ready(html) || TInstant::Now() >= deadline) {
+            return html;
+        }
+
+        Sleep(TDuration::MilliSeconds(10));
+    }
 }
 
 }   // namespace
@@ -294,6 +408,105 @@ Y_UNIT_TEST_SUITE(TRequestHandlerTest)
         doneFuture.Wait();
 
         UNIT_ASSERT_C(handlerCalled, "MountVolume handler was not called");
+
+        env.Target->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldShowMountedVolumeOfConnectionOnMonPage)
+    {
+        auto service = std::make_shared<TTestService>();
+        service->MountVolumeHandler =
+            [&](std::shared_ptr<NProto::TMountVolumeRequest> request)
+        {
+            Y_UNUSED(request);
+            return NThreading::MakeFuture(NProto::TMountVolumeResponse{});
+        };
+
+        auto env = CreateTestEnv(service);
+        auto handler = env.GetHandler();
+        auto endpoint = env.GetEndpoint();
+
+        TTestSession session(4242);
+        handler->OnSessionCreated(session);
+
+        NProto::TMountVolumeRequest request;
+        request.SetDiskId("vol-1");
+        request.MutableHeaders()->SetClientId("client-a");
+        request.SetVolumeAccessMode(NProto::VOLUME_ACCESS_READ_ONLY);
+        request.SetVolumeMountMode(NProto::VOLUME_MOUNT_LOCAL);
+        request.SetMountSeqNumber(11);
+
+        const size_t inSize =
+            NCloud::NStorage::NRdma::TProtoMessageSerializer::MessageByteSize(
+                request,
+                0);
+        TString inBuf(inSize, 0);
+        NCloud::NStorage::NRdma::TProtoMessageSerializer::Serialize(
+            inBuf,
+            TBlockStoreServerProtocol::EvMountVolumeRequest,
+            0,
+            request);
+
+        TString outBuf(4_KB, 0);
+
+        TTestRequest context(session.GetId());
+
+        auto doneFuture = endpoint->WaitDone();
+        handler->HandleRequest(
+            &context,
+            handler->CreateCallContext(),
+            inBuf,
+            outBuf);
+
+        doneFuture.Wait();
+
+        const TString html = WaitForRenderedPage(
+            env.Monitoring,
+            [](const TString& html) { return html.Contains("vol-1"); });
+
+        UNIT_ASSERT_STRING_CONTAINS(html, "10.0.0.1:41234");
+        UNIT_ASSERT_STRING_CONTAINS(html, "vol-1");
+        UNIT_ASSERT_STRING_CONTAINS(html, "client-a");
+        UNIT_ASSERT_STRING_CONTAINS(html, "VOLUME_ACCESS_READ_ONLY");
+        UNIT_ASSERT_STRING_CONTAINS(html, "VOLUME_MOUNT_LOCAL");
+
+        env.Target->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldShowConnectionWithoutMountsAndForgetItOnClose)
+    {
+        auto service = std::make_shared<TTestService>();
+        auto env = CreateTestEnv(service);
+        auto handler = env.GetHandler();
+
+        TTestSession session(4242);
+        handler->OnSessionCreated(session);
+
+        auto html = WaitForRenderedPage(
+            env.Monitoring,
+            [](const TString& html)
+            { return html.Contains("10.0.0.1:41234"); });
+        UNIT_ASSERT_STRING_CONTAINS(html, "10.0.0.1:41234");
+
+        handler->OnSessionClosed(session.GetId());
+
+        html = WaitForRenderedPage(
+            env.Monitoring,
+            [](const TString& html)
+            { return !html.Contains("10.0.0.1:41234"); });
+        UNIT_ASSERT_C(
+            !html.Contains("10.0.0.1:41234"),
+            "closed connection is still shown: " << html);
+
+        env.Target->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldRegisterMonPageUnderBlockStoreIndex)
+    {
+        auto service = std::make_shared<TTestService>();
+        auto env = CreateTestEnv(service);
+
+        UNIT_ASSERT(FindRootPage(env.Monitoring)->FindPage("RdmaTarget"));
 
         env.Target->Stop();
     }

--- a/cloud/blockstore/libs/service_rdma/ut/ya.make
+++ b/cloud/blockstore/libs/service_rdma/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(cloud/blockstore/libs/service_rdma)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
+    mount_registry_ut.cpp
     rdma_target_ut.cpp
 )
 

--- a/cloud/blockstore/libs/service_rdma/ya.make
+++ b/cloud/blockstore/libs/service_rdma/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    mount_registry.cpp
     rdma_protocol.cpp
     rdma_target.cpp
 )

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -52,7 +52,7 @@ enum class ECheckRange
 
 struct TRequestDetails
 {
-    void* Context = nullptr;
+    NCloud::NStorage::NRdma::IServerRequest* Context = nullptr;
     TStringBuf Out;
     TStringBuf DataBuffer; // if non empty, zero copy is possible
     TString DeviceUUID;
@@ -182,7 +182,7 @@ public:
     }
 
     void HandleRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextBasePtr callContext,
         TStringBuf in,
         TStringBuf out) override
@@ -257,7 +257,7 @@ public:
 
 private:
     NProto::TError DoHandleRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         TStringBuf in,
         TStringBuf out) const
@@ -535,7 +535,7 @@ private:
     }
 
     NProto::TError HandleReadBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TReadDeviceBlocksRequest& request,
         bool isZeroCopyDataSupported,
@@ -654,7 +654,7 @@ private:
     }
 
     NProto::TError HandleWriteBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TWriteDeviceBlocksRequest& request,
         bool isZeroCopyDataSupported,
@@ -799,7 +799,7 @@ private:
     }
 
     NProto::TError HandleMultiAgentWriteBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TWriteDeviceBlocksRequest& request,
         TStringBuf requestData,
@@ -925,7 +925,7 @@ private:
     }
 
     NProto::TError HandleZeroBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TZeroDeviceBlocksRequest& request,
         TStringBuf requestData,
@@ -1045,7 +1045,7 @@ private:
     }
 
     NProto::TError HandleChecksumBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         NProto::TChecksumDeviceBlocksRequest& request,
         TStringBuf requestData,

--- a/cloud/blockstore/tools/testing/rdma-test/target.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/target.cpp
@@ -76,7 +76,7 @@ public:
     }
 
     void HandleRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextBasePtr callContext,
         TStringBuf in,
         TStringBuf out) override
@@ -108,7 +108,7 @@ public:
 
 private:
     NProto::TError DoHandleRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         TStringBuf in,
         TStringBuf out)
@@ -143,7 +143,7 @@ private:
     }
 
     NProto::TError HandleReadBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         TReadBlocksRequestPtr request,
         TStringBuf requestData,
@@ -191,7 +191,7 @@ private:
     }
 
     NProto::TError HandleWriteBlocksRequest(
-        void* context,
+        NCloud::NStorage::NRdma::IServerRequest* context,
         TCallContextPtr callContext,
         TWriteBlocksRequestPtr request,
         TStringBuf requestData,

--- a/cloud/storage/core/libs/rdma/iface/public.h
+++ b/cloud/storage/core/libs/rdma/iface/public.h
@@ -45,6 +45,10 @@ using IServerEndpointPtr = std::shared_ptr<IServerEndpoint>;
 struct IServerHandler;
 using IServerHandlerPtr = std::shared_ptr<IServerHandler>;
 
+struct IServerSession;
+
+struct IServerRequest;
+
 struct TServerConfig;
 using TServerConfigPtr = std::shared_ptr<TServerConfig>;
 

--- a/cloud/storage/core/libs/rdma/iface/server.h
+++ b/cloud/storage/core/libs/rdma/iface/server.h
@@ -10,6 +10,7 @@
 
 #include <util/datetime/base.h>
 #include <util/generic/string.h>
+#include <util/system/defaults.h>
 
 namespace NCloud::NStorage::NRdma {
 
@@ -48,6 +49,28 @@ struct TServerConfig
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct IServerSession
+{
+    virtual ~IServerSession() = default;
+
+    [[nodiscard]] virtual ui64 GetId() const = 0;
+    [[nodiscard]] virtual TString GetPeer() const = 0;
+    [[nodiscard]] virtual TInstant GetStartTs() const = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IServerRequest
+{
+    virtual ~IServerRequest() = default;
+
+    // Id of the connection the request arrived from, the same one that was
+    // reported by IServerHandler::OnSessionCreated().
+    [[nodiscard]] virtual ui64 GetSessionId() const = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct IServerHandler
 {
     virtual ~IServerHandler() = default;
@@ -55,10 +78,18 @@ struct IServerHandler
     virtual TCallContextBasePtr CreateCallContext() = 0;
 
     virtual void HandleRequest(
-        void* context,
+        IServerRequest* context,
         TCallContextBasePtr callContext,
         TStringBuf in,
         TStringBuf out) = 0;
+
+    virtual void OnSessionCreated(const IServerSession&) noexcept
+    {}
+
+    virtual void OnSessionClosed(ui64 sessionId) noexcept
+    {
+        Y_UNUSED(sessionId);
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -67,8 +98,13 @@ struct IServerEndpoint
 {
     virtual ~IServerEndpoint() = default;
 
-    virtual void SendResponse(void* context, size_t responseBytes) = 0;
-    virtual void SendError(void* context, ui32 error, TStringBuf message) = 0;
+    virtual void SendResponse(
+        IServerRequest* context,
+        size_t responseBytes) = 0;
+    virtual void SendError(
+        IServerRequest* context,
+        ui32 error,
+        TStringBuf message) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/rdma/impl/server.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server.cpp
@@ -83,8 +83,10 @@ enum class ERequestState
 
 struct TRequest
     : TListNode<TRequest>
+    , IServerRequest
 {
     std::weak_ptr<TServerSession> Session;
+    const ui64 SessionId;
 
     ERequestState State = ERequestState::RecvRequest;
 
@@ -104,9 +106,16 @@ struct TRequest
     // hold session buffer references but are not tracked by WR queue sizes.
     bool TransferredToHandler = false;
 
-    TRequest(std::weak_ptr<TServerSession> session)
+    TRequest(std::weak_ptr<TServerSession> session, ui64 sessionId)
         : Session(std::move(session))
+        , SessionId(sessionId)
     {}
+
+    // implements IServerRequest
+    ui64 GetSessionId() const override
+    {
+        return SessionId;
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -253,6 +262,7 @@ struct TEndpointCounters
 
 class TServerSession final
     : public NVerbs::ICompletionHandler
+    , public IServerSession
     , public std::enable_shared_from_this<TServerSession>
 {
     // TODO
@@ -262,6 +272,10 @@ class TServerSession final
 private:
     NVerbs::IVerbsPtr Verbs;
     NVerbs::TConnectionPtr Connection;
+
+    const TString Peer;
+    const TInstant StartTs;
+
     TCompletionPoller* CompletionPoller = nullptr;
     IServerHandlerPtr Handler;
     TServerConfigPtr Config;
@@ -329,12 +343,32 @@ public:
 
     ~TServerSession() override;
 
+    // implements IServerSession
+    ui64 GetId() const override
+    {
+        return Id;
+    }
+
+    TString GetPeer() const override
+    {
+        return Peer;
+    }
+
+    TInstant GetStartTs() const override
+    {
+        return StartTs;
+    }
+
     // called from CM thread
     void CreateQP();
     void SetupQP();
     void Start() noexcept;
     void Stop() noexcept;
     void Flush() noexcept;
+    void NotifySessionCreated() noexcept;
+
+    // called from CQ thread
+    void NotifySessionClosed() noexcept;
 
     // called from external thread
     void EnqueueRequest(TRequestPtr req) noexcept;
@@ -379,6 +413,8 @@ TServerSession::TServerSession(
         int protocolVersion)
     : Verbs(std::move(verbs))
     , Connection(std::move(connection))
+    , Peer(Verbs->GetPeer(Connection.get()))
+    , StartTs(TInstant::Now())
     , CompletionPoller(completionPoller)
     , Handler(std::move(handler))
     , Config(std::move(config))
@@ -397,7 +433,7 @@ TServerSession::TServerSession(
     });
 
     RDMA_INFO(
-        "start session [host=" << Verbs->GetPeer(Connection.get())
+        "start session [host=" << Peer
                                << " send_magic=" << Hex(SendMagic, HF_FULL)
                                << " recv_magic=" << Hex(RecvMagic, HF_FULL)
                                << "]");
@@ -656,6 +692,29 @@ void TServerSession::Flush() noexcept
     }
 }
 
+// Notifications are issued from the CM and CQ threads, so a handler that lets
+// something escape would take the whole server down with it.
+
+void TServerSession::NotifySessionCreated() noexcept
+{
+    try {
+        Handler->OnSessionCreated(*this);
+    } catch (...) {
+        RDMA_ERROR("session created handler: " << CurrentExceptionMessage());
+        Counters->Error();
+    }
+}
+
+void TServerSession::NotifySessionClosed() noexcept
+{
+    try {
+        Handler->OnSessionClosed(Id);
+    } catch (...) {
+        RDMA_ERROR("session closed handler: " << CurrentExceptionMessage());
+        Counters->Error();
+    }
+}
+
 bool TServerSession::IsFlushed() const
 {
     // ExecutingRequests counts requests transferred to the handler whose
@@ -847,7 +906,7 @@ void TServerSession::RecvRequestCompleted(TRecvWr* recv) noexcept
         return;
     }
 
-    auto req = std::make_unique<TRequest>(weak_from_this());
+    auto req = std::make_unique<TRequest>(weak_from_this(), Id);
 
     // TODO restore context from request meta
     req->CallContext = Handler->CreateCallContext();
@@ -1194,7 +1253,7 @@ public:
         return static_cast<TServerEndpoint*>(event->listen_id->context);
     }
 
-    void SendResponse(void* context, size_t responseBytes) override
+    void SendResponse(IServerRequest* context, size_t responseBytes) override
     {
         TRequestPtr req(static_cast<TRequest*>(context));
         req->Status = RDMA_PROTO_OK;
@@ -1205,7 +1264,10 @@ public:
         }
     }
 
-    void SendError(void* context, ui32 error, TStringBuf message) override
+    void SendError(
+        IServerRequest* context,
+        ui32 error,
+        TStringBuf message) override
     {
         TRequestPtr req(static_cast<TRequest*>(context));
         req->Status = RDMA_PROTO_FAIL;
@@ -1397,6 +1459,8 @@ public:
         if (Config->WaitMode == EWaitMode::Poll) {
             PollHandle.Detach(session->CompletionChannel->fd);
         }
+
+        session->NotifySessionClosed();
 
         Sessions.Delete([=](auto other) {
             return session == other.get();
@@ -1984,6 +2048,8 @@ void TServer::Accept(
 
         RDMA_DEBUG("accept " << Verbs->GetPeer(event->id));
         Verbs->Accept(event->id, &acceptParams);
+
+        session->NotifySessionCreated();
 
         // transfer session ownership to the poller
         session->CompletionPoller->Acquire(session);

--- a/cloud/storage/core/libs/rdma/impl/server_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server_ut.cpp
@@ -64,16 +64,27 @@ struct TClientHandler
     }
 };
 
+struct TSessionInfo
+{
+    ui64 Id = 0;
+    TString Peer;
+    TInstant StartTs;
+};
+
 struct TServerHandler
     : IServerHandler
 {
+    TAdaptiveLock SessionLock;
+    TVector<TSessionInfo> CreatedSessions;
+    TVector<ui64> ClosedSessions;
+
     TCallContextBasePtr CreateCallContext() override
     {
         return MakeIntrusive<TCallContextBase>(ui64{0});
     }
 
     void HandleRequest(
-        void* context,
+        IServerRequest* context,
         TCallContextBasePtr callContext,
         TStringBuf in,
         TStringBuf out) override
@@ -83,24 +94,48 @@ struct TServerHandler
         Y_UNUSED(in);
         Y_UNUSED(out);
     }
+
+    void OnSessionCreated(const IServerSession& session) noexcept override
+    {
+        with_lock (SessionLock) {
+            CreatedSessions.push_back(
+                {session.GetId(), session.GetPeer(), session.GetStartTs()});
+        }
+    }
+
+    void OnSessionClosed(ui64 sessionId) noexcept override
+    {
+        with_lock (SessionLock) {
+            ClosedSessions.push_back(sessionId);
+        }
+    }
+
+    TVector<TSessionInfo> GetCreatedSessions()
+    {
+        with_lock (SessionLock) {
+            return CreatedSessions;
+        }
+    }
+
+    TVector<ui64> GetClosedSessions()
+    {
+        with_lock (SessionLock) {
+            return ClosedSessions;
+        }
+    }
 };
 
 struct TDelayedServerHandler final
-    : IServerHandler
+    : TServerHandler
 {
     NThreading::TPromise<void> RequestReceived =
         NThreading::NewPromise<void>();
 
-    void* Context = nullptr;
+    IServerRequest* Context = nullptr;
     TStringBuf Out;
 
-    TCallContextBasePtr CreateCallContext() override
-    {
-        return MakeIntrusive<TCallContextBase>(ui64{0});
-    }
-
     void HandleRequest(
-        void* context,
+        IServerRequest* context,
         TCallContextBasePtr callContext,
         TStringBuf in,
         TStringBuf out) override
@@ -770,6 +805,146 @@ TEST(TRdmaServerTest, ShouldKeepSessionAliveUntilHandlerCompletesOnDisconnect)
     endpoint->SendResponse(handler->Context, 0);
 
     sessionDestroyed.GetFuture().GetValueSync();
+}
+
+TEST(TRdmaServerTest, ShouldNotifyHandlerAboutSessionLifecycle)
+{
+    auto context = MakeIntrusive<NVerbs::TTestContext>();
+
+    // let Stop() complete: the fake verbs only drains the queues if the
+    // transition to the error state flushes them
+    context->ModifyQP = [&](ibv_qp* qp, ibv_qp_attr* attr, int mask)
+    {
+        Y_UNUSED(qp);
+
+        if ((mask & IBV_QP_STATE) && attr->qp_state == IBV_QPS_ERR) {
+            NVerbs::Flush(context);
+        }
+    };
+
+    auto verbs = NVerbs::CreateTestVerbs(context);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto serverConfig = std::make_shared<TServerConfig>();
+    serverConfig->QueueSize = 1;
+    serverConfig->SendQueueSize = 1;
+    serverConfig->RecvQueueSize = 1;
+
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+
+    auto server = CreateTestServer(verbs, logging, monitoring, serverConfig);
+    server->Start();
+
+    auto handler = std::make_shared<TServerHandler>();
+    server->StartEndpoint("::", 10020, handler);
+
+    EXPECT_TRUE(handler->GetCreatedSessions().empty());
+
+    NVerbs::CreateConnection(
+        context,
+        static_cast<ui16>(serverConfig->SendQueueSize),
+        static_cast<ui16>(serverConfig->RecvQueueSize),
+        serverConfig->MaxBufferSize);
+
+    auto activeRecv = GetServerCounters(monitoring)->GetCounter("ActiveRecv");
+    while (activeRecv->Val() != serverConfig->RecvQueueSize) {
+        SpinLockPause();
+    }
+
+    auto created = handler->GetCreatedSessions();
+    ASSERT_EQ(1u, created.size());
+    EXPECT_NE(0u, created[0].Id);
+    EXPECT_FALSE(created[0].Peer.empty());
+    EXPECT_NE(TInstant::Zero(), created[0].StartTs);
+
+    // the connection is still up, so nothing has been closed yet
+    EXPECT_TRUE(handler->GetClosedSessions().empty());
+
+    server->Stop();
+
+    auto closed = handler->GetClosedSessions();
+    ASSERT_EQ(1u, closed.size());
+    EXPECT_EQ(created[0].Id, closed[0]);
+}
+
+TEST(TRdmaServerTest, ShouldReportSessionTheRequestArrivedFrom)
+{
+    auto context = MakeIntrusive<NVerbs::TTestContext>();
+
+    context->ModifyQP = [&](ibv_qp* qp, ibv_qp_attr* attr, int mask)
+    {
+        Y_UNUSED(qp);
+
+        if ((mask & IBV_QP_STATE) && attr->qp_state == IBV_QPS_ERR) {
+            NVerbs::Flush(context);
+        }
+    };
+
+    context->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+        PostSend<TResponseMessage>(context, qp, wr);
+    };
+
+    auto verbs = NVerbs::CreateTestVerbs(context);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto serverConfig = std::make_shared<TServerConfig>();
+    serverConfig->QueueSize = 1;
+    serverConfig->SendQueueSize = 1;
+    serverConfig->RecvQueueSize = 1;
+
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+
+    auto server = CreateTestServer(verbs, logging, monitoring, serverConfig);
+    server->Start();
+
+    auto handler = std::make_shared<TDelayedServerHandler>();
+    auto endpoint = server->StartEndpoint("::", 10020, handler);
+
+    NVerbs::CreateConnection(
+        context,
+        static_cast<ui16>(serverConfig->SendQueueSize),
+        static_cast<ui16>(serverConfig->RecvQueueSize),
+        serverConfig->MaxBufferSize);
+
+    auto activeRecv = GetServerCounters(monitoring)->GetCounter("ActiveRecv");
+    while (activeRecv->Val() != serverConfig->RecvQueueSize) {
+        SpinLockPause();
+    }
+
+    with_lock (context->CompletionLock) {
+        ASSERT_FALSE(context->RecvEvents.empty());
+
+        auto* recv = context->RecvEvents.back();
+        context->RecvEvents.pop_back();
+
+        auto* msg = reinterpret_cast<TRequestMessage*>(recv->sg_list[0].addr);
+        memset(msg, 0, sizeof(*msg));
+        InitMessageHeader(msg, RDMA_PROTO_VERSION);
+        msg->ReqId = 1;
+        msg->Out.Length = 4_KB;
+
+        context->ProcessedRecvEvents.push_back(recv);
+        context->CompletionHandle.Set();
+    }
+
+    handler->RequestReceived.GetFuture().GetValueSync();
+    ASSERT_NE(nullptr, handler->Context);
+
+    auto created = handler->GetCreatedSessions();
+    ASSERT_EQ(1u, created.size());
+    EXPECT_EQ(created[0].Id, handler->Context->GetSessionId());
+
+    // an unanswered request keeps the session from being released, so the
+    // handler cannot be told the session is gone while it still owns one
+    EXPECT_TRUE(handler->GetClosedSessions().empty());
+
+    endpoint->SendResponse(handler->Context, 0);
+
+    server->Stop();
+
+    auto closed = handler->GetClosedSessions();
+    ASSERT_EQ(1u, closed.size());
+    EXPECT_EQ(created[0].Id, closed[0]);
 }
 
 int NVerbs::DestroyId(rdma_cm_id* id)


### PR DESCRIPTION
### Notes
RDMA connection monitoring for the blockstore server: a page showing which clients are connected and which volumes are mounted over each connection

**The transport now reports connection lifecycle.**

- IServerSession — a connection descriptor (GetId/GetPeer/GetStartTs), valid only for the duration of the call it is passed to.

- IServerRequest replaces the untyped void* context in HandleRequest/SendResponse/SendError. Hence the mechanical churn across every handler implementation: disk_agent, endpoints_rdma, rdma-test, rdma_test.

- IServerHandler gained OnSessionCreated/OnSessionClosed — noexcept, with empty default bodies, so the other targets are untouched.

- TServerSession caches Peer and StartTs in const fields; TRequest carries SessionId.

**Where the notifications fire is load-bearing:**

- NotifySessionCreated() from Accept(), before Acquire() — otherwise the poller could release the session and report it closed before the handler ever learns it existed.

- NotifySessionClosed() from Release(), which only runs once IsFlushed() holds, i.e. after every in-flight request has been answered.

That yields the invariant the rest depends on: connection announced → all of its mounts → connection closed, strictly in that order.

**Registry (cloud/blockstore/libs/service_rdma/mount_registry.*, new)**

- TMountRegistry maps sessionId → TConnectionInfo{Peer, StartTs, Mounts}. It owns a single-threaded pool; every mutation is asynchronous and serialized on that thread.

The thread exists precisely for ordering: OnSessionCreated arrives on the CM thread, OnSessionClosed on a completion poller. On a multi-threaded pool the close could be applied before the open, leaving the connection in the registry forever.

Exactly one method creates entries — DoAddConnection. DoAddMount goes through FindPtr and ignores a mount for an unknown connection; otherwise it would be a second path for resurrecting a closed one. Removing a connection drops its mounts along with the entry.

**Target (rdma_target.*)**
TRdmaTarget forwards the four events to the registry and renders the table from it: SessionId / Peer / Connected / DiskId / ClientId / AccessMode / MountMode / MountSeqNumber. The RdmaTarget page is registered under /blockstore.

The feature is toggleable: a new ConnectionMonitoringEnabled field on TRdmaTarget in [config/rdma.proto](vscode-webview://151snfid7fjgqi2pjtjs26qqashera4i2s6bulnpqmu9b6osk72g/cloud/blockstore/config/rdma.proto), defaulting to false. When off, the registry is not created, the thread is not started, the page is not registered, and the handler holds an empty pointer.

The factory signature barely moved — IMonitoringServicePtr monitoring was added, the return type stayed IStartablePtr.

### Issue
Put links to the related issues here
