### PR TITLE
[Blockstore] split local nonrepl loadtests by backend

### DIFF
--- a/cloud/blockstore/tests/loadtest/local-nonrepl/embedded-io-uring/ya.make
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/embedded-io-uring/ya.make
@@ -6,7 +6,7 @@ SRCDIR(${ARCADIA_ROOT}/cloud/blockstore/tests/loadtest/local-nonrepl)
 INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/loadtest/local-nonrepl/ya.make.inc)
 
 ENV(DEDICATED_DISK_AGENT="false")
-ENV(NBS_LOCAL_NONREPL_BACKEND="aio")
+ENV(NBS_LOCAL_NONREPL_BACKEND="io_uring")
 
 DEPENDS(
     cloud/blockstore/apps/server

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
@@ -370,6 +370,10 @@ BACKENDS = {
     'io_uring': DISK_AGENT_BACKEND_IO_URING,
 }
 
+SELECTED_BACKEND = os.getenv('NBS_LOCAL_NONREPL_BACKEND')
+if SELECTED_BACKEND:
+    BACKENDS = {SELECTED_BACKEND: BACKENDS[SELECTED_BACKEND]}
+
 
 @pytest.mark.parametrize("test_case", TESTS, ids=[x.name for x in TESTS])
 @pytest.mark.parametrize("backend", BACKENDS.values(), ids=BACKENDS.keys())

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/ya.make
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/ya.make
@@ -1,4 +1,5 @@
 RECURSE_FOR_TESTS(
     dedicated
     embedded
+    embedded-io-uring
 )


### PR DESCRIPTION
## Notes

Allows the `io_uring` test target to be configured independently

- add `NBS_LOCAL_NONREPL_BACKEND` to select one backend in the shared local-nonrepl test;
- keep the existing `embedded` target focused on `aio`;
- add a separate `embedded-io-uring` target;
- register the new target in `RECURSE_FOR_TESTS`.

## Issue

Sandbox tasks run tests on an older Linux kernel (<6.12) by default. The `io_uring` tests require features and fixes from a newer kernel, so enabling them in Arcadia also requires infrastructure changes that provide a suitable VM and kernel environment. This PR contains only the common parts that can be upstreamed to GitHub
