### PR TITLE
issue-5895: fastshard lsn allocation vs write race fix

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.cpp
@@ -134,7 +134,12 @@ NProto::TError TPageStore::WritePage(
     //
 
     if (!p.Dirty) {
-        Y_ABORT_UNLESS(p.Lsn <= lsn);
+        Y_ABORT_UNLESS(
+            p.Lsn <= lsn,
+            "p.Lsn=%lu, lsn=%lu, pageNo=%lu",
+            p.Lsn,
+            lsn,
+            pageNo);
     }
 
     p = {.Content = std::move(page), .Lsn = lsn, .Dirty = true};

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -201,7 +201,6 @@ public:
         : Context(context)
         , Store(store)
     {
-        Context.Lsn = Store.AllocateLsn();
     }
 
     ~TWriteContextGuard()
@@ -212,6 +211,13 @@ public:
         }
 
         // TODO(#5895) - notify storage that this Lsn was skipped
+    }
+
+    // Must be called after shard mutex is taken. Otherwise concurrent shard ops
+    // can race and cause PageStore updates which are not Lsn-ordered.
+    void Init()
+    {
+        Context.Lsn = Store.AllocateLsn();
     }
 };
 
@@ -1245,6 +1251,7 @@ public:
 
         {
             std::lock_guard g(Mutex);
+            wcg.Init();
 
             auto error = Nodes.UpdateNode(
                 request.GetNodeId(),
@@ -1338,6 +1345,7 @@ public:
         NProto::TError error;
         {
             std::lock_guard g(Mutex);
+            wcg.Init();
             error = CreateNodeImpl(
                 request.GetName(),
                 request.GetFile().GetMode(),
@@ -1394,6 +1402,7 @@ public:
 
         {
             std::lock_guard g(Mutex);
+            wcg.Init();
 
             ui64 nodeId = 0;
             auto error = Names.Get(request.GetName(), &nodeId);
@@ -1505,6 +1514,7 @@ public:
         TWriteContextGuard wcg(writeContext, *PageStore);
 
         std::unique_lock l(Mutex);
+        wcg.Init();
 
         ui64 nodeId = request.GetNodeId();
         NProto::TNodeAttr attr;
@@ -1625,6 +1635,7 @@ public:
 
         {
             std::lock_guard g(Mutex);
+            wcg.Init();
 
             auto error = Handles.Delete(request.GetHandle(), writeContext);
             if (HasError(error)) {
@@ -1727,6 +1738,7 @@ public:
 
         TWriteContext writeContext;
         TWriteContextGuard wcg(writeContext, *PageStore);
+        wcg.Init();
 
         //
         // The allocation of all page clusters should happen as a single call.

--- a/cloud/filestore/tools/testing/fmdtest/bin/app.cpp
+++ b/cloud/filestore/tools/testing/fmdtest/bin/app.cpp
@@ -265,6 +265,8 @@ public:
                 TString content = TFileInput(filePath).ReadAll();
                 if (content != file.Content) {
                     STORAGE_ERROR("Content mismatch for " << filePath);
+                    STORAGE_ERROR("E:\t" << file.Content);
+                    STORAGE_ERROR("A:\t" << content);
                     ++errors;
                 }
 


### PR DESCRIPTION
### Notes
Fixing the following race:
1. fiber0 allocates lsn0
2. fiber1 allocates lsn1
3. fiber1 writes into PageStore's page N
4. fiber1 persists and commits its write
5. fiber0 tries to write into PageStore's page N - aborts upon seeing that this page is not dirty but has lsn1 > lsn0

Fix: allocating lsn under shard mutex

The whole read + in-memory write part of the shard logic is currently supposed to be done under a shard-global lock. This is inefficient and will be fixed in the future but right now the code depends on it - it doesn't expect a PageStore write to happen on top of a newer version of the same page and it just aborts, there's no gracefull rollback/retry. Need to change it to something like page-level locks. Or some other solution. Anyway, will think about it.

### Issue
https://github.com/ydb-platform/nbs/issues/5895
