### PR TITLE
Remove sending token inside Authorization header for yatool opensource

### DIFF
--- a/ya
+++ b/ya
@@ -113,18 +113,6 @@ def tool_root():
     return create_dirs(os.getenv('YA_CACHE_DIR_TOOLS') or os.path.join(misc_root(), 'tools'))
 
 
-# TODO: remove when switched to S3, won't be needed in OSS
-def ya_token():
-    def get_token_from_file():
-        try:
-            with open(os.environ.get('YA_TOKEN_PATH', os.path.join(home_dir(), '.ya_token')), 'r') as f:
-                return f.read().strip()
-        except:
-            pass
-
-    return os.getenv('YA_TOKEN') or get_token_from_file()
-
-
 TOOLS_DIR = tool_root()
 
 
@@ -168,14 +156,9 @@ def _fetch(url, into):
 
     from urllib.request import urlopen
     from urllib.request import Request
-    from urllib.parse import urlparse
 
     request = Request(str(url))
-    # TODO: Remove when switched to S3 distribution
     request.add_header('User-Agent', 'ya-bootstrap')
-    token = ya_token()
-    if token:
-        request.add_header('Authorization', 'OAuth {}'.format(token))
 
     md5 = hashlib.md5()
     sys.stderr.write('Downloading %s ' % url)


### PR DESCRIPTION
## Summary

Fix download error with returning HTTP 400 when a local ya token is present

- remove usage `YA_TOKEN` and `.ya_token` in the OSS `ya`
- disable sending useless `Authorization` header to the S3 registry

## Issue 

Error with downloading resources form remote Nebius s3 with Authorization header `https://storage.eu-north2.nebius.cloud`

```
~/github/nbs/cloud/blockstore/apps/server$ ~/github/nbs/ya make 
Downloading https://storage.eu-north2.nebius.cloud/nbs-yatool-resources/8119506702 ERROR: HTTP Error 400: Bad Request
```
