### PR TITLE
issue-1751: [Filestore] WriteBackCache should not crash on corruption

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -41,6 +41,7 @@ namespace NCloud::NFileStore{
     xxx(WriteBackCacheCorruptionError)                                         \
     xxx(WriteBackCacheDataLossError)                                           \
     xxx(WriteBackCacheImpossibleState)                                         \
+    xxx(WriteBackCacheInitializationError)                                     \
     xxx(WriteBackCacheWritingNotAllowedInDrainingMode)                         \
     xxx(ErrorWasSentToTheGuest)                                                \
     xxx(DirectoryHandlesStorageError)                                          \

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/hanging_requests.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/hanging_requests.cpp
@@ -3,6 +3,13 @@
 namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void THangingRequests::Add(
+    NThreading::TPromise<NProto::TReadDataResponse> promise)
+{
+    ReadDataPromises.push_back(std::move(promise));
+}
+
 NThreading::TFuture<TResultOrError<ui64>>
 THangingRequests::CreateAcquireBarrierResponse()
 {
@@ -18,15 +25,6 @@ THangingRequests::CreateFlushOrReleaseHandleResponse()
     auto promise = NThreading::NewPromise<NProto::TError>();
     auto future = promise.GetFuture();
     FlushOrReleaseHandlePromises.push_back(std::move(promise));
-    return future;
-}
-
-NThreading::TFuture<NProto::TReadDataResponse>
-THangingRequests::CreateReadDataResponse()
-{
-    auto promise = NThreading::NewPromise<NProto::TReadDataResponse>();
-    auto future = promise.GetFuture();
-    ReadDataPromises.push_back(std::move(promise));
     return future;
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/hanging_requests.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/hanging_requests.cpp
@@ -1,0 +1,42 @@
+#include "hanging_requests.h"
+
+namespace NCloud::NFileStore::NFuse::NWriteBackCache {
+
+////////////////////////////////////////////////////////////////////////////////
+NThreading::TFuture<TResultOrError<ui64>>
+THangingRequests::CreateAcquireBarrierResponse()
+{
+    auto promise = NThreading::NewPromise<TResultOrError<ui64>>();
+    auto future = promise.GetFuture();
+    AcquireBarrierPromises.push_back(std::move(promise));
+    return future;
+}
+
+NThreading::TFuture<NProto::TError>
+THangingRequests::CreateFlushOrReleaseHandleResponse()
+{
+    auto promise = NThreading::NewPromise<NProto::TError>();
+    auto future = promise.GetFuture();
+    FlushOrReleaseHandlePromises.push_back(std::move(promise));
+    return future;
+}
+
+NThreading::TFuture<NProto::TReadDataResponse>
+THangingRequests::CreateReadDataResponse()
+{
+    auto promise = NThreading::NewPromise<NProto::TReadDataResponse>();
+    auto future = promise.GetFuture();
+    ReadDataPromises.push_back(std::move(promise));
+    return future;
+}
+
+NThreading::TFuture<NProto::TWriteDataResponse>
+THangingRequests::CreateWriteDataResponse()
+{
+    auto promise = NThreading::NewPromise<NProto::TWriteDataResponse>();
+    auto future = promise.GetFuture();
+    WriteDataPromises.push_back(std::move(promise));
+    return future;
+}
+
+}   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/hanging_requests.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/hanging_requests.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cloud/filestore/public/api/protos/data.pb.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <library/cpp/threading/future/core/future.h>
+
+#include <util/generic/vector.h>
+
+namespace NCloud::NFileStore::NFuse::NWriteBackCache {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Requests that are hanging due to WriteBackCache failed state
+// The class is not thread-safe
+class THangingRequests
+{
+private:
+    TVector<NThreading::TPromise<TResultOrError<ui64>>> AcquireBarrierPromises;
+    TVector<NThreading::TPromise<NProto::TError>> FlushOrReleaseHandlePromises;
+    TVector<NThreading::TPromise<NProto::TReadDataResponse>> ReadDataPromises;
+    TVector<NThreading::TPromise<NProto::TWriteDataResponse>> WriteDataPromises;
+
+public:
+    NThreading::TFuture<TResultOrError<ui64>> CreateAcquireBarrierResponse();
+    NThreading::TFuture<NProto::TError> CreateFlushOrReleaseHandleResponse();
+    NThreading::TFuture<NProto::TReadDataResponse> CreateReadDataResponse();
+    NThreading::TFuture<NProto::TWriteDataResponse> CreateWriteDataResponse();
+};
+
+}   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/hanging_requests.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/hanging_requests.h
@@ -23,9 +23,9 @@ private:
     TVector<NThreading::TPromise<NProto::TWriteDataResponse>> WriteDataPromises;
 
 public:
+    void Add(NThreading::TPromise<NProto::TReadDataResponse> promise);
     NThreading::TFuture<TResultOrError<ui64>> CreateAcquireBarrierResponse();
     NThreading::TFuture<NProto::TError> CreateFlushOrReleaseHandleResponse();
-    NThreading::TFuture<NProto::TReadDataResponse> CreateReadDataResponse();
     NThreading::TFuture<NProto::TWriteDataResponse> CreateWriteDataResponse();
 };
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
@@ -33,6 +33,9 @@ struct TCachedData
     // This is needed to avoid truncation when there are unflushed data parts
     // beyond the requested range.
     ui64 ReadDataByteCount = 0;
+
+    // WriteBackCache is in failed state
+    bool Failed = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
@@ -33,9 +33,6 @@ struct TCachedData
     // This is needed to avoid truncation when there are unflushed data parts
     // beyond the requested range.
     ui64 ReadDataByteCount = 0;
-
-    // WriteBackCache is in failed state
-    bool Failed = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache_ut.cpp
@@ -173,7 +173,7 @@ struct TBootstrap
         *request->MutableBuffer() = std::move(data);
 
         auto res = RequestManager.AddRequest(std::move(request));
-        return std::get<1>(std::move(res));
+        return std::move(res.CachedRequest);
     }
 
     TString GetCachedData(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -1,5 +1,7 @@
 #include "persistent_storage.h"
 
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -9,6 +11,7 @@
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/intrlist.h>
+#include <util/string/printf.h>
 
 namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
@@ -42,12 +45,10 @@ public:
         , LogTag(std::move(logTag))
     {
         SetCounters();
-    }
 
-    NProto::TError Init()
-    {
         if (Storage.IsCorrupted()) {
-            return MakeError(E_FAIL, "Data structure is corrupted");
+            // Reporting corrupted state is handled by TFileRingBuffer
+            return;
         }
 
         NJsonWriter::TBuf json;
@@ -65,9 +66,8 @@ public:
             .EndObject();
 
         STORAGE_INFO(
-            LogTag << " WriteBackCache has been initialized " << json.Str());
-
-        return {};
+            LogTag << " WriteBackCache storage has been initialized "
+                   << json.Str());
     }
 
     bool Empty() const override
@@ -75,7 +75,12 @@ public:
         return Storage.Empty();
     }
 
-    void Visit(const TVisitor& visitor) override
+    bool IsCorrupted() const override
+    {
+        return Storage.IsCorrupted();
+    }
+
+    NProto::TError Visit(const TVisitor& visitor) override
     {
         auto visitResult = Storage.Visit(
             [&visitor](ui32 checksum, ui32 tag, TStringBuf entry)
@@ -84,11 +89,16 @@ public:
                 visitor(tag, {entry.data(), entry.size()});
             });
 
-        // TODO(#1751): To be resolved in
-        // https://github.com/ydb-platform/nbs/pull/6867
-        Y_UNUSED(visitResult);
-
         SetCounters();
+
+        if (HasError(visitResult)) {
+            ReportWriteBackCacheCorruptionError(Sprintf(
+                "%s Storage::Visit failed with an error: %s",
+                LogTag.c_str(),
+                FormatError(visitResult).c_str()));
+        }
+
+        return visitResult;
     }
 
     ui64 GetMaxSupportedAllocationByteCount() const override
@@ -99,38 +109,62 @@ public:
     TResultOrError<char*> Alloc(size_t size) override
     {
         auto allocResult = Storage.Alloc(size);
+
         if (HasError(allocResult.Error)) {
+            ReportWriteBackCacheCorruptionError(Sprintf(
+                "%s Storage::Alloc failed with an error: %s",
+                LogTag.c_str(),
+                FormatError(allocResult.Error).c_str()));
             return allocResult.Error;
-        } else {
-            return allocResult.AllocationPtr;
         }
+
+        return allocResult.AllocationPtr;
     }
 
-    void Commit() override
+    NProto::TError Commit() override
     {
-        auto res = Storage.Commit();
-        Y_ENSURE(
-            !HasError(res),
-            "Failed to commit allocation: " << FormatError(res));
+        auto commitResult = Storage.Commit();
+
         SetCounters();
+
+        if (HasError(commitResult)) {
+            ReportWriteBackCacheCorruptionError(Sprintf(
+                "%s Storage::Commit failed with an error: %s",
+                LogTag.c_str(),
+                FormatError(commitResult).c_str()));
+        }
+
+        return commitResult;
     }
 
-    void Free(const void* ptr) override
+    NProto::TError Free(const void* ptr) override
     {
-        auto res = Storage.Free(ptr);
-        Y_ENSURE(
-            !HasError(res),
-            "Failed to free pointer " << ptr << ": " << FormatError(res));
+        auto freeResult = Storage.Free(ptr);
+
         SetCounters();
+
+        if (HasError(freeResult)) {
+            ReportWriteBackCacheCorruptionError(Sprintf(
+                "%s Storage::Free failed with an error: %s",
+                LogTag.c_str(),
+                FormatError(freeResult).c_str()));
+        }
+
+        return freeResult;
     }
 
-    void SetTag(const void* ptr, ui32 tag) override
+    NProto::TError SetTag(const void* ptr, ui32 tag) override
     {
         auto setTagResult = Storage.SetTag(ptr, tag);
 
-        // TODO(#1751): To be resolved in
-        // https://github.com/ydb-platform/nbs/pull/6867
-        Y_UNUSED(setTagResult);
+        if (HasError(setTagResult)) {
+            ReportWriteBackCacheCorruptionError(Sprintf(
+                "%s Storage::SetTag failed with an error: %s",
+                LogTag.c_str(),
+                FormatError(setTagResult).c_str()));
+        }
+
+        return setTagResult;
     }
 
     void UpdateStats() const override
@@ -157,24 +191,17 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TResultOrError<IPersistentStoragePtr> CreateFileRingBufferPersistentStorage(
+IPersistentStoragePtr CreateFileRingBufferPersistentStorage(
     IPersistentStorageStatsPtr stats,
     TPersistentStorageConfig config,
     TLog log,
     TString logTag)
 {
-    auto storage = std::make_shared<TFileRingBufferStorage>(
+    return std::make_shared<TFileRingBufferStorage>(
         std::move(stats),
         std::move(config),
         std::move(log),
         std::move(logTag));
-
-    auto error = storage->Init();
-    if (HasError(error)) {
-        return error;
-    }
-
-    return static_cast<IPersistentStoragePtr>(storage);
 }
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -22,14 +22,24 @@ struct IPersistentStorage
     virtual ~IPersistentStorage() = default;
 
     virtual bool Empty() const = 0;
-
-    // Enumerates the contents of the persistent storage in the allocation order
-    virtual void Visit(const TVisitor& visitor) = 0;
+    virtual bool IsCorrupted() const = 0;
 
     /**
-     * Gets the maximum possible buffer size that can be allocated.
-     * Alloc is guaranteed to succeed for any size <=
-     * MaxSupportedAllocationByteCount when the storage is empty.
+     * Enumerates the contents of the persistent storage in the allocation order
+     *
+     * Does not visit anything and returns an error if the buffer is corrupted.
+     */
+    [[nodiscard]] virtual NProto::TError Visit(const TVisitor& visitor) = 0;
+
+    /**
+     * Returns the number of bytes that can be successfully allocated by
+     * PushBack and Alloc for an empty buffer without exceeding the capacity.
+     *
+     * Returns zero if the buffer is corrupted.
+     *
+     * Note: the purpose of this method is to provide a guarantee that an
+     * allocation of this size will eventually succeed. Allocations of higher
+     * sizes will fail with an error.
      */
     virtual ui64 GetMaxSupportedAllocationByteCount() const = 0;
 
@@ -39,29 +49,43 @@ struct IPersistentStorage
      * On successful allocation, returns a pointer to the buffer in persistent
      * storage. The caller should fill the buffer and call Commit.
      *
-     * Returns nullptr if there is not enough free space in the storage.
+     * On failure, returns nullptr if the buffer is full or an error if
+     * allocation is not possible due to corruption or invalid argument.
      *
-     * Returns an error if allocation is not possible due to other reasons.
+     * Note: only one allocation is possible at a time. Repeated Alloc will
+     * return an error.
      */
     [[nodiscard]] virtual TResultOrError<char*> Alloc(size_t size) = 0;
 
     /**
-     * Commits previous memory allocation
+     * Commits previously allocated memory buffer.
+     *
+     * Once committed, it is not allowed to modify the contents of the allocated
+     * entry. If there is a need to augment the allocation with additional data,
+     * SetTag can be used.
      *
      * Memory that was allocated but not committed will be lost at buffer
      * recreation.
      *
-     * Returns true if the commit was successful.
-     * Returns false if Alloc was not called.
+     * An error is returned if there is no incomplete allocation or the buffer
+     * is corrupted.
      */
-    virtual void Commit() = 0;
+    [[nodiscard]] virtual NProto::TError Commit() = 0;
 
-    // Frees a previously allocated buffer.
-    virtual void Free(const void* ptr) = 0;
+    /**
+     * Frees a previously allocated and committed buffer.
+     *
+     * An error is returned if the pointer is invalid or the buffer is corrupted
+     */
+    [[nodiscard]] virtual NProto::TError Free(const void* ptr) = 0;
 
-    // Once committed, entries should remain immutable.
-    // But it is possible to assign a small mutable tag to the entry.
-    virtual void SetTag(const void* ptr, ui32 tag) = 0;
+    /**
+     * Sets the tag value associated with the allocation.
+     *
+     * Returns an error if the pointer is invalid, the tag value exceeds the
+     * maximal supported value or if the buffer is corrupted.
+     */
+    [[nodiscard]] virtual NProto::TError SetTag(const void* ptr, ui32 tag) = 0;
 
     virtual void UpdateStats() const = 0;
 };
@@ -79,7 +103,8 @@ struct TPersistentStorageConfig
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TResultOrError<IPersistentStoragePtr> CreateFileRingBufferPersistentStorage(
+// Errors are also reported as critical events in this implementation
+IPersistentStoragePtr CreateFileRingBufferPersistentStorage(
     IPersistentStorageStatsPtr stats,
     TPersistentStorageConfig config,
     TLog log,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -26,14 +26,13 @@ struct IPersistentStorage
 
     /**
      * Enumerates the contents of the persistent storage in the allocation order
-     *
-     * Does not visit anything and returns an error if the buffer is corrupted.
+     * Stops visiting when corruption is detected.
      */
     [[nodiscard]] virtual NProto::TError Visit(const TVisitor& visitor) = 0;
 
     /**
-     * Returns the number of bytes that can be successfully allocated by
-     * PushBack and Alloc for an empty buffer without exceeding the capacity.
+     * Returns the number of bytes that can be successfully allocated by Alloc
+     * for an empty buffer without exceeding the capacity.
      *
      * Returns zero if the buffer is corrupted.
      *

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -41,7 +41,7 @@ struct TBootstrap
 
     NProto::TError Initialize()
     {
-        auto res = CreateFileRingBufferPersistentStorage(
+        Storage = CreateFileRingBufferPersistentStorage(
             Stats,
             {.FilePath = TempFile.GetName(),
              .DataCapacity = DefaultCapacity,
@@ -49,12 +49,7 @@ struct TBootstrap
             Log,
             "[tag]");
 
-        if (HasError(res)) {
-            return res.GetError();
-        }
-
-        Storage = res.ExtractResult();
-        return {};
+        return MakeError(Storage->IsCorrupted() ? E_FAIL : S_OK);
     }
 
     void Deinitialize()
@@ -78,7 +73,7 @@ struct TBootstrap
         char* ptr = allocationResult.GetResult();
         if (ptr != nullptr) {
             data.copy(ptr, data.size());
-            Storage->Commit();
+            UNIT_ASSERT(!HasError(Storage->Commit()));
         }
         return ptr;
     }
@@ -89,15 +84,15 @@ struct TBootstrap
         return HasError(allocationResult);
     }
 
-    void Free(const void* ptr) const
+    NProto::TError Free(const void* ptr) const
     {
-        Storage->Free(ptr);
+        return Storage->Free(ptr);
     }
 
     TString Dump() const
     {
         TString res;
-        Storage->Visit(
+        auto visitResult = Storage->Visit(
             [&res](ui32 tag, TStringBuf entry)
             {
                 Y_UNUSED(tag);
@@ -106,7 +101,7 @@ struct TBootstrap
                 }
                 res.append(entry);
             });
-
+        UNIT_ASSERT(!HasError(visitResult));
         return res;
     }
 };
@@ -157,7 +152,7 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         UNIT_ASSERT_VALUES_EQUAL(0, stats.EntryCount->Get());
     }
 
-    Y_UNIT_TEST(ShouldThrowOnDoubleFree)
+    Y_UNIT_TEST(ShouldReturnErrorOnDoubleFree)
     {
         TBootstrap b;
 
@@ -170,11 +165,11 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         const auto* ptr2 = b.Alloc("567890");
         UNIT_ASSERT(ptr2);
 
-        b.Free(ptr2);
-        UNIT_ASSERT_EXCEPTION(b.Free(ptr2), yexception);
+        UNIT_ASSERT(!HasError(b.Free(ptr2)));
+        UNIT_ASSERT(HasError(b.Free(ptr2)));
 
-        b.Free(ptr1);
-        UNIT_ASSERT_EXCEPTION(b.Free(ptr1), yexception);
+        UNIT_ASSERT(!HasError(b.Free(ptr1)));
+        UNIT_ASSERT(HasError(b.Free(ptr1)));
     }
 
     Y_UNIT_TEST(ShouldValidateAllocationSize)

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.cpp
@@ -342,14 +342,8 @@ TReadResponseBuilder::TReadResponseBuilder(
 
 std::optional<NProto::TReadDataResponse>
 TReadResponseBuilder::TryFullyServeFromCache(
-    TWriteBackCacheState& state,
-    TNodeCachedDataPin pin) const
+    const TCachedData& cachedData) const
 {
-    auto cachedData = state.GetCachedData(NodeId, Offset, Length, pin);
-    if (cachedData.Failed) {
-        return std::nullopt;
-    }
-
     Validate(cachedData, Length);
 
     ui64 contiguousCachedDataByteCount = 0;
@@ -371,22 +365,16 @@ TReadResponseBuilder::TryFullyServeFromCache(
 
 bool TReadResponseBuilder::AugmentResponseWithCachedData(
     NProto::TReadDataResponse& response,
-    TWriteBackCacheState& state,
-    TNodeCachedDataPin pin) const
+    const TCachedData& cachedData) const
 {
-    auto cachedData = state.GetCachedData(NodeId, Offset, Length, pin);
-    if (cachedData.Failed) {
-        return false;
-    }
-
     Validate(cachedData, Length);
 
-    AugmentResponseWithCachedData(response, cachedData);
+    DoAugmentResponseWithCachedData(response, cachedData);
 
     return !cachedData.Parts.empty();
 }
 
-void TReadResponseBuilder::AugmentResponseWithCachedData(
+void TReadResponseBuilder::DoAugmentResponseWithCachedData(
     NProto::TReadDataResponse& response,
     const TCachedData& cachedData) const
 {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.cpp
@@ -346,6 +346,10 @@ TReadResponseBuilder::TryFullyServeFromCache(
     TNodeCachedDataPin pin) const
 {
     auto cachedData = state.GetCachedData(NodeId, Offset, Length, pin);
+    if (cachedData.Failed) {
+        return std::nullopt;
+    }
+
     Validate(cachedData, Length);
 
     ui64 contiguousCachedDataByteCount = 0;
@@ -371,6 +375,10 @@ bool TReadResponseBuilder::AugmentResponseWithCachedData(
     TNodeCachedDataPin pin) const
 {
     auto cachedData = state.GetCachedData(NodeId, Offset, Length, pin);
+    if (cachedData.Failed) {
+        return false;
+    }
+
     Validate(cachedData, Length);
 
     AugmentResponseWithCachedData(response, cachedData);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "write_back_cache_state.h"
+#include "node_cache.h"
 
 #include <cloud/filestore/public/api/protos/data.pb.h>
 
@@ -29,23 +29,31 @@ public:
         return NodeId;
     }
 
+    ui64 GetOffset() const
+    {
+        return Offset;
+    }
+
+    ui64 GetLength() const
+    {
+        return Length;
+    }
+
     // Attempt to build a complete TReadDataResponse using only data from cache.
     // If the entire requested byte range is available in the cache, returns
     // a populated TReadDataResponse or std::nullopt otherwise
     std::optional<NProto::TReadDataResponse> TryFullyServeFromCache(
-        TWriteBackCacheState& state,
-        TNodeCachedDataPin pin) const;
+        const TCachedData& cachedData) const;
 
     // Apply cached data on top of the response returned from backend.
     // Returns true if the response was augmented with cached data.
     // Returns false if no cached data was applied to the response.
     bool AugmentResponseWithCachedData(
         NProto::TReadDataResponse& response,
-        TWriteBackCacheState& state,
-        TNodeCachedDataPin pin) const;
+        const TCachedData& cachedData) const;
 
 private:
-    void AugmentResponseWithCachedData(
+    void DoAugmentResponseWithCachedData(
         NProto::TReadDataResponse& response,
         const TCachedData& cachedData) const;
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
@@ -86,8 +86,16 @@ public:
             }
         }
 
+        auto cachedData = State.GetCachedData(
+            1,
+            request->GetOffset(),
+            request->GetLength(),
+            {});
+
+        UNIT_ASSERT(cachedData);
+
         TReadResponseBuilder builder(*request);
-        builder.AugmentResponseWithCachedData(response, State, /* pin = */ {});
+        builder.AugmentResponseWithCachedData(response, *cachedData);
 
         return result.substr(0, response.GetLength());
     }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
@@ -37,6 +37,7 @@ public:
         : Stats(CreateWriteBackCacheStats())
         , State(
               *this,
+              CreateTestStorage(Stats),
               std::make_shared<TTestTimer>(),
               Stats->GetWriteBackCacheStateStats(),
               Stats->GetWriteDataRequestManagerStats(),
@@ -44,7 +45,7 @@ public:
               TFlushBatchLimits{},
               "[tag]")
     {
-        State.Init(CreateTestStorage(Stats));
+        State.Init();
 
         Write(2, "ABCD");
         Write(10, "IJKL");

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
@@ -57,7 +57,9 @@ NProto::TError TTestStorage::Commit()
 NProto::TError TTestStorage::Free(const void* ptr)
 {
     auto it = Data.find(ptr);
-    Y_ENSURE(it != Data.end(), "Double free detected");
+    if (it == Data.end()) {
+        return MakeError(E_ARGUMENT, "Double free detected");
+    }
 
     Data.erase(it);
 
@@ -68,7 +70,9 @@ NProto::TError TTestStorage::Free(const void* ptr)
 NProto::TError TTestStorage::SetTag(const void* ptr, ui32 tag)
 {
     auto it = Data.find(ptr);
-    Y_ENSURE(it != Data.end(), "Entry not found");
+    if (it == Data.end()) {
+        return MakeError(E_ARGUMENT);
+    }
 
     it->second->Tag = tag;
     return {};

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
@@ -13,11 +13,17 @@ bool TTestStorage::Empty() const
     return Data.empty();
 }
 
-void TTestStorage::Visit(const TVisitor& visitor)
+bool TTestStorage::IsCorrupted() const
+{
+    return false;
+}
+
+NProto::TError TTestStorage::Visit(const TVisitor& visitor)
 {
     for (const auto& it: List) {
         visitor(it.Tag, it.Data);
     }
+    return {};
 }
 
 ui64 TTestStorage::GetMaxSupportedAllocationByteCount() const
@@ -43,10 +49,12 @@ TResultOrError<char*> TTestStorage::Alloc(size_t size)
     return res;
 }
 
-void TTestStorage::Commit()
-{}
+NProto::TError TTestStorage::Commit()
+{
+    return {};
+}
 
-void TTestStorage::Free(const void* ptr)
+NProto::TError TTestStorage::Free(const void* ptr)
 {
     auto it = Data.find(ptr);
     Y_ENSURE(it != Data.end(), "Double free detected");
@@ -54,14 +62,16 @@ void TTestStorage::Free(const void* ptr)
     Data.erase(it);
 
     SetStats();
+    return {};
 }
 
-void TTestStorage::SetTag(const void* ptr, ui32 tag)
+NProto::TError TTestStorage::SetTag(const void* ptr, ui32 tag)
 {
     auto it = Data.find(ptr);
     Y_ENSURE(it != Data.end(), "Entry not found");
 
     it->second->Tag = tag;
+    return {};
 }
 
 void TTestStorage::UpdateStats() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
@@ -29,12 +29,13 @@ public:
     explicit TTestStorage(IPersistentStorageStatsPtr stats);
 
     bool Empty() const override;
-    void Visit(const TVisitor& visitor) override;
+    bool IsCorrupted() const override;
+    NProto::TError Visit(const TVisitor& visitor) override;
     ui64 GetMaxSupportedAllocationByteCount() const override;
     TResultOrError<char*> Alloc(size_t size) override;
-    void Commit() override;
-    void Free(const void* ptr) override;
-    void SetTag(const void* ptr, ui32 tag) override;
+    NProto::TError Commit() override;
+    NProto::TError Free(const void* ptr) override;
+    NProto::TError SetTag(const void* ptr, ui32 tag) override;
     void UpdateStats() const override;
 
     void SetCapacity(size_t capacity);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -80,8 +80,8 @@ private:
     const TString LogTag;
     const TString FileSystemId;
     const TString FilePath;
+    const IPersistentStoragePtr PersistentStorage;
 
-    IPersistentStoragePtr PersistentStorage;
     TWriteBackCacheState State;
 
     std::atomic<bool> DrainRequested = false;
@@ -262,7 +262,7 @@ public:
              promise = std::move(promise)](
                 const TFuture<NProto::TReadDataResponse>& future) mutable
         {
-            auto response = UnsafeExtractValue(future);
+            auto response = ExtractResponse(future);
             bool shouldHang = false;
 
             if (auto self = ptr.lock()) {
@@ -454,7 +454,7 @@ private:
         auto batchBuilder =
             RequestBuilder->CreateWriteDataRequestBatchBuilder(nodeId);
 
-        State.VisitUnflushedRequestsFromFrontFlushBatch(
+        bool success = State.VisitUnflushedRequestsFromFrontFlushBatch(
             nodeId,
             [&batchBuilder](const TCachedWriteDataRequest* request)
             {
@@ -463,11 +463,31 @@ private:
                     request->GetBuffer());
             });
 
+        if (!success) {
+            // This may happen if the storage is corrupted or an internal
+            // problem in the logic has happened. This is fatal and should
+            // result in suspending all operations. Flush will remain in-flight
+            // until manual resolution takes place.
+            return;
+        }
+
         auto writeDataBatch = batchBuilder->Build();
 
         if (writeDataBatch.Requests.empty()) {
-            // This may happen when the cache entered failed state after
-            // flush has been scheduled
+            // Flush can be scheduled only when there are requests to flush.
+            // The only reason why VisitUnflushedRequestsFromFrontFlushBatch()
+            // may return an empty batch for a non-empty unflushed queue is a
+            // presence of a barrier with BarrierId less than SequenceId for all
+            // unflushed requests. This cannot happen because:
+            // - newly added barriers cannot have BarrierId less than SequenceId
+            //   for any existing WriteData request;
+            // - flush cannot be scheduled if an existing barrier prevents it.
+            ReportWriteBackCacheImpossibleState(Sprintf(
+                "Flush is scheduled for node %lu but flush batch is empty",
+                nodeId));
+
+            // We do not fail flush because it may cause dropping WriteData
+            // requests
             State.FlushSucceeded(nodeId, 0);
             return;
         }
@@ -509,9 +529,7 @@ private:
 
             handle = State.GetLiveHandle(flushState->GetNodeId());
             if (handle == NProto::E_INVALID_HANDLE) {
-                // This may happen when WriteBackCache entered failed state
-                // concurrently after FlushFailed was called
-                // We stop any further processing including metrics reporting
+                ScheduleRetryFlush(flushState);
                 return;
             }
         }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -109,61 +109,36 @@ public:
               args.ClientId.c_str()))
         , FileSystemId(args.FileSystemId)
         , FilePath(args.FilePath)
+        , PersistentStorage(CreateFileRingBufferPersistentStorage(
+              args.Stats->GetPersistentStorageStats(),
+              {.FilePath = args.FilePath, .DataCapacity = args.CapacityBytes},
+              Log,
+              LogTag))
         , State(
               *this,
+              PersistentStorage,
               Timer,
               args.Stats->GetWriteBackCacheStateStats(),
               args.Stats->GetWriteDataRequestManagerStats(),
               args.Stats->GetNodeStateHolderStats(),
               BuildFlushBatchLimits(args),
               LogTag)
-    {
-        auto createPersistentStorageResult =
-            CreateFileRingBufferPersistentStorage(
-                args.Stats->GetPersistentStorageStats(),
-                {.FilePath = args.FilePath, .DataCapacity = args.CapacityBytes},
-                Log,
-                LogTag);
-
-        if (HasError(createPersistentStorageResult)) {
-            ReportWriteBackCacheCorruptionError(
-                TStringBuilder()
-                << LogTag
-                << " WriteBackCache persistent storage initialization failed: "
-                << createPersistentStorageResult.GetError()
-                << ", FilePath: " << args.FilePath.Quote());
-            return;
-        }
-
-        PersistentStorage = createPersistentStorageResult.ExtractResult();
-
-        // File ring buffer should be able to store any valid TWriteDataRequest.
-        // Inability to store it will cause this and future requests to remain
-        // in the pending queue forever (including requests with smaller size).
-        // Should fit 1 MiB of data plus some headers (assume 1 KiB is enough).
-        Y_ABORT_UNLESS(
-            PersistentStorage->GetMaxSupportedAllocationByteCount() >=
-            1024 * 1024 + 1016);
-    }
+    {}
 
     // This method should be called outside TImpl constructor because
     // it captures weak_from_this()
     void Init()
     {
-        if (!PersistentStorage) {
-            return;
-        }
+        auto error = State.Init();
 
-        if (!State.Init(PersistentStorage)) {
-            ReportWriteBackCacheCorruptionError(
+        if (HasError(error)) {
+            ReportWriteBackCacheInitializationError(
                 TStringBuilder()
-                << LogTag
-                << " WriteBackCache failed to deserialize requests from the "
-                   "persistent storage due to corruption"
-                << ", FilePath: " << FilePath.Quote());
+                << LogTag << " WriteBackCache initialization failure: "
+                << FormatError(error) << ", FilePath: " << FilePath.Quote());
+        } else {
+            ScheduleAutomaticFlushIfNeeded();
         }
-
-        ScheduleAutomaticFlushIfNeeded();
     }
 
     void ScheduleAutomaticFlushIfNeeded()
@@ -453,20 +428,8 @@ private:
         auto writeDataBatch = batchBuilder->Build();
 
         if (writeDataBatch.Requests.empty()) {
-            // Flush can be scheduled only when there are requests to flush.
-            // The only reason why VisitUnflushedRequestsFromFrontFlushBatch()
-            // may return an empty batch for a non-empty unflushed queue is a
-            // presence of a barrier with BarrierId less than SequenceId for all
-            // unflushed requests. This cannot happen because:
-            // - newly added barriers cannot have BarrierId less than SequenceId
-            //   for any existing WriteData request;
-            // - flush cannot be scheduled if an existing barrier prevents it.
-            ReportWriteBackCacheImpossibleState(Sprintf(
-                "Flush is scheduled for node %lu but flush batch is empty",
-                nodeId));
-
-            // We do not fail flush because it may cause dropping WriteData
-            // requests
+            // This may happen when the cache entered failed state after
+            // flush has been scheduled
             State.FlushSucceeded(nodeId, 0);
             return;
         }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -223,48 +223,86 @@ public:
             return MakeFuture(std::move(response));
         }
 
+        auto promise = NewPromise<NProto::TReadDataResponse>();
+
         // Prevent unflushed data parts from being evicted from storage until
         // the response is completed
         const auto pin = State.PinCachedData(request->GetNodeId());
 
         TReadResponseBuilder responseBuilder(*request);
-        if (auto response = responseBuilder.TryFullyServeFromCache(State, pin))
+
+        auto cachedData = State.GetCachedData(
+            request->GetNodeId(),
+            request->GetOffset(),
+            request->GetLength(),
+            pin);
+
+        if (!cachedData) {
+            // WriteBackCache is in failed state - hang the request
+            State.UnpinCachedData(request->GetNodeId(), pin);
+            State.AddHangingRequest(promise);
+            return promise.GetFuture();
+        }
+
+        if (auto response = responseBuilder.TryFullyServeFromCache(*cachedData))
         {
             State.UnpinCachedData(request->GetNodeId(), pin);
             InternalStats->AddReadDataStats(
                 EReadDataRequestCacheStatus::FullHit);
-            return MakeFuture(std::move(*response));
+            promise.SetValue(std::move(*response));
+            return promise.GetFuture();
         }
 
-        auto callback = [ptr = weak_from_this(),
-                         responseBuilder = std::move(responseBuilder),
-                         pin](TFuture<NProto::TReadDataResponse> future)
+        auto future = promise.GetFuture();
+
+        auto callback =
+            [ptr = weak_from_this(),
+             responseBuilder = std::move(responseBuilder),
+             pin,
+             promise = std::move(promise)](
+                const TFuture<NProto::TReadDataResponse>& future) mutable
         {
             auto response = UnsafeExtractValue(future);
+            bool shouldHang = false;
 
             if (auto self = ptr.lock()) {
                 if (!HasError(response)) {
-                    bool cachedDataApplied =
-                        responseBuilder.AugmentResponseWithCachedData(
-                            response,
-                            self->State,
-                            pin);
+                    auto cachedData = self->State.GetCachedData(
+                        responseBuilder.GetNodeId(),
+                        responseBuilder.GetOffset(),
+                        responseBuilder.GetLength(),
+                        pin);
 
-                    if (cachedDataApplied) {
-                        self->InternalStats->AddReadDataStats(
-                            EReadDataRequestCacheStatus::PartialHit);
+                    if (cachedData) {
+                        bool cachedDataApplied =
+                            responseBuilder.AugmentResponseWithCachedData(
+                                response,
+                                *cachedData);
+
+                        if (cachedDataApplied) {
+                            self->InternalStats->AddReadDataStats(
+                                EReadDataRequestCacheStatus::PartialHit);
+                        } else {
+                            self->InternalStats->AddReadDataStats(
+                                EReadDataRequestCacheStatus::Miss);
+                        }
                     } else {
-                        self->InternalStats->AddReadDataStats(
-                            EReadDataRequestCacheStatus::Miss);
+                        self->State.AddHangingRequest(promise);
+                        shouldHang = true;
                     }
                 }
                 self->State.UnpinCachedData(responseBuilder.GetNodeId(), pin);
             }
-            return response;
+
+            if (!shouldHang) {
+                promise.SetValue(std::move(response));
+            }
         };
 
-        return Session->ReadData(std::move(callContext), std::move(request))
-            .Apply(std::move(callback));
+        Session->ReadData(std::move(callContext), std::move(request))
+            .Subscribe(std::move(callback));
+
+        return future;
     }
 
     TFuture<NProto::TWriteDataResponse> WriteData(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -482,12 +482,17 @@ private:
 
     void ExecuteFlush(std::shared_ptr<TNodeFlushState> flushState)
     {
+        // TODO(#6201): until handleless IO is implemented, flush needs a live
+        // handle to execute WriteData requests
         auto handle = State.GetLiveHandle(flushState->GetNodeId());
 
         if (handle == NProto::E_INVALID_HANDLE) {
-            // It is not possible to flush data when all handles are released
-            // TODO(#6201): this will not be needed after adding support for
-            // handleless IO
+            // This may happen in the following cases:
+            // - Flush has been requested while there are no live handles
+            //   remaining;
+            // - WriteBackCache is in failed state (storage is corrupted or an
+            //   error in the logic has occured).
+
             auto retryStatus = State.FlushFailed(
                 flushState->GetNodeId(),
                 MakeError(
@@ -496,18 +501,19 @@ private:
                     "%lu",
                     flushState->GetNodeId()));
 
-            // A live handle could appear between GetLiveHandle and FlushFailed
+            // A live handle could appear concurrently between GetLiveHandle and
+            // FlushFailed
             if (retryStatus == EFlushRetryStatus::ShouldNotRetry) {
                 return;
             }
 
             handle = State.GetLiveHandle(flushState->GetNodeId());
-
-            Y_ABORT_UNLESS(
-                handle != NProto::E_INVALID_HANDLE,
-                "There are no known live handles to flush data for node %lu, "
-                "but FlushFailed returned ShouldRetry",
-                flushState->GetNodeId());
+            if (handle == NProto::E_INVALID_HANDLE) {
+                // This may happen when WriteBackCache entered failed state
+                // concurrently after FlushFailed was called
+                // We stop any further processing including metrics reporting
+                return;
+            }
         }
 
         auto requests = flushState->BeginFlush();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -142,7 +142,9 @@ public:
      * EWriteBackCacheMode::Drained.
      *
      * The returned future is completed successfully when WriteBackCache become
-     * drained. An error is returned if flush is failed.
+     * drained. An error is returned if flush is failed. The returned future
+     * never completes if WriteBackCache is in failed state due to underlying
+     * storage corrption or logic failure.
      *
      * The call has no effect if WriteBackCache is already drained and will
      * return a completed future immediately.

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -65,7 +65,7 @@ bool TWriteBackCacheState::IsDrained() const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    return DrainingMode && !FailedFlag &&
+    return DrainingMode && !IsFailed &&
            !RequestManager.HasPendingOrUnflushedRequests();
 }
 
@@ -93,7 +93,7 @@ TFuture<TWriteDataResponse> TWriteBackCacheState::AddWriteDataRequest(
                 "WriteBackCache doesn't accept new WriteData requests"));
     }
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return HangingRequests.CreateWriteDataResponse();
     }
 
@@ -116,7 +116,7 @@ TFuture<TError> TWriteBackCacheState::AddFlushRequest(ui64 nodeId)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return HangingRequests.CreateFlushOrReleaseHandleResponse();
     }
 
@@ -147,7 +147,7 @@ TFuture<TError> TWriteBackCacheState::AddFlushAllRequest()
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return HangingRequests.CreateFlushOrReleaseHandleResponse();
     }
 
@@ -170,7 +170,7 @@ TFuture<TError> TWriteBackCacheState::AddReleaseHandleRequest(
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return HangingRequests.CreateFlushOrReleaseHandleResponse();
     }
 
@@ -224,7 +224,7 @@ std::optional<TCachedData> TWriteBackCacheState::GetCachedData(
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return std::nullopt;
     }
 
@@ -243,7 +243,7 @@ ui64 TWriteBackCacheState::GetMaxWrittenOffset(ui64 nodeId) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return 0;
     }
 
@@ -257,7 +257,7 @@ void TWriteBackCacheState::ResetMaxWrittenOffset(ui64 nodeId)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return;
     }
 
@@ -329,7 +329,7 @@ void TWriteBackCacheState::VisitUnflushedRequestsFromFrontFlushBatch(
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return;
     }
 
@@ -352,7 +352,7 @@ ui64 TWriteBackCacheState::GetLiveHandle(ui64 nodeId) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return NProto::E_INVALID_HANDLE;
     }
 
@@ -374,7 +374,7 @@ void TWriteBackCacheState::FlushSucceeded(ui64 nodeId, size_t requestCount)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return;
     }
 
@@ -413,7 +413,7 @@ EFlushRetryStatus TWriteBackCacheState::FlushFailed(
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return EFlushRetryStatus::ShouldNotRetry;
     }
 
@@ -530,7 +530,7 @@ NThreading::TFuture<TResultOrError<ui64>> TWriteBackCacheState::AcquireBarrier(
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (FailedFlag) {
+    if (IsFailed) {
         return HangingRequests.CreateAcquireBarrierResponse();
     }
 
@@ -779,6 +779,11 @@ void TWriteBackCacheState::EvictUnpinnedFlushedEntries(
     ui64 nodeId,
     TNodeState& nodeState)
 {
+    if (IsFailed) {
+        // Prevent from firing repeated critical events on each storage access
+        return;
+    }
+
     bool shouldProcessPendingRequests = false;
 
     const ui64 allowedToEvictMaxSequenceId =
@@ -1076,7 +1081,7 @@ void TWriteBackCacheState::SetFailedFlag()
     // FailedFlag is set only when a failed result is returned from
     // PersistentStorage. Each failure in PersistentStorage is already reported
     // as a critical event - no need to fire an event again.
-    FailedFlag = true;
+    IsFailed = true;
 }
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -65,7 +65,8 @@ bool TWriteBackCacheState::IsDrained() const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    return DrainingMode && !RequestManager.HasPendingOrUnflushedRequests();
+    return DrainingMode && !FailedFlag &&
+           !RequestManager.HasPendingOrUnflushedRequests();
 }
 
 TFuture<TWriteDataResponse> TWriteBackCacheState::AddWriteDataRequest(
@@ -200,11 +201,12 @@ TFuture<TError> TWriteBackCacheState::AddReleaseHandleRequest(
     return handleState->ReleaseHandleRequest->ReadyToReleasePromise.GetFuture();
 }
 
-TFuture<TReadDataResponse> TWriteBackCacheState::AddHandingReadDataResponse()
+void TWriteBackCacheState::AddHangingRequest(
+    NThreading::TPromise<NProto::TReadDataResponse> promise)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    return HangingRequests.CreateReadDataResponse();
+    HangingRequests.Add(std::move(promise));
 }
 
 void TWriteBackCacheState::TriggerPeriodicFlushAll()
@@ -214,7 +216,7 @@ void TWriteBackCacheState::TriggerPeriodicFlushAll()
     TriggerFlushAll(false);
 }
 
-TCachedData TWriteBackCacheState::GetCachedData(
+std::optional<TCachedData> TWriteBackCacheState::GetCachedData(
     ui64 nodeId,
     ui64 offset,
     ui64 byteCount,
@@ -223,12 +225,12 @@ TCachedData TWriteBackCacheState::GetCachedData(
     auto guard = LockStateAndPostponeQueuedOperations();
 
     if (FailedFlag) {
-        return {.Parts = {}, .Failed = true};
+        return std::nullopt;
     }
 
     const auto* nodeState = Nodes.GetNodeState(nodeId);
     if (nodeState == nullptr) {
-        return {};
+        return TCachedData{};
     }
 
     return nodeState->Cache.GetCachedData(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -16,6 +16,7 @@ using ERequestType = IWriteBackCacheStateStats::ERequestType;
 
 TWriteBackCacheState::TWriteBackCacheState(
     IQueuedOperationsProcessor& processor,
+    IPersistentStoragePtr persistentStorage,
     ITimerPtr timer,
     IWriteBackCacheStateStatsPtr writeBackCacheStateStats,
     IWriteDataRequestManagerStatsPtr writeDataRequestManagerStats,
@@ -25,28 +26,32 @@ TWriteBackCacheState::TWriteBackCacheState(
     : SequenceIdGenerator(std::make_shared<TSequenceIdGenerator>())
     , Timer(std::move(timer))
     , Stats(std::move(writeBackCacheStateStats))
-    , RequestManagerStats(std::move(writeDataRequestManagerStats))
     , FlushBatchLimits(flushBatchLimits)
     , LogTag(std::move(logTag))
     , Nodes(Timer, std::move(nodeStateHolderStats))
+    , RequestManager(
+          SequenceIdGenerator,
+          std::move(persistentStorage),
+          Timer,
+          std::move(writeDataRequestManagerStats))
     , QueuedOperations(processor)
 {}
 
-bool TWriteBackCacheState::Init(IPersistentStoragePtr persistentStorage)
+NProto::TError TWriteBackCacheState::Init()
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    RequestManager = TWriteDataRequestManager(
-        SequenceIdGenerator,
-        std::move(persistentStorage),
-        Timer,
-        RequestManagerStats);
-
-    return RequestManager.Init(
+    auto error = RequestManager.Init(
         [this](
             std::unique_ptr<TCachedWriteDataRequest> request,
             bool handleReleased)
         { AddRequest(std::move(request), handleReleased); });
+
+    if (HasError(error)) {
+        SetFailedFlag();
+    }
+
+    return error;
 }
 
 void TWriteBackCacheState::SetDrainingMode()
@@ -87,16 +92,32 @@ TFuture<TWriteDataResponse> TWriteBackCacheState::AddWriteDataRequest(
                 "WriteBackCache doesn't accept new WriteData requests"));
     }
 
-    auto variant = RequestManager.AddRequest(std::move(request));
+    if (FailedFlag) {
+        return HangingRequests.CreateWriteDataResponse();
+    }
 
-    return std::visit(
-        [this](auto res) { return AddRequest(std::move(res)); },
-        std::move(variant));
+    auto res = RequestManager.AddRequest(std::move(request));
+
+    if (res.PendingRequest) {
+        return AddRequest(std::move(res.PendingRequest));
+    }
+
+    if (res.CachedRequest) {
+        return AddRequest(std::move(res.CachedRequest));
+    }
+
+    SetFailedFlag();
+
+    return HangingRequests.CreateWriteDataResponse();
 }
 
 TFuture<TError> TWriteBackCacheState::AddFlushRequest(ui64 nodeId)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
+
+    if (FailedFlag) {
+        return HangingRequests.CreateFlushOrReleaseHandleResponse();
+    }
 
     auto* nodeState = Nodes.GetNodeState(nodeId, /* includeDeleted = */ false);
     if (nodeState == nullptr ||
@@ -125,6 +146,10 @@ TFuture<TError> TWriteBackCacheState::AddFlushAllRequest()
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
+    if (FailedFlag) {
+        return HangingRequests.CreateFlushOrReleaseHandleResponse();
+    }
+
     if (!RequestManager.HasPendingOrUnflushedRequests()) {
         Stats->RequestCompletedImmediately(ERequestType::FlushAll);
         return MakeFuture<TError>();
@@ -143,6 +168,10 @@ TFuture<TError> TWriteBackCacheState::AddReleaseHandleRequest(
     ui64 handle)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
+
+    if (FailedFlag) {
+        return HangingRequests.CreateFlushOrReleaseHandleResponse();
+    }
 
     auto* nodeState = Nodes.GetNodeState(nodeId, /* includeDeleted = */ false);
     if (nodeState == nullptr) {
@@ -171,6 +200,13 @@ TFuture<TError> TWriteBackCacheState::AddReleaseHandleRequest(
     return handleState->ReleaseHandleRequest->ReadyToReleasePromise.GetFuture();
 }
 
+TFuture<TReadDataResponse> TWriteBackCacheState::AddHandingReadDataResponse()
+{
+    auto guard = LockStateAndPostponeQueuedOperations();
+
+    return HangingRequests.CreateReadDataResponse();
+}
+
 void TWriteBackCacheState::TriggerPeriodicFlushAll()
 {
     auto guard = LockStateAndPostponeQueuedOperations();
@@ -185,6 +221,10 @@ TCachedData TWriteBackCacheState::GetCachedData(
     TNodeCachedDataPin pin) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
+
+    if (FailedFlag) {
+        return {.Parts = {}, .Failed = true};
+    }
 
     const auto* nodeState = Nodes.GetNodeState(nodeId);
     if (nodeState == nullptr) {
@@ -201,6 +241,10 @@ ui64 TWriteBackCacheState::GetMaxWrittenOffset(ui64 nodeId) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
+    if (FailedFlag) {
+        return 0;
+    }
+
     const auto* nodeState =
         Nodes.GetNodeState(nodeId, /* includeDeleted = */ true);
 
@@ -210,6 +254,10 @@ ui64 TWriteBackCacheState::GetMaxWrittenOffset(ui64 nodeId) const
 void TWriteBackCacheState::ResetMaxWrittenOffset(ui64 nodeId)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
+
+    if (FailedFlag) {
+        return;
+    }
 
     auto& nodeState = Nodes.GetOrCreateNodeState(nodeId);
 
@@ -279,6 +327,10 @@ void TWriteBackCacheState::VisitUnflushedRequestsFromFrontFlushBatch(
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
+    if (FailedFlag) {
+        return;
+    }
+
     auto* nodeState = Nodes.GetNodeState(nodeId, /* includeDeleted = */ false);
     if (nodeState == nullptr || !nodeState->Cache.HasUnflushedRequests()) {
         return;
@@ -298,6 +350,10 @@ ui64 TWriteBackCacheState::GetLiveHandle(ui64 nodeId) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
+    if (FailedFlag) {
+        return NProto::E_INVALID_HANDLE;
+    }
+
     const auto* nodeState = Nodes.GetNodeState(nodeId);
     if (nodeState == nullptr) {
         return NProto::E_INVALID_HANDLE;
@@ -316,6 +372,10 @@ void TWriteBackCacheState::FlushSucceeded(ui64 nodeId, size_t requestCount)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
+    if (FailedFlag) {
+        return;
+    }
+
     auto& nodeState = Nodes.GetOrCreateNodeState(nodeId);
 
     Y_ABORT_UNLESS(
@@ -331,7 +391,12 @@ void TWriteBackCacheState::FlushSucceeded(ui64 nodeId, size_t requestCount)
         Y_ABORT_UNLESS(nodeState.Cache.HasUnflushedRequests());
         auto* cachedRequest =
             nodeState.Cache.MoveFrontUnflushedRequestToFlushed();
-        RequestManager.SetFlushed(cachedRequest);
+
+        if (!RequestManager.SetFlushed(cachedRequest)) {
+            SetFailedFlag();
+            return;
+        }
+
         RemoveActiveRequestFromHandleState(nodeState, cachedRequest);
     }
 
@@ -345,6 +410,10 @@ EFlushRetryStatus TWriteBackCacheState::FlushFailed(
     const TError& error)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
+
+    if (FailedFlag) {
+        return EFlushRetryStatus::ShouldNotRetry;
+    }
 
     auto& nodeState = Nodes.GetOrCreateNodeState(nodeId);
 
@@ -419,7 +488,10 @@ EFlushRetryStatus TWriteBackCacheState::FlushFailed(
 
         while (!handleState.UnflushedRequests.Empty()) {
             auto* request = handleState.UnflushedRequests.PopFront();
-            RequestManager.SetHandleReleased(request);
+            if (!RequestManager.SetHandleReleased(request)) {
+                SetFailedFlag();
+                return EFlushRetryStatus::ShouldNotRetry;
+            }
         }
 
         if (handleState.ReleaseHandleRequest) {
@@ -455,6 +527,10 @@ NThreading::TFuture<TResultOrError<ui64>> TWriteBackCacheState::AcquireBarrier(
     ui64 nodeId)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
+
+    if (FailedFlag) {
+        return HangingRequests.CreateAcquireBarrierResponse();
+    }
 
     auto& nodeState = Nodes.GetOrCreateNodeState(nodeId);
 
@@ -713,7 +789,10 @@ void TWriteBackCacheState::EvictUnpinnedFlushedEntries(
             break;
         }
         auto cachedRequest = nodeState.Cache.DequeueFlushedRequest();
-        RequestManager.Evict(std::move(cachedRequest));
+        if (!RequestManager.Evict(std::move(cachedRequest))) {
+            SetFailedFlag();
+            return;
+        }
         shouldProcessPendingRequests = true;
     }
 
@@ -800,7 +879,13 @@ void TWriteBackCacheState::CheckAndAcquireBarriers(TNodeState& nodeState)
 void TWriteBackCacheState::ProcessPendingRequests()
 {
     while (RequestManager.HasPendingRequests()) {
-        auto request = RequestManager.TryProcessPendingRequest();
+        auto res = RequestManager.TryProcessPendingRequest();
+        if (res.Failed) {
+            SetFailedFlag();
+            return;
+        }
+
+        auto request = std::move(res.CachedRequest);
         if (!request) {
             TriggerFlushAll(false);
             break;
@@ -909,7 +994,10 @@ void TWriteBackCacheState::DropCachedData(
 
     while (nodeState.Cache.HasUnflushedRequests()) {
         auto* request = nodeState.Cache.MoveFrontUnflushedRequestToFlushed();
-        RequestManager.SetFlushed(request);
+        if (!RequestManager.SetFlushed(request)) {
+            SetFailedFlag();
+            return;
+        }
         Stats->WriteDataRequestDropped();
     }
 
@@ -979,6 +1067,14 @@ void TWriteBackCacheState::FailAllPendingRequests(
             CheckAndAcquireBarriers(nodeState);
         }
     }
+}
+
+void TWriteBackCacheState::SetFailedFlag()
+{
+    // FailedFlag is set only when a failed result is returned from
+    // PersistentStorage. Each failure in PersistentStorage is already reported
+    // as a critical event - no need to fire an event again.
+    FailedFlag = true;
 }
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -213,6 +213,10 @@ void TWriteBackCacheState::TriggerPeriodicFlushAll()
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
+    if (IsFailed) {
+        return;
+    }
+
     TriggerFlushAll(false);
 }
 
@@ -243,10 +247,6 @@ ui64 TWriteBackCacheState::GetMaxWrittenOffset(ui64 nodeId) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    if (IsFailed) {
-        return 0;
-    }
-
     const auto* nodeState =
         Nodes.GetNodeState(nodeId, /* includeDeleted = */ true);
 
@@ -256,10 +256,6 @@ ui64 TWriteBackCacheState::GetMaxWrittenOffset(ui64 nodeId) const
 void TWriteBackCacheState::ResetMaxWrittenOffset(ui64 nodeId)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
-
-    if (IsFailed) {
-        return;
-    }
 
     auto& nodeState = Nodes.GetOrCreateNodeState(nodeId);
 
@@ -323,29 +319,30 @@ void TWriteBackCacheState::UnpinNodeStates(TNodeStatePin pinId)
     Nodes.Unpin(pinId);
 }
 
-void TWriteBackCacheState::VisitUnflushedRequestsFromFrontFlushBatch(
+bool TWriteBackCacheState::VisitUnflushedRequestsFromFrontFlushBatch(
     ui64 nodeId,
     const TEntryVisitor& visitor)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
     if (IsFailed) {
-        return;
+        return false;
     }
 
     auto* nodeState = Nodes.GetNodeState(nodeId, /* includeDeleted = */ false);
     if (nodeState == nullptr || !nodeState->Cache.HasUnflushedRequests()) {
-        return;
+        return true;
     }
 
     if (!nodeState->Barriers.empty()) {
         const ui64 minBarrierId = nodeState->Barriers.cbegin()->first;
         if (minBarrierId < nodeState->Cache.GetMinUnflushedSequenceId()) {
-            return;
+            return true;
         }
     }
 
     nodeState->Cache.VisitUnflushedRequestsFromFrontFlushBatch(visitor);
+    return true;
 }
 
 ui64 TWriteBackCacheState::GetLiveHandle(ui64 nodeId) const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -80,11 +80,14 @@ private:
     TIntrusiveList<TReleaseHandleRequest> ReleaseHandleRequests;
 
     // Requests that are hanging due to WriteBackCache failed state
+    // It will be used in the future to prevent hanging on session destroy.
     THangingRequests HangingRequests;
 
     // Either the persistent storage is corrupted or an internal problem in
-    // the logic has happened
+    // the logic has happened. This is fatal and should result in suspending all
+    // operations until manual resolution takes place.
     bool IsFailed = false;
+
     bool DrainingMode = false;
 
 public:
@@ -126,7 +129,8 @@ public:
         ui64 nodeId,
         ui64 handle);
 
-    void AddHangingRequest(NThreading::TPromise<NProto::TReadDataResponse> promise);
+    void AddHangingRequest(
+        NThreading::TPromise<NProto::TReadDataResponse> promise);
 
     void TriggerPeriodicFlushAll();
 
@@ -156,16 +160,19 @@ public:
     TNodeStatePin PinNodeStates();
     void UnpinNodeStates(TNodeStatePin pinId);
 
-    // Returns empty batch if flush is not allowed due to barriers
+    // Visits the requests from the front flush batch that are not prevented
+    // from flushing by barriers.
     // Forces completion of an incomplete flush batch if there are no completed
-    // flush batches
-    void VisitUnflushedRequestsFromFrontFlushBatch(
+    // flush batches.
+    // Returns true on success or false when TWriteBackCacheState::IsFailed is
+    // set
+    bool VisitUnflushedRequestsFromFrontFlushBatch(
         ui64 nodeId,
         const TEntryVisitor& visitor);
 
     // Returns a known live handle that should be used for flushing requests or
     // NProto::E_INVALID_HANDLE if there are no unflushed requests with live
-    // handles
+    // handles or TWriteBackCacheState::IsFailed is set
     ui64 GetLiveHandle(ui64 nodeId) const;
 
     // Inform that the first |requestCount| unflushed changes requests have

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -22,8 +22,6 @@
 #include <util/generic/hash_set.h>
 #include <util/generic/intrlist.h>
 
-#include <atomic>
-
 namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -84,7 +82,9 @@ private:
     // Requests that are hanging due to WriteBackCache failed state
     THangingRequests HangingRequests;
 
-    bool FailedFlag = false;
+    // Either the persistent storage is corrupted or an internal problem in
+    // the logic has happened
+    bool IsFailed = false;
     bool DrainingMode = false;
 
 public:

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "hanging_requests.h"
 #include "node_cache.h"
 #include "node_state.h"
 #include "node_state_holder.h"
@@ -20,6 +21,8 @@
 #include <util/generic/function_ref.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/intrlist.h>
+
+#include <atomic>
 
 namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
@@ -54,7 +57,6 @@ private:
     const ISequenceIdGeneratorPtr SequenceIdGenerator;
     const ITimerPtr Timer;
     const IWriteBackCacheStateStatsPtr Stats;
-    const IWriteDataRequestManagerStatsPtr RequestManagerStats;
     const TFlushBatchLimits FlushBatchLimits;
     const TString LogTag;
 
@@ -79,6 +81,10 @@ private:
     TIntrusiveList<TFlushRequest> FlushRequests;
     TIntrusiveList<TReleaseHandleRequest> ReleaseHandleRequests;
 
+    // Requests that are hanging due to WriteBackCache failed state
+    THangingRequests HangingRequests;
+
+    bool FailedFlag = false;
     bool DrainingMode = false;
 
 public:
@@ -86,6 +92,7 @@ public:
 
     TWriteBackCacheState(
         IQueuedOperationsProcessor& processor,
+        IPersistentStoragePtr persistentStorage,
         ITimerPtr timer,
         IWriteBackCacheStateStatsPtr writeBackCacheStateStats,
         IWriteDataRequestManagerStatsPtr writeDataRequestManagerStats,
@@ -93,8 +100,8 @@ public:
         const TFlushBatchLimits& flushBatchLimits,
         TString logTag);
 
-    // Read state from the persistent storage
-    bool Init(IPersistentStoragePtr persistentStorage);
+    // Reads state from the persistent storage and schedules node flush
+    NProto::TError Init();
 
     // Prevent new WriteData requests from being added to the cache - they
     // will fail with E_REJECTED error.
@@ -118,6 +125,8 @@ public:
     NThreading::TFuture<NCloud::NProto::TError> AddReleaseHandleRequest(
         ui64 nodeId,
         ui64 handle);
+
+    NThreading::TFuture<NProto::TReadDataResponse> AddHandingReadDataResponse();
 
     void TriggerPeriodicFlushAll();
 
@@ -245,6 +254,8 @@ private:
         const NCloud::NProto::TError& error);
 
     void FailAllPendingRequests(const NCloud::NProto::TError& error);
+
+    void SetFailedFlag();
 };
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -126,14 +126,15 @@ public:
         ui64 nodeId,
         ui64 handle);
 
-    NThreading::TFuture<NProto::TReadDataResponse> AddHandingReadDataResponse();
+    void AddHangingRequest(NThreading::TPromise<NProto::TReadDataResponse> promise);
 
     void TriggerPeriodicFlushAll();
 
     // Includes both flushed and unflushed data.
     // TCachedData::Parts is calculated over pinned data.
     // TCachedData::ReadDataByteCount is calculated over all data.
-    TCachedData GetCachedData(
+    // Returns std::nullopt in a failed state
+    std::optional<TCachedData> GetCachedData(
         ui64 nodeId,
         ui64 offset,
         ui64 byteCount,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -151,8 +151,10 @@ struct TBootstrap
         auto cachedData =
             State->GetCachedData(nodeId, offset, byteCount, pin);
 
+        UNIT_ASSERT(cachedData);
+
         TStringBuilder out;
-        for (const auto& part: cachedData.Parts) {
+        for (const auto& part: cachedData->Parts) {
             if (!out.empty()) {
                 out << ", ";
             }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -166,7 +166,7 @@ struct TBootstrap
     TString GetFrontFlushBatch(ui64 nodeId) const
     {
         TStringBuilder out;
-        State->VisitUnflushedRequestsFromFrontFlushBatch(
+        auto success = State->VisitUnflushedRequestsFromFrontFlushBatch(
             nodeId,
             [&out](const TCachedWriteDataRequest* entry)
             {
@@ -176,6 +176,7 @@ struct TBootstrap
                 out << entry->GetOffset() << ":" << entry->GetBuffer();
                 return true;
             });
+        UNIT_ASSERT(success);
         return out;
     }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -113,6 +113,7 @@ struct TBootstrap
     {
         State = std::make_unique<TWriteBackCacheState>(
             Processor,
+            Storage,
             Timer,
             Stats->GetWriteBackCacheStateStats(),
             Stats->GetWriteDataRequestManagerStats(),
@@ -120,7 +121,7 @@ struct TBootstrap
             FlushBatchLimits,
             "[test]");
 
-        return State->Init(Storage);
+        return !HasError(State->Init());
     }
 
     void UpdateStats() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2818,7 +2818,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         auto setNodeAttrFuture =
             b.Cache.SetNodeAttr(b.CallContext, std::move(setNodeAttrRequest));
 
-        Sleep(TDuration::Seconds(1));
+        // All requests are processed synchronously - no need to wait here
 
         UNIT_ASSERT(!writeFuture.HasValue());
         UNIT_ASSERT(!readFuture.HasValue());
@@ -2873,7 +2873,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
         // Flush is succeded because flush completion happens before data
         // eviction
-        UNIT_ASSERT(flushFuture.HasValue());
+        UNIT_ASSERT(!HasError(flushFuture.GetValue()));
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -13,6 +13,7 @@
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/common/timer_test.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -2766,6 +2767,113 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             b.Metrics.WriteDataRequestDroppedCount->Get());
+    }
+
+    Y_UNIT_TEST(ShouldReportStatsWhenFileRingBufferIsCorrupted)
+    {
+        TBootstrap b;
+
+        b.TempFileHandle.Pwrite("Corrupt cache", 13, 0);
+        b.TempFileHandle.Flush();
+
+        b.RecreateCache();
+
+        b.ModuleStats->UpdateStats(TInstant::Now());
+
+        UNIT_ASSERT_VALUES_EQUAL(1, b.Metrics.Storage.Corrupted->Get());
+    }
+
+    void TestHangWhenFileRingBufferIsCorrupted(TBootstrap& b)
+    {
+        auto writeFuture = b.WriteToCache(1, 0, "abc");
+        auto readFuture = b.ReadFromCache(1, 0, 3);
+        auto flushFuture = b.Cache.FlushNodeData(1);
+        auto flushAllFuture = b.Cache.FlushAllData();
+        auto releaseHandleFuture = b.Cache.ReleaseHandle(1, 101);
+
+        auto writeRequest = std::make_shared<NProto::TWriteDataRequest>();
+        writeRequest->SetNodeId(1);
+        writeRequest->SetHandle(101);
+        writeRequest->SetOffset(0);
+        writeRequest->SetBuffer("abc");
+
+        auto directWriteFuture =
+            b.Cache.WriteDataDirect(b.CallContext, std::move(writeRequest));
+
+        auto readRequest = std::make_shared<NProto::TReadDataRequest>();
+        readRequest->SetNodeId(1);
+        readRequest->SetHandle(101);
+        readRequest->SetOffset(0);
+        readRequest->SetLength(3);
+
+        auto directReadFuture =
+            b.Cache.ReadDataDirect(b.CallContext, std::move(readRequest));
+
+        auto setNodeAttrRequest =
+            std::make_shared<NProto::TSetNodeAttrRequest>();
+        setNodeAttrRequest->SetFlags(
+            ProtoFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE));
+        setNodeAttrRequest->SetNodeId(1);
+
+        auto setNodeAttrFuture =
+            b.Cache.SetNodeAttr(b.CallContext, std::move(setNodeAttrRequest));
+
+        Sleep(TDuration::Seconds(1));
+
+        UNIT_ASSERT(!writeFuture.HasValue());
+        UNIT_ASSERT(!readFuture.HasValue());
+        UNIT_ASSERT(!flushFuture.HasValue());
+        UNIT_ASSERT(!flushAllFuture.HasValue());
+        UNIT_ASSERT(!releaseHandleFuture.HasValue());
+        UNIT_ASSERT(!directWriteFuture.HasValue());
+        UNIT_ASSERT(!directReadFuture.HasValue());
+        UNIT_ASSERT(!setNodeAttrFuture.HasValue());
+    }
+
+    Y_UNIT_TEST(ShouldHangWhenFileRingBufferIsCorruptedAtInitialization)
+    {
+        TBootstrap b;
+
+        b.TempFileHandle.Pwrite("Corrupt cache", 13, 0);
+        b.TempFileHandle.Flush();
+
+        b.RecreateCache();
+
+        TestHangWhenFileRingBufferIsCorrupted(b);
+    }
+
+    Y_UNIT_TEST(ShouldHangWhenFileRingBufferBecomesCorruptedAtFlush)
+    {
+        TBootstrap b;
+
+        b.WriteToCacheSync(1, 10, "def");
+        b.WriteToCacheSync(2, 0, "abc");
+
+        {
+            TFileMapFileRingBufferAccessor accessor(
+                b.TempFileHandle.GetName(),
+                EFileRingBufferAccessorValidationMode::Normal,
+                TMemoryMapCommon::EOpenModeFlag::oRdWr);
+
+            UNIT_ASSERT(!HasError(accessor.Map()));
+            UNIT_ASSERT(
+                EFileRingBufferAccessorValidationStatus::Success ==
+                accessor.ValidateAndInitialize());
+
+            auto eh = accessor.GetDataProcessor()->ReadEntryHeader(0);
+            eh.DataSize = accessor.GetCapabilities().MaxAllocationByteCount;
+            UNIT_ASSERT(accessor.GetDataProcessor()->WriteEntryHeader(0, eh));
+        }
+
+        // Corruption should have been detected on an attempt to remove the
+        // front element after flushing the data
+        auto flushFuture = b.Cache.FlushNodeData(1);
+
+        TestHangWhenFileRingBufferIsCorrupted(b);
+
+        // Flush is succeded because flush completion happens before data
+        // eviction
+        UNIT_ASSERT(flushFuture.HasValue());
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/libs/service/request.h>
 
 #include <util/stream/mem.h>
+#include <util/string/printf.h>
 
 namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
@@ -97,17 +98,47 @@ TWriteDataRequestManager::TWriteDataRequestManager(
     , Stats(std::move(stats))
 {}
 
-bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
+NProto::TError TWriteDataRequestManager::Init(
+    const TCachedRequestVisitor& visitor)
 {
-    bool success = true;
+    if (PersistentStorage->IsCorrupted()) {
+        return MakeError(E_FAIL, "Persistent storage is corrupted");
+    }
+
+    // File ring buffer should be able to store any valid TWriteDataRequest.
+    // Inability to store it will cause this and future requests to remain
+    // in the pending queue forever (including requests with smaller size).
+    // Should fit 1 MiB of data plus some headers (assume 1 KiB is enough).
+    const ui64 maxAllocationByteCount = 1024 * 1024 + 1016;
+
+    const ui64 maxSupportedAllocationByteCount =
+        PersistentStorage->GetMaxSupportedAllocationByteCount();
+
+    if (maxSupportedAllocationByteCount < maxAllocationByteCount) {
+        return MakeError(
+            E_FAIL,
+            Sprintf(
+                "MaxSupportedAllocationByteCount (%lu) is less than the "
+                "minimal allowed value (%lu)",
+                maxSupportedAllocationByteCount,
+                maxAllocationByteCount));
+    }
+
+    NProto::TError error = {};
 
     TVector<TLoadedWriteDataRequest> loadedRequests;
 
-    PersistentStorage->Visit(
-        [this, &success, &loadedRequests](ui32 tag, const TStringBuf allocation)
+    auto visitResult = PersistentStorage->Visit(
+        [this, &error, &loadedRequests](ui32 tag, const TStringBuf allocation)
         {
             if (tag > static_cast<ui32>(ECachedWriteDataRequestTag::Max)) {
-                success = false;
+                error = MakeError(
+                    E_FAIL,
+                    Sprintf(
+                        "Request deserialization error: tag value %u exceeds "
+                        "the maximal value %u",
+                        tag,
+                        static_cast<ui32>(ECachedWriteDataRequestTag::Max)));
                 return;
             }
 
@@ -117,7 +148,7 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
                 allocation);
 
             if (!request) {
-                success = false;
+                error = MakeError(E_FAIL, "Request deserialization error");
                 return;
             }
 
@@ -126,8 +157,12 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
                  .Request = std::move(request)});
         });
 
-    if (!success) {
-        return false;
+    if (HasError(error)) {
+        return error;
+    }
+
+    if (HasError(visitResult)) {
+        return visitResult;
     }
 
     for (auto& request: loadedRequests) {
@@ -150,7 +185,13 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
                 // There could be pins that prevented flushed requests from
                 // eviction before restart, but they are erased on restart
                 // so nothing prevents flushed requests from being removed
-                PersistentStorage->Free(request.Request->GetAllocationPtr());
+                auto freeResult = PersistentStorage->Free(
+                    request.Request->GetAllocationPtr());
+
+                if (HasError(freeResult)) {
+                    return freeResult;
+                }
+
                 break;
             }
         }
@@ -158,7 +199,7 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
 
     PendingRequests.Clear();
 
-    return true;
+    return {};
 }
 
 bool TWriteDataRequestManager::HasPendingRequests() const
@@ -207,14 +248,16 @@ auto TWriteDataRequestManager::AddRequest(
     const auto now = Timer->Now();
 
     if (PendingRequests.Empty()) {
-        auto cachedRequest = TryStoreRequestInPersistentStorage(
-            sequenceId,
-            now,
-            *request);
+        auto res =
+            TryStoreRequestInPersistentStorage(sequenceId, now, *request);
 
-        if (cachedRequest) {
-            UnflushedRequestsPushBack(cachedRequest.get());
-            return cachedRequest;
+        if (res.Failed) {
+            return {};
+        }
+
+        if (res.CachedRequest) {
+            UnflushedRequestsPushBack(res.CachedRequest.get());
+            return {.CachedRequest = std::move(res.CachedRequest)};
         }
     }
 
@@ -224,29 +267,31 @@ auto TWriteDataRequestManager::AddRequest(
         std::move(request));
 
     PendingRequestsPushBack(pendingRequest.get());
-    return pendingRequest;
+    return {.PendingRequest = std::move(pendingRequest)};
 }
 
 auto TWriteDataRequestManager::TryProcessPendingRequest()
-    -> std::unique_ptr<TCachedWriteDataRequest>
+    -> TProcessPendingRequestRequest
 {
     if (PendingRequests.Empty()) {
-        return nullptr;
+        return {};
     }
 
     auto* pendingRequest = PendingRequests.Front();
 
-    auto cachedRequest = TryStoreRequestInPersistentStorage(
+    auto res = TryStoreRequestInPersistentStorage(
         pendingRequest->GetSequenceId(),
         Timer->Now(),
         pendingRequest->GetRequest());
 
-    if (cachedRequest) {
-        PendingRequestsPopFront();
-        UnflushedRequestsPushBack(cachedRequest.get());
+    if (!res.CachedRequest) {
+        return {.Failed = res.Failed};
     }
 
-    return cachedRequest;
+    PendingRequestsPopFront();
+    UnflushedRequestsPushBack(res.CachedRequest.get());
+
+    return {.CachedRequest = std::move(res.CachedRequest)};
 }
 
 TPendingWriteDataRequest* TWriteDataRequestManager::TryPopFrontPendingRequest()
@@ -266,30 +311,51 @@ void TWriteDataRequestManager::Remove(
     PendingRequestsRemove(request.get());
 }
 
-void TWriteDataRequestManager::SetFlushed(TCachedWriteDataRequest* request)
+bool TWriteDataRequestManager::SetFlushed(TCachedWriteDataRequest* request)
 {
     UnflushedRequestsRemove(request);
     request->Time = Timer->Now();
     FlushedRequestsPushBack(request);
 
-    PersistentStorage->SetTag(
+    auto setTagResult = PersistentStorage->SetTag(
         request->GetAllocationPtr(),
         static_cast<ui32>(ECachedWriteDataRequestTag::Flushed));
+
+    if (HasError(setTagResult)) {
+        // log
+        return false;
+    }
+
+    return true;
 }
 
-void TWriteDataRequestManager::SetHandleReleased(
+bool TWriteDataRequestManager::SetHandleReleased(
     TCachedWriteDataRequest* request)
 {
-    PersistentStorage->SetTag(
+    auto setTagResult = PersistentStorage->SetTag(
         request->GetAllocationPtr(),
         static_cast<ui32>(ECachedWriteDataRequestTag::UnflushedHandleReleased));
+
+    if (HasError(setTagResult)) {
+        // log
+        return false;
+    }
+
+    return true;
 }
 
-void TWriteDataRequestManager::Evict(
+bool TWriteDataRequestManager::Evict(
     std::unique_ptr<TCachedWriteDataRequest> request)
 {
     FlushedRequestsRemove(request.get());
-    PersistentStorage->Free(request->GetAllocationPtr());
+    auto freeResult = PersistentStorage->Free(request->GetAllocationPtr());
+
+    if (HasError(freeResult)) {
+        // log
+        return false;
+    }
+
+    return true;
 }
 
 bool TWriteDataRequestManager::SetBackpressureStatusForNode(ui64 nodeId)
@@ -333,11 +399,10 @@ void TWriteDataRequestManager::UpdateStats() const
 
 // Private methods
 
-std::unique_ptr<TCachedWriteDataRequest>
-TWriteDataRequestManager::TryStoreRequestInPersistentStorage(
+auto TWriteDataRequestManager::TryStoreRequestInPersistentStorage(
     ui64 sequenceId,
     TInstant time,
-    const NProto::TWriteDataRequest& request)
+    const NProto::TWriteDataRequest& request) -> TProcessPendingRequestRequest
 {
     if (NodesWithBackpressure.contains(request.GetNodeId())) {
         // Known limitation: pending requests are global FIFO.
@@ -346,7 +411,7 @@ TWriteDataRequestManager::TryStoreRequestInPersistentStorage(
         // block requests for unrelated nodes. This is intentional for the
         // current implementation; per-node pending queues/fair scheduling
         // should be added separately.
-        return nullptr;
+        return {};
     }
 
     const ui64 byteCount = NCloud::NFileStore::CalculateByteCount(request) -
@@ -357,14 +422,13 @@ TWriteDataRequestManager::TryStoreRequestInPersistentStorage(
 
     auto allocationResult = PersistentStorage->Alloc(allocationSize);
 
-    Y_ABORT_UNLESS(
-        !HasError(allocationResult),
-        "Allocation failed with error: %s",
-        allocationResult.GetError().GetMessage().data());
+    if (HasError(allocationResult)) {
+        return {.Failed = true};
+    }
 
     char* allocationPtr = allocationResult.GetResult();
     if (allocationPtr == nullptr) {
-        return nullptr;
+        return {};
     }
 
     TMemoryOutput memoryOutput(allocationPtr, allocationSize);
@@ -375,13 +439,18 @@ TWriteDataRequestManager::TryStoreRequestInPersistentStorage(
         memoryOutput.Exhausted(),
         "Buffer is expected to be written completely");
 
-    PersistentStorage->Commit();
+    auto commitResult = PersistentStorage->Commit();
+    if (HasError(commitResult)) {
+        return {.Failed = true};
+    }
 
-    return std::make_unique<TCachedWriteDataRequest>(
+    auto res = std::make_unique<TCachedWriteDataRequest>(
         sequenceId,
         time,
         allocationPtr,
         data);
+
+    return {.CachedRequest = std::move(res)};
 }
 
 // Access methods that triggers stats update

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -102,7 +102,7 @@ NProto::TError TWriteDataRequestManager::Init(
     const TCachedRequestVisitor& visitor)
 {
     if (PersistentStorage->IsCorrupted()) {
-        return MakeError(E_FAIL, "Persistent storage is corrupted");
+        return MakeError(E_INVALID_STATE, "Persistent storage is corrupted");
     }
 
     // File ring buffer should be able to store any valid TWriteDataRequest.
@@ -116,7 +116,7 @@ NProto::TError TWriteDataRequestManager::Init(
 
     if (maxSupportedAllocationByteCount < maxAllocationByteCount) {
         return MakeError(
-            E_FAIL,
+            E_ARGUMENT,
             Sprintf(
                 "MaxSupportedAllocationByteCount (%lu) is less than the "
                 "minimal allowed value (%lu)",
@@ -133,7 +133,7 @@ NProto::TError TWriteDataRequestManager::Init(
         {
             if (tag > static_cast<ui32>(ECachedWriteDataRequestTag::Max)) {
                 error = MakeError(
-                    E_FAIL,
+                    E_INVALID_STATE,
                     Sprintf(
                         "Request deserialization error: tag value %u exceeds "
                         "the maximal value %u",
@@ -148,7 +148,8 @@ NProto::TError TWriteDataRequestManager::Init(
                 allocation);
 
             if (!request) {
-                error = MakeError(E_FAIL, "Request deserialization error");
+                error =
+                    MakeError(E_INVALID_STATE, "Request deserialization error");
                 return;
             }
 
@@ -252,7 +253,7 @@ auto TWriteDataRequestManager::AddRequest(
             TryStoreRequestInPersistentStorage(sequenceId, now, *request);
 
         if (res.Failed) {
-            return {};
+            return {.Failed = true};
         }
 
         if (res.CachedRequest) {
@@ -271,7 +272,7 @@ auto TWriteDataRequestManager::AddRequest(
 }
 
 auto TWriteDataRequestManager::TryProcessPendingRequest()
-    -> TProcessPendingRequestRequest
+    -> TProcessPendingRequestResult
 {
     if (PendingRequests.Empty()) {
         return {};
@@ -313,20 +314,18 @@ void TWriteDataRequestManager::Remove(
 
 bool TWriteDataRequestManager::SetFlushed(TCachedWriteDataRequest* request)
 {
-    UnflushedRequestsRemove(request);
-    request->Time = Timer->Now();
-    FlushedRequestsPushBack(request);
-
     auto setTagResult = PersistentStorage->SetTag(
         request->GetAllocationPtr(),
         static_cast<ui32>(ECachedWriteDataRequestTag::Flushed));
 
-    if (HasError(setTagResult)) {
-        // log
-        return false;
+    if (!HasError(setTagResult)) {
+        UnflushedRequestsRemove(request);
+        request->Time = Timer->Now();
+        FlushedRequestsPushBack(request);
+        return true;
     }
 
-    return true;
+    return false;
 }
 
 bool TWriteDataRequestManager::SetHandleReleased(
@@ -336,12 +335,7 @@ bool TWriteDataRequestManager::SetHandleReleased(
         request->GetAllocationPtr(),
         static_cast<ui32>(ECachedWriteDataRequestTag::UnflushedHandleReleased));
 
-    if (HasError(setTagResult)) {
-        // log
-        return false;
-    }
-
-    return true;
+    return !HasError(setTagResult);
 }
 
 bool TWriteDataRequestManager::Evict(
@@ -350,12 +344,7 @@ bool TWriteDataRequestManager::Evict(
     FlushedRequestsRemove(request.get());
     auto freeResult = PersistentStorage->Free(request->GetAllocationPtr());
 
-    if (HasError(freeResult)) {
-        // log
-        return false;
-    }
-
-    return true;
+    return !HasError(freeResult);
 }
 
 bool TWriteDataRequestManager::SetBackpressureStatusForNode(ui64 nodeId)
@@ -402,7 +391,7 @@ void TWriteDataRequestManager::UpdateStats() const
 auto TWriteDataRequestManager::TryStoreRequestInPersistentStorage(
     ui64 sequenceId,
     TInstant time,
-    const NProto::TWriteDataRequest& request) -> TProcessPendingRequestRequest
+    const NProto::TWriteDataRequest& request) -> TProcessPendingRequestResult
 {
     if (NodesWithBackpressure.contains(request.GetNodeId())) {
         // Known limitation: pending requests are global FIFO.

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -131,6 +131,10 @@ NProto::TError TWriteDataRequestManager::Init(
     auto visitResult = PersistentStorage->Visit(
         [this, &error, &loadedRequests](ui32 tag, const TStringBuf allocation)
         {
+            if (HasError(error)) {
+                return;
+            }
+
             if (tag > static_cast<ui32>(ECachedWriteDataRequestTag::Max)) {
                 error = MakeError(
                     E_INVALID_STATE,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
@@ -37,9 +37,10 @@ public:
     {
         std::unique_ptr<TPendingWriteDataRequest> PendingRequest = nullptr;
         std::unique_ptr<TCachedWriteDataRequest> CachedRequest = nullptr;
+        bool Failed = false;
     };
 
-    struct TProcessPendingRequestRequest
+    struct TProcessPendingRequestResult
     {
         std::unique_ptr<TCachedWriteDataRequest> CachedRequest = nullptr;
         bool Failed = false;
@@ -49,7 +50,6 @@ public:
         std::unique_ptr<TCachedWriteDataRequest> request,
         bool handleReleased)>;
 
-    TWriteDataRequestManager() = default;
     TWriteDataRequestManager(TWriteDataRequestManager&&) = default;
     TWriteDataRequestManager& operator=(TWriteDataRequestManager&&) = default;
 
@@ -84,7 +84,8 @@ public:
      * the storage is full or backpressure is in effect, and the request has
      * been added to the pending queue.
      *
-     * Returns empty result if the storage is in failed state.
+     * Returns result with TAddRequestResult::Failed == true if the storage is
+     * in failed state.
      */
     [[nodiscard]] TAddRequestResult AddRequest(
         std::shared_ptr<NProto::TWriteDataRequest> request);
@@ -103,7 +104,7 @@ public:
      * Returns result with empty TAddRequestResult::CachedRequest and
      * TAddRequestResult::Failed == true if the storage is in failed state.
      */
-    [[nodiscard]] TProcessPendingRequestRequest TryProcessPendingRequest();
+    [[nodiscard]] TProcessPendingRequestResult TryProcessPendingRequest();
 
     // Takes and removes front request from the pending queue.
     // Returns the removed request or nullptr if there are no pending requests.
@@ -150,7 +151,7 @@ public:
     void UpdateStats() const;
 
 private:
-    TProcessPendingRequestRequest TryStoreRequestInPersistentStorage(
+    TProcessPendingRequestResult TryStoreRequestInPersistentStorage(
         ui64 sequenceId,
         TInstant time,
         const NProto::TWriteDataRequest& request);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
@@ -94,14 +94,14 @@ public:
      * Takes front request from the pending queue and tries to store it into
      * the persistent storage.
      *
-     * Returns result with non-empty TAddRequestResult::CachedRequest if the
-     * front request has been successfully stored in the storage.
+     * Returns result with non-empty TProcessPendingRequestResult::CachedRequest
+     * if the front request has been successfully stored in the storage.
      *
-     * Returns result with empty TAddRequestResult::CachedRequest and
+     * Returns result with empty TProcessPendingRequestResult::CachedRequest and
      * TAddRequestResult::Failed == false if the storage is full, backpressure
      * is in effect or the pending queue is empty.
      *
-     * Returns result with empty TAddRequestResult::CachedRequest and
+     * Returns result with empty TProcessPendingRequestResult::CachedRequest and
      * TAddRequestResult::Failed == true if the storage is in failed state.
      */
     [[nodiscard]] TProcessPendingRequestResult TryProcessPendingRequest();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
@@ -33,9 +33,17 @@ private:
     THashSet<ui64> NodesWithBackpressure;
 
 public:
-    using TAddRequestResult = std::variant<
-        std::unique_ptr<TPendingWriteDataRequest>,
-        std::unique_ptr<TCachedWriteDataRequest>>;
+    struct TAddRequestResult
+    {
+        std::unique_ptr<TPendingWriteDataRequest> PendingRequest = nullptr;
+        std::unique_ptr<TCachedWriteDataRequest> CachedRequest = nullptr;
+    };
+
+    struct TProcessPendingRequestRequest
+    {
+        std::unique_ptr<TCachedWriteDataRequest> CachedRequest = nullptr;
+        bool Failed = false;
+    };
 
     using TCachedRequestVisitor = TFunctionRef<void(
         std::unique_ptr<TCachedWriteDataRequest> request,
@@ -52,7 +60,7 @@ public:
         IWriteDataRequestManagerStatsPtr stats);
 
     // Reads state from the persistent storage
-    bool Init(const TCachedRequestVisitor& visitor);
+    NProto::TError Init(const TCachedRequestVisitor& visitor);
 
     bool HasPendingRequests() const;
     bool HasPendingOrUnflushedRequests() const;
@@ -67,33 +75,39 @@ public:
     ui64 GetMaxUnflushedSequenceId() const;
 
     /**
-     * Adds a WriteData request to the storage.
+     * Adds a WriteData request to the persistent storage.
      *
-     * Returns std::unique_ptr<TCachedWriteDataRequest> when the request is
-     * successfully stored in the persistent storage.
+     * Returns result with non-empty TAddRequestResult::CachedRequest if the
+     * request has been successfully stored in the storage.
      *
-     * Returns std::unique_ptr<TPendingWriteDataRequest> when the storage is
-     * full or backpressure is in effect, and the request is added to the
-     * pending queue.
+     * Returns result with non-empty TAddRequestResult::PendingRequest if the
+     * the storage is full or backpressure is in effect, and the request has
+     * been added to the pending queue.
+     *
+     * Returns empty result if the storage is in failed state.
      */
-    TAddRequestResult AddRequest(
+    [[nodiscard]] TAddRequestResult AddRequest(
         std::shared_ptr<NProto::TWriteDataRequest> request);
 
     /**
-     * Takes a front request from the pending queue and tries to store it into
+     * Takes front request from the pending queue and tries to store it into
      * the persistent storage.
      *
-     * Returns std::unique_ptr<TCachedWriteDataRequest> if the request is
-     * successfully processed.
+     * Returns result with non-empty TAddRequestResult::CachedRequest if the
+     * front request has been successfully stored in the storage.
      *
-     * Returns nullptr if there are no pending requests or the persistent
-     * storage is full or backpressure is in effect.
+     * Returns result with empty TAddRequestResult::CachedRequest and
+     * TAddRequestResult::Failed == false if the storage is full, backpressure
+     * is in effect or the pending queue is empty.
+     *
+     * Returns result with empty TAddRequestResult::CachedRequest and
+     * TAddRequestResult::Failed == true if the storage is in failed state.
      */
-    std::unique_ptr<TCachedWriteDataRequest> TryProcessPendingRequest();
+    [[nodiscard]] TProcessPendingRequestRequest TryProcessPendingRequest();
 
     // Takes and removes front request from the pending queue.
     // Returns the removed request or nullptr if there are no pending requests.
-    TPendingWriteDataRequest* TryPopFrontPendingRequest();
+    [[nodiscard]] TPendingWriteDataRequest* TryPopFrontPendingRequest();
 
     // Removes the request from the pending queue
     void Remove(std::unique_ptr<TPendingWriteDataRequest> request);
@@ -101,18 +115,29 @@ public:
     /**
      * Marks the request as flushed
      * It continues residing in the persistent storage until Evict is called
+     *
+     * Returns true on success
+     * Returns false on invalid argument or corrupted state
      */
-    void SetFlushed(TCachedWriteDataRequest* request);
+    [[nodiscard]] bool SetFlushed(TCachedWriteDataRequest* request);
 
     /**
      * Marks the request as related to a released handle and stores this in
      * the persistent storage.
      * This allows the request to be properly handled after restart.
+     *
+     * Returns true on success
+     * Returns false on invalid argument or corrupted state
      */
-    void SetHandleReleased(TCachedWriteDataRequest* request);
+    [[nodiscard]] bool SetHandleReleased(TCachedWriteDataRequest* request);
 
-    // Removes previously flushed request from the persistent storage
-    void Evict(std::unique_ptr<TCachedWriteDataRequest> request);
+    /**
+     * Removes previously flushed request from the persistent storage
+     *
+     * Returns true on success
+     * Returns false on invalid argument or corrupted state
+     */
+    [[nodiscard]] bool Evict(std::unique_ptr<TCachedWriteDataRequest> request);
 
     // Prevent from adding new requests to the unflushed queue for the node
     // Returns true if backpressure was not previously set, false otherwise
@@ -125,7 +150,7 @@ public:
     void UpdateStats() const;
 
 private:
-    std::unique_ptr<TCachedWriteDataRequest> TryStoreRequestInPersistentStorage(
+    TProcessPendingRequestRequest TryStoreRequestInPersistentStorage(
         ui64 sequenceId,
         TInstant time,
         const NProto::TWriteDataRequest& request);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager_ut.cpp
@@ -11,8 +11,6 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
-#include <util/generic/overloaded.h>
-
 namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
 namespace {
@@ -55,27 +53,24 @@ struct TBootstrap
 
         auto res = RequestManager.AddRequest(std::move(request));
 
-        return std::visit(
-            TOverloaded(
-                [this](std::unique_ptr<TPendingWriteDataRequest> request)
-                {
-                    auto future = request->AccessPromise().GetFuture();
-                    PendingRequests[request->GetSequenceId()] =
-                        std::move(request);
-                    return future.IgnoreResult();
-                },
-                [this](std::unique_ptr<TCachedWriteDataRequest> request)
-                {
-                    CachedRequests[request->GetSequenceId()] =
-                        std::move(request);
-                    return NThreading::MakeFuture();
-                }),
-            std::move(res));
+        if (res.PendingRequest) {
+            UNIT_ASSERT(!res.CachedRequest);
+            auto future = res.PendingRequest->AccessPromise().GetFuture();
+            PendingRequests[res.PendingRequest->GetSequenceId()] =
+                std::move(res.PendingRequest);
+            return future.IgnoreResult();
+        }
+
+        UNIT_ASSERT(res.CachedRequest);
+        CachedRequests[res.CachedRequest->GetSequenceId()] =
+            std::move(res.CachedRequest);
+        return NThreading::MakeFuture();
     }
 
     void SetFlushed(ui64 sequenceId)
     {
-        RequestManager.SetFlushed(CachedRequests[sequenceId].get());
+        UNIT_ASSERT(
+            RequestManager.SetFlushed(CachedRequests[sequenceId].get()));
     }
 
     void Remove(ui64 sequenceId)
@@ -86,14 +81,17 @@ struct TBootstrap
 
     void Evict(ui64 sequenceId)
     {
-        RequestManager.Evict(std::move(CachedRequests[sequenceId]));
+        UNIT_ASSERT(
+            RequestManager.Evict(std::move(CachedRequests[sequenceId])));
         CachedRequests.erase(sequenceId);
     }
 
     bool TryProcessPendingRequests()
     {
         while (RequestManager.HasPendingRequests()) {
-            auto request = RequestManager.TryProcessPendingRequest();
+            auto res = RequestManager.TryProcessPendingRequest();
+            UNIT_ASSERT(!res.Failed);
+            auto request = std::move(res.CachedRequest);
             if (!request) {
                 return false;
             }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     disjoint_interval_builder.cpp
     flush_batch_write_request_counter.cpp
+    hanging_requests.cpp
     node_cache.cpp
     node_flush_state.cpp
     node_state_holder.cpp


### PR DESCRIPTION
### Notes

Implement correct behavior for WriteBackCache when corruption is detected.

Previous behavior:
- Incomplete object creation caused null pointer access in various scenarios, for example, metrics collection.
- Multiple `Y_ABORT_UNLESS` in different places, for example, when trying to add a write request.
Both resulted in a crash loop.

Expected behavior when storage corruption happens:
- WriteBackCache is fully constructed;
- WriteBackCache doesn't serve requests and hangs;
- No errors are sent to the guest;
- Critical events are reported instead of `Y_ABORT_UNLESS`.

Manual resolution should be conducted in order to resolve the corrupted state.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
