### PR TITLE
Fix use-after-dtor in TTabletMetrics

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -91,6 +91,16 @@ TTabletMetrics::TTabletMetrics(IMetricsRegistryPtr metricsRegistry)
     , AggregatableFsRegistry(CreateMetricsRegistryStub())
 {}
 
+TTabletMetrics::~TTabletMetrics()
+{
+    MaxUsedQuota.Unregister(MaxUsedQuotaKey);
+    ReadDataPostponed.Unregister(ReadDataPostponedKey);
+    WriteDataPostponed.Unregister(WriteDataPostponedKey);
+
+    AggregatableFsRegistry.reset();
+    FsRegistry.reset();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TTabletMetrics::Register(
@@ -334,14 +344,14 @@ void TTabletMetrics::Register(
     REGISTER_LOCAL(RejectedRequests, EMetricType::MT_DERIVATIVE);
     REGISTER_LOCAL(PostponedRequests, EMetricType::MT_DERIVATIVE);
     REGISTER_LOCAL(UsedQuota, EMetricType::MT_DERIVATIVE);
-    MaxUsedQuota.Register(
+    MaxUsedQuotaKey = MaxUsedQuota.Register(
         FsRegistry,
         {CreateSensor("MaxUsedQuota")},
         EAggregationType::AT_MAX);
-    ReadDataPostponed.Register(
+    ReadDataPostponedKey = ReadDataPostponed.Register(
         FsRegistry,
         {CreateLabel("request", "ReadData"), CreateLabel("histogram", "ThrottlerDelay")});
-    WriteDataPostponed.Register(
+    WriteDataPostponedKey = WriteDataPostponed.Register(
         FsRegistry,
         {CreateLabel("request", "WriteData"), CreateLabel("histogram", "ThrottlerDelay")});
 

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -5,6 +5,7 @@
 #include "tablet_tx.h"
 
 #include <cloud/filestore/libs/diagnostics/metrics/histogram.h>
+#include <cloud/filestore/libs/diagnostics/metrics/key.h>
 #include <cloud/filestore/libs/diagnostics/metrics/public.h>
 #include <cloud/filestore/libs/diagnostics/metrics/window_calculator.h>
 
@@ -332,7 +333,13 @@ struct TTabletMetrics: TAtomicRefCount<TTabletMetrics>
     NMetrics::IMetricsRegistryPtr FsRegistry;
     NMetrics::IMetricsRegistryPtr AggregatableFsRegistry;
 
+    // Keys of the registrations that hold FsRegistry alive, needed by ~TTabletMetrics().
+    NMetrics::TMetricKey MaxUsedQuotaKey;
+    NMetrics::TMetricKey ReadDataPostponedKey;
+    NMetrics::TMetricKey WriteDataPostponedKey;
+
     explicit TTabletMetrics(NMetrics::IMetricsRegistryPtr metricsRegistry);
+    ~TTabletMetrics();
 
     void Register(
         const TString& fsId,


### PR DESCRIPTION
`MaxUsedQuota`, `ReadDataPostponed` and `WriteDataPostponed` each keep a shared_ptr to `FsRegistry`, so merely releasing the `FsRegistry` member does not destroy it - its REGISTER_LOCAL registrations would stay live in the process-wide registry while the counters declared after those three members are already destroyed, and the metrics service's periodic `Update()` would read them.
Drop every registration in `~TTabletMetrics()`, while all members are still alive.
