### PR TITLE
issue-5895: fmdtest - added more details into test file content

### DIFF
--- a/cloud/filestore/tools/testing/fmdtest/bin/app.cpp
+++ b/cloud/filestore/tools/testing/fmdtest/bin/app.cpp
@@ -264,7 +264,8 @@ public:
 
                 TString content = TFileInput(filePath).ReadAll();
                 if (content != file.Content) {
-                    STORAGE_ERROR("Content mismatch for " << filePath);
+                    STORAGE_ERROR("Content mismatch for " << filePath
+                        << " (ino=" << file.Ino << ")");
                     STORAGE_ERROR("E:\t" << file.Content);
                     STORAGE_ERROR("A:\t" << content);
                     ++errors;
@@ -524,7 +525,8 @@ private:
 
             TString content = TFileInput(filePath).ReadAll();
             if (content != file.Content) {
-                STORAGE_ERROR("Content mismatch for stolen file " << filePath);
+                STORAGE_ERROR("Content mismatch for stolen file " << filePath
+                    << " (ino=" << file.Ino << ")");
                 STORAGE_ERROR("E:\t" << file.Content);
                 STORAGE_ERROR("A:\t" << content);
                 ++errors;

--- a/cloud/filestore/tools/testing/fmdtest/bin/app.cpp
+++ b/cloud/filestore/tools/testing/fmdtest/bin/app.cpp
@@ -292,10 +292,19 @@ private:
     void CreateFile()
     {
         TString fileName = TStringBuilder() << "file_" << FileNo;
-        ++FileNo;
         TFsPath filePath = DirPath / fileName;
 
-        TString content(Options.FileSize, 'a' + (ThreadId % ('z' - 'a' + 1)));
+        TString content;
+        TStringOutput builder(content);
+        builder << "F=" << FileNo << ";T=" << ThreadId << ";Data=";
+        content.reserve(Options.FileSize);
+        for (ui64 i = content.size(); i < Options.FileSize; ++i) {
+            const char c = 'a' + ThreadId % ('z' - 'a' + 1);
+            content.push_back(c);
+        }
+
+        ++FileNo;
+
         static constexpr EOpenMode OpenMode = CreateAlways | WrOnly | Seq;
         THPTimer timer;
 
@@ -516,6 +525,8 @@ private:
             TString content = TFileInput(filePath).ReadAll();
             if (content != file.Content) {
                 STORAGE_ERROR("Content mismatch for stolen file " << filePath);
+                STORAGE_ERROR("E:\t" << file.Content);
+                STORAGE_ERROR("A:\t" << content);
                 ++errors;
             }
         }


### PR DESCRIPTION
### Notes
To see things like this upon mismatch:
```
2026-08-21T13:03:18.209100Z :BENCH ERROR: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:267: Content mismatch for /mnt/fs0/create_unlink_steal_wd/producer_2/file_1255                                                                              
2026-08-21T13:03:18.209146Z :BENCH ERROR: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:268: E:→F=1255;T=2;Data=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
2026-08-21T13:03:18.209153Z :BENCH ERROR: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:269: A:→F=1174;T=1;Data=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
```

```
2026-08-21T15:42:19.052462Z :BENCH ERROR: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:529: Content mismatch for stolen file /mnt/fs0/create_unlink_steal_wd/stealer_0/stolen_p3_file_230 (ino=144365362124005044)
2026-08-21T15:42:19.052625Z :BENCH ERROR: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:530: E:→F=230;T=3;Data=ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
2026-08-21T15:42:19.052633Z :BENCH ERROR: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:531: A:→F=1504;T=3;Data=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
```

very convenient for debugging

### Issue
https://github.com/ydb-platform/nbs/issues/5895
