### PR TITLE
NBSNEBIUS-1807: [Disk Manager] Add federated credentials support

### DIFF
--- a/cloud/disk_manager/internal/pkg/auth/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/auth/config/config.proto
@@ -15,6 +15,21 @@ message ServiceAccount {
     required string TokenSigningCertFile = 4;
 }
 
+message TypedToken {
+    required string TokenType = 1;
+
+    oneof Source {
+        string Value = 2;
+        string File = 3;
+    }
+}
+
+message FederatedCredentials {
+    required string TokenExchangeEndpoint = 1;
+    required TypedToken SubjectToken = 2;
+    optional TypedToken ActorToken = 3;
+}
+
 message AuthConfig {
     optional bool DisableAuthorization = 1;
     optional string MetadataUrl = 2;
@@ -28,4 +43,5 @@ message AuthConfig {
     optional string FolderId = 10;
     optional string AuthorizationCacheLifetime = 11 [default = "15s"];
     optional ServiceAccount ServiceAccount = 12;
+    optional FederatedCredentials FederatedCredentials = 13;
 }

--- a/cloud/disk_manager/internal/pkg/auth/credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/credentials.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	auth_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth/config"
-	public_auth "github.com/ydb-platform/nbs/cloud/disk_manager/pkg/auth"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/pkg/auth"
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 	"github.com/ydb-platform/ydb-go-sdk/v3/credentials"
@@ -20,7 +20,7 @@ import (
 
 type AuthConfig = auth_config.AuthConfig
 
-type Credentials = public_auth.Credentials
+type Credentials = auth.Credentials
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/disk_manager/internal/pkg/auth/credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/credentials.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	auth_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth/config"
-	"github.com/ydb-platform/nbs/cloud/disk_manager/pkg/auth"
+	public_auth "github.com/ydb-platform/nbs/cloud/disk_manager/pkg/auth"
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 	"github.com/ydb-platform/ydb-go-sdk/v3/credentials"
@@ -18,42 +18,64 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-type Credentials = auth.Credentials
+type AuthConfig = auth_config.AuthConfig
+
+type Credentials = public_auth.Credentials
+
+////////////////////////////////////////////////////////////////////////////////
 
 func NewCredentials(
 	ctx context.Context,
-	config *auth_config.AuthConfig,
-) Credentials {
+	config *AuthConfig,
+) (Credentials, error) {
 
-	if len(config.GetMetadataUrl()) == 0 {
-		return nil
-	}
-	var (
-		impl Credentials
-		err  error
-	)
-	if config.GetServiceAccount() != nil {
+	var impl Credentials
+
+	if config.GetFederatedCredentials() != nil {
+		if config.GetMetadataUrl() != "" || config.GetServiceAccount() != nil {
+			return nil, fmt.Errorf(
+				"federated credentials cannot be combined with metadata URL " +
+					"or service account credentials",
+			)
+		}
+
+		var err error
+		impl, err = NewFederatedCredentials(config.GetFederatedCredentials())
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to create federated credentials: %w",
+				err,
+			)
+		}
+	} else if config.GetMetadataUrl() == "" {
+		return nil, nil
+	} else if config.GetServiceAccount() != nil {
+		var err error
 		impl, err = credentials.NewOauth2TokenExchangeCredentials(
 			credentials.WithTokenEndpoint(config.GetMetadataUrl()),
 			credentials.WithAudience(config.GetServiceAccount().GetAudience()),
 			credentials.WithJWTSubjectToken(
 				credentials.WithSigningMethod(jwt.SigningMethodRS256),
 				credentials.WithKeyID(config.GetServiceAccount().GetKeyId()),
-				credentials.WithRSAPrivateKeyPEMFile(config.GetServiceAccount().GetTokenSigningCertFile()),
+				credentials.WithRSAPrivateKeyPEMFile(
+					config.GetServiceAccount().GetTokenSigningCertFile(),
+				),
 				credentials.WithIssuer(config.GetServiceAccount().GetId()),
 				credentials.WithSubject(config.GetServiceAccount().GetId()),
 				credentials.WithAudience(config.GetServiceAccount().GetAudience()),
 			),
 		)
 		if err != nil {
-			logging.Error(ctx, "failed to create token credentials: %v", err)
-			return nil
+			return nil, fmt.Errorf("failed to create token credentials: %w", err)
 		}
 	} else {
 		impl = metadata.NewInstanceServiceAccount(
 			metadata.WithURL(config.GetMetadataUrl()),
 			metadata.WithTrace(trace.Trace{
-				OnRefreshToken: func(info trace.RefreshTokenStartInfo) func(trace.RefreshTokenDoneInfo) {
+				OnRefreshToken: func(
+					info trace.RefreshTokenStartInfo,
+				) func(trace.RefreshTokenDoneInfo) {
+
 					return func(info trace.RefreshTokenDoneInfo) {
 						if info.Error == nil {
 							logging.Info(
@@ -70,9 +92,10 @@ func NewCredentials(
 			}),
 		)
 	}
+
 	return &credentialsWrapper{
 		impl: impl,
-	}
+	}, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/auth/credentials_test.go
+++ b/cloud/disk_manager/internal/pkg/auth/credentials_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	task_errors "github.com/ydb-platform/nbs/cloud/tasks/errors"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type credentialsMock struct {
+	token string
+	err   error
+}
+
+func (c *credentialsMock) Token(context.Context) (string, error) {
+	return c.token, c.err
+}
+
+func TestNewCredentialsWithoutConfiguration(t *testing.T) {
+	credentials, err := NewCredentials(context.Background(), nil)
+	require.NoError(t, err)
+	require.Nil(t, credentials)
+}
+
+func TestNewCredentialsRejectsMixedFederatedConfiguration(t *testing.T) {
+	credentials, err := NewCredentials(context.Background(), &AuthConfig{
+		MetadataUrl: stringPointer("http://metadata.invalid"),
+		FederatedCredentials: &FederatedCredentials{
+			TokenExchangeEndpoint: stringPointer("https://sts.example.com"),
+			SubjectToken:          tokenValue("token", "token-type"),
+		},
+	})
+	require.ErrorContains(t, err, "cannot be combined")
+	require.Nil(t, credentials)
+}
+
+func TestCredentialsWrapper(t *testing.T) {
+	credentials := &credentialsWrapper{
+		impl: &credentialsMock{token: "token"},
+	}
+	token, err := credentials.Token(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "token", token)
+
+	credentials = &credentialsWrapper{
+		impl: &credentialsMock{err: fmt.Errorf("token error")},
+	}
+	_, err = credentials.Token(context.Background())
+	require.ErrorContains(t, err, "token error")
+	require.True(t, task_errors.CanRetry(err))
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/cloud/disk_manager/internal/pkg/auth/credentials_test.go
+++ b/cloud/disk_manager/internal/pkg/auth/credentials_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	task_errors "github.com/ydb-platform/nbs/cloud/tasks/errors"
 )
@@ -28,9 +29,9 @@ func TestNewCredentialsWithoutConfiguration(t *testing.T) {
 
 func TestNewCredentialsRejectsMixedFederatedConfiguration(t *testing.T) {
 	credentials, err := NewCredentials(context.Background(), &AuthConfig{
-		MetadataUrl: stringPointer("http://metadata.invalid"),
+		MetadataUrl: proto.String("http://metadata.invalid"),
 		FederatedCredentials: &FederatedCredentials{
-			TokenExchangeEndpoint: stringPointer("https://sts.example.com"),
+			TokenExchangeEndpoint: proto.String("https://sts.example.com"),
 			SubjectToken:          tokenValue("token", "token-type"),
 		},
 	})
@@ -52,8 +53,4 @@ func TestCredentialsWrapper(t *testing.T) {
 	_, err = credentials.Token(context.Background())
 	require.ErrorContains(t, err, "token error")
 	require.True(t, task_errors.CanRetry(err))
-}
-
-func stringPointer(value string) *string {
-	return &value
 }

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	auth_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/credentials"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type FederatedCredentials = auth_config.FederatedCredentials
+
+type TypedToken = auth_config.TypedToken
+
+////////////////////////////////////////////////////////////////////////////////
+
+type tokenSource struct {
+	value     string
+	file      string
+	tokenType string
+}
+
+func (s *tokenSource) Token() (credentials.Token, error) {
+	value := s.value
+	if s.file != "" {
+		token, err := os.ReadFile(s.file)
+		if err != nil {
+			return credentials.Token{}, fmt.Errorf("read token file: %w", err)
+		}
+		value = string(token)
+	}
+
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return credentials.Token{}, fmt.Errorf("token is empty")
+	}
+
+	return credentials.Token{
+		Token:     value,
+		TokenType: s.tokenType,
+	}, nil
+}
+
+func (s *tokenSource) String() string {
+	if s.file != "" {
+		return fmt.Sprintf(
+			"FileTokenSource{File:%q,Type:%s}",
+			s.file,
+			s.tokenType,
+		)
+	}
+
+	return fmt.Sprintf("FixedTokenSource{Type:%s}", s.tokenType)
+}
+
+func newTokenSource(
+	name string,
+	config *TypedToken,
+) (*tokenSource, error) {
+
+	if config == nil {
+		return nil, fmt.Errorf("%s token is missing", name)
+	}
+
+	tokenType := strings.TrimSpace(config.GetTokenType())
+	if tokenType == "" {
+		return nil, fmt.Errorf("%s token type is empty", name)
+	}
+
+	if config.GetSource() == nil {
+		return nil, fmt.Errorf("%s token source is missing", name)
+	}
+
+	value := strings.TrimSpace(config.GetValue())
+	file := strings.TrimSpace(config.GetFile())
+
+	return &tokenSource{
+		value:     value,
+		file:      file,
+		tokenType: tokenType,
+	}, nil
+}
+
+func NewFederatedCredentials(
+	config *FederatedCredentials,
+) (Credentials, error) {
+
+	tokenExchangeEndpoint := strings.TrimSpace(
+		config.GetTokenExchangeEndpoint(),
+	)
+	endpoint, err := url.ParseRequestURI(tokenExchangeEndpoint)
+	if err != nil || endpoint.Host == "" ||
+		(endpoint.Scheme != "http" && endpoint.Scheme != "https") {
+
+		return nil, fmt.Errorf(
+			"invalid HTTP token exchange endpoint %q",
+			tokenExchangeEndpoint,
+		)
+	}
+
+	subjectToken, err := newTokenSource(
+		"subject",
+		config.GetSubjectToken(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	options := []credentials.Oauth2TokenExchangeCredentialsOption{
+		credentials.WithTokenEndpoint(tokenExchangeEndpoint),
+		credentials.WithSubjectToken(subjectToken),
+	}
+
+	if actorTokenConfig := config.GetActorToken(); actorTokenConfig != nil {
+		actorToken, err := newTokenSource(
+			"actor",
+			actorTokenConfig,
+		)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, credentials.WithActorToken(actorToken))
+	}
+
+	result, err := credentials.NewOauth2TokenExchangeCredentials(options...)
+	if err != nil {
+		return nil, fmt.Errorf("create OAuth2 token exchange credentials: %w", err)
+	}
+
+	return result, nil
+}

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials.go
@@ -29,14 +29,18 @@ func (s *tokenSource) Token() (credentials.Token, error) {
 	if s.file != "" {
 		token, err := os.ReadFile(s.file)
 		if err != nil {
-			return credentials.Token{}, fmt.Errorf("read token file: %w", err)
+			return credentials.Token{}, fmt.Errorf(
+				"read token file %q: %w",
+				s.file,
+				err,
+			)
 		}
 		value = string(token)
 	}
 
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return credentials.Token{}, fmt.Errorf("token is empty")
+		return credentials.Token{}, fmt.Errorf("token from %s is empty", s)
 	}
 
 	return credentials.Token{

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials.go
@@ -100,11 +100,10 @@ func NewFederatedCredentials(
 		config.GetTokenExchangeEndpoint(),
 	)
 	endpoint, err := url.ParseRequestURI(tokenExchangeEndpoint)
-	if err != nil || endpoint.Host == "" ||
-		(endpoint.Scheme != "http" && endpoint.Scheme != "https") {
+	if err != nil || endpoint.Host == "" || endpoint.Scheme != "https" {
 
 		return nil, fmt.Errorf(
-			"invalid HTTP token exchange endpoint %q",
+			"invalid HTTPS token exchange endpoint %q",
 			tokenExchangeEndpoint,
 		)
 	}

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials.go
@@ -77,6 +77,9 @@ func newTokenSource(
 
 	value := strings.TrimSpace(config.GetValue())
 	file := strings.TrimSpace(config.GetFile())
+	if value == "" && file == "" {
+		return nil, fmt.Errorf("%s token source is empty", name)
+	}
 
 	return &tokenSource{
 		value:     value,
@@ -88,6 +91,10 @@ func newTokenSource(
 func NewFederatedCredentials(
 	config *FederatedCredentials,
 ) (Credentials, error) {
+
+	if config == nil {
+		return nil, fmt.Errorf("federated credentials config is missing")
+	}
 
 	tokenExchangeEndpoint := strings.TrimSpace(
 		config.GetTokenExchangeEndpoint(),

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	auth_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth/config"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestNewFederatedCredentials(t *testing.T) {
+	const (
+		subjectTokenType = "urn:example:params:oauth:token-type:subject"
+		actorTokenType   = "urn:ietf:params:oauth:token-type:jwt"
+	)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		requestCount++
+		require.Equal(t, http.MethodPost, request.Method)
+		require.NoError(t, request.ParseForm())
+		require.Equal(
+			t,
+			"urn:ietf:params:oauth:grant-type:token-exchange",
+			request.Form.Get("grant_type"),
+		)
+		require.Equal(
+			t,
+			"urn:ietf:params:oauth:token-type:access_token",
+			request.Form.Get("requested_token_type"),
+		)
+		require.Equal(t, "subject-token", request.Form.Get("subject_token"))
+		require.Equal(
+			t,
+			subjectTokenType,
+			request.Form.Get("subject_token_type"),
+		)
+		require.Equal(t, "actor-token", request.Form.Get("actor_token"))
+		require.Equal(
+			t,
+			actorTokenType,
+			request.Form.Get("actor_token_type"),
+		)
+
+		writer.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprint(writer, `{
+			"access_token": "iam-token",
+			"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+			"token_type": "Bearer",
+			"expires_in": 3600
+		}`)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	credentials, err := NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: stringPointer(server.URL),
+		SubjectToken:          tokenValue("subject-token", subjectTokenType),
+		ActorToken: tokenFile(
+			writeTokenFile(t, "actor-token\n"),
+			actorTokenType,
+		),
+	})
+	require.NoError(t, err)
+
+	token, err := credentials.Token(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Bearer iam-token", token)
+
+	token, err = credentials.Token(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Bearer iam-token", token)
+	require.Equal(t, 1, requestCount)
+}
+
+func TestTokenSourceRereadsTokenFile(t *testing.T) {
+	tokenPath := writeTokenFile(t, "token-1\n")
+	source, err := newTokenSource(
+		"subject",
+		tokenFile(tokenPath, "token-type"),
+	)
+	require.NoError(t, err)
+
+	token, err := source.Token()
+	require.NoError(t, err)
+	require.Equal(t, "token-1", token.Token)
+
+	require.NoError(t, os.WriteFile(tokenPath, []byte("token-2\n"), 0600))
+	token, err = source.Token()
+	require.NoError(t, err)
+	require.Equal(t, "token-2", token.Token)
+}
+
+func TestFederatedCredentialsValidation(t *testing.T) {
+	_, err := NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: stringPointer("grpcs://tokens.example.com"),
+		SubjectToken:          tokenValue("token", "token-type"),
+	})
+	require.ErrorContains(t, err, "invalid HTTP token exchange endpoint")
+
+	_, err = NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: stringPointer("https://sts.example.com"),
+	})
+	require.ErrorContains(t, err, "subject token is missing")
+
+	_, err = NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: stringPointer("https://sts.example.com"),
+		SubjectToken: &TypedToken{
+			TokenType: stringPointer("token-type"),
+		},
+	})
+	require.ErrorContains(t, err, "subject token source is missing")
+}
+
+func tokenValue(value string, tokenType string) *TypedToken {
+	return &TypedToken{
+		TokenType: stringPointer(tokenType),
+		Source:    &auth_config.TypedToken_Value{Value: value},
+	}
+}
+
+func tokenFile(file string, tokenType string) *TypedToken {
+	return &TypedToken{
+		TokenType: stringPointer(tokenType),
+		Source:    &auth_config.TypedToken_File{File: file},
+	}
+}
+
+func writeTokenFile(t *testing.T, token string) string {
+	file, err := os.CreateTemp(t.TempDir(), "federated-token-")
+	require.NoError(t, err)
+	defer file.Close()
+
+	_, err = file.WriteString(token)
+	require.NoError(t, err)
+	return file.Name()
+}

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	auth_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth/config"
 )
@@ -63,7 +64,7 @@ func TestNewFederatedCredentials(t *testing.T) {
 	defer server.Close()
 
 	credentials, err := NewFederatedCredentials(&FederatedCredentials{
-		TokenExchangeEndpoint: stringPointer(server.URL),
+		TokenExchangeEndpoint: proto.String(server.URL),
 		SubjectToken:          tokenValue("subject-token", subjectTokenType),
 		ActorToken: tokenFile(
 			writeTokenFile(t, "actor-token\n"),
@@ -102,20 +103,20 @@ func TestTokenSourceRereadsTokenFile(t *testing.T) {
 
 func TestFederatedCredentialsValidation(t *testing.T) {
 	_, err := NewFederatedCredentials(&FederatedCredentials{
-		TokenExchangeEndpoint: stringPointer("grpcs://tokens.example.com"),
+		TokenExchangeEndpoint: proto.String("grpcs://tokens.example.com"),
 		SubjectToken:          tokenValue("token", "token-type"),
 	})
 	require.ErrorContains(t, err, "invalid HTTP token exchange endpoint")
 
 	_, err = NewFederatedCredentials(&FederatedCredentials{
-		TokenExchangeEndpoint: stringPointer("https://sts.example.com"),
+		TokenExchangeEndpoint: proto.String("https://sts.example.com"),
 	})
 	require.ErrorContains(t, err, "subject token is missing")
 
 	_, err = NewFederatedCredentials(&FederatedCredentials{
-		TokenExchangeEndpoint: stringPointer("https://sts.example.com"),
+		TokenExchangeEndpoint: proto.String("https://sts.example.com"),
 		SubjectToken: &TypedToken{
-			TokenType: stringPointer("token-type"),
+			TokenType: proto.String("token-type"),
 		},
 	})
 	require.ErrorContains(t, err, "subject token source is missing")
@@ -123,14 +124,14 @@ func TestFederatedCredentialsValidation(t *testing.T) {
 
 func tokenValue(value string, tokenType string) *TypedToken {
 	return &TypedToken{
-		TokenType: stringPointer(tokenType),
+		TokenType: proto.String(tokenType),
 		Source:    &auth_config.TypedToken_Value{Value: value},
 	}
 }
 
 func tokenFile(file string, tokenType string) *TypedToken {
 	return &TypedToken{
-		TokenType: stringPointer(tokenType),
+		TokenType: proto.String(tokenType),
 		Source:    &auth_config.TypedToken_File{File: file},
 	}
 }

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
@@ -70,7 +70,10 @@ func TestTokenSourceRereadsTokenFile(t *testing.T) {
 }
 
 func TestFederatedCredentialsValidation(t *testing.T) {
-	_, err := NewFederatedCredentials(&FederatedCredentials{
+	_, err := NewFederatedCredentials(nil)
+	require.ErrorContains(t, err, "federated credentials config is missing")
+
+	_, err = NewFederatedCredentials(&FederatedCredentials{
 		TokenExchangeEndpoint: proto.String("grpcs://tokens.example.com"),
 		SubjectToken:          tokenValue("token", "token-type"),
 	})
@@ -88,6 +91,18 @@ func TestFederatedCredentialsValidation(t *testing.T) {
 		},
 	})
 	require.ErrorContains(t, err, "subject token source is missing")
+
+	_, err = NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: proto.String("https://sts.example.com"),
+		SubjectToken:          tokenValue(" ", "token-type"),
+	})
+	require.ErrorContains(t, err, "subject token source is empty")
+
+	_, err = NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: proto.String("https://sts.example.com"),
+		SubjectToken:          tokenFile(" ", "token-type"),
+	})
+	require.ErrorContains(t, err, "subject token source is empty")
 }
 
 func tokenValue(value string, tokenType string) *TypedToken {

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
@@ -2,8 +2,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -11,6 +9,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	auth_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth/config"
+	tokenexchange_mock "github.com/ydb-platform/nbs/cloud/disk_manager/test/mocks/tokenexchange"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -21,46 +20,8 @@ func TestNewFederatedCredentials(t *testing.T) {
 		actorTokenType   = "urn:ietf:params:oauth:token-type:jwt"
 	)
 
-	requestCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(
-		writer http.ResponseWriter,
-		request *http.Request,
-	) {
-		requestCount++
-		require.Equal(t, http.MethodPost, request.Method)
-		require.NoError(t, request.ParseForm())
-		require.Equal(
-			t,
-			"urn:ietf:params:oauth:grant-type:token-exchange",
-			request.Form.Get("grant_type"),
-		)
-		require.Equal(
-			t,
-			"urn:ietf:params:oauth:token-type:access_token",
-			request.Form.Get("requested_token_type"),
-		)
-		require.Equal(t, "subject-token", request.Form.Get("subject_token"))
-		require.Equal(
-			t,
-			subjectTokenType,
-			request.Form.Get("subject_token_type"),
-		)
-		require.Equal(t, "actor-token", request.Form.Get("actor_token"))
-		require.Equal(
-			t,
-			actorTokenType,
-			request.Form.Get("actor_token_type"),
-		)
-
-		writer.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprint(writer, `{
-			"access_token": "iam-token",
-			"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
-			"token_type": "Bearer",
-			"expires_in": 3600
-		}`)
-		require.NoError(t, err)
-	}))
+	mock := tokenexchange_mock.New("iam-token")
+	server := httptest.NewServer(mock)
 	defer server.Close()
 
 	credentials, err := NewFederatedCredentials(&FederatedCredentials{
@@ -80,7 +41,14 @@ func TestNewFederatedCredentials(t *testing.T) {
 	token, err = credentials.Token(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "Bearer iam-token", token)
-	require.Equal(t, 1, requestCount)
+	require.Equal(t, []tokenexchange_mock.Request{{
+		GrantType:          tokenexchange_mock.TokenExchangeGrantType,
+		RequestedTokenType: tokenexchange_mock.AccessTokenType,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   subjectTokenType,
+		ActorToken:         "actor-token",
+		ActorTokenType:     actorTokenType,
+	}}, mock.Requests())
 }
 
 func TestTokenSourceRereadsTokenFile(t *testing.T) {

--- a/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
+++ b/cloud/disk_manager/internal/pkg/auth/federated_credentials_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -21,8 +22,14 @@ func TestNewFederatedCredentials(t *testing.T) {
 	)
 
 	mock := tokenexchange_mock.New("iam-token")
-	server := httptest.NewServer(mock)
+	server := httptest.NewTLSServer(mock)
 	defer server.Close()
+
+	defaultTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() {
+		http.DefaultTransport = defaultTransport
+	}()
 
 	credentials, err := NewFederatedCredentials(&FederatedCredentials{
 		TokenExchangeEndpoint: proto.String(server.URL),
@@ -77,7 +84,13 @@ func TestFederatedCredentialsValidation(t *testing.T) {
 		TokenExchangeEndpoint: proto.String("grpcs://tokens.example.com"),
 		SubjectToken:          tokenValue("token", "token-type"),
 	})
-	require.ErrorContains(t, err, "invalid HTTP token exchange endpoint")
+	require.ErrorContains(t, err, "invalid HTTPS token exchange endpoint")
+
+	_, err = NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: proto.String("http://sts.example.com"),
+		SubjectToken:          tokenValue("token", "token-type"),
+	})
+	require.ErrorContains(t, err, "invalid HTTPS token exchange endpoint")
 
 	_, err = NewFederatedCredentials(&FederatedCredentials{
 		TokenExchangeEndpoint: proto.String("https://sts.example.com"),
@@ -103,6 +116,20 @@ func TestFederatedCredentialsValidation(t *testing.T) {
 		SubjectToken:          tokenFile(" ", "token-type"),
 	})
 	require.ErrorContains(t, err, "subject token source is empty")
+
+	_, err = NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: proto.String("https://sts.example.com"),
+		SubjectToken:          tokenValue("subject-token", "token-type"),
+		ActorToken:            tokenValue(" ", "token-type"),
+	})
+	require.ErrorContains(t, err, "actor token source is empty")
+
+	_, err = NewFederatedCredentials(&FederatedCredentials{
+		TokenExchangeEndpoint: proto.String("https://sts.example.com"),
+		SubjectToken:          tokenValue("subject-token", "token-type"),
+		ActorToken:            tokenFile(" ", "token-type"),
+	})
+	require.ErrorContains(t, err, "actor token source is empty")
 }
 
 func tokenValue(value string, tokenType string) *TypedToken {

--- a/cloud/disk_manager/internal/pkg/auth/rfc8693_credentials_test.go
+++ b/cloud/disk_manager/internal/pkg/auth/rfc8693_credentials_test.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
+	auth_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth/config"
+	tokenexchange_mock "github.com/ydb-platform/nbs/cloud/disk_manager/test/mocks/tokenexchange"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestNewCredentialsWithRFC8693ServiceAccount(t *testing.T) {
+	const (
+		serviceAccountID = "service-account-id"
+		keyID            = "key-id"
+		audience         = "test-audience"
+	)
+
+	mock := tokenexchange_mock.New("iam-token")
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	privateKey, privateKeyFile := writePrivateKey(t)
+	credentials, err := NewCredentials(context.Background(), &AuthConfig{
+		MetadataUrl: proto.String(server.URL),
+		ServiceAccount: &auth_config.ServiceAccount{
+			Id:                   proto.String(serviceAccountID),
+			KeyId:                proto.String(keyID),
+			Audience:             proto.String(audience),
+			TokenSigningCertFile: proto.String(privateKeyFile),
+		},
+	})
+	require.NoError(t, err)
+
+	token, err := credentials.Token(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Bearer iam-token", token)
+
+	requests := mock.Requests()
+	require.Len(t, requests, 1)
+	request := requests[0]
+	require.Equal(t, tokenexchange_mock.TokenExchangeGrantType, request.GrantType)
+	require.Equal(t, tokenexchange_mock.AccessTokenType, request.RequestedTokenType)
+	require.Equal(
+		t,
+		"urn:ietf:params:oauth:token-type:jwt",
+		request.SubjectTokenType,
+	)
+	require.Equal(t, audience, request.Audience)
+	require.Empty(t, request.ActorToken)
+	require.Empty(t, request.ActorTokenType)
+
+	jwtToken, err := jwt.Parse(request.SubjectToken, func(
+		token *jwt.Token,
+	) (interface{}, error) {
+
+		require.Equal(t, jwt.SigningMethodRS256, token.Method)
+		require.Equal(t, keyID, token.Header["kid"])
+		return &privateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+	require.True(t, jwtToken.Valid)
+
+	claims, ok := jwtToken.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	require.Equal(t, serviceAccountID, claims["iss"])
+	require.Equal(t, serviceAccountID, claims["sub"])
+	require.True(t, claims.VerifyAudience(audience, true))
+}
+
+func writePrivateKey(t *testing.T) (*rsa.PrivateKey, string) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	privateKeyFile := filepath.Join(t.TempDir(), "private-key.pem")
+	require.NoError(t, os.WriteFile(
+		privateKeyFile,
+		pem.EncodeToMemory(&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+		}),
+		0600,
+	))
+
+	return privateKey, privateKeyFile
+}

--- a/cloud/disk_manager/internal/pkg/auth/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/auth/tests/ya.make
@@ -1,0 +1,3 @@
+GO_TEST_FOR(cloud/disk_manager/internal/pkg/auth)
+
+END()

--- a/cloud/disk_manager/internal/pkg/auth/ya.make
+++ b/cloud/disk_manager/internal/pkg/auth/ya.make
@@ -8,6 +8,7 @@ SRCS(
 GO_TEST_SRCS(
     credentials_test.go
     federated_credentials_test.go
+    rfc8693_credentials_test.go
 )
 
 END()

--- a/cloud/disk_manager/internal/pkg/auth/ya.make
+++ b/cloud/disk_manager/internal/pkg/auth/ya.make
@@ -2,10 +2,20 @@ GO_LIBRARY()
 
 SRCS(
     credentials.go
+    federated_credentials.go
+)
+
+GO_TEST_SRCS(
+    credentials_test.go
+    federated_credentials_test.go
 )
 
 END()
 
 RECURSE(
     config
+)
+
+RECURSE_FOR_TESTS(
+    tests
 )

--- a/cloud/disk_manager/pkg/admin/common.go
+++ b/cloud/disk_manager/pkg/admin/common.go
@@ -88,7 +88,10 @@ func newYDBClient(
 	config *server_config.ServerConfig,
 ) (*persistence.YDBClient, error) {
 
-	creds := auth.NewCredentials(ctx, config.AuthConfig)
+	creds, err := auth.NewCredentials(ctx, config.AuthConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create credentials: %w", err)
+	}
 
 	db, err := persistence.NewYDBClient(
 		ctx,

--- a/cloud/disk_manager/pkg/app/run.go
+++ b/cloud/disk_manager/pkg/app/run.go
@@ -131,7 +131,11 @@ func run(
 		defer shutdown(ctx)
 	}
 
-	creds := internal_auth.NewCredentials(ctx, config.GetAuthConfig())
+	creds, err := internal_auth.NewCredentials(ctx, config.GetAuthConfig())
+	if err != nil {
+		logging.Error(ctx, "Failed to create credentials: %v", err)
+		return err
+	}
 
 	logging.Info(ctx, "Initializing YDB client")
 	ydbClientRegistry := mon.NewRegistry("ydb_client")

--- a/cloud/disk_manager/pkg/schema/create.go
+++ b/cloud/disk_manager/pkg/schema/create.go
@@ -79,7 +79,10 @@ func create(
 
 	logging.Info(ctx, "Initiliazing schema")
 
-	creds := auth.NewCredentials(ctx, config.GetAuthConfig())
+	creds, err := auth.NewCredentials(ctx, config.GetAuthConfig())
+	if err != nil {
+		return err
+	}
 
 	db, err := persistence.NewYDBClient(
 		ctx,

--- a/cloud/disk_manager/test/mocks/tokenexchange/token_exchange_mock.go
+++ b/cloud/disk_manager/test/mocks/tokenexchange/token_exchange_mock.go
@@ -2,6 +2,7 @@ package tokenexchange
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sync"
 )
@@ -34,6 +35,42 @@ func New(accessToken string) *Mock {
 	return &Mock{accessToken: accessToken}
 }
 
+func validateRequest(request Request) error {
+	if request.GrantType != TokenExchangeGrantType {
+		return fmt.Errorf(
+			"unexpected grant_type %q, expected %q",
+			request.GrantType,
+			TokenExchangeGrantType,
+		)
+	}
+
+	if request.RequestedTokenType != AccessTokenType {
+		return fmt.Errorf(
+			"unexpected requested_token_type %q, expected %q",
+			request.RequestedTokenType,
+			AccessTokenType,
+		)
+	}
+
+	if request.SubjectToken == "" {
+		return fmt.Errorf("subject_token is missing")
+	}
+
+	if request.SubjectTokenType == "" {
+		return fmt.Errorf("subject_token_type is missing")
+	}
+
+	if request.ActorToken == "" && request.ActorTokenType != "" {
+		return fmt.Errorf("actor_token is missing")
+	}
+
+	if request.ActorToken != "" && request.ActorTokenType == "" {
+		return fmt.Errorf("actor_token_type is missing")
+	}
+
+	return nil
+}
+
 func (m *Mock) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	if request.Method != http.MethodPost {
 		http.Error(writer, "only POST is supported", http.StatusMethodNotAllowed)
@@ -55,14 +92,8 @@ func (m *Mock) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		Audience:           request.Form.Get("audience"),
 	}
 
-	if tokenExchangeRequest.GrantType != TokenExchangeGrantType ||
-		tokenExchangeRequest.RequestedTokenType != AccessTokenType ||
-		tokenExchangeRequest.SubjectToken == "" ||
-		tokenExchangeRequest.SubjectTokenType == "" ||
-		(tokenExchangeRequest.ActorToken == "") !=
-			(tokenExchangeRequest.ActorTokenType == "") {
-
-		http.Error(writer, "invalid token exchange request", http.StatusBadRequest)
+	if err := validateRequest(tokenExchangeRequest); err != nil {
+		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/cloud/disk_manager/test/mocks/tokenexchange/token_exchange_mock.go
+++ b/cloud/disk_manager/test/mocks/tokenexchange/token_exchange_mock.go
@@ -1,0 +1,89 @@
+package tokenexchange
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+const (
+	TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
+	AccessTokenType        = "urn:ietf:params:oauth:token-type:access_token"
+)
+
+type Request struct {
+	GrantType          string
+	RequestedTokenType string
+	SubjectToken       string
+	SubjectTokenType   string
+	ActorToken         string
+	ActorTokenType     string
+	Audience           string
+}
+
+type Mock struct {
+	accessToken string
+
+	mutex    sync.Mutex
+	requests []Request
+}
+
+func New(accessToken string) *Mock {
+	return &Mock{accessToken: accessToken}
+}
+
+func (m *Mock) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodPost {
+		http.Error(writer, "only POST is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := request.ParseForm(); err != nil {
+		http.Error(writer, "failed to parse form", http.StatusBadRequest)
+		return
+	}
+
+	tokenExchangeRequest := Request{
+		GrantType:          request.Form.Get("grant_type"),
+		RequestedTokenType: request.Form.Get("requested_token_type"),
+		SubjectToken:       request.Form.Get("subject_token"),
+		SubjectTokenType:   request.Form.Get("subject_token_type"),
+		ActorToken:         request.Form.Get("actor_token"),
+		ActorTokenType:     request.Form.Get("actor_token_type"),
+		Audience:           request.Form.Get("audience"),
+	}
+
+	if tokenExchangeRequest.GrantType != TokenExchangeGrantType ||
+		tokenExchangeRequest.RequestedTokenType != AccessTokenType ||
+		tokenExchangeRequest.SubjectToken == "" ||
+		tokenExchangeRequest.SubjectTokenType == "" ||
+		(tokenExchangeRequest.ActorToken == "") !=
+			(tokenExchangeRequest.ActorTokenType == "") {
+
+		http.Error(writer, "invalid token exchange request", http.StatusBadRequest)
+		return
+	}
+
+	m.mutex.Lock()
+	m.requests = append(m.requests, tokenExchangeRequest)
+	m.mutex.Unlock()
+
+	writer.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(writer).Encode(map[string]interface{}{
+		"access_token":      m.accessToken,
+		"issued_token_type": AccessTokenType,
+		"token_type":        "Bearer",
+		"expires_in":        3600,
+	}); err != nil {
+		http.Error(writer, "failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func (m *Mock) Requests() []Request {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return append([]Request(nil), m.requests...)
+}

--- a/cloud/disk_manager/test/mocks/tokenexchange/ya.make
+++ b/cloud/disk_manager/test/mocks/tokenexchange/ya.make
@@ -1,0 +1,7 @@
+GO_LIBRARY()
+
+SRCS(
+    token_exchange_mock.go
+)
+
+END()

--- a/cloud/disk_manager/test/mocks/ya.make
+++ b/cloud/disk_manager/test/mocks/ya.make
@@ -4,4 +4,5 @@ RECURSE(
     kms
     metadata
     s3-quota-proxy
+    tokenexchange
 )


### PR DESCRIPTION
### Notes
Add OAuth 2.0 Token Exchange credentials to Disk Manager.

Supports subject and optional actor tokens supplied as values or files. File-backed tokens are reread on refresh.

Credential initialization errors are now propagated to callers.

### Configuration example

```
    FederatedCredentials: {
        TokenExchangeEndpoint: "https://sts.iam.endpoint:443/oauth2/token/exchange"
        SubjectToken: {
            TokenType: "urn:nebius:params:oauth:token-type:subject_identifier"
            Value: "serviceaccount-disk-manager-ydb"
        }
        ActorToken: {
            TokenType: "urn:ietf:params:oauth:token-type:jwt"
            File: "/var/run/secrets/serviceaccount/token"
        }
    }
```


### Issue
Put links to the related issues here
