### PR TITLE
issue-5895: fastshard - TString -> TBuffer where possible

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.cpp
@@ -26,7 +26,7 @@ protected:
 private:
     struct TPage
     {
-        TString Content;
+        TBuffer Content;
         ui64 Lsn = 0;
         bool Dirty = false;
     };
@@ -52,10 +52,10 @@ public:
     NProto::TError WritePage(
         ui64 lsn,
         ui64 pageNo,
-        TString page,
+        TBuffer page,
         TVector<TPageGroup>& logRecord) override;
     NProto::TError
-    ReadPage(ui64 lsn, ui64 pageNo, TString* page) const override;
+    ReadPage(ui64 lsn, ui64 pageNo, TBuffer* page) const override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -89,7 +89,7 @@ void TPageStore::RollbackPages(const TVector<ui64>& pages)
 NProto::TError TPageStore::WritePage(
     ui64 lsn,
     ui64 pageNo,
-    TString page,
+    TBuffer page,
     TVector<TPageGroup>& logRecord)
 {
     std::lock_guard g(Mutex);
@@ -126,7 +126,7 @@ NProto::TError TPageStore::WritePage(
 
     if (!found) {
         logRecord.push_back(
-            {.FirstPageNo = pageNo, .Content = TVector<TString>({page})});
+            {.FirstPageNo = pageNo, .Content = TVector<TBuffer>({page})});
     }
 
     //
@@ -147,9 +147,9 @@ NProto::TError TPageStore::WritePage(
     return {};
 }
 
-NProto::TError TPageStore::ReadPage(ui64 lsn, ui64 pageNo, TString* page) const
+NProto::TError TPageStore::ReadPage(ui64 lsn, ui64 pageNo, TBuffer* page) const
 {
-    page->clear();
+    page->Clear();
 
     TPageCache::iterator cachedPage;
     {
@@ -185,7 +185,7 @@ NProto::TError TPageStore::ReadPage(ui64 lsn, ui64 pageNo, TString* page) const
     {
         std::lock_guard g(Mutex);
 
-        if (page->empty()) {
+        if (page->Empty()) {
             PageCache.erase(cachedPage);
         } else {
             cachedPage->second.Content = *page;
@@ -231,11 +231,11 @@ NProto::TError TPageStore::ReadPage(ui64 lsn, ui64 pageNo, TString* page) const
                 << "unexpected page count: " << rpg.Content.size());
     }
 
-    if (rpg.Content[0].size() < PageSize) {
+    if (rpg.Content[0].Size() < PageSize) {
         return MakeError(
             E_BADMSG,
             TStringBuilder()
-                << "unexpected page size: " << rpg.Content[0].size());
+                << "unexpected page size: " << rpg.Content[0].Size());
     }
 
     *page = std::move(rpg.Content[0]);
@@ -251,11 +251,12 @@ public:
         : TPageStore(nullptr /* storage */, pageSize)
     {}
 
-    NProto::TError ReadPage(ui64 lsn, ui64 pageNo, TString* page) const override
+    NProto::TError ReadPage(ui64 lsn, ui64 pageNo, TBuffer* page) const override
     {
         auto error = TPageStore::ReadPage(lsn, pageNo, page);
         if (error.GetCode() == E_NOT_FOUND) {
-            *page = TString(PageSize, 0);
+            page->Clear();
+            page->Fill(0, PageSize);
             return {};
         }
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.h
@@ -3,6 +3,8 @@
 #include <cloud/filestore/libs/service/error.h>
 #include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h>
 
+#include <util/generic/buffer.h>
+
 #include <memory>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
@@ -20,10 +22,10 @@ public:
     [[nodiscard]] virtual NProto::TError WritePage(
         ui64 lsn,
         ui64 pageNo,
-        TString page,
+        TBuffer page,
         TVector<TPageGroup>& logRecord) = 0;
     [[nodiscard]] virtual NProto::TError
-    ReadPage(ui64 lsn, ui64 pageNo, TString* page) const = 0;
+    ReadPage(ui64 lsn, ui64 pageNo, TBuffer* page) const = 0;
 };
 
 using IPageStorePtr = std::shared_ptr<IPageStore>;

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
@@ -11,12 +11,12 @@ namespace {
 constexpr ui64 InvalidBitNo = Max<ui64>();
 constexpr ui64 BitsPerWord = 64;
 
-bool IsFull(const TString& bitmapPage)
+bool IsFull(const TBuffer& bitmapPage)
 {
-    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+    Y_ABORT_UNLESS(bitmapPage.Size() % sizeof(ui64) == 0);
 
-    for (ui64 i = 0; i < bitmapPage.size(); i += sizeof(ui64)) {
-        const ui64* word = reinterpret_cast<const ui64*>(bitmapPage.data() + i);
+    for (ui64 i = 0; i < bitmapPage.Size(); i += sizeof(ui64)) {
+        const ui64* word = reinterpret_cast<const ui64*>(bitmapPage.Data() + i);
         if (~*word != 0) {
             return false;
         }
@@ -37,34 +37,34 @@ static ui16 PopCount(ui64 x)
     return byteSums * 0x0101010101010101ULL >> 56;
 }
 
-ui64 PopCount(const TString& bitmapPage)
+ui64 PopCount(const TBuffer& bitmapPage)
 {
-    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+    Y_ABORT_UNLESS(bitmapPage.Size() % sizeof(ui64) == 0);
     ui64 c = 0;
 
-    for (ui64 i = 0; i < bitmapPage.size(); i += sizeof(ui64)) {
-        const ui64* word = reinterpret_cast<const ui64*>(bitmapPage.data() + i);
+    for (ui64 i = 0; i < bitmapPage.Size(); i += sizeof(ui64)) {
+        const ui64* word = reinterpret_cast<const ui64*>(bitmapPage.Data() + i);
         c += PopCount(*word);
     }
 
     return c;
 }
 
-bool GetBit(TString& bitmapPage, ui64 bit)
+bool GetBit(TBuffer& bitmapPage, ui64 bit)
 {
-    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+    Y_ABORT_UNLESS(bitmapPage.Size() % sizeof(ui64) == 0);
 
     ui64* word =
-        reinterpret_cast<ui64*>(bitmapPage.begin()) + bit / BitsPerWord;
+        reinterpret_cast<ui64*>(bitmapPage.Data()) + bit / BitsPerWord;
     return (*word & (1ULL << (bit % BitsPerWord))) != 0;
 }
 
-void SetBit(TString& bitmapPage, ui64 bit, bool isReset)
+void SetBit(TBuffer& bitmapPage, ui64 bit, bool isReset)
 {
-    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+    Y_ABORT_UNLESS(bitmapPage.Size() % sizeof(ui64) == 0);
 
     ui64* word =
-        reinterpret_cast<ui64*>(bitmapPage.begin()) + bit / BitsPerWord;
+        reinterpret_cast<ui64*>(bitmapPage.Data()) + bit / BitsPerWord;
     if (isReset) {
         *word &= ~(1ULL << (bit % BitsPerWord));
     } else {
@@ -72,12 +72,12 @@ void SetBit(TString& bitmapPage, ui64 bit, bool isReset)
     }
 }
 
-ui64 FindFirstFreeBit(const TString& bitmapPage)
+ui64 FindFirstFreeBit(const TBuffer& bitmapPage)
 {
-    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+    Y_ABORT_UNLESS(bitmapPage.Size() % sizeof(ui64) == 0);
 
-    for (ui64 i = 0; i < bitmapPage.size(); i += sizeof(ui64)) {
-        const ui64* word = reinterpret_cast<const ui64*>(bitmapPage.data() + i);
+    for (ui64 i = 0; i < bitmapPage.Size(); i += sizeof(ui64)) {
+        const ui64* word = reinterpret_cast<const ui64*>(bitmapPage.Data() + i);
         if (~*word != 0) {
             return i * 8 + std::countr_one(*word);
         }
@@ -237,7 +237,7 @@ NProto::TError TPersistentBitmap::InitIfNeeded() const
             return error;
         }
 
-        Y_ABORT_UNLESS(BitmapPages[i].size() == PageSize);
+        Y_ABORT_UNLESS(BitmapPages[i].Size() == PageSize);
 
         if (!IsFull(BitmapPages[i])) {
             BitmapPagesWithFreeBits.push(i);

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
@@ -4,6 +4,7 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 
+#include <util/generic/buffer.h>
 #include <util/generic/stack.h>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
@@ -19,7 +20,7 @@ private:
     const ui64 BitsPerPage;
     IPageStorePtr PageStore;
 
-    mutable TVector<TString> BitmapPages;
+    mutable TVector<TBuffer> BitmapPages;
     mutable TStack<ui64> BitmapPagesWithFreeBits;
 
 public:

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
@@ -9,6 +9,7 @@
 #include <silk/util/logger.h>
 
 #include <util/digest/city.h>
+#include <util/generic/buffer.h>
 #include <util/string/builder.h>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
@@ -58,13 +59,13 @@ private:
         const ui64 SlotSize;
         const ui64 SlotCount;
         const ui64 SlotsPerPage;
-        TString Page;
+        TBuffer Page;
         bool Dirty = false;
         ui64 SlotNo;
 
         struct TDirtyPage
         {
-            TString Content;
+            TBuffer Content;
             ui64 PageNo = 0;
         };
 
@@ -140,7 +141,7 @@ private:
         [[nodiscard]] const char* GetRaw() const
         {
             const ui64 offsetInPage = (SlotNo % SlotsPerPage) * SlotSize;
-            return Page.data() + offsetInPage;
+            return Page.Data() + offsetInPage;
         }
 
         [[nodiscard]] const TValue& Get() const
@@ -151,7 +152,7 @@ private:
         void Write(const char* data)
         {
             const ui64 offsetInPage = (SlotNo % SlotsPerPage) * SlotSize;
-            char* dst = Page.begin() + offsetInPage;
+            char* dst = Page.Data() + offsetInPage;
             memcpy(dst, data, sizeof(TValue));
             dst += sizeof(TValue);
             const ui64 tail = SlotSize - sizeof(TValue);
@@ -164,7 +165,7 @@ private:
         void Clear()
         {
             const ui64 offsetInPage = (SlotNo % SlotsPerPage) * SlotSize;
-            memset(Page.begin() + offsetInPage, 0, SlotSize);
+            memset(Page.Data() + offsetInPage, 0, SlotSize);
             Dirty = true;
         }
 
@@ -310,7 +311,7 @@ private:
     [[nodiscard]] NProto::TError WritePage(
         ui64 lsn,
         ui64 slotNo,
-        TString page,
+        TBuffer page,
         TVector<TPageGroup>& pageGroups)
     {
         const ui64 pageNo = FirstPageNo + slotNo / SlotsPerPage;
@@ -318,7 +319,7 @@ private:
     }
 
     [[nodiscard]] NProto::TError
-    ReadPage(ui64 lsn, ui64 slotNo, TString* page) const
+    ReadPage(ui64 lsn, ui64 slotNo, TBuffer* page) const
     {
         const ui64 pageNo = FirstPageNo + slotNo / SlotsPerPage;
         return PageStore->ReadPage(lsn, pageNo, page);
@@ -337,14 +338,14 @@ private:
     [[nodiscard]] NProto::TError
     LookupSlot(ui64 lsn, ui64 slotNo, TValue* v) const
     {
-        TString page;
+        TBuffer page;
         auto error = ReadPage(lsn, slotNo, &page);
         if (HasError(error)) {
             return error;
         }
 
         const ui32 relSlotNo = slotNo % SlotsPerPage;
-        const char* ptr = page.data() + relSlotNo * SlotSize;
+        const char* ptr = page.Data() + relSlotNo * SlotSize;
         return LookupSlot(ptr, v) ? MakeError(S_OK) : MakeError(S_FALSE);
     }
 
@@ -466,14 +467,14 @@ private:
         ui64 slotNo,
         TVector<TPageGroup>& pageGroups)
     {
-        TString page;
+        TBuffer page;
         auto error = ReadPage(lsn, slotNo, &page);
         if (HasError(error)) {
             return error;
         }
 
         const ui32 relSlotNo = slotNo % SlotsPerPage;
-        char* ptr = page.begin() + relSlotNo * SlotSize;
+        char* ptr = page.Data() + relSlotNo * SlotSize;
         memcpy(ptr, &v, sizeof(TValue));
 
         error = WritePage(lsn, slotNo, std::move(page), pageGroups);

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -22,6 +22,7 @@
 #include <library/cpp/resource/resource.h>
 
 #include <util/digest/city.h>
+#include <util/generic/buffer.h>
 #include <util/random/random.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
@@ -1832,7 +1833,7 @@ public:
                     break;
                 }
 
-                TString page;
+                TBuffer page;
                 if (isUnalignedHead || isUnalignedTail) {
                     error = PageStore->ReadPage(
                         writeContext.Lsn,
@@ -1846,7 +1847,7 @@ public:
                         break;
                     }
                 } else {
-                    page.ReserveAndResize(PageSize);
+                    page.Resize(PageSize);
                 }
 
                 const ui64 offsetInPage =
@@ -1856,7 +1857,7 @@ public:
                 const ui64 toCopy =
                     Min(pageEnd, endOffset) - (pageStart + offsetInPage);
                 memcpy(
-                    page.begin() + offsetInPage,
+                    page.Data() + offsetInPage,
                     request.GetBuffer().data() + bufferOffset,
                     toCopy);
 
@@ -2034,7 +2035,7 @@ public:
                     break;
                 }
 
-                TString page;
+                TBuffer page;
                 error = PageStore->ReadPage(0 /* lsn */, storagePageNo, &page);
 
                 if (HasError(error)) {
@@ -2052,7 +2053,7 @@ public:
                     Min(pageEnd, endOffset) - (pageStart + offsetInPage);
                 memcpy(
                     buffer.begin() + bufferOffset,
-                    page.begin() + offsetInPage,
+                    page.Data() + offsetInPage,
                     toCopy);
 
                 bufferOffset += toCopy;

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_error.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_error.cpp
@@ -51,7 +51,13 @@ struct TTempError
 
 struct TTestStorageGroup: IStorageGroup
 {
-    TVector<TString> Pages{PageCount};
+    //
+    // Deliberately not brace-initialized: TBuffer(size_t) is implicit, so
+    // {PageCount} would create a single buffer instead of PageCount empty
+    // pages.
+    //
+
+    TVector<TBuffer> Pages = TVector<TBuffer>(PageCount);
     TTempError ReadError;
     TTempError WriteError;
 
@@ -102,8 +108,8 @@ struct TTestStorageGroup: IStorageGroup
             pg.FirstPageNo = pgr.FirstPageNo;
             for (ui64 i = 0; i < pgr.PageCount; ++i) {
                 pg.Content.push_back(Pages[pgr.FirstPageNo + i]);
-                if (pg.Content.back().empty()) {
-                    pg.Content.back().resize(PageSize, 0);
+                if (pg.Content.back().Empty()) {
+                    pg.Content.back().Fill(0, PageSize);
                 }
             }
         }

--- a/cloud/filestore/libs/storage/fastshard/sn/impl/storage_node.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/impl/storage_node.cpp
@@ -5,6 +5,7 @@
 #include <silk/fibers/fiber.h>
 
 #include <util/generic/algorithm.h>
+#include <util/generic/buffer.h>
 #include <util/generic/string.h>
 #include <util/generic/utility.h>
 #include <util/generic/vector.h>
@@ -221,7 +222,7 @@ public:
             ui64 FirstPageNo = 0;
             ui64 PageCount = 0;
             ui32 PageSize = 0;
-            TString Buffer;
+            TBuffer Buffer;
             iovec Iov{};
             ui64 BytesRead = 0;
             FiberScheduler::IoFuture Future;
@@ -242,9 +243,9 @@ public:
             op.FirstPageNo = ref.GetFirstPageNo();
             op.PageCount = ref.GetPageCount();
             op.PageSize = ref.GetPageSize();
-            op.Buffer.ReserveAndResize(op.PageCount * op.PageSize);
-            op.Iov.iov_base = op.Buffer.begin();
-            op.Iov.iov_len = op.Buffer.size();
+            op.Buffer.Resize(op.PageCount * op.PageSize);
+            op.Iov.iov_base = op.Buffer.Data();
+            op.Iov.iov_len = op.Buffer.Size();
             const ui64 offset = op.FirstPageNo * op.PageSize;
             FiberScheduler::read(
                 fd,
@@ -303,9 +304,9 @@ public:
             auto* pg = resp.AddPageGroups();
             pg->SetFirstPageNo(op.FirstPageNo);
             for (ui64 i = 0; i < op.PageCount; ++i) {
-                pg->AddContent(op.Buffer.substr(
-                    static_cast<size_t>(i) * op.PageSize,
-                    op.PageSize));
+                pg->AddContent()->assign(
+                    op.Buffer.Data() + static_cast<size_t>(i) * op.PageSize,
+                    op.PageSize);
             }
         }
         return resp;

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
@@ -104,8 +104,10 @@ public:
             auto* w = request.AddPageGroups();
             w->SetFirstPageNo(pg.FirstPageNo);
             w->MutableContent()->Reserve(pg.Content.size());
-            for (auto& c: pg.Content) {
-                *w->AddContent() = std::move(c);
+            for (const auto& c: pg.Content) {
+                // proto content is TString - the copy stays until the
+                // protocol itself switches away from TString
+                w->AddContent()->assign(c.Data(), c.Size());
             }
         }
         SILK_DEBUG("sg write: %s", DebugMessage(request).c_str());
@@ -146,8 +148,8 @@ public:
                 auto& r = pageGroups->emplace_back();
                 r.FirstPageNo = pg.GetFirstPageNo();
                 r.Content.reserve(pg.ContentSize());
-                for (auto& c: *pg.MutableContent()) {
-                    r.Content.emplace_back(std::move(c));
+                for (const auto& c: pg.GetContent()) {
+                    r.Content.emplace_back(c.data(), c.size());
                 }
             }
         }

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
@@ -2,6 +2,7 @@
 
 #include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
 
+#include <util/generic/buffer.h>
 #include <util/generic/vector.h>
 
 #include <memory>
@@ -20,7 +21,7 @@ struct TPageGroupRef
 struct TPageGroup
 {
     ui64 FirstPageNo = 0;
-    TVector<TString> Content;
+    TVector<TBuffer> Content;
 };
 
 /**

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
@@ -120,10 +120,11 @@ TEST(NaiveGroupTest, MirrorsWrites)
             TStorageFixture fx;
 
             {
-                TVector<TPageGroup> pageGroups = {{
-                    .FirstPageNo = 111,
-                    .Content = {"page1", "page2"},
-                }};
+                TPageGroup pageGroup{.FirstPageNo = 111};
+                pageGroup.Content.emplace_back("page1", 5U /* len */);
+                pageGroup.Content.emplace_back("page2", 5U /* len */);
+                TVector<TPageGroup> pageGroups;
+                pageGroups.push_back(std::move(pageGroup));
 
                 auto error = fx.Group->WriteLogRecord(
                     defaultHeaders,
@@ -196,9 +197,10 @@ TEST(NaiveGroupTest, RoundRobinsRead)
                             pageGroups[j].Content.size());
                         for (ui64 k = 0; k < pageGroups[j].Content.size(); ++k)
                         {
-                            EXPECT_STREQ(
-                                epg.GetContent(k).c_str(),
-                                pageGroups[j].Content[k].c_str());
+                            const auto& c = pageGroups[j].Content[k];
+                            EXPECT_EQ(
+                                epg.GetContent(k),
+                                TString(c.Data(), c.Size()));
                         }
                     }
                 }


### PR DESCRIPTION
### Notes
`TString` usage for pages is inefficient because it allocates slightly more than one page so we end up using the next allocator slot. Will change the protocol to avoid repeated string/bytes usage for pages separately. 

### Issue
https://github.com/ydb-platform/nbs/issues/5895
