### PR TITLE
[Filestore] expose availability counters to user stats

### DIFF
--- a/cloud/filestore/libs/diagnostics/user_counter.cpp
+++ b/cloud/filestore/libs/diagnostics/user_counter.cpp
@@ -31,6 +31,14 @@ constexpr TStringBuf FILESTORE_INDEX_LATENCY         = "filestore.index_latency"
 constexpr TStringBuf FILESTORE_INDEX_ERRORS          = "filestore.index_errors";
 constexpr TStringBuf FILESTORE_INDEX_CUMULATIVE_TIME = "filestore.index_cumulative_time";
 
+// Availability counters
+constexpr TStringBuf FILESTORE_AVAILABILITY_TOTAL_INTERVALS =
+    "filestore.availability_total_intervals";
+constexpr TStringBuf FILESTORE_AVAILABILITY_AVAILABLE_INTERVALS =
+    "filestore.availability_available_intervals";
+constexpr TStringBuf FILESTORE_AVAILABILITY_UNAVAILABLE_INTERVALS =
+    "filestore.availability_unavailable_intervals";
+
 TLabels MakeFilestoreLabels(
     const TString& cloudId,
     const TString& folderId,
@@ -171,6 +179,36 @@ void RegisterFilestore(
         FILESTORE_WRITE_LATENCY,
         histogramCounterOptions);
 
+    // Availability counters. The availability tracker registers them
+    // lazily (and only when the tracking feature is enabled), while the
+    // user metric wrappers capture the source counters eagerly at
+    // registration time - so the counters are created here with the same
+    // flags the tracker uses; they stay at zero until (and unless) the
+    // tracking is enabled.
+    for (const auto* name:
+         {"Availability_TotalIntervals",
+          "Availability_AvailableIntervals",
+          "Availability_UnavailableIntervals"})
+    {
+        src->GetCounter(name, true /* derivative */);
+    }
+
+    AddUserMetric(
+        dsc,
+        commonLabels,
+        { { src, "Availability_TotalIntervals" } },
+        FILESTORE_AVAILABILITY_TOTAL_INTERVALS);
+    AddUserMetric(
+        dsc,
+        commonLabels,
+        { { src, "Availability_AvailableIntervals" } },
+        FILESTORE_AVAILABILITY_AVAILABLE_INTERVALS);
+    AddUserMetric(
+        dsc,
+        commonLabels,
+        { { src, "Availability_UnavailableIntervals" } },
+        FILESTORE_AVAILABILITY_UNAVAILABLE_INTERVALS);
+
     TVector<TBaseDynamicCounters> indexOpsCounters;
     TVector<TBaseDynamicCounters> indexErrorCounters;
 
@@ -258,6 +296,16 @@ void UnregisterFilestore(
     dsc.RemoveUserMetric(commonLabels, FILESTORE_WRITE_BYTES_BURST);
     dsc.RemoveUserMetric(commonLabels, FILESTORE_WRITE_LATENCY);
     dsc.RemoveUserMetric(commonLabels, FILESTORE_WRITE_ERRORS);
+
+    dsc.RemoveUserMetric(
+        commonLabels,
+        FILESTORE_AVAILABILITY_TOTAL_INTERVALS);
+    dsc.RemoveUserMetric(
+        commonLabels,
+        FILESTORE_AVAILABILITY_AVAILABLE_INTERVALS);
+    dsc.RemoveUserMetric(
+        commonLabels,
+        FILESTORE_AVAILABILITY_UNAVAILABLE_INTERVALS);
 
     dsc.RemoveUserMetric(commonLabels, FILESTORE_INDEX_OPS);
     dsc.RemoveUserMetric(commonLabels, FILESTORE_INDEX_ERRORS);

--- a/cloud/filestore/libs/diagnostics/user_counter_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/user_counter_ut.cpp
@@ -264,6 +264,62 @@ Y_UNIT_TEST_SUITE(TUserWrapperTest)
         ValidateTestResult(Supplier, emptyJson);
     }
 
+    Y_UNIT_TEST_F(ShouldReportAvailabilityCounters, TEnv)
+    {
+        const TString fsId = "test_fs";
+        const TString clientId = "test_client";
+        const TString cloudId = "test_cloud";
+        const TString folderId = "test_folder";
+
+        Registry->GetFileSystemStats(fsId, clientId, cloudId, folderId);
+        Registry->RegisterUserStats(fsId, clientId, cloudId, folderId);
+
+        auto counters = Counters->GetSubgroup("component", METRIC_FS_COMPONENT)
+                            ->GetSubgroup("host", "cluster")
+                            ->GetSubgroup("filesystem", fsId)
+                            ->GetSubgroup("client", clientId)
+                            ->GetSubgroup("cloud", cloudId)
+                            ->GetSubgroup("folder", folderId);
+
+        // The user stats registration pre-creates the availability
+        // counters (the availability tracker registers them lazily), so
+        // setting them here reuses the very counters the user metrics are
+        // bound to - the same way the tracker does.
+        counters->GetCounter("Availability_TotalIntervals", true)->Set(30);
+        counters->GetCounter("Availability_AvailableIntervals", true)
+            ->Set(29);
+        counters->GetCounter("Availability_UnavailableIntervals", true)
+            ->Set(1);
+
+        const TString testResult = R"--({
+            "sensors": [
+                {
+                    "labels":
+                        {"name": "filestore.availability_total_intervals"},
+                    "value": 30
+                },
+                {
+                    "labels":
+                        {"name": "filestore.availability_available_intervals"},
+                    "value": 29
+                },
+                {
+                    "labels":
+                        {"name":
+                            "filestore.availability_unavailable_intervals"},
+                    "value": 1
+                }
+            ]
+        })--";
+        auto expectedJson = NJson::ReadJsonFastTree(testResult, true);
+        ValidateTestResult(Supplier, expectedJson);
+
+        // unregistration removes the availability user metrics as well
+        Registry->Unregister(fsId, clientId);
+        auto emptyJson = NJson::ReadJsonFastTree("{}", true);
+        ValidateTestResult(Supplier, emptyJson);
+    }
+
     Y_UNIT_TEST_F(ShouldReportUserStatsIsSourceMetricsChanged, TEnv)
     {
         const TString fsId = "test_fs";


### PR DESCRIPTION
### Notes
Right now the availability counters are exposed only in aggregated form, because I'm still not sure about the request names (whether we should use FUSE callbacks for availability request names or some other naming)

### Issue
#6825 