### PR TITLE
[Filestore] add critical events for availability counters 

### DIFF
--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -64,6 +64,7 @@ const char* GetAvailabilityRequestTypeName(
 ////////////////////////////////////////////////////////////////////////////////
 
 void TAvailabilityCounters::EnableAndRegister(
+    TString fileSystemId,
     TDuration intervalDuration,
     NMonitoring::TDynamicCounters& counters)
 {
@@ -73,6 +74,8 @@ void TAvailabilityCounters::EnableAndRegister(
     if (CountersRegistered.load(std::memory_order_acquire)) {
         return;
     }
+
+    FileSystemId = std::move(fileSystemId);
 
     // A zero interval duration selects the default one.
     IntervalDuration = intervalDuration == TDuration::Zero()
@@ -327,6 +330,9 @@ void TAvailabilityCounters::RollIntervals(TInstant now)
             (alignedNow - CurrentIntervalStart).MicroSeconds() /
             IntervalDuration.MicroSeconds();
         MissingIntervalsCounter->Add(missingIntervals);
+        ReportAvailabilityCountersMissingIntervals(
+            TStringBuilder() << "filesystem " << FileSystemId << ": "
+                << missingIntervals << " intervals were missed");
 
         CurrentIntervalStart = alignedNow;
     }
@@ -339,6 +345,7 @@ void TAvailabilityCounters::RollIntervals(TInstant now)
 void TAvailabilityCounters::RollInterval(bool publishCounters)
 {
     bool intervalAvailable = true;
+    TStringBuilder unavailableRequestTypes;
 
     // Index 0 is EFileStoreAvailabilityRequestType::None, stays unused.
     for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
@@ -349,6 +356,9 @@ void TAvailabilityCounters::RollInterval(bool publishCounters)
             // The aggregated interval availability is the logical AND over
             // the request types.
             intervalAvailable = false;
+            unavailableRequestTypes << " "
+                << GetAvailabilityRequestTypeName(
+                    static_cast<EFileStoreAvailabilityRequestType>(i));
         }
     }
 
@@ -360,6 +370,13 @@ void TAvailabilityCounters::RollInterval(bool publishCounters)
             UnavailableIntervalsCounter->Inc();
         }
         *LastIntervalAvailableCounter = intervalAvailable ? 1 : 0;
+
+        if (!intervalAvailable) {
+            ReportAvailabilityCountersUnavailableInterval(
+                TStringBuilder() << "filesystem " << FileSystemId
+                    << ", unavailable request types:"
+                    << unavailableRequestTypes);
+        }
     }
 
     CurrentIntervalStart += IntervalDuration;

--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -63,8 +63,11 @@ const char* GetAvailabilityRequestTypeName(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TAvailabilityCounters::TAvailabilityCounters(TString fileSystemId)
+    : FileSystemId{std::move(fileSystemId)}
+{}
+
 void TAvailabilityCounters::EnableAndRegister(
-    TString fileSystemId,
     TDuration intervalDuration,
     NMonitoring::TDynamicCounters& counters)
 {
@@ -74,8 +77,6 @@ void TAvailabilityCounters::EnableAndRegister(
     if (CountersRegistered.load(std::memory_order_acquire)) {
         return;
     }
-
-    FileSystemId = std::move(fileSystemId);
 
     // A zero interval duration selects the default one.
     IntervalDuration = intervalDuration == TDuration::Zero()

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -177,13 +177,14 @@ private:
     // Serializes EnableAndRegister() calls.
     TAdaptiveLock EnableLock;
 
-    TString FileSystemId;
+    const TString FileSystemId;
 
 public:
+    explicit TAvailabilityCounters(TString fileSystemId);
+
     // Registers the sensors and enables the tracking with the given
     // interval duration (zero selects the default one).
     void EnableAndRegister(
-        TString fileSystemId,
         TDuration intervalDuration,
         NMonitoring::TDynamicCounters& counters);
 

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -61,10 +61,10 @@ const char* GetAvailabilityRequestTypeName(
 //
 // Published sensors (registered on the per-filesystem per-client counters
 // subgroup of the request stats):
-//  * Availability_TotalIntervals       - derivative, finished 5-min intervals;
+//  * Availability_TotalIntervals       - derivative, finished intervals;
 //  * Availability_AvailableIntervals   - derivative, available intervals;
 //  * Availability_UnavailableIntervals - derivative, unavailable intervals;
-//  * Availability_LastIntervalAvailable - gauge, 1 if the last finished
+//  * Availability_LastIntervalAvailable - gauge, 1 if the last evaluated
 //                                        interval was available, 0 otherwise;
 // Availability_{Available,Unavailable}Intervals and
 // Availability_LastIntervalAvailable are also published per availability
@@ -177,11 +177,13 @@ private:
     // Serializes EnableAndRegister() calls.
     TAdaptiveLock EnableLock;
 
+    TString FileSystemId;
+
 public:
     // Registers the sensors and enables the tracking with the given
-    // interval duration (zero selects the default one). Thread-safe;
-    // repeated calls are no-ops.
+    // interval duration (zero selects the default one).
     void EnableAndRegister(
+        TString fileSystemId,
         TDuration intervalDuration,
         NMonitoring::TDynamicCounters& counters);
 

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -1,4 +1,5 @@
 #include "availability_counters.h"
+#include "critical_events.h"
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -37,7 +38,7 @@ struct TEnv
         // obvious
         : Now(TInstant::Hours(100))
     {
-        Counters.EnableAndRegister(IntervalDuration, *CounterGroup);
+        Counters.EnableAndRegister("fs", IntervalDuration, *CounterGroup);
         // the first call only initializes the interval boundary
         Counters.UpdateStats(Now);
 
@@ -211,6 +212,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
+        InitCriticalEventsCounter(env.CounterGroup);
+        const TString unavailableEvent =
+            "AppCriticalEvents/AvailabilityCountersUnavailableInterval";
+
         for (int i = 0; i < 3; ++i) {
             auto callContext = env.Start("write");
             env.CompleteWithErrno(callContext, EIO);
@@ -222,14 +227,22 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             0,       // available
             1,       // unavailable
             false);  // last interval available
+        // the unavailable interval raises the critical event
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            env.CounterGroup->GetCounter(unavailableEvent, true)->Val());
 
-        // the next interval has no requests => available again
+        // the next interval has no requests => available again, and no new
+        // critical event is raised
         env.FinishInterval();
         env.AssertIntervals(
             2,       // total
             1,       // available
             1,       // unavailable
             true);   // last interval available
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            env.CounterGroup->GetCounter(unavailableEvent, true)->Val());
     }
 
     Y_UNIT_TEST(ShouldReportMixedEioAndSuccessAsAvailable)
@@ -534,9 +547,13 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
     Y_UNIT_TEST(ShouldCountIntervalsMissedBeyondCatchUpLimit)
     {
+        const TString missingEvent =
+            "AppCriticalEvents/AvailabilityCountersMissingIntervals";
+
         // exactly at the catch-up limit every elapsed interval is evaluated
         {
             TEnv env;
+            InitCriticalEventsCounter(env.CounterGroup);
             env.Now += IntervalDuration * 30;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
@@ -545,11 +562,16 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 0,       // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(0, env.MissingIntervals->Val());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                env.CounterGroup->GetCounter(missingEvent, true)->Val());
         }
 
         // one interval beyond the limit is reported as missing, not dropped
+        // and raises the critical event
         {
             TEnv env;
+            InitCriticalEventsCounter(env.CounterGroup);
             env.Now += IntervalDuration * 31;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
@@ -558,11 +580,15 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 0,       // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(1, env.MissingIntervals->Val());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                env.CounterGroup->GetCounter(missingEvent, true)->Val());
         }
 
         // a five-hour gap: half evaluated, half reported as missing
         {
             TEnv env;
+            InitCriticalEventsCounter(env.CounterGroup);
             env.Now += IntervalDuration * 60;
             env.Counters.UpdateStats(env.Now);
             env.AssertIntervals(
@@ -571,6 +597,10 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 0,       // unavailable
                 true);   // last interval available
             UNIT_ASSERT_VALUES_EQUAL(30, env.MissingIntervals->Val());
+            // the realignment raises the event once, whatever the gap size
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                env.CounterGroup->GetCounter(missingEvent, true)->Val());
 
             // measurement continues normally afterwards
             env.FinishInterval();
@@ -951,11 +981,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         std::atomic<bool> go = false;
         std::thread enabler1([&] {
             while (!go.load()) {}
-            counters.EnableAndRegister(IntervalDuration, *counterGroup);
+            counters.EnableAndRegister("fs", IntervalDuration, *counterGroup);
         });
         std::thread enabler2([&] {
             while (!go.load()) {}
-            counters.EnableAndRegister(IntervalDuration, *counterGroup);
+            counters.EnableAndRegister("fs", IntervalDuration, *counterGroup);
         });
         go = true;
         enabler1.join();
@@ -1008,7 +1038,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         auto counterGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
         TAvailabilityCounters counters;
-        counters.EnableAndRegister(IntervalDuration, *counterGroup);
+        counters.EnableAndRegister("fs", IntervalDuration, *counterGroup);
 
         // The measurement begins with the first observed activity after
         // enabling - here the request event itself, with no updater tick

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -24,7 +24,7 @@ struct TEnv
 {
     NMonitoring::TDynamicCountersPtr CounterGroup =
         MakeIntrusive<NMonitoring::TDynamicCounters>();
-    TAvailabilityCounters Counters;
+    TAvailabilityCounters Counters{"fs"};
     TInstant Now;
 
     NMonitoring::TDynamicCounters::TCounterPtr TotalIntervals;
@@ -38,7 +38,7 @@ struct TEnv
         // obvious
         : Now(TInstant::Hours(100))
     {
-        Counters.EnableAndRegister("fs", IntervalDuration, *CounterGroup);
+        Counters.EnableAndRegister(IntervalDuration, *CounterGroup);
         // the first call only initializes the interval boundary
         Counters.UpdateStats(Now);
 
@@ -940,7 +940,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     Y_UNIT_TEST(ShouldEnableConcurrentlyWithRequestProcessing)
     {
         auto counterGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
-        TAvailabilityCounters counters;
+        TAvailabilityCounters counters{"fs"};
         const TInstant start = TInstant::Hours(100);
 
         // a request started before the tracking is enabled gets no stamp
@@ -981,11 +981,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         std::atomic<bool> go = false;
         std::thread enabler1([&] {
             while (!go.load()) {}
-            counters.EnableAndRegister("fs", IntervalDuration, *counterGroup);
+            counters.EnableAndRegister(IntervalDuration, *counterGroup);
         });
         std::thread enabler2([&] {
             while (!go.load()) {}
-            counters.EnableAndRegister("fs", IntervalDuration, *counterGroup);
+            counters.EnableAndRegister(IntervalDuration, *counterGroup);
         });
         go = true;
         enabler1.join();
@@ -1037,8 +1037,8 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     Y_UNIT_TEST(ShouldSkipPartiallyObservedFirstInterval)
     {
         auto counterGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
-        TAvailabilityCounters counters;
-        counters.EnableAndRegister("fs", IntervalDuration, *counterGroup);
+        TAvailabilityCounters counters{"fs"};
+        counters.EnableAndRegister(IntervalDuration, *counterGroup);
 
         // The measurement begins with the first observed activity after
         // enabling - here the request event itself, with no updater tick

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -67,6 +67,8 @@ namespace NCloud::NFileStore{
     xxx(ResetSessionInterrupted)                                               \
     xxx(DestroySessionInterrupted)                                             \
     xxx(IncompatibleFeatures)                                                  \
+    xxx(AvailabilityCountersUnavailableInterval)                               \
+    xxx(AvailabilityCountersMissingIntervals)                                  \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_CRITICAL_EVENTS_WITHOUT_LOGGING(xxx)                         \

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -472,15 +472,13 @@ public:
         , Predictor{std::move(predictor)}
         , PredictorStats{counters, std::move(timer)}
         , StatsCounters{std::move(counters)}
+        , AvailabilityCounters{FileSystemId}
     {}
 
     void EnableAvailabilityTracking(TDuration interval) override
     {
         // a zero interval selects the default one
-        AvailabilityCounters.EnableAndRegister(
-            FileSystemId,
-            interval,
-            *StatsCounters);
+        AvailabilityCounters.EnableAndRegister(interval, *StatsCounters);
     }
 
     void SetUserMetadata(TUserMetadata userMetadata)

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -477,7 +477,10 @@ public:
     void EnableAvailabilityTracking(TDuration interval) override
     {
         // a zero interval selects the default one
-        AvailabilityCounters.EnableAndRegister(interval, *StatsCounters);
+        AvailabilityCounters.EnableAndRegister(
+            FileSystemId,
+            interval,
+            *StatsCounters);
     }
 
     void SetUserMetadata(TUserMetadata userMetadata)


### PR DESCRIPTION
### Notes
Adding `AvailabilityCountersUnavailableInterval, AvailabilityCountersMissingIntervals` critical events.

The missing intervals critical event fires when the availability counters stall for some time and can't publish some counters on time

### Issue
#6825 
