### PR TITLE
[Filestore] Availability request names should match the request names reported in user stats

### DIFF
--- a/cloud/filestore/libs/diagnostics/availability_counters.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters.cpp
@@ -27,38 +27,38 @@ constexpr TDuration DefaultIntervalDuration = TDuration::Minutes(2);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const char* GetAvailabilityRequestTypeName(
-    EFileStoreAvailabilityRequestType requestType)
+const char* GetAvailabilityRequestName(EFileStoreRequest requestType)
 {
-    using EType = EFileStoreAvailabilityRequestType;
+    using EType = EFileStoreRequest;
     switch (requestType) {
-        case EType::Lookup: return "lookup";
-        case EType::GetAttr: return "getattr";
-        case EType::SetAttr: return "setattr";
+        case EType::AccessNode: return "access";
+        case EType::AcquireLock: return "acquirelock";
+        case EType::AllocateData: return "fallocate";
+        case EType::CreateHandle: return "open";
+        case EType::CreateNode: return "createnode";
+        case EType::DestroyHandle: return "release";
+        case EType::GetNodeAttr: return "getattr";
+        case EType::GetNodeXAttr: return "getxattr";
+        case EType::ListNodeXAttr: return "listxattr";
+        case EType::ListNodes: return "readdir";
+        case EType::ReadData: return "read";
         case EType::ReadLink: return "readlink";
-        case EType::MkDir: return "mkdir";
-        case EType::RmDir: return "rmdir";
-        case EType::Unlink: return "unlink";
-        case EType::SymLink: return "symlink";
-        case EType::Link: return "link";
-        case EType::Rename: return "rename";
-        case EType::Open: return "open";
-        case EType::Create: return "create";
-        case EType::Read: return "read";
-        case EType::Write: return "write";
-        case EType::WriteBuf: return "write_buf";
-        case EType::Flush: return "flush";
-        case EType::Fsync: return "fsync";
-        case EType::Release: return "release";
-        case EType::OpenDir: return "opendir";
-        case EType::ReadDir: return "readdir";
-        case EType::ReadDirPlus: return "readdirplus";
-        case EType::ReleaseDir: return "releasedir";
-        case EType::None:
-        case EType::MAX:
-            break;
+        case EType::ReleaseLock: return "releaselock";
+        case EType::RemoveNodeXAttr: return "removexattr";
+        case EType::RenameNode: return "rename";
+        case EType::SetNodeAttr: return "setattr";
+        case EType::SetNodeXAttr: return "setxattr";
+        case EType::StatFileStore: return "statfs";
+        case EType::UnlinkNode: return "unlink";
+        case EType::WriteData: return "write";
+        default:
+            return nullptr;
     }
-    return "unknown";
+}
+
+bool IsAvailabilityTrackedRequest(EFileStoreRequest requestType)
+{
+    return GetAvailabilityRequestName(requestType) != nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -101,13 +101,16 @@ void TAvailabilityCounters::EnableAndRegister(
     // No intervals have been reported yet - start as available.
     *LastIntervalAvailableCounter = 1;
 
-    // Index 0 is EFileStoreAvailabilityRequestType::None and stays unused.
-    for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
+    // Only the tracked request types get per-type sensors.
+    for (size_t i = 0; i < RequestTypeStates.size(); ++i) {
+        const auto requestType = static_cast<EFileStoreRequest>(i);
+        if (!IsAvailabilityTrackedRequest(requestType)) {
+            continue;
+        }
         auto& state = RequestTypeStates[i];
         auto requestCounters = counters.GetSubgroup(
             "request",
-            GetAvailabilityRequestTypeName(
-                static_cast<EFileStoreAvailabilityRequestType>(i)));
+            GetAvailabilityRequestName(requestType));
 
         state.AvailableIntervalsCounter = requestCounters->GetCounter(
             "Availability_AvailableIntervals",
@@ -133,14 +136,12 @@ void TAvailabilityCounters::RequestStarted(
         return;
     }
 
-    if (callContext.AvailabilityRequestType ==
-        EFileStoreAvailabilityRequestType::None)
-    {
+    if (!IsAvailabilityTrackedRequest(callContext.RequestType)) {
         return;
     }
 
     auto& state = RequestTypeStates[
-        static_cast<size_t>(callContext.AvailabilityRequestType)];
+        static_cast<size_t>(callContext.RequestType)];
 
     for (;;) {
         // Assign the event to its actual wall-clock interval: roll the
@@ -174,7 +175,7 @@ void TAvailabilityCounters::DoRequestStarted(
     if (callContext.AvailabilityIntervalSeqNo != 0) {
         ReportAvailabilityCountersDoubleRegistration(
             TStringBuilder() << "request type: "
-                << static_cast<ui32>(callContext.AvailabilityRequestType));
+                << GetAvailabilityRequestName(callContext.RequestType));
         return;
     }
 
@@ -192,14 +193,12 @@ void TAvailabilityCounters::RequestCompleted(
         return;
     }
 
-    if (callContext.AvailabilityRequestType ==
-        EFileStoreAvailabilityRequestType::None)
-    {
+    if (!IsAvailabilityTrackedRequest(callContext.RequestType)) {
         return;
     }
 
     auto& state = RequestTypeStates[
-        static_cast<size_t>(callContext.AvailabilityRequestType)];
+        static_cast<size_t>(callContext.RequestType)];
 
     for (;;) {
         // Assign the event to its actual wall-clock interval: roll the
@@ -348,8 +347,11 @@ void TAvailabilityCounters::RollInterval(bool publishCounters)
     bool intervalAvailable = true;
     TStringBuilder unavailableRequestTypes;
 
-    // Index 0 is EFileStoreAvailabilityRequestType::None, stays unused.
-    for (size_t i = 1; i < RequestTypeStates.size(); ++i) {
+    for (size_t i = 0; i < RequestTypeStates.size(); ++i) {
+        const auto requestType = static_cast<EFileStoreRequest>(i);
+        if (!IsAvailabilityTrackedRequest(requestType)) {
+            continue;
+        }
         if (!RollRequestTypeStateAndReturnAvailability(
                 RequestTypeStates[i],
                 publishCounters))
@@ -358,8 +360,7 @@ void TAvailabilityCounters::RollInterval(bool publishCounters)
             // the request types.
             intervalAvailable = false;
             unavailableRequestTypes << " "
-                << GetAvailabilityRequestTypeName(
-                    static_cast<EFileStoreAvailabilityRequestType>(i));
+                << GetAvailabilityRequestName(requestType);
         }
     }
 

--- a/cloud/filestore/libs/diagnostics/availability_counters.h
+++ b/cloud/filestore/libs/diagnostics/availability_counters.h
@@ -20,10 +20,12 @@ namespace NCloud::NFileStore {
 ////////////////////////////////////////////////////////////////////////////////
 
 // The value of the "request" label of the per-request-type availability
-// sensors: the FUSE request name in lower case, as listed in the SLA (e.g.
-// "lookup", "write_buf").
-const char* GetAvailabilityRequestTypeName(
-    EFileStoreAvailabilityRequestType requestType);
+// sensors: the request name in lower case, as listed in the SLA (e.g.
+// "lookup", "write").
+const char* GetAvailabilityRequestName(EFileStoreRequest requestType);
+
+// Whether the backend request type is subject to the availability SLA.
+bool IsAvailabilityTrackedRequest(EFileStoreRequest requestType);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -49,12 +51,6 @@ const char* GetAvailabilityRequestTypeName(
 // A request is hung if it was outstanding for the entire duration of the N-minute
 // interval.
 //
-// Request type - an individual FUSE request type subject to the SLA, see
-// EFileStoreAvailabilityRequestType. Distinct FUSE request types are
-// accounted independently even when they map to the same backend request
-// type, and requests outside the SLA (AvailabilityRequestType == None) are
-// ignored entirely.
-//
 // The EIO classification is based on TCallContext::GuestReplyErrno - the
 // errno actually sent to the guest - because the internal request error does
 // not always match the guest-visible outcome.
@@ -68,7 +64,7 @@ const char* GetAvailabilityRequestTypeName(
 //                                        interval was available, 0 otherwise;
 // Availability_{Available,Unavailable}Intervals and
 // Availability_LastIntervalAvailable are also published per availability
-// request type, on the "request=<type>" subgroup (e.g. request=lookup):
+// request type, on the "request=<type>" subgroup (e.g. request=read):
 // there an interval is available if that request type alone shows no
 // unavailability evidence.
 //
@@ -142,7 +138,7 @@ private:
     // Assigned by EnableAndRegister().
     TDuration IntervalDuration;
 
-    std::array<TRequestTypeState, FileStoreAvailabilityRequestTypeCount>
+    std::array<TRequestTypeState, FileStoreRequestCount>
         RequestTypeStates;
 
     // Guarded by RollLock.

--- a/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/availability_counters_ut.cpp
@@ -16,7 +16,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-using ERequestType = EFileStoreAvailabilityRequestType;
+using ERequestType = EFileStoreRequest;
 
 constexpr TDuration IntervalDuration = TDuration::Minutes(5);
 
@@ -72,21 +72,21 @@ struct TEnv
     // production forward mapping.
     static ERequestType RequestTypeByName(const TString& requestName)
     {
-        // index 0 is ERequestType::None, which has no published name
-        for (size_t i = 1; i < FileStoreAvailabilityRequestTypeCount; ++i) {
+        for (size_t i = 0; i < FileStoreRequestCount; ++i) {
             const auto requestType = static_cast<ERequestType>(i);
-            if (requestName == GetAvailabilityRequestTypeName(requestType)) {
+            const auto* name = GetAvailabilityRequestName(requestType);
+            if (name && requestName == name) {
                 return requestType;
             }
         }
         UNIT_FAIL("unknown availability request name: " << requestName);
-        return ERequestType::None;
+        return ERequestType::MAX;
     }
 
     TCallContextPtr Start(const TString& requestName)
     {
         auto callContext = MakeIntrusive<TCallContext>();
-        callContext->AvailabilityRequestType = RequestTypeByName(requestName);
+        callContext->RequestType = RequestTypeByName(requestName);
         Counters.RequestStarted(*callContext, Now);
         return callContext;
     }
@@ -197,7 +197,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // completion with an error response other than EIO is a normal
         // terminal outcome
-        auto callContext = env.Start("getattr");
+        auto callContext = env.Start("setattr");
         env.CompleteWithErrno(callContext, ENOENT);
 
         env.FinishInterval();
@@ -268,7 +268,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         // the request is started in interval 1...
-        auto callContext = env.Start("fsync");
+        auto callContext = env.Start("access");
 
         // ...so it is not hung during interval 1 (it has not been
         // outstanding throughout the entire interval)
@@ -493,13 +493,16 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
+        // Ping is outside the tracked set (the request types exposed in
+        // the user stats), so it must not affect the metric even if it
+        // fails with EIO or hangs.
         auto eioContext = MakeIntrusive<TCallContext>();
-        eioContext->AvailabilityRequestType = ERequestType::None;
+        eioContext->RequestType = ERequestType::Ping;
         env.Counters.RequestStarted(*eioContext, env.Now);
         env.CompleteWithErrno(eioContext, EIO);
         // never completed
         auto hungContext = MakeIntrusive<TCallContext>();
-        hungContext->AvailabilityRequestType = ERequestType::None;
+        hungContext->RequestType = ERequestType::Ping;
         env.Counters.RequestStarted(*hungContext, env.Now);
 
         env.FinishInterval();
@@ -666,7 +669,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         TEnv env;
 
         // a request hangs and the stats updater stalls for 3 intervals
-        auto callContext = env.Start("getattr");
+        auto callContext = env.Start("setattr");
         env.FinishInterval();
         env.AssertIntervals(
             1,       // total
@@ -699,7 +702,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // an EIO completion of a request that both started and finished
         // within the interval still makes the interval unavailable
-        auto callContext = env.Start("mkdir");
+        auto callContext = env.Start("readdir");
         env.AdvanceWithinInterval(TDuration::Seconds(30));
         env.CompleteWithErrno(callContext, EIO);
 
@@ -714,11 +717,11 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     Y_UNIT_TEST(ShouldAccountRequestTypesIndependently)
     {
         {
-            // lookup and getattr both map to GetNodeAttr
+            // attribute reads and writes are distinct request types
             TEnv env;
-            auto bad = env.Start("lookup");
+            auto bad = env.Start("getattr");
             env.CompleteWithErrno(bad, EIO);
-            auto good = env.Start("getattr");
+            auto good = env.Start("setattr");
             env.CompleteOk(good);
 
             env.FinishInterval();
@@ -728,23 +731,23 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 1,       // unavailable
                 false);  // last interval available
             env.AssertRequestIntervals(
-                "lookup",
+                "getattr",
                 0,       // available
                 1,       // unavailable
                 false);  // last interval available
             env.AssertRequestIntervals(
-                "getattr",
+                "setattr",
                 1,       // available
                 0,       // unavailable
                 true);   // last interval available
         }
 
         {
-            // open and create both map to CreateHandle
+            // handle creation and node creation are distinct request types
             TEnv env;
             auto bad = env.Start("open");
             env.CompleteWithErrno(bad, EIO);
-            auto good = env.Start("create");
+            auto good = env.Start("createnode");
             env.CompleteOk(good);
 
             env.FinishInterval();
@@ -759,18 +762,18 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 1,       // unavailable
                 false);  // last interval available
             env.AssertRequestIntervals(
-                "create",
+                "createnode",
                 1,       // available
                 0,       // unavailable
                 true);   // last interval available
         }
 
         {
-            // mkdir and symlink both map to CreateNode
+            // directory listing and rename are distinct request types
             TEnv env;
-            auto bad = env.Start("mkdir");
+            auto bad = env.Start("readdir");
             env.CompleteWithErrno(bad, EIO);
-            auto good = env.Start("symlink");
+            auto good = env.Start("rename");
             env.CompleteOk(good);
 
             env.FinishInterval();
@@ -780,23 +783,23 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 1,       // unavailable
                 false);  // last interval available
             env.AssertRequestIntervals(
-                "mkdir",
+                "readdir",
                 0,       // available
                 1,       // unavailable
                 false);  // last interval available
             env.AssertRequestIntervals(
-                "symlink",
+                "rename",
                 1,       // available
                 0,       // unavailable
                 true);   // last interval available
         }
 
         {
-            // write and write_buf both map to WriteData
+            // data writes and node unlinks are distinct request types
             TEnv env;
             auto bad = env.Start("write");
             env.CompleteWithErrno(bad, EIO);
-            auto good = env.Start("write_buf");
+            auto good = env.Start("unlink");
             env.CompleteOk(good);
 
             env.FinishInterval();
@@ -811,7 +814,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
                 1,       // unavailable
                 false);  // last interval available
             env.AssertRequestIntervals(
-                "write_buf",
+                "unlink",
                 1,       // available
                 0,       // unavailable
                 true);   // last interval available
@@ -945,7 +948,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // a request started before the tracking is enabled gets no stamp
         auto preEnable = MakeIntrusive<TCallContext>();
-        preEnable->AvailabilityRequestType = ERequestType::Read;
+        preEnable->RequestType = ERequestType::ReadData;
         counters.RequestStarted(*preEnable, start);
         UNIT_ASSERT_VALUES_EQUAL(0, preEnable->AvailabilityIntervalSeqNo);
 
@@ -961,7 +964,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         std::thread requester([&] {
             while (!stop.load()) {
                 auto context = MakeIntrusive<TCallContext>();
-                context->AvailabilityRequestType = ERequestType::Read;
+                context->RequestType = ERequestType::ReadData;
                 const auto now = TInstant::MicroSeconds(nowUs.load());
                 counters.RequestStarted(*context, now);
                 counters.RequestCompleted(*context, now);
@@ -1010,7 +1013,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
         const auto end = TInstant::MicroSeconds(nowUs.load());
         counters.RequestCompleted(*preEnable, end);
         auto repeated = MakeIntrusive<TCallContext>();
-        repeated->AvailabilityRequestType = ERequestType::Read;
+        repeated->RequestType = ERequestType::ReadData;
         counters.RequestStarted(*repeated, end);
         counters.RequestCompleted(*repeated, end);
         counters.RequestCompleted(*repeated, end);
@@ -1048,7 +1051,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
 
         // an EIO completion within the partially observed interval
         auto context = MakeIntrusive<TCallContext>();
-        context->AvailabilityRequestType = ERequestType::Read;
+        context->RequestType = ERequestType::ReadData;
         counters.RequestStarted(*context, firstEventTime);
         context->GuestReplyErrno = EIO;
         counters.RequestCompleted(*context, firstEventTime);
@@ -1083,17 +1086,8 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
     {
         TEnv env;
 
-        // the "request" label value is the lower-case FUSE request name as
-        // listed in the SLA
-        UNIT_ASSERT_VALUES_EQUAL(
-            "write",
-            TString(GetAvailabilityRequestTypeName(
-                ERequestType::Write)));
-        UNIT_ASSERT_VALUES_EQUAL(
-            "write_buf",
-            TString(GetAvailabilityRequestTypeName(
-                ERequestType::WriteBuf)));
-
+        // the "request" label value is the user stats name of the request
+        // type (e.g. read, open, fallocate)
         auto badContext = env.Start("write");
         env.CompleteWithErrno(badContext, EIO);
 
@@ -1151,7 +1145,7 @@ Y_UNIT_TEST_SUITE(TAvailabilityCountersTest)
             0,       // unavailable
             true);   // last interval available
         env.AssertRequestIntervals(
-            "lookup",
+            "getattr",
             0,       // available
             0,       // unavailable
             true);   // last interval available

--- a/cloud/filestore/libs/service/context.h
+++ b/cloud/filestore/libs/service/context.h
@@ -20,11 +20,6 @@ public:
 
     EFileStoreRequest RequestType = EFileStoreRequest::MAX;
 
-    // The request type as accounted by the per-client availability
-    // metric (None for requests outside the availability SLA).
-    EFileStoreAvailabilityRequestType AvailabilityRequestType =
-        EFileStoreAvailabilityRequestType::None;
-
     ui64 RequestSize = 0;
     bool Unaligned = false;
 

--- a/cloud/filestore/libs/service/request.h
+++ b/cloud/filestore/libs/service/request.h
@@ -225,49 +225,6 @@ constexpr size_t FileStoreRequestCount = static_cast<size_t>(EFileStoreRequest::
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Guest (FUSE) request types for which the per-client filesystem availability
-// SLA is defined: readdir, readdirplus, opendir, releasedir, lookup, getattr,
-// setattr, write, write_buf, read, open, create, release, mkdir, rmdir,
-// unlink, rename, link, symlink, readlink, flush, fsync.
-//
-// A dedicated enum is required because EFileStoreRequest maps several
-// distinct FUSE request types onto one backend request type (e.g. lookup and
-// getattr both map to GetNodeAttr, and mkdir, symlink, link and even mknod
-// all map to CreateNode).
-enum class EFileStoreAvailabilityRequestType
-{
-    // the request is not subject to the availability SLA
-    None = 0,
-
-    Lookup = 1,
-    GetAttr = 2,
-    SetAttr = 3,
-    ReadLink = 4,
-    MkDir = 5,
-    RmDir = 6,
-    Unlink = 7,
-    SymLink = 8,
-    Link = 9,
-    Rename = 10,
-    Open = 11,
-    Create = 12,
-    Read = 13,
-    Write = 14,
-    WriteBuf = 15,
-    Flush = 16,
-    Fsync = 17,
-    Release = 18,
-    OpenDir = 19,
-    ReadDir = 20,
-    ReadDirPlus = 21,
-    ReleaseDir = 22,
-
-    MAX = 23,
-};
-
-constexpr size_t FileStoreAvailabilityRequestTypeCount =
-    static_cast<size_t>(EFileStoreAvailabilityRequestType::MAX);
-
 const TString& GetFileStoreRequestName(EFileStoreRequest requestType);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -7537,8 +7537,8 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                 "Availability_AvailableIntervals",
                 true)->Val());
 
-        // the fuse create callback is published under request=create
-        auto createCounters = counters->FindSubgroup("request", "create");
+        // the fuse create callback is published under request=open
+        auto createCounters = counters->FindSubgroup("request", "open");
         UNIT_ASSERT(createCounters);
         UNIT_ASSERT_VALUES_EQUAL(
             1,
@@ -7606,7 +7606,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             counters->GetCounter(
                 "Availability_LastIntervalAvailable")->Val());
 
-        auto createCounters = counters->FindSubgroup("request", "create");
+        auto createCounters = counters->FindSubgroup("request", "open");
         UNIT_ASSERT(createCounters);
         UNIT_ASSERT_VALUES_EQUAL(
             1,

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1615,7 +1615,6 @@ private:
         Method&& m,
         const char* name,
         EFileStoreRequest requestType,
-        EFileStoreAvailabilityRequestType availabilityRequestType,
         ui32 requestSize,
         fuse_req_t req,
         Args&&... args) noexcept
@@ -1627,7 +1626,6 @@ private:
             pThis->Config->GetFileSystemId(),
             fuse_req_unique(req));
         callContext->RequestType = requestType;
-        callContext->AvailabilityRequestType = availabilityRequestType;
         callContext->RequestSize = requestSize;
         callContext->LoopThreadId = TThread::CurrentThreadNumericId();
 
@@ -1678,18 +1676,15 @@ private:
 
     static void InitOps(fuse_lowlevel_ops& ops)
     {
-#define CALL(m, requestType, availabilityRequestType, requestSize, req, ...)  \
+#define CALL(m, requestType, requestSize, req, ...)                            \
     TFileSystemLoop::Call(                                                     \
         &IFileSystem::m,                                                       \
         #m,                                                                    \
         requestType,                                                           \
-        availabilityRequestType,                                               \
         requestSize,                                                           \
         req,                                                                   \
         __VA_ARGS__)                                                           \
 // CALL
-
-        using EAvailability = EFileStoreAvailabilityRequestType;
 
         // clang-format off
 
@@ -1709,7 +1704,7 @@ private:
         //
 
         ops.statfs = [] (fuse_req_t req, fuse_ino_t ino) {
-            CALL(StatFs, EFileStoreRequest::StatFileStore, EAvailability::None, 0, req, ino);
+            CALL(StatFs, EFileStoreRequest::StatFileStore, 0, req, ino);
         };
 
         //
@@ -1717,43 +1712,43 @@ private:
         //
 
         ops.lookup = [] (fuse_req_t req, fuse_ino_t parent, const char* name) {
-            CALL(Lookup, EFileStoreRequest::GetNodeAttr, EAvailability::Lookup, 0, req, parent, name);
+            CALL(Lookup, EFileStoreRequest::GetNodeAttr, 0, req, parent, name);
         };
         ops.forget = [] (fuse_req_t req, fuse_ino_t ino, unsigned long nlookup) {
-            CALL(Forget, EFileStoreRequest::Forget, EAvailability::None, 0, req, ino, nlookup);
+            CALL(Forget, EFileStoreRequest::Forget, 0, req, ino, nlookup);
         };
         ops.forget_multi = [] (fuse_req_t req, size_t count, fuse_forget_data* forgets) {
-            CALL(ForgetMulti, EFileStoreRequest::ForgetMulti, EAvailability::None, 0, req, count, forgets);
+            CALL(ForgetMulti, EFileStoreRequest::ForgetMulti, 0, req, count, forgets);
         };
         ops.mkdir = [] (fuse_req_t req, fuse_ino_t parent, const char* name, mode_t mode) {
-            CALL(MkDir, EFileStoreRequest::CreateNode, EAvailability::MkDir, 0, req, parent, name, mode);
+            CALL(MkDir, EFileStoreRequest::CreateNode, 0, req, parent, name, mode);
         };
         ops.rmdir = [] (fuse_req_t req, fuse_ino_t parent, const char* name) {
-            CALL(RmDir, EFileStoreRequest::UnlinkNode, EAvailability::RmDir, 0, req, parent, name);
+            CALL(RmDir, EFileStoreRequest::UnlinkNode, 0, req, parent, name);
         };
         ops.mknod = [] (fuse_req_t req, fuse_ino_t parent, const char* name, mode_t mode, dev_t rdev) {
-            CALL(MkNode, EFileStoreRequest::CreateNode, EAvailability::None, 0, req, parent, name, mode, rdev);
+            CALL(MkNode, EFileStoreRequest::CreateNode, 0, req, parent, name, mode, rdev);
         };
         ops.unlink = [] (fuse_req_t req, fuse_ino_t parent, const char* name) {
-            CALL(Unlink, EFileStoreRequest::UnlinkNode, EAvailability::Unlink, 0, req, parent, name);
+            CALL(Unlink, EFileStoreRequest::UnlinkNode, 0, req, parent, name);
         };
 #if defined(FUSE_VIRTIO)
         ops.rename = [] (fuse_req_t req, fuse_ino_t parent, const char* name, fuse_ino_t newparent, const char* newname, uint32_t flags) {
-            CALL(Rename, EFileStoreRequest::RenameNode, EAvailability::Rename, 0, req, parent, name, newparent, newname, flags);
+            CALL(Rename, EFileStoreRequest::RenameNode, 0, req, parent, name, newparent, newname, flags);
         };
 #else
         ops.rename = [] (fuse_req_t req, fuse_ino_t parent, const char* name, fuse_ino_t newparent, const char* newname) {
-            CALL(Rename, EFileStoreRequest::RenameNode, EAvailability::Rename, 0, req, parent, name, newparent, newname, 0);
+            CALL(Rename, EFileStoreRequest::RenameNode, 0, req, parent, name, newparent, newname, 0);
         };
 #endif
         ops.symlink = [] (fuse_req_t req, const char* link, fuse_ino_t parent, const char* name) {
-            CALL(SymLink, EFileStoreRequest::CreateNode, EAvailability::SymLink, 0, req, link, parent, name);
+            CALL(SymLink, EFileStoreRequest::CreateNode, 0, req, link, parent, name);
         };
         ops.link = [] (fuse_req_t req, fuse_ino_t ino, fuse_ino_t newparent, const char* newname) {
-            CALL(Link, EFileStoreRequest::CreateNode, EAvailability::Link, 0, req, ino, newparent, newname);
+            CALL(Link, EFileStoreRequest::CreateNode, 0, req, ino, newparent, newname);
         };
         ops.readlink = [] (fuse_req_t req, fuse_ino_t ino) {
-            CALL(ReadLink, EFileStoreRequest::ReadLink, EAvailability::ReadLink, 0, req, ino);
+            CALL(ReadLink, EFileStoreRequest::ReadLink, 0, req, ino);
         };
 
         //
@@ -1761,13 +1756,13 @@ private:
         //
 
         ops.setattr = [] (fuse_req_t req, fuse_ino_t ino, struct stat* attr, int to_set, fuse_file_info* fi) {
-            CALL(SetAttr, EFileStoreRequest::SetNodeAttr, EAvailability::SetAttr, 0, req, ino, attr, to_set, fi);
+            CALL(SetAttr, EFileStoreRequest::SetNodeAttr, 0, req, ino, attr, to_set, fi);
         };
         ops.getattr = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(GetAttr, EFileStoreRequest::GetNodeAttr, EAvailability::GetAttr, 0, req, ino, fi);
+            CALL(GetAttr, EFileStoreRequest::GetNodeAttr, 0, req, ino, fi);
         };
         ops.access = [] (fuse_req_t req, fuse_ino_t ino, int mask) {
-            CALL(Access, EFileStoreRequest::AccessNode, EAvailability::None, 0, req, ino, mask);
+            CALL(Access, EFileStoreRequest::AccessNode, 0, req, ino, mask);
         };
 
         //
@@ -1775,16 +1770,16 @@ private:
         //
 
         ops.setxattr = [] (fuse_req_t req, fuse_ino_t ino, const char* name, const char* value, size_t size, int flags) {
-            CALL(SetXAttr, EFileStoreRequest::SetNodeXAttr, EAvailability::None, 0, req, ino, name, TString{value, size}, flags);
+            CALL(SetXAttr, EFileStoreRequest::SetNodeXAttr, 0, req, ino, name, TString{value, size}, flags);
         };
         ops.getxattr = [] (fuse_req_t req, fuse_ino_t ino, const char* name, size_t size) {
-            CALL(GetXAttr, EFileStoreRequest::GetNodeXAttr, EAvailability::None, 0, req, ino, name, size);
+            CALL(GetXAttr, EFileStoreRequest::GetNodeXAttr, 0, req, ino, name, size);
         };
         ops.listxattr = [] (fuse_req_t req, fuse_ino_t ino, size_t size) {
-            CALL(ListXAttr, EFileStoreRequest::ListNodeXAttr, EAvailability::None, 0, req, ino, size);
+            CALL(ListXAttr, EFileStoreRequest::ListNodeXAttr, 0, req, ino, size);
         };
         ops.removexattr = [] (fuse_req_t req, fuse_ino_t ino, const char* name) {
-            CALL(RemoveXAttr, EFileStoreRequest::RemoveNodeXAttr, EAvailability::None, 0, req, ino, name);
+            CALL(RemoveXAttr, EFileStoreRequest::RemoveNodeXAttr, 0, req, ino, name);
         };
 
         //
@@ -1792,19 +1787,19 @@ private:
         //
 
         ops.opendir = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(OpenDir, EFileStoreRequest::OpenDir, EAvailability::OpenDir, 0, req, ino, fi);
+            CALL(OpenDir, EFileStoreRequest::OpenDir, 0, req, ino, fi);
         };
 #if defined(FUSE_VIRTIO)
         ops.readdirplus = [] (fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, fuse_file_info* fi) {
-            CALL(ReadDir, EFileStoreRequest::ListNodes, EAvailability::ReadDirPlus, 0, req, ino, size, offset, fi);
+            CALL(ReadDir, EFileStoreRequest::ListNodes, 0, req, ino, size, offset, fi);
         };
 #else
         ops.readdir = [] (fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, fuse_file_info* fi) {
-            CALL(ReadDir, EFileStoreRequest::ListNodes, EAvailability::ReadDir, 0, req, ino, size, offset, fi);
+            CALL(ReadDir, EFileStoreRequest::ListNodes, 0, req, ino, size, offset, fi);
         };
 #endif
         ops.releasedir = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(ReleaseDir, EFileStoreRequest::ReleaseDir, EAvailability::ReleaseDir, 0, req, ino, fi);
+            CALL(ReleaseDir, EFileStoreRequest::ReleaseDir, 0, req, ino, fi);
         };
 
         //
@@ -1812,34 +1807,34 @@ private:
         //
 
         ops.create = [] (fuse_req_t req, fuse_ino_t parent, const char* name, mode_t mode, fuse_file_info* fi) {
-            CALL(Create, EFileStoreRequest::CreateHandle, EAvailability::Create, 0, req, parent, name, mode, fi);
+            CALL(Create, EFileStoreRequest::CreateHandle, 0, req, parent, name, mode, fi);
         };
         ops.open = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Open, EFileStoreRequest::CreateHandle, EAvailability::Open, 0, req, ino, fi);
+            CALL(Open, EFileStoreRequest::CreateHandle, 0, req, ino, fi);
         };
         ops.read = [] (fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, fuse_file_info* fi) {
-            CALL(Read, EFileStoreRequest::ReadData, EAvailability::Read, size, req, ino, size, offset, fi);
+            CALL(Read, EFileStoreRequest::ReadData, size, req, ino, size, offset, fi);
         };
         ops.write = [] (fuse_req_t req, fuse_ino_t ino, const char* buf, size_t size, off_t offset, fuse_file_info* fi) {
-            CALL(Write, EFileStoreRequest::WriteData, EAvailability::Write, size, req, ino, TStringBuf{buf, size}, offset, fi);
+            CALL(Write, EFileStoreRequest::WriteData, size, req, ino, TStringBuf{buf, size}, offset, fi);
         };
         ops.write_buf = [] (fuse_req_t req, fuse_ino_t ino, fuse_bufvec* bufv, off_t offset, fuse_file_info* fi) {
-            CALL(WriteBuf, EFileStoreRequest::WriteData, EAvailability::WriteBuf, fuse_buf_size(bufv), req, ino, bufv, offset, fi);
+            CALL(WriteBuf, EFileStoreRequest::WriteData, fuse_buf_size(bufv), req, ino, bufv, offset, fi);
         };
         ops.fallocate = [] (fuse_req_t req, fuse_ino_t ino, int mode, off_t offset, off_t length, fuse_file_info* fi) {
-            CALL(FAllocate, EFileStoreRequest::AllocateData, EAvailability::None, length, req, ino, mode, offset, length, fi);
+            CALL(FAllocate, EFileStoreRequest::AllocateData, length, req, ino, mode, offset, length, fi);
         };
         ops.flush = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Flush, EFileStoreRequest::FuseFlush, EAvailability::Flush, 0, req, ino, fi);
+            CALL(Flush, EFileStoreRequest::FuseFlush, 0, req, ino, fi);
         };
         ops.fsync = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
-            CALL(FSync, EFileStoreRequest::FuseFsync, EAvailability::Fsync, 0, req, ino, datasync, fi);
+            CALL(FSync, EFileStoreRequest::FuseFsync, 0, req, ino, datasync, fi);
         };
         ops.fsyncdir = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
-            CALL(FSyncDir, EFileStoreRequest::FuseFsyncDir, EAvailability::None, 0, req, ino, datasync, fi);
+            CALL(FSyncDir, EFileStoreRequest::FuseFsyncDir, 0, req, ino, datasync, fi);
         };
         ops.release = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Release, EFileStoreRequest::DestroyHandle, EAvailability::Release, 0, req, ino, fi);
+            CALL(Release, EFileStoreRequest::DestroyHandle, 0, req, ino, fi);
         };
 
         //
@@ -1847,13 +1842,13 @@ private:
         //
 
         ops.getlk = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi, struct flock* lock) {
-            CALL(GetLock, EFileStoreRequest::TestLock, EAvailability::None, lock->l_len, req, ino, fi, lock);
+            CALL(GetLock, EFileStoreRequest::TestLock, lock->l_len, req, ino, fi, lock);
         };
         ops.setlk = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi, struct flock* lock, int sleep) {
-            CALL(SetLock, GetLockRequestType(lock), EAvailability::None, lock->l_len, req, ino, fi, lock, sleep != 0);
+            CALL(SetLock, GetLockRequestType(lock), lock->l_len, req, ino, fi, lock, sleep != 0);
         };
         ops.flock = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi, int op) {
-            CALL(FLock, GetLockRequestType(op), EAvailability::None, 0, req, ino, fi, op);
+            CALL(FLock, GetLockRequestType(op), 0, req, ino, fi, op);
         };
 #undef CALL
 


### PR DESCRIPTION
### Notes
It would be less contradictory to report the same availability request types that we report to user stats. See https://github.com/ydb-platform/nbs/blob/360c8a46179a00b2ad84471a6c43875af602c449/cloud/filestore/libs/diagnostics/user_counter.cpp#L48

### Issue
#6825 
