### PR TITLE
issue-5895: fastshard - enforcing proper bit count limit in TPersistentBitmap

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
@@ -1,5 +1,7 @@
 #include "persistent_bitmap.h"
 
+#include <silk/util/logger.h>
+
 #include <util/string/builder.h>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
@@ -251,8 +253,7 @@ NProto::TError TPersistentBitmap::InitIfNeeded() const
             const ui64 endBit = MaxBits % bitsPerPage;
             if (endBit) {
                 if (endBit % 8 != 0) {
-                    return MakeError(E_INVALID_STATE, TStringBuilder()
-                        << "unaligned max bit count: " << MaxBits);
+                    SILK_WARN("unaligned max bit count: %lu", MaxBits);
                 }
 
                 const ui64 endByte = endBit / 8;

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
@@ -92,12 +92,12 @@ ui64 FindFirstFreeBit(const TBuffer& bitmapPage)
 
 bool TPersistentBitmap::Validate(ui64 bit, NProto::TError* error) const
 {
-    if (bit >= PageCount * BitsPerPage) {
+    if (bit >= MaxBits) {
         *error = MakeError(
             E_ARGUMENT,
             TStringBuilder() << "out of bounds"
                                 " bitmap access: "
-                             << bit << " >= " << (PageCount * BitsPerPage));
+                             << bit << " >= " << MaxBits);
         return false;
     }
 
@@ -218,6 +218,13 @@ NProto::TError TPersistentBitmap::Allocate(
         *bits += PopCount(page);
     }
 
+    Y_ABORT_UNLESS(
+        *bits >= UnusedBits,
+        "bits=%lu, unused=%lu",
+        *bits,
+        UnusedBits);
+    *bits -= UnusedBits;
+
     return {};
 }
 
@@ -227,9 +234,10 @@ NProto::TError TPersistentBitmap::InitIfNeeded() const
         return {};
     }
 
-    BitmapPages.resize(PageCount);
+    const ui64 bitsPerPage = CalcBitsPerPage(PageSize);
+    BitmapPages.resize(GetPageCount());
 
-    for (ui64 i = 0; i < PageCount; ++i) {
+    for (ui64 i = 0; i < BitmapPages.size(); ++i) {
         const ui64 pageNo = FirstPageNo + i;
         auto error = PageStore->ReadPage(0 /* lsn */, pageNo, &BitmapPages[i]);
         if (HasError(error)) {
@@ -238,6 +246,23 @@ NProto::TError TPersistentBitmap::InitIfNeeded() const
         }
 
         Y_ABORT_UNLESS(BitmapPages[i].Size() == PageSize);
+
+        if (i == BitmapPages.size() - 1) {
+            const ui64 endBit = MaxBits % bitsPerPage;
+            if (endBit) {
+                if (endBit % 8 != 0) {
+                    return MakeError(E_INVALID_STATE, TStringBuilder()
+                        << "unaligned max bit count: " << MaxBits);
+                }
+
+                const ui64 endByte = endBit / 8;
+                memset(
+                    BitmapPages[i].data() + endByte,
+                    0xFF,
+                    PageSize - endByte);
+                UnusedBits = (PageSize - endByte) * 8;
+            }
+        }
 
         if (!IsFull(BitmapPages[i])) {
             BitmapPagesWithFreeBits.push(i);

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
@@ -15,22 +15,23 @@ class TPersistentBitmap
 {
 private:
     const ui64 FirstPageNo;
-    const ui64 PageCount;
+    const ui64 MaxBits;
     const ui64 PageSize;
     const ui64 BitsPerPage;
     IPageStorePtr PageStore;
 
     mutable TVector<TBuffer> BitmapPages;
     mutable TStack<ui64> BitmapPagesWithFreeBits;
+    mutable ui64 UnusedBits = 0;
 
 public:
     TPersistentBitmap(
         ui64 firstPageNo,
-        ui64 pageCount,
+        ui64 maxBits,
         ui64 pageSize,
         IPageStorePtr pageStore)
         : FirstPageNo(firstPageNo)
-        , PageCount(pageCount)
+        , MaxBits(maxBits)
         , PageSize(pageSize)
         , BitsPerPage(CalcBitsPerPage(pageSize))
         , PageStore(std::move(pageStore))
@@ -44,14 +45,25 @@ public:
     Allocate(ui64 lsn, ui64* bit, TVector<TPageGroup>& pageGroups);
     [[nodiscard]] NProto::TError CountBits(ui64* bits) const;
 
-    [[nodiscard]] static ui64 CalcBitsPerPage(ui64 pageSize)
+    [[nodiscard]] ui64 GetMaxBits() const
     {
-        return pageSize * 8;
+        return MaxBits;
+    }
+
+    [[nodiscard]] ui64 GetPageCount() const
+    {
+        const ui64 bitsPerPage = CalcBitsPerPage(PageSize);
+        return AlignUp(MaxBits, bitsPerPage) / bitsPerPage;
     }
 
 private:
     [[nodiscard]] bool Validate(ui64 bit, NProto::TError* error) const;
     [[nodiscard]] NProto::TError InitIfNeeded() const;
+
+    [[nodiscard]] static ui64 CalcBitsPerPage(ui64 pageSize)
+    {
+        return pageSize * 8;
+    }
 };
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
@@ -49,12 +49,13 @@ void Rollback(TVector<TPageGroup>& groups, IPageStore& pageStore)
 struct TFixture
 {
     const ui64 FirstPageNo = 10;
-    const ui64 MaxBits = 60000;
+    const ui64 MaxBits;
 
     IPageStorePtr PageStore = CreateMemPageStore(PageSize);
     std::unique_ptr<TPersistentBitmap> Bitmap;
 
-    TFixture()
+    TFixture(ui64 maxBits = 60000)
+        : MaxBits(maxBits)
     {
         Reload();
     }
@@ -140,9 +141,9 @@ TEST(PersistentBitmapTest, SetResetAllocate)
     ASSERT_TRUE(bit2 != bit3) << bit;
 }
 
-TEST(PersistentBitmapTest, OutOfSpace)
+void DoTestOutOfSpace(ui64 maxBits)
 {
-    TFixture fx;
+    TFixture fx(maxBits);
 
     TVector<TPageGroup> pageGroups;
 
@@ -176,6 +177,16 @@ TEST(PersistentBitmapTest, OutOfSpace)
     ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
     Flush(pageGroups, *fx.PageStore);
     ASSERT_EQ(1000ULL, bit);
+}
+
+TEST(PersistentBitmapTest, OutOfSpace1Page)
+{
+    DoTestOutOfSpace(30000);
+}
+
+TEST(PersistentBitmapTest, OutOfSpace2Pages)
+{
+    DoTestOutOfSpace(60000);
 }
 
 TEST(PersistentBitmapTest, SetResetAllocateRandomized)

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
@@ -49,7 +49,7 @@ void Rollback(TVector<TPageGroup>& groups, IPageStore& pageStore)
 struct TFixture
 {
     const ui64 FirstPageNo = 10;
-    const ui64 PageCount = 2;
+    const ui64 MaxBits = 60000;
 
     IPageStorePtr PageStore = CreateMemPageStore(PageSize);
     std::unique_ptr<TPersistentBitmap> Bitmap;
@@ -63,7 +63,7 @@ struct TFixture
     {
         Bitmap = std::make_unique<TPersistentBitmap>(
             FirstPageNo,
-            PageCount,
+            MaxBits,
             PageSize,
             PageStore);
     }
@@ -146,8 +146,7 @@ TEST(PersistentBitmapTest, OutOfSpace)
 
     TVector<TPageGroup> pageGroups;
 
-    const ui64 cap =
-        TPersistentBitmap::CalcBitsPerPage(PageSize) * fx.PageCount;
+    const ui64 cap = fx.MaxBits;
 
     THashSet<ui64> bitSet;
 
@@ -188,8 +187,7 @@ TEST(PersistentBitmapTest, SetResetAllocateRandomized)
     const double setProb = 0.01;
     const double resetProb = 0.5;
     const double allocateProb = 0.6;
-    const ui64 cap =
-        TPersistentBitmap::CalcBitsPerPage(PageSize) * fx.PageCount;
+    const ui64 cap = fx.MaxBits;
 
     TDynBitMap refImpl;
     refImpl.Reserve(cap);

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -730,6 +730,7 @@ private:
     std::unique_ptr<TPersistentBitmap> Bitmap;
     ui64 FirstStoragePageClusterId = 0;
     ui64 BitCount = 0;
+    ui64 BitmapSize = 0;
 
 public:
     ui64 Init(
@@ -738,20 +739,18 @@ public:
         IPageStorePtr pageStore)
     {
         const ui64 pageClusterCount = CalcPageClusterCount(config);
-        const ui64 bitsPerPage = TPersistentBitmap::CalcBitsPerPage(PageSize);
-        BitCount = RoundUp(pageClusterCount, bitsPerPage);
-        const ui64 bitmapPageCount = BitCount / bitsPerPage;
+        BitCount = pageClusterCount;
         Bitmap = std::make_unique<TPersistentBitmap>(
             firstPageNo,
-            bitmapPageCount,
+            BitCount,
             PageSize,
             std::move(pageStore));
-        firstPageNo += bitmapPageCount;
-        FirstStoragePageClusterId =
-            RoundUp(firstPageNo + bitmapPageCount, PageClusterPageCount) /
-            PageClusterPageCount;
+        BitmapSize = Bitmap->GetPageCount() * PageSize;
+        firstPageNo += Bitmap->GetPageCount();
+        FirstStoragePageClusterId = RoundUp(firstPageNo, PageClusterPageCount)
+            / PageClusterPageCount;
 
-        return bitmapPageCount + pageClusterCount * PageClusterPageCount;
+        return Bitmap->GetPageCount() + pageClusterCount * PageClusterPageCount;
     }
 
     [[nodiscard]] ui64 GetBitCount() const
@@ -761,8 +760,7 @@ public:
 
     [[nodiscard]] ui64 GetBitmapSize() const
     {
-        return PageSize
-            * (BitCount / TPersistentBitmap::CalcBitsPerPage(PageSize));
+        return BitmapSize;
     }
 
     [[nodiscard]] ui64 GetDataOffset() const

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -750,7 +750,9 @@ public:
         FirstStoragePageClusterId = RoundUp(firstPageNo, PageClusterPageCount)
             / PageClusterPageCount;
 
-        return Bitmap->GetPageCount() + pageClusterCount * PageClusterPageCount;
+        return Bitmap->GetPageCount()
+            + (FirstStoragePageClusterId * PageClusterPageCount - firstPageNo)
+            + pageClusterCount * PageClusterPageCount;
     }
 
     [[nodiscard]] ui64 GetBitCount() const

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
@@ -395,7 +395,7 @@ TEST(NaiveMirroredShardTest, WritesAndReadsFiles)
         EXPECT_EQ(0ULL, stats.UsedHandleCount);
         EXPECT_EQ(768ULL, stats.TotalHandleCount);
         EXPECT_EQ(0ULL, stats.UsedPageCount);
-        EXPECT_EQ(17680ULL, stats.TotalPageCount);
+        EXPECT_EQ(16384ULL, stats.TotalPageCount);
     }
 
     ui64 nodeId = 0;
@@ -460,7 +460,7 @@ TEST(NaiveMirroredShardTest, WritesAndReadsFiles)
         EXPECT_EQ(1ULL, stats.UsedHandleCount);
         EXPECT_EQ(768ULL, stats.TotalHandleCount);
         EXPECT_EQ(8ULL, stats.UsedPageCount);
-        EXPECT_EQ(17680ULL, stats.TotalPageCount);
+        EXPECT_EQ(16384ULL, stats.TotalPageCount);
     }
 
     {
@@ -484,7 +484,7 @@ TEST(NaiveMirroredShardTest, WritesAndReadsFiles)
         EXPECT_EQ(0ULL, stats.UsedHandleCount);
         EXPECT_EQ(768ULL, stats.TotalHandleCount);
         EXPECT_EQ(8ULL, stats.UsedPageCount);
-        EXPECT_EQ(17680ULL, stats.TotalPageCount);
+        EXPECT_EQ(16384ULL, stats.TotalPageCount);
     }
 }
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_layout.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_layout.cpp
@@ -165,15 +165,15 @@ TEST(NaiveMirroredShardLayoutTest, DumpsLayout)
         EXPECT_EQ("PageAllocatorBitmap", c["name"].GetString());
         EXPECT_EQ(76_KB, c["offsetBytes"].GetUInteger());
         EXPECT_EQ(4_KB, c["sizeBytes"].GetUInteger());
-        EXPECT_EQ(32768ULL, c["slotCount"].GetUInteger());
+        EXPECT_EQ(2048ULL, c["slotCount"].GetUInteger());
     }
 
     {
         const auto& c = components[5];
         EXPECT_EQ("DataPages", c["name"].GetString());
         EXPECT_EQ(96_KB, c["offsetBytes"].GetUInteger());
-        EXPECT_EQ(1_GB, c["sizeBytes"].GetUInteger());
-        EXPECT_EQ(32768ULL, c["slotCount"].GetUInteger());
+        EXPECT_EQ(64_MB, c["sizeBytes"].GetUInteger());
+        EXPECT_EQ(2048ULL, c["slotCount"].GetUInteger());
     }
 
     //


### PR DESCRIPTION
### Notes
Fastshard's allocator bitmap bit count used to be inflated - it thought that it had BitmapPageCount * BitsPerPage bits available whereas the actual limit could've been lower (BitmapPageCount * BitsPerPage is greater than the actual limit because it rounds the number of bits up to a multiple of BitsPerPage). Fixed this - now the tail of the last bitmap page is filled with 1s upon initialization.

### Issue
https://github.com/ydb-platform/nbs/issues/5895
