### PR TITLE
util: TArrayRef - proper Y_LIFETIME_BOUND usage

### DIFF
--- a/util/generic/array_ref.h
+++ b/util/generic/array_ref.h
@@ -71,7 +71,7 @@ public:
     }
 
     template <size_t N>
-    constexpr inline TArrayRef(T (&array)[N] Y_LIFETIME_BOUND) noexcept
+    constexpr inline TArrayRef(T (&array Y_LIFETIME_BOUND)[N]) noexcept
         : T_(array)
         , S_(N)
     {


### PR DESCRIPTION
### Notes
clang-16 seems to accept both placements, newer clang versions generate this error:
```
In included file: 'clang::lifetimebound' attribute only applies to parameters and implicit object parameters  /home/astr/git/nbs/util/generic/array_ref.h:74:46: note: error occurred here     
  [attribute_wrong_decl_type]
```

fixing it

### Issue
None