### PR TITLE
keep .so files in build results(backport fix from ydb-platform/ydb)

### DIFF
--- a/build/ymake.core.conf
+++ b/build/ymake.core.conf
@@ -1023,12 +1023,15 @@ when ($EMBED_LINKER_MAP == "yes" || $EMBED_LINKER_CREF == "yes") {
         $OBJCOPY_TOOL $LINK_ADDITIONAL_SECTIONS $TARGET
 }
 
-_SO_EXT_FILTER=${ext=.so:PEERS} ${hide;late_out;ext=.so;pre=$BINDIR/;nopath;tags_cut:PEERS}
+_SO_EXT_FILTER=${ext=.so:PEERS} ${hide;late_out:_SO_EXT_FILTER__LATEOUT__}
+_SO_EXT_FILTER__LATEOUT__=${ext=.so;pre=$BINDIR/;nopath;tags_cut:PEERS}
 when ($OS_WINDOWS == "yes") {
-    _SO_EXT_FILTER=${ext=.dll:PEERS} ${hide;late_out;ext=.dll;pre=$BINDIR/;nopath;tags_cut:PEERS}
+    _SO_EXT_FILTER=${ext=.dll:PEERS} ${hide;late_out:_SO_EXT_FILTER__LATEOUT__}
+    _SO_EXT_FILTER__LATEOUT__=${ext=.dll;pre=$BINDIR/;nopath;tags_cut:PEERS}
 }
 elsewhen ($OS_DARWIN == "yes" || $OS_IOS == "yes") {
-    _SO_EXT_FILTER=${ext=.dylib:PEERS} ${hide;late_out;ext=.dylib;pre=$BINDIR/;nopath;tags_cut:PEERS}
+    _SO_EXT_FILTER=${ext=.dylib:PEERS} ${hide;late_out:_SO_EXT_FILTER__LATEOUT__}
+    _SO_EXT_FILTER__LATEOUT__=${ext=.dylib;pre=$BINDIR/;nopath;tags_cut:PEERS}
 }
 
 LINK_OR_COPY_SO_CMD=


### PR DESCRIPTION
### Notes
Keep shared libraries in build results. Some of our examples and local setups rely on .so files being preserved after the build, broken  after updating to 25-1

Backport fix from ydb-platform/ydb https://github.com/ydb-platform/ydb/commit/dba8986f6b1a5fc7c4f230bee510113995a48970#diff-9833712bfa35f2b6bae41cd556ca7005365f1dc7033f9e3708e981adfaf83f6d

