### PR TITLE
[NBS] Add cleanup in test_restore_endpoint_when_socket_directory_does_not_exist

### DIFF
--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -580,8 +580,11 @@ def test_restore_endpoint_when_socket_directory_does_not_exist():
     except subprocess.CalledProcessError as e:
         log_called_process_error(e)
         raise
+    finally:
+        run("stopendpoint", "--socket", socket_path)
+        run("destroyvolume", "--disk-id", volume_name, input=volume_name)
 
-    cleanup_after_test(env)
+        cleanup_after_test(env)
 
 
 def test_discard_device():


### PR DESCRIPTION
Stop the restored endpoint and delete the test disk during cleanup to prevent `/dev/nbd0` from remaining in a stale state and affecting subsequent tests.
