### PR TITLE
[Disk Manager] Keep use_dataplane_tasks true during mixed-fleet rollout

### DIFF
--- a/cloud/disk_manager/internal/pkg/resources/images.go
+++ b/cloud/disk_manager/internal/pkg/resources/images.go
@@ -64,6 +64,7 @@ type imageState struct {
 	deleteTaskID      string
 	deletingAt        time.Time
 	deletedAt         time.Time
+	useDataplaneTasks bool
 	size              uint64
 	storageSize       uint64
 	encryptionMode    uint32
@@ -76,18 +77,19 @@ func (s *imageState) toImageMeta() *ImageMeta {
 	// TODO: Image.CreateRequest should be []byte, because we can't unmarshal
 	// it here, without knowing particular protobuf message type.
 	return &ImageMeta{
-		ID:            s.id,
-		FolderID:      s.folderID,
-		SrcDiskID:     s.srcDiskID,
-		CheckpointID:  s.checkpointID,
-		SrcImageID:    s.srcImageID,
-		SrcSnapshotID: s.srcSnapshotID,
-		CreateTaskID:  s.createTaskID,
-		CreatingAt:    s.creatingAt,
-		CreatedBy:     s.createdBy,
-		DeleteTaskID:  s.deleteTaskID,
-		Size:          s.size,
-		StorageSize:   s.storageSize,
+		ID:                s.id,
+		FolderID:          s.folderID,
+		SrcDiskID:         s.srcDiskID,
+		CheckpointID:      s.checkpointID,
+		SrcImageID:        s.srcImageID,
+		SrcSnapshotID:     s.srcSnapshotID,
+		CreateTaskID:      s.createTaskID,
+		CreatingAt:        s.creatingAt,
+		CreatedBy:         s.createdBy,
+		DeleteTaskID:      s.deleteTaskID,
+		UseDataplaneTasks: s.useDataplaneTasks,
+		Size:              s.size,
+		StorageSize:       s.storageSize,
 		Encryption: &types.EncryptionDesc{
 			Mode: types.EncryptionMode(s.encryptionMode),
 			Key: &types.EncryptionDesc_KeyHash{
@@ -114,6 +116,7 @@ func (s *imageState) structValue() persistence.Value {
 		persistence.StructFieldValue("delete_task_id", persistence.UTF8Value(s.deleteTaskID)),
 		persistence.StructFieldValue("deleting_at", persistence.TimestampValue(s.deletingAt)),
 		persistence.StructFieldValue("deleted_at", persistence.TimestampValue(s.deletedAt)),
+		persistence.StructFieldValue("use_dataplane_tasks", persistence.BoolValue(true)), // legacy
 		persistence.StructFieldValue("size", persistence.Uint64Value(s.size)),
 		persistence.StructFieldValue("storage_size", persistence.Uint64Value(s.storageSize)),
 		persistence.StructFieldValue("encryption_mode", persistence.Uint32Value(s.encryptionMode)),
@@ -138,6 +141,7 @@ func scanImageState(res persistence.Result) (state imageState, err error) {
 		persistence.OptionalWithDefault("delete_task_id", &state.deleteTaskID),
 		persistence.OptionalWithDefault("deleting_at", &state.deletingAt),
 		persistence.OptionalWithDefault("deleted_at", &state.deletedAt),
+		persistence.OptionalWithDefault("use_dataplane_tasks", &state.useDataplaneTasks),
 		persistence.OptionalWithDefault("status", &state.status),
 		persistence.OptionalWithDefault("size", &state.size),
 		persistence.OptionalWithDefault("storage_size", &state.storageSize),
@@ -183,6 +187,7 @@ func imageStateStructTypeString() string {
 		delete_task_id: Utf8,
 		deleting_at: Timestamp,
 		deleted_at: Timestamp,
+		use_dataplane_tasks: Bool, /* legacy */
 		size: Uint64,
 		storage_size: Uint64,
 		encryption_mode: Uint32,
@@ -206,6 +211,7 @@ func imageStateTableDescription() persistence.CreateTableDescription {
 		persistence.WithColumn("delete_task_id", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("deleting_at", persistence.Optional(persistence.TypeTimestamp)),
 		persistence.WithColumn("deleted_at", persistence.Optional(persistence.TypeTimestamp)),
+		persistence.WithColumn("use_dataplane_tasks", persistence.Optional(persistence.TypeBool)), // legacy
 		persistence.WithColumn("size", persistence.Optional(persistence.TypeUint64)),
 		persistence.WithColumn("storage_size", persistence.Optional(persistence.TypeUint64)),
 		persistence.WithColumn("encryption_mode", persistence.Optional(persistence.TypeUint32)),
@@ -400,15 +406,16 @@ func (s *storageYDB) createImage(
 	}
 
 	state := imageState{
-		id:            image.ID,
-		folderID:      image.FolderID,
-		srcDiskID:     image.SrcDiskID,
-		srcImageID:    image.SrcImageID,
-		srcSnapshotID: image.SrcSnapshotID,
-		createRequest: createRequest,
-		createTaskID:  image.CreateTaskID,
-		creatingAt:    image.CreatingAt,
-		createdBy:     image.CreatedBy,
+		id:                image.ID,
+		folderID:          image.FolderID,
+		srcDiskID:         image.SrcDiskID,
+		srcImageID:        image.SrcImageID,
+		srcSnapshotID:     image.SrcSnapshotID,
+		createRequest:     createRequest,
+		createTaskID:      image.CreateTaskID,
+		creatingAt:        image.CreatingAt,
+		createdBy:         image.CreatedBy,
+		useDataplaneTasks: true,
 
 		status: imageStatusCreating,
 	}

--- a/cloud/disk_manager/internal/pkg/resources/images_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/images_test.go
@@ -25,6 +25,7 @@ func requireImagesAreEqual(t *testing.T, expected ImageMeta, actual ImageMeta) {
 	}
 	require.Equal(t, expected.CreatedBy, actual.CreatedBy)
 	require.Equal(t, expected.DeleteTaskID, actual.DeleteTaskID)
+	require.True(t, actual.UseDataplaneTasks)
 	require.Equal(t, expected.Size, actual.Size)
 	require.Equal(t, expected.StorageSize, actual.StorageSize)
 	require.Equal(t, expected.Ready, actual.Ready)
@@ -57,6 +58,12 @@ func TestImagesCreateImage(t *testing.T) {
 	created, err := storage.CreateImage(ctx, image)
 	require.NoError(t, err)
 	require.Equal(t, image.ID, created.ID)
+	require.True(t, created.UseDataplaneTasks)
+
+	meta, err := storage.GetImageMeta(ctx, image.ID)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	require.True(t, meta.UseDataplaneTasks)
 
 	// Check idempotency.
 	created, err = storage.CreateImage(ctx, image)
@@ -65,6 +72,12 @@ func TestImagesCreateImage(t *testing.T) {
 
 	err = storage.ImageCreated(ctx, image.ID, "", time.Now(), 0, 0)
 	require.NoError(t, err)
+
+	meta, err = storage.GetImageMeta(ctx, image.ID)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	require.True(t, meta.UseDataplaneTasks)
+	require.True(t, meta.Ready)
 
 	// Check idempotency.
 	err = storage.ImageCreated(ctx, image.ID, "", time.Now(), 0, 0)

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -63,6 +63,7 @@ type snapshotState struct {
 	deleteTaskID      string
 	deletingAt        time.Time
 	deletedAt         time.Time
+	useDataplaneTasks bool
 	size              uint64
 	storageSize       uint64
 	encryptionMode    uint32
@@ -82,13 +83,14 @@ func (s *snapshotState) toSnapshotMeta() *SnapshotMeta {
 			ZoneId: s.zoneID,
 			DiskId: s.diskID,
 		},
-		CheckpointID: s.checkpointID,
-		CreateTaskID: s.createTaskID,
-		CreatingAt:   s.creatingAt,
-		CreatedBy:    s.createdBy,
-		DeleteTaskID: s.deleteTaskID,
-		Size:         s.size,
-		StorageSize:  s.storageSize,
+		CheckpointID:      s.checkpointID,
+		CreateTaskID:      s.createTaskID,
+		CreatingAt:        s.creatingAt,
+		CreatedBy:         s.createdBy,
+		DeleteTaskID:      s.deleteTaskID,
+		UseDataplaneTasks: s.useDataplaneTasks,
+		Size:              s.size,
+		StorageSize:       s.storageSize,
 		Encryption: &types.EncryptionDesc{
 			Mode: types.EncryptionMode(s.encryptionMode),
 			Key: &types.EncryptionDesc_KeyHash{
@@ -115,6 +117,7 @@ func (s *snapshotState) structValue() persistence.Value {
 		persistence.StructFieldValue("deleting_at", persistence.TimestampValue(s.deletingAt)),
 		persistence.StructFieldValue("deleted_at", persistence.TimestampValue(s.deletedAt)),
 		persistence.StructFieldValue("incremental", persistence.BoolValue(true)), // deprecated
+		persistence.StructFieldValue("use_dataplane_tasks", persistence.BoolValue(true)), // legacy
 		persistence.StructFieldValue("size", persistence.Uint64Value(s.size)),
 		persistence.StructFieldValue("storage_size", persistence.Uint64Value(s.storageSize)),
 		persistence.StructFieldValue("encryption_mode", persistence.Uint32Value(s.encryptionMode)),
@@ -138,6 +141,7 @@ func scanSnapshotState(res persistence.Result) (state snapshotState, err error) 
 		persistence.OptionalWithDefault("delete_task_id", &state.deleteTaskID),
 		persistence.OptionalWithDefault("deleting_at", &state.deletingAt),
 		persistence.OptionalWithDefault("deleted_at", &state.deletedAt),
+		persistence.OptionalWithDefault("use_dataplane_tasks", &state.useDataplaneTasks),
 		persistence.OptionalWithDefault("size", &state.size),
 		persistence.OptionalWithDefault("storage_size", &state.storageSize),
 		persistence.OptionalWithDefault("encryption_mode", &state.encryptionMode),
@@ -183,6 +187,7 @@ func snapshotStateStructTypeString() string {
 		deleting_at: Timestamp,
 		deleted_at: Timestamp,
 		incremental: Bool, /* deprecated */
+		use_dataplane_tasks: Bool, /* legacy */
 		size: Uint64,
 		storage_size: Uint64,
 		encryption_mode: Uint32,
@@ -206,6 +211,7 @@ func snapshotStateTableDescription() persistence.CreateTableDescription {
 		persistence.WithColumn("deleting_at", persistence.Optional(persistence.TypeTimestamp)),
 		persistence.WithColumn("deleted_at", persistence.Optional(persistence.TypeTimestamp)),
 		persistence.WithColumn("incremental", persistence.Optional(persistence.TypeBool)), // deprecated
+		persistence.WithColumn("use_dataplane_tasks", persistence.Optional(persistence.TypeBool)), // legacy
 		persistence.WithColumn("size", persistence.Optional(persistence.TypeUint64)),
 		persistence.WithColumn("storage_size", persistence.Optional(persistence.TypeUint64)),
 		persistence.WithColumn("encryption_mode", persistence.Optional(persistence.TypeUint32)),
@@ -379,14 +385,15 @@ func (s *storageYDB) createSnapshot(
 	}
 
 	state := snapshotState{
-		id:            snapshot.ID,
-		folderID:      snapshot.FolderID,
-		zoneID:        snapshot.Disk.ZoneId,
-		diskID:        snapshot.Disk.DiskId,
-		createRequest: createRequest,
-		createTaskID:  snapshot.CreateTaskID,
-		creatingAt:    snapshot.CreatingAt,
-		createdBy:     snapshot.CreatedBy,
+		id:                snapshot.ID,
+		folderID:          snapshot.FolderID,
+		zoneID:            snapshot.Disk.ZoneId,
+		diskID:            snapshot.Disk.DiskId,
+		createRequest:     createRequest,
+		createTaskID:      snapshot.CreateTaskID,
+		creatingAt:        snapshot.CreatingAt,
+		createdBy:         snapshot.CreatedBy,
+		useDataplaneTasks: true,
 
 		status: snapshotStatusCreating,
 	}

--- a/cloud/disk_manager/internal/pkg/resources/snapshots.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots.go
@@ -116,7 +116,7 @@ func (s *snapshotState) structValue() persistence.Value {
 		persistence.StructFieldValue("delete_task_id", persistence.UTF8Value(s.deleteTaskID)),
 		persistence.StructFieldValue("deleting_at", persistence.TimestampValue(s.deletingAt)),
 		persistence.StructFieldValue("deleted_at", persistence.TimestampValue(s.deletedAt)),
-		persistence.StructFieldValue("incremental", persistence.BoolValue(true)), // deprecated
+		persistence.StructFieldValue("incremental", persistence.BoolValue(true)),         // deprecated
 		persistence.StructFieldValue("use_dataplane_tasks", persistence.BoolValue(true)), // legacy
 		persistence.StructFieldValue("size", persistence.Uint64Value(s.size)),
 		persistence.StructFieldValue("storage_size", persistence.Uint64Value(s.storageSize)),
@@ -210,7 +210,7 @@ func snapshotStateTableDescription() persistence.CreateTableDescription {
 		persistence.WithColumn("delete_task_id", persistence.Optional(persistence.TypeUTF8)),
 		persistence.WithColumn("deleting_at", persistence.Optional(persistence.TypeTimestamp)),
 		persistence.WithColumn("deleted_at", persistence.Optional(persistence.TypeTimestamp)),
-		persistence.WithColumn("incremental", persistence.Optional(persistence.TypeBool)), // deprecated
+		persistence.WithColumn("incremental", persistence.Optional(persistence.TypeBool)),         // deprecated
 		persistence.WithColumn("use_dataplane_tasks", persistence.Optional(persistence.TypeBool)), // legacy
 		persistence.WithColumn("size", persistence.Optional(persistence.TypeUint64)),
 		persistence.WithColumn("storage_size", persistence.Optional(persistence.TypeUint64)),

--- a/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
+++ b/cloud/disk_manager/internal/pkg/resources/snapshots_test.go
@@ -26,6 +26,7 @@ func requireSnapshotsAreEqual(t *testing.T, expected SnapshotMeta, actual Snapsh
 	}
 	require.Equal(t, expected.CreatedBy, actual.CreatedBy)
 	require.Equal(t, expected.DeleteTaskID, actual.DeleteTaskID)
+	require.True(t, actual.UseDataplaneTasks)
 	require.Equal(t, expected.Size, actual.Size)
 	require.Equal(t, expected.StorageSize, actual.StorageSize)
 	require.Equal(t, expected.Ready, actual.Ready)
@@ -61,6 +62,12 @@ func TestSnapshotsCreateSnapshot(t *testing.T) {
 	created, err := storage.CreateSnapshot(ctx, snapshot)
 	require.NoError(t, err)
 	require.Equal(t, snapshot.ID, created.ID)
+	require.True(t, created.UseDataplaneTasks)
+
+	meta, err := storage.GetSnapshotMeta(ctx, snapshot.ID)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	require.True(t, meta.UseDataplaneTasks)
 
 	// Check idempotency.
 	created, err = storage.CreateSnapshot(ctx, snapshot)
@@ -69,6 +76,12 @@ func TestSnapshotsCreateSnapshot(t *testing.T) {
 
 	err = storage.SnapshotCreated(ctx, snapshot.ID, "", time.Now(), 0, 0)
 	require.NoError(t, err)
+
+	meta, err = storage.GetSnapshotMeta(ctx, snapshot.ID)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	require.True(t, meta.UseDataplaneTasks)
+	require.True(t, meta.Ready)
 
 	// Check idempotency.
 	err = storage.SnapshotCreated(ctx, snapshot.ID, "", time.Now(), 0, 0)

--- a/cloud/disk_manager/internal/pkg/resources/storage.go
+++ b/cloud/disk_manager/internal/pkg/resources/storage.go
@@ -38,37 +38,39 @@ type DiskMeta struct {
 }
 
 type ImageMeta struct {
-	ID            string                `json:"id"`
-	FolderID      string                `json:"folder_id"`
-	SrcDiskID     string                `json:"src_disk_id"`
-	CheckpointID  string                `json:"checkpoint_id"`
-	SrcImageID    string                `json:"src_image_id"`
-	SrcSnapshotID string                `json:"src_snapshot_id"`
-	CreateRequest proto.Message         `json:"create_request"`
-	CreateTaskID  string                `json:"create_task_id"`
-	CreatingAt    time.Time             `json:"creating_at"`
-	CreatedBy     string                `json:"created_by"`
-	DeleteTaskID  string                `json:"delete_task_id"`
-	Size          uint64                `json:"size"`
-	StorageSize   uint64                `json:"storage_size"`
-	Encryption    *types.EncryptionDesc `json:"encryption"`
-	Ready         bool                  `json:"ready"`
+	ID                string                `json:"id"`
+	FolderID          string                `json:"folder_id"`
+	SrcDiskID         string                `json:"src_disk_id"`
+	CheckpointID      string                `json:"checkpoint_id"`
+	SrcImageID        string                `json:"src_image_id"`
+	SrcSnapshotID     string                `json:"src_snapshot_id"`
+	CreateRequest     proto.Message         `json:"create_request"`
+	CreateTaskID      string                `json:"create_task_id"`
+	CreatingAt        time.Time             `json:"creating_at"`
+	CreatedBy         string                `json:"created_by"`
+	DeleteTaskID      string                `json:"delete_task_id"`
+	UseDataplaneTasks bool                  `json:"use_dataplane_tasks"` // legacy
+	Size              uint64                `json:"size"`
+	StorageSize       uint64                `json:"storage_size"`
+	Encryption        *types.EncryptionDesc `json:"encryption"`
+	Ready             bool                  `json:"ready"`
 }
 
 type SnapshotMeta struct {
-	ID            string                `json:"id"`
-	FolderID      string                `json:"folder_id"`
-	Disk          *types.Disk           `json:"disk"`
-	CheckpointID  string                `json:"checkpoint_id"`
-	CreateRequest proto.Message         `json:"create_request"`
-	CreateTaskID  string                `json:"create_task_id"`
-	CreatingAt    time.Time             `json:"creating_at"`
-	CreatedBy     string                `json:"created_by"`
-	DeleteTaskID  string                `json:"delete_task_id"`
-	Size          uint64                `json:"size"`
-	StorageSize   uint64                `json:"storage_size"`
-	Encryption    *types.EncryptionDesc `json:"encryption"`
-	Ready         bool                  `json:"ready"`
+	ID                string                `json:"id"`
+	FolderID          string                `json:"folder_id"`
+	Disk              *types.Disk           `json:"disk"`
+	CheckpointID      string                `json:"checkpoint_id"`
+	CreateRequest     proto.Message         `json:"create_request"`
+	CreateTaskID      string                `json:"create_task_id"`
+	CreatingAt        time.Time             `json:"creating_at"`
+	CreatedBy         string                `json:"created_by"`
+	DeleteTaskID      string                `json:"delete_task_id"`
+	UseDataplaneTasks bool                  `json:"use_dataplane_tasks"` // legacy
+	Size              uint64                `json:"size"`
+	StorageSize       uint64                `json:"storage_size"`
+	Encryption        *types.EncryptionDesc `json:"encryption"`
+	Ready             bool                  `json:"ready"`
 }
 
 type FilesystemMeta struct {


### PR DESCRIPTION
## Problem

#6804 stopped writing `use_dataplane_tasks`. New images/snapshots leave the column `NULL`. Pre-6804 CP reads that as `false` and schedules `TransferFromLegacySnapshotToDisk`, which looks in empty legacy storage.

## Solution

Write `use_dataplane_tasks = true` on every image/snapshot UPSERT. The column is marked legacy; this binary already always schedules dataplane tasks. The legacy storage path is not restored.

## Removing the column later

After no binary in the fleet still branches on the flag, remove the field from Go. The YDB column can stay.