### PR TITLE
[Filestore] issue-5432: defer node destruction after a tablet restart

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -887,7 +887,9 @@ message TStorageConfig
     // Time after a tablet start during which an operation on an unknown handle
     // returns a retriable error instead of E_FS_BADHANDLE, so that a client can
     // recover a handle lost by a tablet restart via its queued
-    // ConfirmCreateHandle. 0 disables the grace window. In ms.
+    // ConfirmCreateHandle. During the same window the destruction of a node
+    // that becomes unreferenced is deferred, so that such a handle can still be
+    // confirmed for it. 0 disables the grace window. In ms.
     optional uint32 UnconfirmedCreateHandleGraceTimeout = 536;
 
     // Limits the number of entries when tracking
@@ -906,4 +908,12 @@ message TStorageConfig
     // Delay between processing entries in the async handle operations queue,
     // in ms.
     optional uint32 AsyncHandleOperationDrainPeriod = 541;
+
+    // Limits the number of nodes whose destruction is deferred by
+    // UnconfirmedCreateHandleGraceTimeout. 0 disables the deferral.
+    optional uint64 MaxDeferredNodeDestructionCount = 542;
+
+    // Limits the number of nodes destroyed by a single transaction of the
+    // background task that destroys the deferred nodes.
+    optional uint32 MaxDeferredNodeDestructionsPerTx = 543;
 }

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -28,6 +28,7 @@ namespace NCloud::NFileStore{
     xxx(DuplicateRequestId)                                                    \
     xxx(InvalidDupCacheEntry)                                                  \
     xxx(GeneratedOrphanNode)                                                   \
+    xxx(DeferredNodeDestructionLimitExceeded)                                  \
     xxx(ReceivedNodeOpErrorFromShard)                                          \
     xxx(LocalFsMaxSessionNodesInUse)                                           \
     xxx(LocalFsMaxSessionFileHandlesInUse)                                     \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -270,6 +270,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
                                        TDuration,  TDuration::Zero()          )\
     xxx(UnconfirmedCreateHandleGraceTimeout,                                   \
                                        TDuration,  TDuration::Minutes(2)      )\
+    xxx(MaxDeferredNodeDestructionCount,                ui64,       100'000   )\
+    xxx(MaxDeferredNodeDestructionsPerTx,               ui32,       1'000     )\
                                                                                \
     xxx(NodeRegistrationMaxAttempts,         ui32,      10                    )\
     xxx(NodeRegistrationTimeout,             TDuration, TDuration::Seconds(5) )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -280,6 +280,8 @@ public:
     TDuration GetAsyncHandleOperationIdlePeriod() const;
     TDuration GetAsyncHandleOperationDrainPeriod() const;
     TDuration GetUnconfirmedCreateHandleGraceTimeout() const;
+    ui64 GetMaxDeferredNodeDestructionCount() const;
+    ui32 GetMaxDeferredNodeDestructionsPerTx() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -674,7 +674,7 @@ bool TIndexTabletActor::NeedsNodeDestructionDeferral(
         && IsInUnconfirmedCreateHandleGracePeriod(ctx)
         && !GetFileSystem().GetIsFastShard()
         && node.Attrs.GetType() == NProto::E_REGULAR_NODE
-        && node.NodeId <= MaxNodeIdAtStart;
+        && node.NodeId <= MaxNodeIdAtTabletStart;
 }
 
 bool TIndexTabletActor::ShouldDeferNodeDestruction(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -314,18 +314,15 @@ void TIndexTabletActor::DestroySessionHandlesAndRemoveNodes(
                 nodeId,
                 it->Attrs.GetSize());
 
-            auto e = RemoveNode(
+            const bool removed = DeferNodeDestructionOrRemoveNode(
                 db,
+                ctx,
                 *it,
-                it->MinCommitId,
-                commitId);
+                commitId,
+                TStringBuilder() << operation << ": "
+                                 << session->GetSessionId());
 
-            if (HasError(e)) {
-                WriteOrphanNode(db, TStringBuilder()
-                    << "DestroySession: " << session->GetSessionId()
-                    << ", RemoveNode: " << nodeId
-                    << ", Error: " << FormatError(e), nodeId);
-            } else {
+            if (removed) {
                 ++removedNodeCount;
             }
         }
@@ -657,6 +654,83 @@ NProto::TError TIndexTabletActor::IsDataOperationAllowed() const
     return {};
 }
 
+bool TIndexTabletActor::IsInUnconfirmedCreateHandleGracePeriod(
+    const TActorContext& ctx) const
+{
+    const auto graceTimeout = Config->GetUnconfirmedCreateHandleGraceTimeout();
+
+    return graceTimeout
+        && Config->GetAsyncCreateHandleEnabled()
+        && ctx.Now() < TabletStartTs + graceTimeout;
+}
+
+bool TIndexTabletActor::NeedsNodeDestructionDeferral(
+    const TActorContext& ctx,
+    const INodeIndexTabletDatabase::TNode& node) const
+{
+    // After a restart, defer destruction of nodes that may still have an
+    // unconfirmed handle. Only pre-existing regular nodes can have one.
+    return Config->GetMaxDeferredNodeDestructionCount()
+        && IsInUnconfirmedCreateHandleGracePeriod(ctx)
+        && !GetFileSystem().GetIsFastShard()
+        && node.Attrs.GetType() == NProto::E_REGULAR_NODE
+        && node.NodeId <= MaxNodeIdAtStart;
+}
+
+bool TIndexTabletActor::ShouldDeferNodeDestruction(
+    const TActorContext& ctx,
+    const INodeIndexTabletDatabase::TNode& node,
+    TStringBuf operation)
+{
+    if (!UnlinkDestroysNode(node) || !NeedsNodeDestructionDeferral(ctx, node)) {
+        return false;
+    }
+
+    const ui64 deferredCount = GetDeferredNodeDestructionCount();
+    if (deferredCount >= Config->GetMaxDeferredNodeDestructionCount()) {
+        ReportDeferredNodeDestructionLimitExceeded(TStringBuilder()
+            << operation << ": NodeId: " << node.NodeId
+            << ", DeferredNodeDestructionCount: " << deferredCount);
+
+        Metrics->NodeDestructionsDeferralSkipped.fetch_add(
+            1,
+            std::memory_order_relaxed);
+
+        return false;
+    }
+
+    return true;
+}
+
+bool TIndexTabletActor::DeferNodeDestructionOrRemoveNode(
+    IIndexTabletDatabase& db,
+    const TActorContext& ctx,
+    const INodeIndexTabletDatabase::TNode& node,
+    ui64 commitId,
+    const TString& operation)
+{
+    if (ShouldDeferNodeDestruction(ctx, node, operation)) {
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+            "%s Deferring node destruction upon %s n:%lu",
+            LogTag.c_str(),
+            operation.c_str(),
+            node.NodeId);
+
+        AddDeferredNodeDestruction(db, node.NodeId);
+        return false;
+    }
+
+    auto e = RemoveNode(db, node, node.MinCommitId, commitId);
+    if (HasError(e)) {
+        WriteOrphanNode(db, TStringBuilder()
+            << operation << ": RemoveNode: " << node.NodeId
+            << ", Error: " << FormatError(e), node.NodeId);
+        return false;
+    }
+
+    return true;
+}
+
 NProto::TError TIndexTabletActor::ErrorHandleNotFound(
     const TActorContext& ctx,
     ui64 handle) const
@@ -665,11 +739,7 @@ NProto::TError TIndexTabletActor::ErrorHandleNotFound(
     // inside that window loses the handle. The client retries its queued
     // ConfirmCreateHandle, which recreates the very same handle, so ask the
     // client to retry instead of failing the operation with EBADF.
-    const auto graceTimeout = Config->GetUnconfirmedCreateHandleGraceTimeout();
-    if (graceTimeout
-        && Config->GetAsyncCreateHandleEnabled()
-        && ctx.Now() < TabletStartTs + graceTimeout)
-    {
+    if (IsInUnconfirmedCreateHandleGracePeriod(ctx)) {
         ui32 flags = 0;
         SetProtoFlag(flags, NCloud::NProto::EF_INSTANT_RETRIABLE);
         return MakeError(
@@ -1930,6 +2000,7 @@ bool TIndexTabletActor::BehaveAsShard(const NProto::THeaders& headers) const
 void TIndexTabletActor::RunRegularTasks(const TActorContext& ctx)
 {
     DeleteOldResponseLogEntries(ctx);
+    DestroyDeferredNodes(ctx);
 
     ctx.Schedule(Config->GetTabletRegularTasksSchedulePeriod(),
         new TEvIndexTabletPrivate::TEvRunRegularTasks());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -189,7 +189,7 @@ private:
     TInstant TabletStartTs;
     // The largest node id that existed when this tablet incarnation started.
     // A handle lost by the restart can only refer to this or an earlier node.
-    ui64 MaxNodeIdAtStart = 0;
+    ui64 MaxNodeIdAtTabletStart = 0;
 
     TThrottlerLogger ThrottlerLogger;
     ITabletThrottlerPtr Throttler;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -187,6 +187,9 @@ private:
     TInstant ReassignRequestSentTs;
 
     TInstant TabletStartTs;
+    // The largest node id that existed when this tablet incarnation started.
+    // A handle lost by the restart can only refer to this or an earlier node.
+    ui64 MaxNodeIdAtStart = 0;
 
     TThrottlerLogger ThrottlerLogger;
     ITabletThrottlerPtr Throttler;
@@ -326,6 +329,7 @@ private:
     void CalculateActorCPUUsage(const NActors::TActorContext& ctx);
 
     void DeleteOldResponseLogEntries(const NActors::TActorContext& ctx);
+    void DestroyDeferredNodes(const NActors::TActorContext& ctx);
     void RunRegularTasks(const NActors::TActorContext& ctx);
 
     void ScheduleSyncSessions(const NActors::TActorContext& ctx);
@@ -606,6 +610,26 @@ private:
         bool validateHandle);
 
     NProto::TError IsDataOperationAllowed() const;
+    bool IsInUnconfirmedCreateHandleGracePeriod(
+        const NActors::TActorContext& ctx) const;
+    bool NeedsNodeDestructionDeferral(
+        const NActors::TActorContext& ctx,
+        const INodeIndexTabletDatabase::TNode& node) const;
+    // True if unlinking this node should keep it in the index until the grace
+    // period is over. Reports a critical event if the node needs the deferral
+    // but the limit leaves no room for it.
+    bool ShouldDeferNodeDestruction(
+        const NActors::TActorContext& ctx,
+        const INodeIndexTabletDatabase::TNode& node,
+        TStringBuf operation);
+    // Returns true if the node was actually removed, false if its destruction
+    // was deferred or failed (in the latter case an orphan node is written).
+    bool DeferNodeDestructionOrRemoveNode(
+        IIndexTabletDatabase& db,
+        const NActors::TActorContext& ctx,
+        const INodeIndexTabletDatabase::TNode& node,
+        ui64 commitId,
+        const TString& operation);
     NProto::TError ErrorHandleNotFound(
         const NActors::TActorContext& ctx,
         ui64 handle) const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -555,6 +555,9 @@ void TIndexTabletActor::UpdateMetrics(
         nodeToSessionCounters.NodesOpenForReadingByMultipleSessions);
 
     Store(Metrics->OrphanNodesCount, miscNodeStats.OrphanNodesCount);
+    Store(
+        Metrics->DeferredNodeDestructionCount,
+        miscNodeStats.DeferredNodeDestructionCount);
 
     Metrics->BusyIdleCalc.OnUpdateStats();
     Metrics->UpdatePerformanceMetrics(now, diagConfig, fileSystem);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroydeferrednodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroydeferrednodes.cpp
@@ -60,9 +60,8 @@ void TIndexTabletActor::ExecuteTx_DestroyDeferredNodes(
 
     const ui64 commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {
-        return ScheduleRebootTabletOnCommitIdOverflow(
-            ctx,
-            "DestroyDeferredNodes");
+        args.OnCommitIdOverflow();
+        return;
     }
 
     for (ui32 i = 0; i < args.NodeIds.size(); ++i) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroydeferrednodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroydeferrednodes.cpp
@@ -1,0 +1,126 @@
+#include "tablet_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::DestroyDeferredNodes(const TActorContext& ctx)
+{
+    if (IsInUnconfirmedCreateHandleGracePeriod(ctx)) {
+        return;
+    }
+
+    if (HasError(IsDataOperationAllowed())) {
+        return;
+    }
+
+    auto nodeIds = GetDeferredNodeDestructionIds(
+        Config->GetMaxDeferredNodeDestructionsPerTx());
+    if (nodeIds.empty()) {
+        return;
+    }
+
+    ExecuteTx<TDestroyDeferredNodes>(ctx, std::move(nodeIds));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_DestroyDeferredNodes(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TDestroyDeferredNodes& args)
+{
+    Y_UNUSED(ctx);
+
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+    const ui64 commitId = GetCurrentCommitId();
+
+    bool ready = true;
+    args.Nodes.resize(args.NodeIds.size());
+    for (ui32 i = 0; i < args.NodeIds.size(); ++i) {
+        if (!ReadNode(*db, args.NodeIds[i], commitId, args.Nodes[i])) {
+            ready = false;   // not ready
+        }
+    }
+
+    return ready;
+}
+
+void TIndexTabletActor::ExecuteTx_DestroyDeferredNodes(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TDestroyDeferredNodes& args)
+{
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+
+    const ui64 commitId = GenerateCommitId();
+    if (commitId == InvalidCommitId) {
+        return ScheduleRebootTabletOnCommitIdOverflow(
+            ctx,
+            "DestroyDeferredNodes");
+    }
+
+    for (ui32 i = 0; i < args.NodeIds.size(); ++i) {
+        const ui64 nodeId = args.NodeIds[i];
+        const auto& node = args.Nodes[i];
+
+        // The node is owned by the regular destruction paths from now on: it is
+        // either already destroyed, or referenced again, or opened by a handle
+        // that has been confirmed in the meantime.
+        RemoveDeferredNodeDestruction(*db, nodeId);
+
+        if (!node) {
+            continue;
+        }
+
+        if (node->Attrs.GetLinks() || HasOpenHandles(nodeId)) {
+            ++args.CancelledNodeCount;
+            continue;
+        }
+
+        auto e = RemoveNode(*db, *node, node->MinCommitId, commitId);
+        if (HasError(e)) {
+            WriteOrphanNode(*db, TStringBuilder()
+                << "DestroyDeferredNodes: RemoveNode: " << nodeId
+                << ", Error: " << FormatError(e), nodeId);
+            continue;
+        }
+
+        ++args.DestroyedNodeCount;
+    }
+
+    EnqueueTruncateIfNeeded(ctx);
+}
+
+void TIndexTabletActor::CompleteTx_DestroyDeferredNodes(
+    const TActorContext& ctx,
+    TTxIndexTablet::TDestroyDeferredNodes& args)
+{
+    LOG_INFO(ctx, TFileStoreComponents::TABLET,
+        "%s Destroyed %lu deferred nodes, %lu nodes are still in use,"
+        " %lu nodes left in the queue",
+        LogTag.c_str(),
+        args.DestroyedNodeCount,
+        args.CancelledNodeCount,
+        GetDeferredNodeDestructionCount());
+
+    Metrics->DeferredNodeDestructionsCompleted.fetch_add(
+        args.DestroyedNodeCount,
+        std::memory_order_relaxed);
+    Metrics->DeferredNodeDestructionsCancelled.fetch_add(
+        args.CancelledNodeCount,
+        std::memory_order_relaxed);
+
+    for (const ui64 nodeId: args.NodeIds) {
+        InvalidateReadAheadCache(nodeId);
+    }
+
+    EnqueueBlobIndexOpIfNeeded(ctx);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -123,17 +123,13 @@ void TIndexTabletActor::ExecuteTx_DestroyHandle(
 
     if (args.Node->Attrs.GetLinks() == 0 && !HasOpenHandles(args.Node->NodeId))
     {
-        auto e = RemoveNode(*db, *args.Node, args.Node->MinCommitId, commitId);
-
-        if (HasError(e)) {
-            WriteOrphanNode(
-                *db,
-                TStringBuilder() << "DestroyHandle: " << args.SessionId
-                                 << ", Handle: " << args.Request.GetHandle()
-                                 << ", RemoveNode: " << args.Node->NodeId
-                                 << ", Error: " << FormatError(e),
-                args.Node->NodeId);
-        }
+        DeferNodeDestructionOrRemoveNode(
+            *db,
+            ctx,
+            *args.Node,
+            commitId,
+            TStringBuilder() << "DestroyHandle: " << args.SessionId
+                             << ", Handle: " << args.Request.GetHandle());
     }
 
     EnqueueTruncateIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -5,6 +5,7 @@
 
 #include <cloud/filestore/libs/storage/fastshard/impl/mem/memshard.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h>
+#include <cloud/filestore/libs/storage/model/utils.h>
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/metrics/operations.h>
@@ -121,6 +122,7 @@ bool TIndexTabletActor::PrepareTx_LoadState(
         db->ReadResponseLog(args.ResponseLog),
         db->ReadLargeDeletionMarkers(args.LargeDeletionMarkers),
         db->ReadOrphanNodes(args.OrphanNodeIds),
+        db->ReadDeferredNodeDestructions(args.DeferredNodeDestructionIds),
         db->ReadUnconfirmedData(args.UnconfirmedData),
     };
 
@@ -267,6 +269,7 @@ void TIndexTabletActor::CompleteAdapterLoadState(
         args.TabletStorageInfo,
         args.LargeDeletionMarkers,
         args.OrphanNodeIds,
+        args.DeferredNodeDestructionIds,
         args.OpLog,
         args.ResponseLog,
         config);
@@ -400,6 +403,11 @@ void TIndexTabletActor::CompleteTx_LoadState(
             LogTag << " Read " << args.OrphanNodeIds.size()
             << " orphan nodes");
     }
+    if (args.DeferredNodeDestructionIds) {
+        LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
+            LogTag << " Read " << args.DeferredNodeDestructionIds.size()
+            << " nodes with deferred destruction");
+    }
 
     LoadState(
         Executor()->Generation(),
@@ -409,10 +417,13 @@ void TIndexTabletActor::CompleteTx_LoadState(
         args.TabletStorageInfo,
         args.LargeDeletionMarkers,
         args.OrphanNodeIds,
+        args.DeferredNodeDestructionIds,
         args.OpLog,
         args.ResponseLog,
         config);
     UpdateLogTag();
+
+    MaxNodeIdAtStart = ShardedId(GetLastNodeId(), GetFileSystem().GetShardNo());
 
     NMetrics::Store(Metrics->OpLogEntryCount, GetOpLogEntryCount());
     NMetrics::Store(Metrics->ResponseLogEntryCount, GetResponseLogEntryCount());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -423,7 +423,8 @@ void TIndexTabletActor::CompleteTx_LoadState(
         config);
     UpdateLogTag();
 
-    MaxNodeIdAtStart = ShardedId(GetLastNodeId(), GetFileSystem().GetShardNo());
+    MaxNodeIdAtTabletStart =
+        ShardedId(GetLastNodeId(), GetFileSystem().GetShardNo());
 
     NMetrics::Store(Metrics->OpLogEntryCount, GetOpLogEntryCount());
     NMetrics::Store(Metrics->ResponseLogEntryCount, GetResponseLogEntryCount());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1136,6 +1136,10 @@ void TIndexTabletActor::RenderHttpInfo_OverviewTab(
 
         TAG(TH3) { out << "State"; }
         DIV() { out << "Current commitId: " << GetCurrentCommitId(); }
+        DIV() {
+            out << "Nodes with deferred destruction: "
+                << GetDeferredNodeDestructionCount();
+        }
         DIV() { DumpOperationState("Flush", FlushState, out); }
         DIV() { DumpOperationState("BlobIndexOp", BlobIndexOpState, out); }
         DIV() { DumpOperationState("CollectGarbage", CollectGarbageState, out); }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -580,7 +580,11 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
                 *args.NewChildNode,
                 args.NewChildRef->MinCommitId,
                 args.CommitId,
-                /* removeNodeRef */ true);
+                /* removeNodeRef */ true,
+                ShouldDeferNodeDestruction(
+                    ctx,
+                    *args.NewChildNode,
+                    "RenameNode"));
 
             if (HasError(e)) {
                 const auto nodeId = args.NewChildNode->NodeId;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -530,7 +530,8 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
             *args.ChildNode,
             args.ChildNode->MinCommitId,
             args.CommitId,
-            /* removeNodeRef */ !Config->GetParentlessFilesOnly());
+            /* removeNodeRef */ !Config->GetParentlessFilesOnly(),
+            ShouldDeferNodeDestruction(ctx, *args.ChildNode, "UnlinkNode"));
 
         if (HasError(e)) {
             args.Error = std::move(e);

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -326,6 +326,19 @@ void TTabletMetrics::Register(
 
     REGISTER_AGGREGATABLE_SUM(OrphanNodesCount, EMetricType::MT_ABSOLUTE);
 
+    REGISTER_AGGREGATABLE_SUM(
+        DeferredNodeDestructionCount,
+        EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
+        DeferredNodeDestructionsCompleted,
+        EMetricType::MT_DERIVATIVE);
+    REGISTER_AGGREGATABLE_SUM(
+        DeferredNodeDestructionsCancelled,
+        EMetricType::MT_DERIVATIVE);
+    REGISTER_AGGREGATABLE_SUM(
+        NodeDestructionsDeferralSkipped,
+        EMetricType::MT_DERIVATIVE);
+
     // Throttling
     REGISTER_LOCAL(MaxReadBandwidth, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(MaxWriteBandwidth, EMetricType::MT_ABSOLUTE);

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -265,6 +265,12 @@ struct TTabletMetrics: TAtomicRefCount<TTabletMetrics>
 
     std::atomic<i64> OrphanNodesCount{0};
 
+    // Deferred node destruction stats
+    std::atomic<i64> DeferredNodeDestructionCount{0};
+    std::atomic<i64> DeferredNodeDestructionsCompleted{0};
+    std::atomic<i64> DeferredNodeDestructionsCancelled{0};
+    std::atomic<i64> NodeDestructionsDeferralSkipped{0};
+
     NMetrics::TDefaultWindowCalculator MaxUsedQuota{0};
 
     using TLatHistogram =

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -1592,6 +1592,49 @@ bool TIndexTabletDatabase::ReadOrphanNodes(TVector<ui64>& nodeIds)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// DeferredNodeDestruction
+
+void TIndexTabletDatabase::WriteDeferredNodeDestruction(ui64 nodeId)
+{
+    using TTable = TIndexTabletSchema::DeferredNodeDestruction;
+
+    Table<TTable>()
+        .Key(nodeId)
+        .Update();
+}
+
+void TIndexTabletDatabase::DeleteDeferredNodeDestruction(ui64 nodeId)
+{
+    using TTable = TIndexTabletSchema::DeferredNodeDestruction;
+
+    Table<TTable>()
+        .Key(nodeId)
+        .Delete();
+}
+
+bool TIndexTabletDatabase::ReadDeferredNodeDestructions(TVector<ui64>& nodeIds)
+{
+    using TTable = TIndexTabletSchema::DeferredNodeDestruction;
+
+    auto it = Table<TTable>()
+        .Select();
+
+    if (!it.IsReady()) {
+        return false;   // not ready
+    }
+
+    while (it.IsValid()) {
+        nodeIds.emplace_back(it.GetValue<TTable::NodeId>());
+
+        if (!it.Next()) {
+            return false;   // not ready
+        }
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // NewBlobs
 
 void TIndexTabletDatabase::WriteNewBlob(const TPartialBlobId& blobId)

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -423,6 +423,14 @@ public:
     bool ReadOrphanNodes(TVector<ui64>& nodeIds) override;
 
     //
+    // DeferredNodeDestruction
+    //
+
+    void WriteDeferredNodeDestruction(ui64 nodeId) override;
+    void DeleteDeferredNodeDestruction(ui64 nodeId) override;
+    bool ReadDeferredNodeDestructions(TVector<ui64>& nodeIds) override;
+
+    //
     // NewBlobs
     //
 

--- a/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.cpp
@@ -748,6 +748,28 @@ bool TIndexTabletDatabaseWithFailureInjection::ReadOrphanNodes(TVector<ui64>& no
     return Real->ReadOrphanNodes(nodeIds);
 }
 
+void TIndexTabletDatabaseWithFailureInjection::WriteDeferredNodeDestruction(
+    ui64 nodeId)
+{
+    Real->WriteDeferredNodeDestruction(nodeId);
+}
+
+void TIndexTabletDatabaseWithFailureInjection::DeleteDeferredNodeDestruction(
+    ui64 nodeId)
+{
+    Real->DeleteDeferredNodeDestruction(nodeId);
+}
+
+bool TIndexTabletDatabaseWithFailureInjection::ReadDeferredNodeDestructions(
+    TVector<ui64>& nodeIds)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadDeferredNodeDestructions(nodeIds);
+}
+
 void TIndexTabletDatabaseWithFailureInjection::WriteNewBlob(
     const TPartialBlobId& blobId)
 {

--- a/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h
@@ -367,6 +367,14 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     bool ReadOrphanNodes(TVector<ui64>& nodeIds) override;
 
     //
+    // DeferredNodeDestruction
+    //
+
+    void WriteDeferredNodeDestruction(ui64 nodeId) override;
+    void DeleteDeferredNodeDestruction(ui64 nodeId) override;
+    bool ReadDeferredNodeDestructions(TVector<ui64>& nodeIds) override;
+
+    //
     // NewBlobs
     //
 

--- a/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
@@ -565,6 +565,41 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
         });
     }
 
+    Y_UNIT_TEST(ShouldStoreDeferredNodeDestructions)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&] (TIndexTabletDatabase db) {
+            db.InitSchema();
+        });
+
+        executor.WriteTx([&] (TIndexTabletDatabase db) {
+            db.WriteDeferredNodeDestruction(111);
+            db.WriteDeferredNodeDestruction(222);
+            db.WriteDeferredNodeDestruction(333);
+        });
+
+        executor.ReadTx([&] (TIndexTabletDatabase db) {
+            TVector<ui64> nodeIds;
+            UNIT_ASSERT(db.ReadDeferredNodeDestructions(nodeIds));
+            UNIT_ASSERT_VALUES_EQUAL(3, nodeIds.size());
+            UNIT_ASSERT_VALUES_EQUAL(111, nodeIds[0]);
+            UNIT_ASSERT_VALUES_EQUAL(222, nodeIds[1]);
+            UNIT_ASSERT_VALUES_EQUAL(333, nodeIds[2]);
+        });
+
+        executor.WriteTx([&] (TIndexTabletDatabase db) {
+            db.DeleteDeferredNodeDestruction(222);
+        });
+
+        executor.ReadTx([&] (TIndexTabletDatabase db) {
+            TVector<ui64> nodeIds;
+            UNIT_ASSERT(db.ReadDeferredNodeDestructions(nodeIds));
+            UNIT_ASSERT_VALUES_EQUAL(2, nodeIds.size());
+            UNIT_ASSERT_VALUES_EQUAL(111, nodeIds[0]);
+            UNIT_ASSERT_VALUES_EQUAL(333, nodeIds[1]);
+        });
+    }
+
     Y_UNIT_TEST(ShouldUseNoAutoPrechargeArgForNodeRefs)
     {
         TTestExecutor executor;

--- a/cloud/filestore/libs/storage/tablet/tablet_schema.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_schema.h
@@ -628,6 +628,20 @@ struct TIndexTabletSchema
         using StoragePolicy = TStoragePolicy<IndexChannel>;
     };
 
+    // Nodes kept alive during the post-restart handle confirmation grace period
+    struct DeferredNodeDestruction: TTableSchema<32>
+    {
+        struct NodeId       : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
+
+        using TKey = TableKey<NodeId>;
+
+        using TColumns = TableColumns<
+            NodeId
+        >;
+
+        using StoragePolicy = TStoragePolicy<IndexChannel>;
+    };
+
     using TTables = SchemaTables<
         FileSystem,
         Sessions,
@@ -659,7 +673,8 @@ struct TIndexTabletSchema
         ResponseLog,
         UnconfirmedData,
         Quotas,
-        QuotaUsage
+        QuotaUsage,
+        DeferredNodeDestruction
     >;
 
     using TSettings = SchemaSettings<

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -189,6 +189,7 @@ void TIndexTabletState::LoadState(
     const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo,
     const TVector<TDeletionMarker>& largeDeletionMarkers,
     const TVector<ui64>& orphanNodeIds,
+    const TVector<ui64>& deferredNodeDestructionIds,
     const TVector<NProto::TOpLogEntry>& opLog,
     const TVector<NProtoPrivate::TResponseLogEntry>& responseLog,
     const TThrottlerConfig& throttlerConfig)
@@ -262,6 +263,10 @@ void TIndexTabletState::LoadState(
     }
 
     Impl->OrphanNodeIds.insert(orphanNodeIds.begin(), orphanNodeIds.end());
+
+    Impl->DeferredNodeDestructionIds.insert(
+        deferredNodeDestructionIds.begin(),
+        deferredNodeDestructionIds.end());
 
     for (const auto& entry: opLog) {
         Impl->OpLogEntryIds.insert(entry.GetEntryId());
@@ -361,6 +366,8 @@ TMiscNodeStats TIndexTabletState::GetMiscNodeStats() const
 {
     return {
         .OrphanNodesCount = static_cast<i64>(Impl->OrphanNodeIds.size()),
+        .DeferredNodeDestructionCount =
+            static_cast<i64>(Impl->DeferredNodeDestructionIds.size()),
     };
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -154,6 +154,7 @@ struct TNodeToSessionCounters
 struct TMiscNodeStats
 {
     i64 OrphanNodesCount{0};
+    i64 DeferredNodeDestructionCount{0};
 };
 
 struct THandlesStats
@@ -294,6 +295,7 @@ public:
         const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo,
         const TVector<TDeletionMarker>& largeDeletionMarkers,
         const TVector<ui64>& orphanNodeIds,
+        const TVector<ui64>& deferredNodeDestructionIds,
         const TVector<NProto::TOpLogEntry>& opLog,
         const TVector<NProtoPrivate::TResponseLogEntry>& responseLog,
         const TThrottlerConfig& throttlerConfig);
@@ -575,6 +577,13 @@ public:
         ui64 minCommitId,
         ui64 maxCommitId);
 
+    // True if unlinking this node destroys it, i.e. it has no other links and
+    // no open handles.
+    bool UnlinkDestroysNode(const INodeIndexTabletDatabase::TNode& node) const;
+
+    // If deferDestruction is set, a node that loses its last reference is kept
+    // in the index and registered for a deferred destruction instead of being
+    // removed right away.
     [[nodiscard]] NProto::TError UnlinkNode(
         IIndexTabletDatabase& db,
         ui64 parentNodeId,
@@ -582,7 +591,8 @@ public:
         const INodeIndexTabletDatabase::TNode& node,
         ui64 minCommitId,
         ui64 maxCommitId,
-        bool removeNodeRef);
+        bool removeNodeRef,
+        bool deferDestruction);
 
     void UnlinkExternalNode(
         IIndexTabletDatabase& db,
@@ -610,6 +620,16 @@ public:
         IIndexTabletDatabase& db,
         const TString& message,
         ui64 nodeId);
+
+    //
+    // DeferredNodeDestruction
+    //
+
+    void AddDeferredNodeDestruction(IIndexTabletDatabase& db, ui64 nodeId);
+    void RemoveDeferredNodeDestruction(IIndexTabletDatabase& db, ui64 nodeId);
+    bool HasDeferredNodeDestruction(ui64 nodeId) const;
+    ui64 GetDeferredNodeDestructionCount() const;
+    TVector<ui64> GetDeferredNodeDestructionIds(ui64 maxCount) const;
 
     bool HasPendingNodeCreateInShard(const TString& nodeName) const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
@@ -533,6 +533,14 @@ public:
     virtual bool ReadOrphanNodes(TVector<ui64>& nodeIds) = 0;
 
     //
+    // DeferredNodeDestruction
+    //
+
+    virtual void WriteDeferredNodeDestruction(ui64 nodeId) = 0;
+    virtual void DeleteDeferredNodeDestruction(ui64 nodeId) = 0;
+    virtual bool ReadDeferredNodeDestructions(TVector<ui64>& nodeIds) = 0;
+
+    //
     // NewBlobs
     //
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -76,6 +76,7 @@ struct TIndexTabletState::TImpl
     TReadAheadCache ReadAheadCache;
     std::unique_ptr<IInMemoryIndexState> InMemoryIndexState;
     TSet<ui64> OrphanNodeIds;
+    TSet<ui64> DeferredNodeDestructionIds;
     TSet<TString> PendingNodeCreateInShardNames;
     THashSet<TNodeRefKey, TNodeRefKeyHash> LockedNodeRefs;
     THashSet<ui64> OpLogEntryIds;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -120,11 +120,6 @@ NProto::TError TIndexTabletState::RemoveNode(
     ui64 minCommitId,
     ui64 maxCommitId)
 {
-    // the node is gone - nothing to destroy later, no matter how this call ends
-    if (HasDeferredNodeDestruction(node.NodeId)) {
-        RemoveDeferredNodeDestruction(db, node.NodeId);
-    }
-
     // SymLinks have size (equal to TargetPath) but store no real data so there
     // is no need to write deletion markers upon SymLink removal
     if (!node.Attrs.GetSymLink()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -120,6 +120,11 @@ NProto::TError TIndexTabletState::RemoveNode(
     ui64 minCommitId,
     ui64 maxCommitId)
 {
+    // the node is gone - nothing to destroy later, no matter how this call ends
+    if (HasDeferredNodeDestruction(node.NodeId)) {
+        RemoveDeferredNodeDestruction(db, node.NodeId);
+    }
+
     // SymLinks have size (equal to TargetPath) but store no real data so there
     // is no need to write deletion markers upon SymLink removal
     if (!node.Attrs.GetSymLink()) {
@@ -156,6 +161,12 @@ NProto::TError TIndexTabletState::RemoveNode(
     return {};
 }
 
+bool TIndexTabletState::UnlinkDestroysNode(
+    const INodeIndexTabletDatabase::TNode& node) const
+{
+    return node.Attrs.GetLinks() <= 1 && !HasOpenHandles(node.NodeId);
+}
+
 NProto::TError TIndexTabletState::UnlinkNode(
     IIndexTabletDatabase& db,
     ui64 parentNodeId,
@@ -163,9 +174,12 @@ NProto::TError TIndexTabletState::UnlinkNode(
     const INodeIndexTabletDatabase::TNode& node,
     ui64 minCommitId,
     ui64 maxCommitId,
-    bool removeNodeRef)
+    bool removeNodeRef,
+    bool deferDestruction)
 {
-    if (node.Attrs.GetLinks() > 1 || HasOpenHandles(node.NodeId)) {
+    const bool destroysNode = UnlinkDestroysNode(node);
+
+    if (!destroysNode || deferDestruction) {
         auto attrs = CopyAttrs(node.Attrs, E_CM_CMTIME | E_CM_UNREF);
         UpdateNode(
             db,
@@ -174,6 +188,10 @@ NProto::TError TIndexTabletState::UnlinkNode(
             maxCommitId,
             attrs,
             node.Attrs);
+
+        if (destroysNode) {
+            AddDeferredNodeDestruction(db, node.NodeId);
+        }
     } else {
         auto e = RemoveNode(
             db,
@@ -275,6 +293,50 @@ void TIndexTabletState::WriteOrphanNode(
     ReportGeneratedOrphanNode(message);
     db.WriteOrphanNode(nodeId);
     Impl->OrphanNodeIds.insert(nodeId);
+}
+
+void TIndexTabletState::AddDeferredNodeDestruction(
+    IIndexTabletDatabase& db,
+    ui64 nodeId)
+{
+    db.WriteDeferredNodeDestruction(nodeId);
+    Impl->DeferredNodeDestructionIds.insert(nodeId);
+}
+
+void TIndexTabletState::RemoveDeferredNodeDestruction(
+    IIndexTabletDatabase& db,
+    ui64 nodeId)
+{
+    db.DeleteDeferredNodeDestruction(nodeId);
+    Impl->DeferredNodeDestructionIds.erase(nodeId);
+}
+
+bool TIndexTabletState::HasDeferredNodeDestruction(ui64 nodeId) const
+{
+    return Impl->DeferredNodeDestructionIds.contains(nodeId);
+}
+
+ui64 TIndexTabletState::GetDeferredNodeDestructionCount() const
+{
+    return Impl->DeferredNodeDestructionIds.size();
+}
+
+TVector<ui64> TIndexTabletState::GetDeferredNodeDestructionIds(
+    ui64 maxCount) const
+{
+    TVector<ui64> nodeIds;
+    nodeIds.reserve(
+        Min<ui64>(maxCount, Impl->DeferredNodeDestructionIds.size()));
+
+    for (const ui64 nodeId: Impl->DeferredNodeDestructionIds) {
+        if (nodeIds.size() >= maxCount) {
+            break;
+        }
+
+        nodeIds.push_back(nodeId);
+    }
+
+    return nodeIds;
 }
 
 bool TIndexTabletState::HasPendingNodeCreateInShard(const TString& nodeName) const

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1406,6 +1406,7 @@ struct TTxIndexTablet
 
     struct TDestroyDeferredNodes
         : TTxIndexTabletBase
+        , TErrorAware
         , TIndexStateNodeUpdates
     {
         // actually unused, needed in tablet_tx.h to avoid sophisticated
@@ -1424,6 +1425,7 @@ struct TTxIndexTablet
 
         void Clear() override
         {
+            TErrorAware::Clear();
             TIndexStateNodeUpdates::Clear();
 
             Nodes.clear();

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -118,6 +118,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(RenameNodeInDestination,            __VA_ARGS__)                       \
     xxx(CommitRenameNodeInSource,           __VA_ARGS__)                       \
     xxx(DeleteResponseLogEntries,           __VA_ARGS__)                       \
+    xxx(DestroyDeferredNodes,               __VA_ARGS__)                       \
     xxx(GetResponseLogEntry,                __VA_ARGS__)                       \
     xxx(WriteResponseLogEntry,              __VA_ARGS__)                       \
                                                                                \
@@ -371,6 +372,7 @@ struct TTxIndexTablet
         TVector<NProtoPrivate::TResponseLogEntry> ResponseLog;
         TVector<TDeletionMarker> LargeDeletionMarkers;
         TVector<ui64> OrphanNodeIds;
+        TVector<ui64> DeferredNodeDestructionIds;
         TVector<TIndexTabletDatabase::TUnconfirmedDataEntry> UnconfirmedData;
 
         void Clear() override
@@ -399,6 +401,7 @@ struct TTxIndexTablet
             ResponseLog.clear();
             LargeDeletionMarkers.clear();
             OrphanNodeIds.clear();
+            DeferredNodeDestructionIds.clear();
             UnconfirmedData.clear();
         }
     };
@@ -1394,6 +1397,38 @@ struct TTxIndexTablet
 
         void Clear() override
         {
+        }
+    };
+
+    //
+    // DestroyDeferredNodes
+    //
+
+    struct TDestroyDeferredNodes
+        : TTxIndexTabletBase
+        , TIndexStateNodeUpdates
+    {
+        // actually unused, needed in tablet_tx.h to avoid sophisticated
+        // template tricks
+        const TRequestInfoPtr RequestInfo;
+
+        const TVector<ui64> NodeIds;
+
+        TVector<TMaybe<INodeIndexTabletDatabase::TNode>> Nodes;
+        ui64 DestroyedNodeCount = 0;
+        ui64 CancelledNodeCount = 0;
+
+        explicit TDestroyDeferredNodes(TVector<ui64> nodeIds)
+            : NodeIds(std::move(nodeIds))
+        {}
+
+        void Clear() override
+        {
+            TIndexStateNodeUpdates::Clear();
+
+            Nodes.clear();
+            DestroyedNodeCount = 0;
+            CancelledNodeCount = 0;
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_handles.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_handles.cpp
@@ -1391,6 +1391,70 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
             response->Record.GetError().GetMessage());
     }
 
+    Y_UNIT_TEST(ShouldDestroyDeferredNodeWithAnotherTransactionInFlight)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        const ui64 id =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        tablet.UnlinkNode(
+            RootNodeId,
+            "test",
+            false /* unlinkDirectory */);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        TVector<TAutoPtr<IEventHandle>> heldCommits;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+
+                if (event->GetTypeRewrite() == NKikimr::TEvTablet::EvCommit &&
+                    event->Get<NKikimr::TEvTablet::TEvCommit>()->TabletID ==
+                        tabletId)
+                {
+                    heldCommits.push_back(std::move(event));
+                    return true;
+                }
+
+                return false;
+            });
+
+        // Keep an unrelated transaction in flight while the regular task
+        // starts the deferred node destruction transaction.
+        tablet.SendRequest(tablet.CreateCreateNodeRequest(
+            TCreateNodeArgs::File(RootNodeId, "blocker")));
+        env.GetRuntime().DispatchEvents(TDispatchOptions{
+            .CustomFinalCondition = [&]() { return !heldCommits.empty(); }});
+
+        tablet.AdvanceTime(TDuration::Seconds(10));
+        env.GetRuntime().DispatchEvents(TDispatchOptions{
+            .CustomFinalCondition = [&]() { return heldCommits.size() >= 2; }});
+
+        env.GetRuntime().SetEventFilter(
+            TTestActorRuntimeBase::DefaultFilterFunc);
+        for (auto& event: heldCommits) {
+            env.GetRuntime().Send(event.Release(), nodeIdx);
+        }
+
+        auto response = tablet.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->Record.GetError().GetCode(),
+            response->Record.GetError().GetMessage());
+
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+        tablet.AssertAccessNodeFailed(id);
+    }
+
     Y_UNIT_TEST(ShouldDestroyDeferredNodeAfterTabletRestart)
     {
         TTestEnv env({}, DeferredNodeDestructionConfig());

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_handles.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_handles.cpp
@@ -1,3 +1,4 @@
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
@@ -9,6 +10,7 @@ namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
 using namespace NKikimr;
+using namespace NMonitoring;
 
 namespace {
 
@@ -62,6 +64,40 @@ ui64 CreateAndLoseAsyncHandle(
     tablet.RecoverSession();
 
     return handle;
+}
+
+NProto::TStorageConfig DeferredNodeDestructionConfig()
+{
+    NProto::TStorageConfig config;
+    config.SetAsyncCreateHandleEnabled(true);
+    config.SetUnconfirmedCreateHandleGraceTimeout(
+        TDuration::Seconds(5).MilliSeconds());
+    config.SetTabletRegularTasksSchedulePeriod(
+        TDuration::Seconds(1).MilliSeconds());
+    return config;
+}
+
+void WriteFileContent(
+    TIndexTabletClient& tablet,
+    ui64 nodeId,
+    ui64 len,
+    char fill)
+{
+    const ui64 handle = CreateHandle(tablet, nodeId);
+    tablet.WriteData(handle, 0, len, fill);
+    tablet.DestroyHandle(handle);
+}
+
+// Lets the grace period expire and the deferred node destruction run.
+void WaitForDeferredNodeDestruction(TTestEnv& env, TIndexTabletClient& tablet)
+{
+    tablet.AdvanceTime(TDuration::Seconds(10));
+    env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+}
+
+ui64 GetUsedNodesCount(TIndexTabletClient& tablet)
+{
+    return GetStorageStats(tablet).GetUsedNodesCount();
 }
 
 }   // namespace
@@ -1273,6 +1309,351 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
             "Expected at least 3 different generations due to tablet reboot, "
             "got "
                 << rebootTracker.GetGenerationCount());
+    }
+
+    Y_UNIT_TEST(ShouldDeferNodeDestructionForUnconfirmedHandle)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        WriteFileContent(tablet, id, 1_KB, 'a');
+
+        const ui64 handle = CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        TIndexTabletClient tablet2(env.GetRuntime(), nodeIdx, tabletId);
+        tablet2.InitSession("client2", "session2");
+
+        // Another client unlinks the node before the lost handle has been
+        // confirmed. The node is unlinked but not destroyed.
+        tablet2.UnlinkNode(RootNodeId, "test", false);
+        tablet2.AssertGetNodeAttrFailed(RootNodeId, "test");
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        tablet.ConfirmCreateHandle(
+            id,
+            handle,
+            TCreateHandleArgs::RDNLY,
+            100500);
+
+        WaitForDeferredNodeDestruction(env, tablet);
+
+        // The confirmed handle keeps the node alive and its data intact.
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+        auto response = tablet.ReadData(handle, 0, 1_KB);
+        UNIT_ASSERT_VALUES_EQUAL(
+            CreateBuffer(1_KB, 'a'),
+            response->Record.GetBuffer());
+
+        tablet.DestroyHandle(handle);
+        UNIT_ASSERT_VALUES_EQUAL(0, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldDestroyDeferredNodeAfterGraceExpires)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        WriteFileContent(tablet, id, 1_KB, 'a');
+
+        const ui64 handle = CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        // Nobody confirmed the handle, so the node is destroyed once the grace
+        // period is over - together with its data.
+        WaitForDeferredNodeDestruction(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(0, GetUsedNodesCount(tablet));
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            GetStorageStats(tablet).GetUsedBlocksCount());
+
+        auto response = tablet.AssertConfirmCreateHandleFailed(
+            id,
+            handle,
+            TCreateHandleArgs::RDNLY,
+            100500);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_FS_NOENT,
+            response->Record.GetError().GetCode(),
+            response->Record.GetError().GetMessage());
+    }
+
+    Y_UNIT_TEST(ShouldDestroyDeferredNodeAfterTabletRestart)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        // The deferred destruction is persistent, so the node is neither
+        // leaked nor destroyed too early after another restart.
+        tablet.RebootTablet();
+        tablet.RecoverSession();
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        WaitForDeferredNodeDestruction(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(0, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldNotDeferNodeDestructionIfGraceTimeoutIsZero)
+    {
+        auto storageConfig = DeferredNodeDestructionConfig();
+        storageConfig.SetUnconfirmedCreateHandleGraceTimeout(0);
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        UNIT_ASSERT_VALUES_EQUAL(0, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldNotDeferNodeDestructionIfLimitIsZero)
+    {
+        auto storageConfig = DeferredNodeDestructionConfig();
+        storageConfig.SetMaxDeferredNodeDestructionCount(0);
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        // The deferral is disabled, so the unlink is neither deferred nor
+        // rejected.
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        UNIT_ASSERT_VALUES_EQUAL(0, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldNotDeferDirectoryDestruction)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateNode(tablet, TCreateNodeArgs::Directory(RootNodeId, "dir"));
+        CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+        UNIT_ASSERT_VALUES_EQUAL(2, GetUsedNodesCount(tablet));
+
+        // A directory can't have handles, so its destruction is never deferred.
+        tablet.UnlinkNode(RootNodeId, "dir", true);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldNotDeferDestructionOfNodesCreatedAfterRestart)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test2"));
+        UNIT_ASSERT_VALUES_EQUAL(2, GetUsedNodesCount(tablet));
+
+        // No handle for a node created after the restart could have been lost
+        // by that restart, so its destruction is not deferred.
+        tablet.UnlinkNode(RootNodeId, "test2", false);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldDeferNodeDestructionUponRenameNode)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test2"));
+
+        const ui64 handle = CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        // Renaming over the node unlinks it just like UnlinkNode does.
+        tablet.RenameNode(RootNodeId, "test2", RootNodeId, "test");
+        UNIT_ASSERT_VALUES_EQUAL(2, GetUsedNodesCount(tablet));
+
+        tablet.ConfirmCreateHandle(
+            id,
+            handle,
+            TCreateHandleArgs::RDNLY,
+            100500);
+
+        WaitForDeferredNodeDestruction(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(2, GetUsedNodesCount(tablet));
+
+        tablet.DestroyHandle(handle);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldDeferNodeDestructionUponDestroyHandle)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        TIndexTabletClient tablet2(env.GetRuntime(), nodeIdx, tabletId);
+        tablet2.InitSession("client2", "session2");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        const ui64 handle2 =
+            CreateHandle(tablet2, id, {}, TCreateHandleArgs::RDNLY);
+
+        const ui64 handle = CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+        // the tablet was rebooted, so the other client's pipe is stale
+        tablet2.ReconnectPipe();
+        tablet2.RecoverSession();
+
+        // The node survives the unlink because of the other session's handle.
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        // Closing that handle would destroy the node - the lost handle is not
+        // known to the tablet yet, so the destruction is deferred instead.
+        tablet2.DestroyHandle(handle2);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        tablet.ConfirmCreateHandle(
+            id,
+            handle,
+            TCreateHandleArgs::RDNLY,
+            100500);
+
+        WaitForDeferredNodeDestruction(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        tablet.DestroyHandle(handle);
+        UNIT_ASSERT_VALUES_EQUAL(0, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldDeferNodeDestructionUponDestroySession)
+    {
+        TTestEnv env({}, DeferredNodeDestructionConfig());
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        TIndexTabletClient tablet2(env.GetRuntime(), nodeIdx, tabletId);
+        tablet2.InitSession("client2", "session2");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateHandle(tablet2, id, {}, TCreateHandleArgs::RDNLY);
+
+        const ui64 handle = CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+        // the tablet was rebooted, so the other client's pipe is stale
+        tablet2.ReconnectPipe();
+        tablet2.RecoverSession();
+
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        // Same as ShouldDeferNodeDestructionUponDestroyHandle, but the other
+        // session's handles are destroyed by the session cleanup.
+        tablet2.DestroySession();
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        tablet.ConfirmCreateHandle(
+            id,
+            handle,
+            TCreateHandleArgs::RDNLY,
+            100500);
+
+        WaitForDeferredNodeDestruction(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+
+        tablet.DestroyHandle(handle);
+        UNIT_ASSERT_VALUES_EQUAL(0, GetUsedNodesCount(tablet));
+    }
+
+    Y_UNIT_TEST(ShouldNotDeferNodeDestructionIfLimitIsReached)
+    {
+        auto storageConfig = DeferredNodeDestructionConfig();
+        storageConfig.SetMaxDeferredNodeDestructionCount(1);
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TDynamicCountersPtr counters = new TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto limitExceeded = counters->GetCounter(
+            "AppCriticalEvents/DeferredNodeDestructionLimitExceeded",
+            true);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test2"));
+
+        CreateAndLoseAsyncHandle(env, tablet, id, 100500);
+
+        // fills up the deferral limit
+        tablet.UnlinkNode(RootNodeId, "test", false);
+        UNIT_ASSERT_VALUES_EQUAL(2, GetUsedNodesCount(tablet));
+        UNIT_ASSERT_VALUES_EQUAL(0, limitExceeded->Val());
+
+        // The limit leaves no room for another deferral. The unlink is not
+        // rejected - a retriable error here would be retried in a loop by the
+        // leader tablet - the node is destroyed and the event is reported.
+        tablet.UnlinkNode(RootNodeId, "test2", false);
+        UNIT_ASSERT_VALUES_EQUAL(1, GetUsedNodesCount(tablet));
+        UNIT_ASSERT_VALUES_EQUAL(1, limitExceeded->Val());
+
+        WaitForDeferredNodeDestruction(env, tablet);
+        UNIT_ASSERT_VALUES_EQUAL(0, GetUsedNodesCount(tablet));
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -37,6 +37,7 @@ SRCS(
     tablet_actor_deletecheckpoint.cpp
     tablet_actor_deletegarbage.cpp
     tablet_actor_destroycheckpoint.cpp
+    tablet_actor_destroydeferrednodes.cpp
     tablet_actor_destroyhandle.cpp
     tablet_actor_destroysession.cpp
     tablet_actor_dumprange.cpp


### PR DESCRIPTION
#5432
#6485
#6486

Async CreateHandle replies before its tx commits, so a restart loses the handle
until the client's queued ConfirmCreateHandle recreates it. Within that window
an unlink - or a rename over the node, or another session closing its last
handle - destroys the node together with its data, and the confirm that follows
fails with E_FS_NOENT.

Such a node is now unlinked but kept until UnconfirmedCreateHandleGraceTimeout
after the tablet start expires. It is recorded in the new
DeferredNodeDestruction table and destroyed later by a background task, unless a
confirm claimed it by then.
