### PR TITLE
[NBS] Add reusable storage config ICB controls

### DIFF
--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -9,6 +9,7 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 
 #include <util/generic/size_literals.h>
+#include <util/system/mutex.h>
 
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -1003,32 +1004,191 @@ constexpr TAtomicBase ConvertToAtomicBase(const TDuration& value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TStorageConfig::TImpl
+// The private control collection owned by one TStorageConfigControls. It keeps
+// one TControlWrapper for every read-write storage setting and applies one of
+// these default-value policies:
+//  - a config-bound set:
+//      - created by the two-argument TStorageConfig constructor
+//      - uses values from its initial proto as ICB defaults
+//      - may be shared only by TStorageConfig copy construction, which also
+//        copies the raw proto
+//  - a config-independent set:
+//      - uses a reserved default to represent "no override" (represents only
+//        explicit ICB overrides)
+//      - may be used by (shared between) multiple TStorageConfig instances
+struct TStorageConfigControls::TImpl
 {
-    NProto::TStorageServiceConfig StorageServiceConfig;
-    NFeatures::TFeaturesConfigPtr FeaturesConfig;
+    // The reserved default used by config-independent controls to mean
+    // "no override". Their lower bound is NoOverride + 1, so ICB cannot set
+    // this value itself.
+    static constexpr TAtomicBase NoOverride = Min<TAtomicBase>();
 
-#define BLOCKSTORE_CONFIG_CONTROL(name, type, value)                           \
-    TControlWrapper Control##name{                                             \
-        ConvertToAtomicBase<type>(BLOCKSTORE_CONFIG_GET_CONFIG_VALUE(          \
-            StorageServiceConfig,                                              \
-            name,                                                              \
-            type,                                                              \
-            value)),                                                           \
-        Min<i64>(),                                                            \
-        Max<i64>()};                                                           \
-    // BLOCKSTORE_CONFIG_CONTROL
+    // The control-set mode: true for config-independent defaults that represent
+    // absent overrides; false for defaults bound to one configuration proto.
+    const bool ConfigIndependent;
+
+    // Registration-state lock. It serializes the first registration and
+    // protects RegisteredBoard.
+    TMutex RegistrationLock;
+
+    // Non-owning address of the registered board. It is null before Register(),
+    // then remains equal to that board for the lifetime of this control set.
+    // Access requires RegistrationLock.
+    TControlBoard* RegisteredBoard = nullptr;
+
+    // One wrapper per BLOCKSTORE_STORAGE_CONFIG_RW field. Each wrapper stores
+    // the field's ICB default, allowed range, and current ICB value.
+#define BLOCKSTORE_CONFIG_CONTROL(name, ...) TControlWrapper Control##name;
 
     BLOCKSTORE_STORAGE_CONFIG_RW(BLOCKSTORE_CONFIG_CONTROL)
 
 #undef BLOCKSTORE_CONFIG_CONTROL
 
+    explicit TImpl(
+        const NProto::TStorageServiceConfig& storageServiceConfig,
+        bool configIndependent)
+        : ConfigIndependent(configIndependent)
+    {
+#define BLOCKSTORE_CONFIG_RESET(name, type, value)                             \
+    Control##name.Reset(                                                       \
+        ConfigIndependent                                                      \
+            ? NoOverride                                                       \
+            : ConvertToAtomicBase<type>(BLOCKSTORE_CONFIG_GET_CONFIG_VALUE(    \
+                  storageServiceConfig,                                        \
+                  name,                                                        \
+                  type,                                                        \
+                  value)),                                                     \
+        ConfigIndependent ? NoOverride + 1 : Min<TAtomicBase>(),               \
+        Max<TAtomicBase>());                                                   \
+    // BLOCKSTORE_CONFIG_RESET
+
+        BLOCKSTORE_STORAGE_CONFIG_RW(BLOCKSTORE_CONFIG_RESET)
+
+#undef BLOCKSTORE_CONFIG_RESET
+    }
+
+    std::optional<i64> ReadOverride(const TControlWrapper& control) const
+    {
+        const TAtomicBase value = static_cast<TAtomicBase>(control);
+        if (value == control.GetDefault()) {
+            return std::nullopt;
+        }
+
+        return static_cast<i64>(value);
+    }
+};
+
+TStorageConfigControls::TStorageConfigControls()
+    : Impl(new TImpl(NProto::TStorageServiceConfig(), true))
+{}
+
+TStorageConfigControls::TStorageConfigControls(
+    const NProto::TStorageServiceConfig& storageServiceConfig)
+    : Impl(new TImpl(storageServiceConfig, false))
+{}
+
+TStorageConfigControls::~TStorageConfigControls() = default;
+
+void TStorageConfigControls::Register(TControlBoard& controlBoard)
+{
+    TGuard<TMutex> guard(Impl->RegistrationLock);
+
+    // Another board could replace wrappers with controls registered under the
+    // same names there, so this control set remains bound to its first board.
+    Y_ABORT_UNLESS(
+        !Impl->RegisteredBoard || Impl->RegisteredBoard == &controlBoard);
+
+    if (Impl->RegisteredBoard) {
+        return;
+    }
+
+    bool allControlsWereInserted = true;
+
+#define BLOCKSTORE_CONFIG_REGISTER(name, ...)                                  \
+    allControlsWereInserted &= controlBoard.RegisterSharedControl(             \
+        Impl->Control##name,                                                   \
+        "BlockStore_" #name);                                                  \
+    // BLOCKSTORE_CONFIG_REGISTER
+
+    BLOCKSTORE_STORAGE_CONFIG_RW(BLOCKSTORE_CONFIG_REGISTER)
+
+#undef BLOCKSTORE_CONFIG_REGISTER
+
+    // On a name collision, RegisterSharedControl replaces the wrapper's control
+    // with the TControl object already registered by another control set.
+    //  - a config-independent wrapper would then lose its NoOverride default
+    //    and adopt that object's default, bounds, and current value
+    //  - config-bound wrappers intentionally preserve the existing
+    //    shared-registration behavior.
+    // Register one config-independent set per board and share it between
+    // TStorageConfig instances; abort if this contract is violated.
+    Y_ABORT_UNLESS(!Impl->ConfigIndependent || allControlsWereInserted);
+    Impl->RegisteredBoard = &controlBoard;
+}
+
+std::optional<i64> TStorageConfigControls::GetOverride(TStringBuf name) const
+{
+#define BLOCKSTORE_CONFIG_GET_OVERRIDE(field, ...)                             \
+    if (name == #field) {                                                      \
+        return Impl->ReadOverride(Impl->Control##field);                       \
+    }                                                                          \
+    // BLOCKSTORE_CONFIG_GET_OVERRIDE
+
+    BLOCKSTORE_STORAGE_CONFIG_RW(BLOCKSTORE_CONFIG_GET_OVERRIDE)
+
+#undef BLOCKSTORE_CONFIG_GET_OVERRIDE
+
+    return std::nullopt;
+}
+
+bool TStorageConfigControls::RestoreDefault(TStringBuf name)
+{
+    {
+        TGuard<TMutex> guard(Impl->RegistrationLock);
+        if (!Impl->RegisteredBoard) {
+            return false;
+        }
+    }
+
+#define BLOCKSTORE_CONFIG_RESTORE_DEFAULT(field, ...)                          \
+    if (name == #field) {                                                      \
+        /* Assign only GetDefault(), because operator= rewrites the control's  \
+           Default as well as control's Value */                               \
+        Impl->Control##field = Impl->Control##field.GetDefault();              \
+        return true;                                                           \
+    }                                                                          \
+    // BLOCKSTORE_CONFIG_RESTORE_DEFAULT
+
+    BLOCKSTORE_STORAGE_CONFIG_RW(BLOCKSTORE_CONFIG_RESTORE_DEFAULT)
+
+#undef BLOCKSTORE_CONFIG_RESTORE_DEFAULT
+
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TStorageConfig::TImpl
+{
+    NProto::TStorageServiceConfig StorageServiceConfig;
+    NFeatures::TFeaturesConfigPtr FeaturesConfig;
+
+    // Non-null ICB controls for all read-write storage fields. The
+    // three-argument constructor can reuse a config-independent collection;
+    // the two-argument constructor creates a config-bound collection; the copy
+    // constructor shares the collection in either mode.
+    TStorageConfigControlsPtr Controls;
+
     TImpl(
-            NProto::TStorageServiceConfig storageServiceConfig,
-            NFeatures::TFeaturesConfigPtr featuresConfig)
+        NProto::TStorageServiceConfig storageServiceConfig,
+        NFeatures::TFeaturesConfigPtr featuresConfig,
+        TStorageConfigControlsPtr controls)
         : StorageServiceConfig(std::move(storageServiceConfig))
         , FeaturesConfig(std::move(featuresConfig))
-    {}
+        , Controls(std::move(controls))
+    {
+        Y_ABORT_UNLESS(Controls);
+    }
 
     void SetFeaturesConfig(NFeatures::TFeaturesConfigPtr featuresConfig)
     {
@@ -1047,11 +1207,11 @@ struct TStorageConfig::TImpl
 
     // Overriding fields with values from ICB
 #define BLOCKSTORE_CONFIG_COPY(name, type, ...)                                \
-    if (!Control##name.IsDefault())                                            \
+    if (const auto value =                                                     \
+            Controls->Impl->ReadOverride(Controls->Impl->Control##name))       \
     {                                                                          \
         using T = decltype(StorageServiceConfig.Get##name());                  \
-        const i64 value = Control##name;                                       \
-        proto.Set##name(ConvertValue<T>(value));                               \
+        proto.Set##name(ConvertValue<T>(*value));                              \
     }                                                                          \
     // BLOCKSTORE_CONFIG_COPY
 
@@ -1066,12 +1226,51 @@ struct TStorageConfig::TImpl
 ////////////////////////////////////////////////////////////////////////////////
 
 TStorageConfig::TStorageConfig(
-        NProto::TStorageServiceConfig storageServiceConfig,
-        NFeatures::TFeaturesConfigPtr featuresConfig)
-    : Impl(new TImpl(std::move(storageServiceConfig), std::move(featuresConfig)))
+    NProto::TStorageServiceConfig storageServiceConfig,
+    NFeatures::TFeaturesConfigPtr featuresConfig)
+    : TStorageConfig(
+          std::move(storageServiceConfig),
+          std::move(featuresConfig),
+          nullptr)
+{}
+
+TStorageConfig::TStorageConfig(
+    NProto::TStorageServiceConfig storageServiceConfig,
+    NFeatures::TFeaturesConfigPtr featuresConfig,
+    TStorageConfigControlsPtr controls)
+{
+    Y_ABORT_UNLESS(!controls || controls->Impl->ConfigIndependent);
+
+    if (!controls) {
+        controls = TStorageConfigControlsPtr(
+            new TStorageConfigControls(storageServiceConfig));
+    }
+
+    Impl = std::make_unique<TImpl>(
+        std::move(storageServiceConfig),
+        std::move(featuresConfig),
+        std::move(controls));
+}
+
+TStorageConfig::TStorageConfig(const TStorageConfig& other)
+    : Impl(std::make_unique<TImpl>(
+          other.Impl->StorageServiceConfig,
+          other.Impl->FeaturesConfig,
+          other.Impl->Controls))
 {}
 
 TStorageConfig::~TStorageConfig() = default;
+
+const TStorageConfigControls::TImpl* TStorageConfig::ControlsImpl() const
+{
+    return Impl->Controls->Impl.get();
+}
+
+TStorageConfigControlsPtr
+TStorageConfig::GetStorageConfigControls() const
+{
+    return ControlsImpl()->ConfigIndependent ? Impl->Controls : nullptr;
+}
 
 void TStorageConfig::SetFeaturesConfig(
     NFeatures::TFeaturesConfigPtr featuresConfig)
@@ -1085,16 +1284,9 @@ void TStorageConfig::SetVolumePreemptionType(
     Impl->SetVolumePreemptionType(volumePreemptionType);
 }
 
-void TStorageConfig::Register(TControlBoard& controlBoard){
-#define BLOCKSTORE_CONFIG_CONTROL(name, type, value)                           \
-    controlBoard.RegisterSharedControl(                                        \
-        Impl->Control##name,                                                   \
-        "BlockStore_" #name);                                                  \
-// BLOCKSTORE_CONFIG_CONTROL
-
-    BLOCKSTORE_STORAGE_CONFIG_RW(BLOCKSTORE_CONFIG_CONTROL)
-
-#undef BLOCKSTORE_CONFIG_CONTROL
+void TStorageConfig::Register(TControlBoard& controlBoard)
+{
+    Impl->Controls->Register(controlBoard);
 }
 
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
@@ -1114,9 +1306,10 @@ BLOCKSTORE_STORAGE_CONFIG_RO(BLOCKSTORE_CONFIG_GETTER)
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
     type TStorageConfig::Get##name() const                                     \
     {                                                                          \
-        if (!Impl->Control##name.IsDefault()) {                                \
-            const i64 value = Impl->Control##name;                             \
-            return ConvertValue<type>(value);                                  \
+        if (const auto value = ControlsImpl()->ReadOverride(                   \
+                ControlsImpl()->Control##name))                                \
+        {                                                                      \
+            return ConvertValue<type>(*value);                                 \
         }                                                                      \
         return BLOCKSTORE_CONFIG_GET_CONFIG_VALUE(                             \
             Impl->StorageServiceConfig,                                        \
@@ -1229,7 +1422,10 @@ TStorageConfigPtr TStorageConfig::Merge(
     TStorageConfigPtr config,
     const NProto::TStorageServiceConfig& patch)
 {
-    const auto configProto = config->GetStorageConfigProto();
+    auto controls = config->GetStorageConfigControls();
+    const auto configProto = controls
+                                 ? config->Impl->StorageServiceConfig
+                                 : config->GetStorageConfigProto();
     auto patchedConfigProto = configProto;
     patchedConfigProto.MergeFrom(patch);
     if (google::protobuf::util::MessageDifferencer::Equals(
@@ -1241,7 +1437,8 @@ TStorageConfigPtr TStorageConfig::Merge(
 
     return std::make_shared<TStorageConfig>(
         std::move(patchedConfigProto),
-        config->Impl->FeaturesConfig);
+        config->Impl->FeaturesConfig,
+        std::move(controls));
 }
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -9,7 +9,11 @@
 
 #include <util/datetime/base.h>
 #include <util/generic/string.h>
+#include <util/generic/strbuf.h>
 #include <util/stream/output.h>
+
+#include <memory>
+#include <optional>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -33,21 +37,96 @@ using TPoolKindToMediaKindMapping =
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Immediate Control Board controls for read-write storage settings.
+// TStorageConfig reads an explicitly set ICB value before the corresponding
+// protobuf value without modifying the proto. A control set has one of these
+// modes:
+//  - config-independent: register one set per board and share it between
+//    TStorageConfig instances; its defaults mean "no ICB override"
+//  - config-bound: create it for one TStorageConfig; copy construction may
+//    share it while copying that config's raw proto. Its defaults match the
+//    original proto values
+// Default construction creates a config-independent set. The two-argument
+// TStorageConfig constructor creates a private config-bound set.
+class TStorageConfigControls
+{
+public:
+    // Create a config-independent control set with no active overrides.
+    TStorageConfigControls();
+    ~TStorageConfigControls();
+
+    TStorageConfigControls(const TStorageConfigControls&) = delete;
+    TStorageConfigControls& operator=(const TStorageConfigControls&) = delete;
+
+    // Register every read-write field control. Repeated registration on the
+    // same board is a no-op; a different board must not be used.
+    void Register(NKikimr::TControlBoard& controlBoard);
+
+    // Return an explicit ICB override for a known read-write field. An empty
+    // result means "no override" - the caller must use its configuration proto
+    // value.
+    std::optional<i64> GetOverride(TStringBuf name) const;
+
+    // Restore a registered field's ICB control to its initial value. For a
+    // config-independent instance, the initial value means "no override". For a
+    // config-bound instance, it equals the field value from the configuration
+    // proto. Return false for an unknown or unregistered field.
+    bool RestoreDefault(TStringBuf name);
+
+private:
+    friend class TStorageConfig;
+
+    struct TImpl;
+
+    // Non-null implementation containing all read-write field controls, their
+    // configuration-binding policy, and the registered board address.
+    std::unique_ptr<TImpl> Impl;
+
+    // Create the private per-config control set used by the two-argument
+    // TStorageConfig constructor. ICB defaults are read from the supplied
+    // proto.
+    explicit TStorageConfigControls(
+        const NProto::TStorageServiceConfig& storageServiceConfig);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TStorageConfig
 {
 private:
     struct TImpl;
     std::unique_ptr<TImpl> Impl;
 
+    const TStorageConfigControls::TImpl* ControlsImpl() const;
+
 public:
     TStorageConfig(
         NProto::TStorageServiceConfig storageServiceConfig,
         NFeatures::TFeaturesConfigPtr featuresConfig);
+
+    // Use the supplied config-independent controls for ICB overrides. If
+    // controls is null, create config-bound controls from storageServiceConfig,
+    // as the two-argument constructor does.
+    TStorageConfig(
+        NProto::TStorageServiceConfig storageServiceConfig,
+        NFeatures::TFeaturesConfigPtr featuresConfig,
+        TStorageConfigControlsPtr controls);
+
+    // Create a raw-proto copy that shares Features and the live ICB controls.
+    TStorageConfig(const TStorageConfig& other);
+    TStorageConfig& operator=(const TStorageConfig&) = delete;
+
     ~TStorageConfig();
+
+    // Return reusable config-independent controls. Return null for
+    // config-bound controls, including controls shared internally by copy
+    // construction.
+    TStorageConfigControlsPtr GetStorageConfigControls() const;
 
     void SetFeaturesConfig(NFeatures::TFeaturesConfigPtr featuresConfig);
 
-    void SetVolumePreemptionType(NProto::EVolumePreemptionType volumePreemptionType);
+    void SetVolumePreemptionType(
+        NProto::EVolumePreemptionType volumePreemptionType);
 
     void Register(NKikimr::TControlBoard& controlBoard);
 

--- a/cloud/blockstore/libs/storage/core/config_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/config_ut.cpp
@@ -4,6 +4,11 @@
 
 #include <contrib/ydb/core/control/immediate_control_board_impl.h>
 
+#include <util/generic/vector.h>
+
+#include <latch>
+#include <thread>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -27,6 +32,280 @@ Y_UNIT_TEST_SUITE(TConfigTest)
             previousValue));
         UNIT_ASSERT_VALUES_EQUAL(0, AtomicGet(previousValue));
         UNIT_ASSERT(config->GetHiveProxyFallbackMode());
+    }
+
+    Y_UNIT_TEST(ShouldSetAndRestoreConfigBoundControlsViaIcb)
+    {
+        // Verify that ICB overrides all configurations when one configuration
+        // default equals the ICB value and the other two defaults differ.
+        NProto::TStorageServiceConfig firstProto;
+        firstProto.SetWriteBlobThreshold(100);
+        auto first = std::make_shared<TStorageConfig>(
+            firstProto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+        UNIT_ASSERT(!first->GetStorageConfigControls());
+
+        NProto::TStorageServiceConfig secondProto;
+        secondProto.SetWriteBlobThreshold(200);
+        auto second = std::make_shared<TStorageConfig>(
+            secondProto,
+            std::make_shared<NFeatures::TFeaturesConfig>(),
+            nullptr);
+        UNIT_ASSERT(!second->GetStorageConfigControls());
+
+        NProto::TStorageServiceConfig thirdProto;
+        thirdProto.SetWriteBlobThreshold(300);
+        auto third = std::make_shared<TStorageConfig>(
+            thirdProto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+        UNIT_ASSERT(!third->GetStorageConfigControls());
+
+        NKikimr::TControlBoard controlBoard;
+        first->Register(controlBoard);
+        second->Register(controlBoard);
+        third->Register(controlBoard);
+
+        TAtomic previousValue = {};
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_WriteBlobThreshold",
+            200,
+            previousValue));
+        UNIT_ASSERT_VALUES_EQUAL(100, AtomicGet(previousValue));
+        UNIT_ASSERT_VALUES_EQUAL(200, first->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(200, second->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(200, third->GetWriteBlobThreshold());
+
+        controlBoard.RestoreDefault("BlockStore_WriteBlobThreshold");
+        UNIT_ASSERT_VALUES_EQUAL(100, first->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(200, second->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(300, third->GetWriteBlobThreshold());
+    }
+
+    Y_UNIT_TEST(ShouldSetAndRestoreConfigIndependentControlsViaIcb)
+    {
+        // Verify that ICB overrides all configurations when one configuration
+        // default equals the ICB value and the other two defaults differ.
+        auto controls = std::make_shared<TStorageConfigControls>();
+        UNIT_ASSERT(!controls->GetOverride("WriteBlobThreshold"));
+        UNIT_ASSERT(!controls->RestoreDefault("WriteBlobThreshold"));
+
+        NKikimr::TControlBoard controlBoard;
+        controls->Register(controlBoard);
+        controls->Register(controlBoard);
+
+        NProto::TStorageServiceConfig firstProto;
+        firstProto.SetWriteBlobThreshold(100);
+        auto first = std::make_shared<TStorageConfig>(
+            firstProto,
+            std::make_shared<NFeatures::TFeaturesConfig>(),
+            controls);
+        UNIT_ASSERT(first->GetStorageConfigControls() == controls);
+
+        NProto::TStorageServiceConfig secondProto;
+        secondProto.SetWriteBlobThreshold(200);
+        auto second = std::make_shared<TStorageConfig>(
+            secondProto,
+            std::make_shared<NFeatures::TFeaturesConfig>(),
+            controls);
+        UNIT_ASSERT(second->GetStorageConfigControls() == controls);
+
+        NProto::TStorageServiceConfig thirdProto;
+        thirdProto.SetWriteBlobThreshold(300);
+        auto third = std::make_shared<TStorageConfig>(
+            thirdProto,
+            std::make_shared<NFeatures::TFeaturesConfig>(),
+            controls);
+        UNIT_ASSERT(third->GetStorageConfigControls() == controls);
+
+        UNIT_ASSERT_VALUES_EQUAL(100, first->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(200, second->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(300, third->GetWriteBlobThreshold());
+
+        TAtomic previousValue = {};
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_WriteBlobThreshold",
+            200,
+            previousValue));
+
+        const auto override = controls->GetOverride("WriteBlobThreshold");
+        UNIT_ASSERT(override);
+        UNIT_ASSERT_VALUES_EQUAL(200, *override);
+        UNIT_ASSERT_VALUES_EQUAL(200, first->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(200, second->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(200, third->GetWriteBlobThreshold());
+
+        UNIT_ASSERT(controls->RestoreDefault("WriteBlobThreshold"));
+        UNIT_ASSERT(!controls->GetOverride("WriteBlobThreshold"));
+        UNIT_ASSERT_VALUES_EQUAL(100, first->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(200, second->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(300, third->GetWriteBlobThreshold());
+        UNIT_ASSERT(!controls->RestoreDefault("UnknownField"));
+    }
+
+    Y_UNIT_TEST(ShouldRegisterConfigIndependentControlsConcurrently)
+    {
+        auto controls = std::make_shared<TStorageConfigControls>();
+        NKikimr::TControlBoard controlBoard;
+
+        constexpr int ThreadCount = 4;
+        std::latch start{ThreadCount + 1};
+        TVector<std::thread> threads;
+        for (int i = 0; i != ThreadCount; ++i) {
+            threads.emplace_back(
+                [&]
+                {
+                    start.arrive_and_wait();
+                    controls->Register(controlBoard);
+                });
+        }
+
+        start.arrive_and_wait();
+        for (auto& thread: threads) {
+            thread.join();
+        }
+
+        TAtomic previousValue = {};
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_WriteBlobThreshold",
+            100,
+            previousValue));
+
+        const auto override = controls->GetOverride("WriteBlobThreshold");
+        UNIT_ASSERT(override);
+        UNIT_ASSERT_VALUES_EQUAL(100, *override);
+    }
+
+    Y_UNIT_TEST(ShouldCopyConfigAndShareControlsViaIcb)
+    {
+        const auto test = [](TStorageConfigControlsPtr controls) {
+            NProto::TStorageServiceConfig proto;
+            proto.SetWriteBlobThreshold(100);
+            proto.SetVolumePreemptionType(NProto::PREEMPTION_NONE);
+
+            NKikimr::TControlBoard controlBoard;
+            TStorageConfigPtr copy;
+            {
+                auto source = std::make_shared<TStorageConfig>(
+                    proto,
+                    std::make_shared<NFeatures::TFeaturesConfig>(),
+                    controls);
+                source->Register(controlBoard);
+
+                TAtomic previousValue = {};
+                UNIT_ASSERT(!controlBoard.SetValue(
+                    "BlockStore_WriteBlobThreshold",
+                    200,
+                    previousValue));
+
+                copy = std::make_shared<TStorageConfig>(*source);
+                UNIT_ASSERT_VALUES_EQUAL(200, copy->GetWriteBlobThreshold());
+                UNIT_ASSERT(copy->GetStorageConfigControls() == controls);
+
+                source->SetVolumePreemptionType(
+                    NProto::PREEMPTION_MOVE_MOST_HEAVY);
+                UNIT_ASSERT(
+                    copy->GetVolumePreemptionType() == NProto::PREEMPTION_NONE);
+            }
+
+            TAtomic previousValue = {};
+            UNIT_ASSERT(!controlBoard.SetValue(
+                "BlockStore_WriteBlobThreshold",
+                300,
+                previousValue));
+            UNIT_ASSERT_VALUES_EQUAL(200, AtomicGet(previousValue));
+            UNIT_ASSERT_VALUES_EQUAL(300, copy->GetWriteBlobThreshold());
+
+            controlBoard.RestoreDefault("BlockStore_WriteBlobThreshold");
+            UNIT_ASSERT_VALUES_EQUAL(100, copy->GetWriteBlobThreshold());
+        };
+
+        test(std::make_shared<TStorageConfigControls>());
+        test(nullptr);
+    }
+
+    Y_UNIT_TEST(ShouldMergeConfigBoundControlsViaIcb)
+    {
+        NProto::TStorageServiceConfig globalConfigProto;
+        globalConfigProto.SetMaxMigrationIoDepth(4);
+        auto globalConfig = std::make_shared<TStorageConfig>(
+            globalConfigProto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        NKikimr::TControlBoard controlBoard;
+        globalConfig->Register(controlBoard);
+
+        TAtomic previousValue = {};
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_MaxMigrationIoDepth",
+            8,
+            previousValue));
+
+        NProto::TStorageServiceConfig patch;
+        patch.SetMaxMigrationIoDepth(1);
+        auto config = TStorageConfig::Merge(globalConfig, patch);
+
+        UNIT_ASSERT_UNEQUAL(config, globalConfig);
+        UNIT_ASSERT(!config->GetStorageConfigControls());
+        UNIT_ASSERT_VALUES_EQUAL(1, config->GetMaxMigrationIoDepth());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            config->GetStorageConfigProto().GetMaxMigrationIoDepth());
+
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_MaxMigrationIoDepth",
+            16,
+            previousValue));
+        UNIT_ASSERT_VALUES_EQUAL(16, globalConfig->GetMaxMigrationIoDepth());
+        UNIT_ASSERT_VALUES_EQUAL(1, config->GetMaxMigrationIoDepth());
+
+        controlBoard.RestoreDefault("BlockStore_MaxMigrationIoDepth");
+        UNIT_ASSERT_VALUES_EQUAL(4, globalConfig->GetMaxMigrationIoDepth());
+        UNIT_ASSERT_VALUES_EQUAL(1, config->GetMaxMigrationIoDepth());
+    }
+
+    Y_UNIT_TEST(ShouldMergeConfigIndependentControlsViaIcb)
+    {
+        auto controls = std::make_shared<TStorageConfigControls>();
+        NKikimr::TControlBoard controlBoard;
+        controls->Register(controlBoard);
+
+        NProto::TStorageServiceConfig globalConfigProto;
+        globalConfigProto.SetMaxMigrationIoDepth(4);
+        auto globalConfig = std::make_shared<TStorageConfig>(
+            globalConfigProto,
+            std::make_shared<NFeatures::TFeaturesConfig>(),
+            controls);
+
+        TAtomic previousValue = {};
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_MaxMigrationIoDepth",
+            8,
+            previousValue));
+
+        NProto::TStorageServiceConfig patch;
+        patch.SetMaxMigrationIoDepth(1);
+        auto config = TStorageConfig::Merge(globalConfig, patch);
+
+        UNIT_ASSERT_UNEQUAL(config, globalConfig);
+        UNIT_ASSERT(config->GetStorageConfigControls() == controls);
+        UNIT_ASSERT_VALUES_EQUAL(8, config->GetMaxMigrationIoDepth());
+        UNIT_ASSERT_VALUES_EQUAL(
+            8,
+            config->GetStorageConfigProto().GetMaxMigrationIoDepth());
+
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_MaxMigrationIoDepth",
+            16,
+            previousValue));
+        UNIT_ASSERT_VALUES_EQUAL(16, globalConfig->GetMaxMigrationIoDepth());
+        UNIT_ASSERT_VALUES_EQUAL(16, config->GetMaxMigrationIoDepth());
+
+        UNIT_ASSERT(controls->RestoreDefault("MaxMigrationIoDepth"));
+        UNIT_ASSERT_VALUES_EQUAL(4, globalConfig->GetMaxMigrationIoDepth());
+        UNIT_ASSERT_VALUES_EQUAL(1, config->GetMaxMigrationIoDepth());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            config->GetStorageConfigProto().GetMaxMigrationIoDepth());
     }
 
     Y_UNIT_TEST(ShouldOverrideConfigFields)

--- a/cloud/blockstore/libs/storage/core/public.h
+++ b/cloud/blockstore/libs/storage/core/public.h
@@ -21,6 +21,9 @@ namespace NStorage {
 class TStorageConfig;
 using TStorageConfigPtr = std::shared_ptr<TStorageConfig>;
 
+class TStorageConfigControls;
+using TStorageConfigControlsPtr = std::shared_ptr<TStorageConfigControls>;
+
 struct IWriteBlocksHandler;
 using IWriteBlocksHandlerPtr = std::shared_ptr<IWriteBlocksHandler>;
 


### PR DESCRIPTION
### Notes

- Add reusable `TStorageConfigControls` for read-write storage parameters, which can be shared between several `TStorageConfig` objects to deliver ICB parameter change to each object.
- Preserve config-bound controls for existing behavior and add config-independent controls for `TStorageConfig` objects that share one control set. Without an explicit ICB override, each such `TStorageConfig` uses its own protobuf value.
- Return a control to its mode-specific initial state in `RestoreDefault()`. The control then has no explicit override in either mode, and each `TStorageConfig` reads its own raw protobuf value.
- Existing runtime configuration flows remain unchanged. Re-registering the same controls set on a different `TControlBoard` now aborts instead of silently rebinding it, but no current in-repository code path performs such re-registration.

#### `TStorageConfig` copy behavior

- Copy the raw `TStorageServiceConfig` by value and share the current Features object and the same live `TStorageConfigControls` object in both control modes.
- Keep copies connected to current and future ICB changes without another `Register()` call, including after the source `TStorageConfig` is destroyed. Keep later raw protobuf changes local to each object.
- Share config-bound controls only through `TStorageConfig` copy construction, where the source raw proto is copied at the same time. `GetStorageConfigControls()` still returns null for config-bound controls, and the public three-argument constructor still accepts only config-independent controls or null. Callers therefore cannot attach config-bound controls to an unrelated proto.

#### `TControlBoard` registration behavior

- Bind every `TStorageConfigControls` instance, in either mode, to the first `TControlBoard` passed to `Register()`. Re-registering the same instance on that board is a no-op; registering it on another board aborts in both modes.
- Preserve the existing same-board behavior for config-bound controls. During their first registration, wrappers may adopt controls already registered under the same names on that board.
- Before this change, the same config-bound wrappers could be registered on several boards. A later registration could silently repoint the wrappers to controls already stored on another board, while the first board retained controls that the `TStorageConfig` no longer read. This was possible through the API but was not an explicit supported contract.
- No current server or DiskAgent path re-registers one controls instance on multiple boards. Each existing config-bound object registers once with its node-local board, so the known in-repository runtime behavior remains unchanged.

#### Config-independent control collisions

- Initialize config-independent controls with the reserved `NoOverride` default. The value means that no explicit ICB override exists and is outside the range set for ICB Control.
- `RegisterSharedControl()` resolves a name collision by replacing the wrapper's underlying `TControl` with the object already registered on the board; it does not verify the control mode or compatibility.
- If a config-independent wrapper adopted a config-bound control, it would also adopt that control's protobuf-derived default, bounds, and current value. The protobuf-derived default differs from `NoOverride`, so it would be treated as an explicit override. `RestoreDefault()` would restore that value and could no longer remove the override.
- Require the first registration of a config-independent set to insert every control name. Any collision aborts, ensuring that the registered controls retain the `NoOverride` semantics.
- Adopting another compatible config-independent set could be valid in principle, but `TControlBoard` does not identify the mode or provide a complete compatibility contract. The implementation therefore rejects all collisions instead of assuming that existing controls are compatible. Register one config-independent set per board and share it between `TStorageConfig` instances.

#### Target controls model

- The config-independent mode is the target model: register one control set per board, share it between configurations, and keep protobuf defaults in each `TStorageConfig` while ICB stores only explicit overrides.
- Keep config-bound controls in this PR for compatibility with existing construction and registration behavior. After callers migrate to config-independent controls, remove the config-bound mode and simplify the constructors, default handling, and mode-specific control logic.

### Issue

#6685
