### PR TITLE
[NBS]  Add aggregate blockstore configuration with atomic access

### DIFF
--- a/cloud/blockstore/config/blockstore.proto
+++ b/cloud/blockstore/config/blockstore.proto
@@ -1,0 +1,48 @@
+syntax = "proto2";
+
+package NCloud.NBlockStore.NProto;
+
+option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/config";
+
+import "cloud/blockstore/config/cells.proto";
+import "cloud/blockstore/config/client.proto";
+import "cloud/blockstore/config/diagnostics.proto";
+import "cloud/blockstore/config/discovery.proto";
+import "cloud/blockstore/config/disk.proto";
+import "cloud/blockstore/config/grpc_client.proto";
+import "cloud/blockstore/config/local_nvme.proto";
+import "cloud/blockstore/config/logbroker.proto";
+import "cloud/blockstore/config/notify.proto";
+import "cloud/blockstore/config/rdma.proto";
+import "cloud/blockstore/config/root_kms.proto";
+import "cloud/blockstore/config/server.proto";
+import "cloud/blockstore/config/spdk.proto";
+import "cloud/blockstore/config/storage.proto";
+import "cloud/blockstore/config/ydbstats.proto";
+import "cloud/storage/core/config/features.proto";
+import "cloud/storage/core/config/iam.proto";
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TBlockstoreConfig
+{
+    optional TServerAppConfig Server = 1;
+    optional TStorageServiceConfig StorageService = 2;
+    optional .NCloud.NProto.TFeaturesConfig Features = 3;
+    optional TDiagnosticsConfig Diagnostics = 4;
+    optional TDiscoveryServiceConfig DiscoveryService = 5;
+    optional TClientAppConfig Endpoint = 6;
+    optional TDiskAgentConfig DiskAgent = 7;
+    optional TDiskRegistryProxyConfig DiskRegistryProxy = 8;
+    optional TSpdkEnvConfig SpdkEnv = 9;
+    optional TRdmaConfig Rdma = 10;
+    optional TYdbStatsConfig YdbStats = 11;
+    optional TLogbrokerConfig Logbroker = 12;
+    optional TNotifyConfig Notify = 13;
+    optional .NCloud.NProto.TIamClientConfig IamClient = 14;
+    optional TGrpcClientConfig KmsClient = 15;
+    optional TGrpcClientConfig ComputeClient = 16;
+    optional TRootKmsConfig RootKms = 17;
+    optional TCellsConfig Cells = 18;
+    optional TLocalNVMeConfig LocalNVMe = 19;
+}

--- a/cloud/blockstore/config/ya.make
+++ b/cloud/blockstore/config/ya.make
@@ -4,6 +4,7 @@ INCLUDE_TAGS(GO_PROTO)
 EXCLUDE_TAGS(JAVA_PROTO)
 
 SRCS(
+    blockstore.proto
     cells.proto
     client.proto
     diagnostics.proto

--- a/cloud/blockstore/libs/cells/iface/public.h
+++ b/cloud/blockstore/libs/cells/iface/public.h
@@ -11,6 +11,7 @@ using TCellConfigPtr = std::shared_ptr<TCellConfig>;
 
 class TCellsConfig;
 using TCellsConfigPtr = std::shared_ptr<TCellsConfig>;
+using TCellsConfigConstPtr = std::shared_ptr<const TCellsConfig>;
 
 struct ICellManager;
 using ICellManagerPtr = std::shared_ptr<ICellManager>;

--- a/cloud/blockstore/libs/client/config.h
+++ b/cloud/blockstore/libs/client/config.h
@@ -32,6 +32,11 @@ private:
 public:
     TClientAppConfig(NProto::TClientAppConfig appConfig = {});
 
+    [[nodiscard]] const NProto::TClientAppConfig& GetConfigProto() const
+    {
+        return AppConfig;
+    }
+
     const NProto::TClientConfig& GetClientConfig() const
     {
         return ClientConfig;

--- a/cloud/blockstore/libs/client/public.h
+++ b/cloud/blockstore/libs/client/public.h
@@ -16,6 +16,7 @@ namespace NClient {
 
 class TClientAppConfig;
 using TClientAppConfigPtr = std::shared_ptr<TClientAppConfig>;
+using TClientAppConfigConstPtr = std::shared_ptr<const TClientAppConfig>;
 
 struct IThrottlerProvider;
 using IThrottlerProviderPtr = std::shared_ptr<IThrottlerProvider>;

--- a/cloud/blockstore/libs/config/blockstore_config.cpp
+++ b/cloud/blockstore/libs/config/blockstore_config.cpp
@@ -1,0 +1,376 @@
+/*******************************************************************************
+
+Configuration construction owns immutable runtime wrappers for all merged
+sections. Storage configuration copies retain the shared ICB controls and use
+the features wrapper created from the merged protobuf configuration.
+
+*******************************************************************************/
+
+#include "blockstore_config.h"
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/vector.h>
+#include <util/system/yassert.h>
+
+namespace NCloud::NBlockStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// The private IBlockstoreConfig implementation and owner of its runtime
+// wrappers and protobuf sections. Only MakeBlockstoreConfig() creates
+// instances.
+class TBlockstoreConfigImpl final: public IBlockstoreConfig
+{
+public:
+    TBlockstoreConfigImpl(
+        const NProto::TBlockstoreConfig& config,
+        NFeatures::TFeaturesConfigConstPtr featuresConfig,
+        NStorage::TStorageConfigConstPtr storageConfig,
+        NStorage::TDiskAgentConfigConstPtr diskAgentConfig);
+
+    const NServer::TServerAppConfigConstPtr& GetServerConfig() const override;
+
+    const NFeatures::TFeaturesConfigConstPtr&
+    GetFeaturesConfig() const override;
+
+    const NStorage::TStorageConfigConstPtr& GetStorageConfig() const override;
+
+    const TDiagnosticsConfigConstPtr& GetDiagnosticsConfig() const override;
+
+    const NDiscovery::TDiscoveryConfigConstPtr&
+    GetDiscoveryServiceConfig() const override;
+
+    const NClient::TClientAppConfigConstPtr& GetEndpointConfig() const override;
+
+    const NStorage::TDiskAgentConfigConstPtr&
+    GetDiskAgentConfig() const override;
+
+    const NStorage::TDiskRegistryProxyConfigConstPtr&
+    GetDiskRegistryProxyConfig() const override;
+
+    const NSpdk::TSpdkEnvConfigConstPtr& GetSpdkEnvConfig() const override;
+
+    const NRdma::TRdmaConfigConstPtr& GetRdmaConfig() const override;
+
+    const NYdbStats::TYdbStatsConfigConstPtr&
+    GetYdbStatsConfig() const override;
+
+    const NLogbroker::TLogbrokerConfigConstPtr&
+    GetLogbrokerConfig() const override;
+
+    const NNotify::TNotifyConfigConstPtr& GetNotifyConfig() const override;
+
+    const NIamClient::TIamClientConfigConstPtr&
+    GetIamClientConfig() const override;
+
+    const TGrpcClientConfigConstPtr& GetKmsClientConfig() const override;
+
+    const TGrpcClientConfigConstPtr& GetComputeClientConfig() const override;
+
+    const TRootKmsConfigConstPtr& GetRootKmsConfig() const override;
+
+    const NCells::TCellsConfigConstPtr& GetCellsConfig() const override;
+
+    const TLocalNVMeConfigConstPtr& GetLocalNVMeConfig() const override;
+
+private:
+    const NServer::TServerAppConfigConstPtr ServerConfig;
+    const NFeatures::TFeaturesConfigConstPtr FeaturesConfig;
+    const NStorage::TStorageConfigConstPtr StorageConfig;
+    const TDiagnosticsConfigConstPtr DiagnosticsConfig;
+    const NDiscovery::TDiscoveryConfigConstPtr DiscoveryServiceConfig;
+    const NClient::TClientAppConfigConstPtr EndpointConfig;
+    const NStorage::TDiskAgentConfigConstPtr DiskAgentConfig;
+    const NStorage::TDiskRegistryProxyConfigConstPtr DiskRegistryProxyConfig;
+    const NSpdk::TSpdkEnvConfigConstPtr SpdkEnvConfig;
+    const NRdma::TRdmaConfigConstPtr RdmaConfig;
+    const NYdbStats::TYdbStatsConfigConstPtr YdbStatsConfig;
+    const NLogbroker::TLogbrokerConfigConstPtr LogbrokerConfig;
+    const NNotify::TNotifyConfigConstPtr NotifyConfig;
+    const NIamClient::TIamClientConfigConstPtr IamClientConfig;
+    const TGrpcClientConfigConstPtr KmsClientConfig;
+    const TGrpcClientConfigConstPtr ComputeClientConfig;
+    const TRootKmsConfigConstPtr RootKmsConfig;
+    const NCells::TCellsConfigConstPtr CellsConfig;
+    const TLocalNVMeConfigConstPtr LocalNVMeConfig;
+};
+
+TBlockstoreConfigImpl::TBlockstoreConfigImpl(
+    const NProto::TBlockstoreConfig& config,
+    NFeatures::TFeaturesConfigConstPtr featuresConfig,
+    NStorage::TStorageConfigConstPtr storageConfig,
+    NStorage::TDiskAgentConfigConstPtr diskAgentConfig)
+    : ServerConfig(
+          std::make_shared<NServer::TServerAppConfig>(config.GetServer()))
+    , FeaturesConfig(std::move(featuresConfig))
+    , StorageConfig(std::move(storageConfig))
+    , DiagnosticsConfig(
+          std::make_shared<TDiagnosticsConfig>(config.GetDiagnostics()))
+    , DiscoveryServiceConfig(
+          std::make_shared<NDiscovery::TDiscoveryConfig>(
+              config.GetDiscoveryService()))
+    , EndpointConfig(
+          std::make_shared<NClient::TClientAppConfig>(config.GetEndpoint()))
+    , DiskAgentConfig(std::move(diskAgentConfig))
+    , DiskRegistryProxyConfig(
+          std::make_shared<NStorage::TDiskRegistryProxyConfig>(
+              config.GetDiskRegistryProxy()))
+    , SpdkEnvConfig(
+          std::make_shared<NSpdk::TSpdkEnvConfig>(config.GetSpdkEnv()))
+    , RdmaConfig(std::make_shared<NRdma::TRdmaConfig>(config.GetRdma()))
+    , YdbStatsConfig(
+          std::make_shared<NYdbStats::TYdbStatsConfig>(config.GetYdbStats()))
+    , LogbrokerConfig(
+          std::make_shared<NLogbroker::TLogbrokerConfig>(config.GetLogbroker()))
+    , NotifyConfig(std::make_shared<NNotify::TNotifyConfig>(config.GetNotify()))
+    , IamClientConfig(
+          std::make_shared<NIamClient::TIamClientConfig>(config.GetIamClient()))
+    , KmsClientConfig(
+          std::make_shared<NProto::TGrpcClientConfig>(config.GetKmsClient()))
+    , ComputeClientConfig(
+          std::make_shared<NProto::TGrpcClientConfig>(
+              config.GetComputeClient()))
+    , RootKmsConfig(
+          std::make_shared<NProto::TRootKmsConfig>(config.GetRootKms()))
+    , CellsConfig(std::make_shared<NCells::TCellsConfig>(config.GetCells()))
+    , LocalNVMeConfig(std::make_shared<TLocalNVMeConfig>(config.GetLocalNVMe()))
+{
+    Y_ABORT_UNLESS(FeaturesConfig);
+    Y_ABORT_UNLESS(StorageConfig);
+    Y_ABORT_UNLESS(DiskAgentConfig);
+}
+
+const NServer::TServerAppConfigConstPtr&
+TBlockstoreConfigImpl::GetServerConfig() const
+{
+    return ServerConfig;
+}
+
+const NFeatures::TFeaturesConfigConstPtr&
+TBlockstoreConfigImpl::GetFeaturesConfig() const
+{
+    return FeaturesConfig;
+}
+
+const NStorage::TStorageConfigConstPtr&
+TBlockstoreConfigImpl::GetStorageConfig() const
+{
+    return StorageConfig;
+}
+
+const TDiagnosticsConfigConstPtr&
+TBlockstoreConfigImpl::GetDiagnosticsConfig() const
+{
+    return DiagnosticsConfig;
+}
+
+const NDiscovery::TDiscoveryConfigConstPtr&
+TBlockstoreConfigImpl::GetDiscoveryServiceConfig() const
+{
+    return DiscoveryServiceConfig;
+}
+
+const NClient::TClientAppConfigConstPtr&
+TBlockstoreConfigImpl::GetEndpointConfig() const
+{
+    return EndpointConfig;
+}
+
+const NStorage::TDiskAgentConfigConstPtr&
+TBlockstoreConfigImpl::GetDiskAgentConfig() const
+{
+    return DiskAgentConfig;
+}
+
+const NStorage::TDiskRegistryProxyConfigConstPtr&
+TBlockstoreConfigImpl::GetDiskRegistryProxyConfig() const
+{
+    return DiskRegistryProxyConfig;
+}
+
+const NSpdk::TSpdkEnvConfigConstPtr&
+TBlockstoreConfigImpl::GetSpdkEnvConfig() const
+{
+    return SpdkEnvConfig;
+}
+
+const NRdma::TRdmaConfigConstPtr& TBlockstoreConfigImpl::GetRdmaConfig() const
+{
+    return RdmaConfig;
+}
+
+const NYdbStats::TYdbStatsConfigConstPtr&
+TBlockstoreConfigImpl::GetYdbStatsConfig() const
+{
+    return YdbStatsConfig;
+}
+
+const NLogbroker::TLogbrokerConfigConstPtr&
+TBlockstoreConfigImpl::GetLogbrokerConfig() const
+{
+    return LogbrokerConfig;
+}
+
+const NNotify::TNotifyConfigConstPtr&
+TBlockstoreConfigImpl::GetNotifyConfig() const
+{
+    return NotifyConfig;
+}
+
+const NIamClient::TIamClientConfigConstPtr&
+TBlockstoreConfigImpl::GetIamClientConfig() const
+{
+    return IamClientConfig;
+}
+
+const TGrpcClientConfigConstPtr&
+TBlockstoreConfigImpl::GetKmsClientConfig() const
+{
+    return KmsClientConfig;
+}
+
+const TGrpcClientConfigConstPtr&
+TBlockstoreConfigImpl::GetComputeClientConfig() const
+{
+    return ComputeClientConfig;
+}
+
+const TRootKmsConfigConstPtr& TBlockstoreConfigImpl::GetRootKmsConfig() const
+{
+    return RootKmsConfig;
+}
+
+const NCells::TCellsConfigConstPtr&
+TBlockstoreConfigImpl::GetCellsConfig() const
+{
+    return CellsConfig;
+}
+
+const TLocalNVMeConfigConstPtr&
+TBlockstoreConfigImpl::GetLocalNVMeConfig() const
+{
+    return LocalNVMeConfig;
+}
+
+// Merge feature definitions by name so an overridden feature has one runtime
+// record. Preserve the existing first-wins behavior within each source layer.
+void MergeFeatures(
+    const NCloud::NProto::TFeaturesConfig& staticFeatures,
+    const NCloud::NProto::TFeaturesConfig& dynamicFeatures,
+    NCloud::NProto::TFeaturesConfig* result)
+{
+    // TFeaturesConfig uses the first record when feature names are duplicated.
+    // Preserve this behavior while canonicalizing the static layer.
+    TVector<NCloud::NProto::TFeatureConfig> features;
+    features.reserve(
+        staticFeatures.FeaturesSize() + dynamicFeatures.FeaturesSize());
+
+    THashMap<TString, size_t> featureIndices;
+    for (const auto& feature: staticFeatures.GetFeatures()) {
+        const bool inserted =
+            featureIndices.emplace(feature.GetName(), features.size()).second;
+        if (inserted) {
+            features.push_back(feature);
+        }
+    }
+
+    // Ignore duplicate names after the first one in the dynamic layer. The
+    // first dynamic record replaces the static record or is appended if none
+    // exists.
+    THashSet<TString> dynamicFeatureNames;
+    for (const auto& feature: dynamicFeatures.GetFeatures()) {
+        if (!dynamicFeatureNames.insert(feature.GetName()).second) {
+            continue;
+        }
+
+        const auto it = featureIndices.find(feature.GetName());
+        if (it != featureIndices.end()) {
+            // Replace the complete static record at its original position, so
+            // fields omitted from the dynamic record do not leak from static.
+            features[it->second].CopyFrom(feature);
+        } else {
+            // Append dynamic-only records in their source order.
+            features.push_back(feature);
+        }
+    }
+
+    // Rebuild only the repeated Features field after the enclosing Features
+    // message has been merged, preserving its other and unknown fields.
+    result->ClearFeatures();
+    for (const auto& feature: features) {
+        result->AddFeatures()->CopyFrom(feature);
+    }
+}
+
+}   // namespace
+
+NProto::TBlockstoreConfig MergeBlockstoreConfig(
+    const NProto::TBlockstoreConfig& staticConfig,
+    const NProto::TBlockstoreConfig& dynamicConfig)
+{
+    auto result = staticConfig;
+    result.MergeFrom(dynamicConfig);
+    if (staticConfig.GetFeatures().FeaturesSize() ||
+        dynamicConfig.GetFeatures().FeaturesSize())
+    {
+        MergeFeatures(
+            staticConfig.GetFeatures(),
+            dynamicConfig.GetFeatures(),
+            result.MutableFeatures());
+    }
+    return result;
+}
+
+IBlockstoreConfigPtr MakeBlockstoreConfig(
+    const NProto::TBlockstoreConfig& staticConfig,
+    const NProto::TBlockstoreConfig& dynamicConfig,
+    NStorage::TStorageConfigControlsPtr controls,
+    TBlockstoreConfigExtraParameters extraParameters)
+{
+    Y_ABORT_UNLESS(controls);
+
+    auto config = MergeBlockstoreConfig(staticConfig, dynamicConfig);
+    auto featuresConfig =
+        std::make_shared<NFeatures::TFeaturesConfig>(config.GetFeatures());
+    auto storageConfig = std::make_shared<NStorage::TStorageConfig>(
+        config.GetStorageService(),
+        featuresConfig,
+        std::move(controls));
+    auto diskAgentConfig = std::make_shared<NStorage::TDiskAgentConfig>(
+        config.GetDiskAgent(),
+        std::move(extraParameters.DiskAgent.Rack),
+        extraParameters.DiskAgent.NetworkMbitThroughput);
+
+    return MakeIntrusive<TBlockstoreConfigImpl>(
+        config,
+        std::move(featuresConfig),
+        std::move(storageConfig),
+        std::move(diskAgentConfig));
+}
+
+IBlockstoreConfigPtr MakeBlockstoreConfig(
+    const NProto::TBlockstoreConfig& staticConfig,
+    const NProto::TBlockstoreConfig& dynamicConfig,
+    const NStorage::TStorageConfig& storageConfig,
+    const NStorage::TDiskAgentConfig& diskAgentConfig)
+{
+    const auto config = MergeBlockstoreConfig(staticConfig, dynamicConfig);
+    auto featuresConfig =
+        std::make_shared<NFeatures::TFeaturesConfig>(config.GetFeatures());
+    auto storageConfigCopy =
+        std::make_shared<NStorage::TStorageConfig>(storageConfig);
+    storageConfigCopy->SetFeaturesConfig(featuresConfig);
+    auto diskAgentConfigCopy =
+        std::make_shared<NStorage::TDiskAgentConfig>(diskAgentConfig);
+
+    return MakeIntrusive<TBlockstoreConfigImpl>(
+        config,
+        std::move(featuresConfig),
+        std::move(storageConfigCopy),
+        std::move(diskAgentConfigCopy));
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/config/blockstore_config.h
+++ b/cloud/blockstore/libs/config/blockstore_config.h
@@ -1,0 +1,157 @@
+/*******************************************************************************
+
+The shared Blockstore configuration model. MakeBlockstoreConfig() builds
+immutable configurations from static and dynamic sources. Readers retain one
+configuration for a logical operation.
+
+*******************************************************************************/
+
+#pragma once
+
+#include <cloud/blockstore/config/blockstore.pb.h>
+#include <cloud/blockstore/libs/cells/iface/config.h>
+#include <cloud/blockstore/libs/client/config.h>
+#include <cloud/blockstore/libs/diagnostics/config.h>
+#include <cloud/blockstore/libs/discovery/config.h>
+#include <cloud/blockstore/libs/local_nvme/config.h>
+#include <cloud/blockstore/libs/logbroker/iface/config.h>
+#include <cloud/blockstore/libs/notify/iface/config.h>
+#include <cloud/blockstore/libs/rdma/config.h>
+#include <cloud/blockstore/libs/server/config.h>
+#include <cloud/blockstore/libs/spdk/iface/config.h>
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/config.h>
+#include <cloud/blockstore/libs/storage/disk_registry_proxy/model/config.h>
+#include <cloud/blockstore/libs/ydbstats/config.h>
+
+#include <cloud/storage/core/libs/features/features_config.h>
+#include <cloud/storage/core/libs/iam/iface/config.h>
+
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TGrpcClientConfigConstPtr =
+    std::shared_ptr<const NProto::TGrpcClientConfig>;
+using TRootKmsConfigConstPtr = std::shared_ptr<const NProto::TRootKmsConfig>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Non-protobuf inputs used to build selected runtime configuration sections.
+struct TBlockstoreConfigExtraParameters
+{
+    // Host-specific inputs used to build the DiskAgent wrapper.
+    struct
+    {
+        // Local DiskAgent rack; empty if the rack is not specified.
+        TString Rack;
+
+        // Local DiskAgent network throughput in megabits per second; zero if
+        // the throughput is not specified.
+        ui32 NetworkMbitThroughput = 0;
+    } DiskAgent;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// An independently owned, read-only set of top-level Blockstore configuration
+// sections. MakeBlockstoreConfig() creates implementations that own all
+// sections. Getters return const owning pointers, so callers may retain the
+// whole configuration or an individual section. The Storage wrapper shares
+// live ICB controls: its effective values may change while its protobuf-backed
+// state remains immutable.
+class IBlockstoreConfig: public TAtomicRefCount<IBlockstoreConfig>
+{
+public:
+    IBlockstoreConfig() = default;
+
+    IBlockstoreConfig(const IBlockstoreConfig&) = delete;
+    IBlockstoreConfig& operator=(const IBlockstoreConfig&) = delete;
+    IBlockstoreConfig(IBlockstoreConfig&&) = delete;
+    IBlockstoreConfig& operator=(IBlockstoreConfig&&) = delete;
+
+    virtual ~IBlockstoreConfig() = default;
+
+    [[nodiscard]] virtual const NServer::TServerAppConfigConstPtr&
+    GetServerConfig() const = 0;
+
+    // Return the top-level Features section for configuration inspection and
+    // serialization. Storage decisions must use the typed feature accessors
+    // provided by TStorageConfig instead of reading this section directly.
+    [[nodiscard]] virtual const NFeatures::TFeaturesConfigConstPtr&
+    GetFeaturesConfig() const = 0;
+
+    [[nodiscard]] virtual const NStorage::TStorageConfigConstPtr&
+    GetStorageConfig() const = 0;
+    [[nodiscard]] virtual const TDiagnosticsConfigConstPtr&
+    GetDiagnosticsConfig() const = 0;
+    [[nodiscard]] virtual const NDiscovery::TDiscoveryConfigConstPtr&
+    GetDiscoveryServiceConfig() const = 0;
+    [[nodiscard]] virtual const NClient::TClientAppConfigConstPtr&
+    GetEndpointConfig() const = 0;
+    [[nodiscard]] virtual const NStorage::TDiskAgentConfigConstPtr&
+    GetDiskAgentConfig() const = 0;
+    [[nodiscard]] virtual const NStorage::TDiskRegistryProxyConfigConstPtr&
+    GetDiskRegistryProxyConfig() const = 0;
+    [[nodiscard]] virtual const NSpdk::TSpdkEnvConfigConstPtr&
+    GetSpdkEnvConfig() const = 0;
+    [[nodiscard]] virtual const NRdma::TRdmaConfigConstPtr&
+    GetRdmaConfig() const = 0;
+    [[nodiscard]] virtual const NYdbStats::TYdbStatsConfigConstPtr&
+    GetYdbStatsConfig() const = 0;
+    [[nodiscard]] virtual const NLogbroker::TLogbrokerConfigConstPtr&
+    GetLogbrokerConfig() const = 0;
+    [[nodiscard]] virtual const NNotify::TNotifyConfigConstPtr&
+    GetNotifyConfig() const = 0;
+    [[nodiscard]] virtual const NIamClient::TIamClientConfigConstPtr&
+    GetIamClientConfig() const = 0;
+    [[nodiscard]] virtual const TGrpcClientConfigConstPtr&
+    GetKmsClientConfig() const = 0;
+    [[nodiscard]] virtual const TGrpcClientConfigConstPtr&
+    GetComputeClientConfig() const = 0;
+    [[nodiscard]] virtual const TRootKmsConfigConstPtr&
+    GetRootKmsConfig() const = 0;
+    [[nodiscard]] virtual const NCells::TCellsConfigConstPtr&
+    GetCellsConfig() const = 0;
+    [[nodiscard]] virtual const TLocalNVMeConfigConstPtr&
+    GetLocalNVMeConfig() const = 0;
+};
+
+using IBlockstoreConfigPtr = TIntrusivePtr<IBlockstoreConfig>;
+using IBlockstoreConfigConstPtr = TIntrusiveConstPtr<IBlockstoreConfig>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Merge dynamicConfig into a copy of staticConfig according to protobuf rules,
+// except for Features. Keep the first feature with each name within a source;
+// replace a matching static feature with the complete dynamic record at its
+// position, and append dynamic-only features in their source order.
+NProto::TBlockstoreConfig MergeBlockstoreConfig(
+    const NProto::TBlockstoreConfig& staticConfig,
+    const NProto::TBlockstoreConfig& dynamicConfig);
+
+// Merge the source protos and create independently owned runtime adapters. The
+// controls pointer must be non-null and becomes the live ICB overlay of the
+// Storage wrapper. Extra parameters supply host-specific DiskAgent values.
+IBlockstoreConfigPtr MakeBlockstoreConfig(
+    const NProto::TBlockstoreConfig& staticConfig,
+    const NProto::TBlockstoreConfig& dynamicConfig,
+    NStorage::TStorageConfigControlsPtr controls,
+    TBlockstoreConfigExtraParameters extraParameters = {});
+
+// Create a bootstrap configuration from merged source protos and copies of the
+// initialized Storage and DiskAgent adapters. The Storage copy shares its
+// live ICB controls in either mode and uses Features from the merged sources.
+// Build every other section from the merged sources.
+IBlockstoreConfigPtr MakeBlockstoreConfig(
+    const NProto::TBlockstoreConfig& staticConfig,
+    const NProto::TBlockstoreConfig& dynamicConfig,
+    const NStorage::TStorageConfig& storageConfig,
+    const NStorage::TDiskAgentConfig& diskAgentConfig);
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/config/blockstore_config_holder.cpp
+++ b/cloud/blockstore/libs/config/blockstore_config_holder.cpp
@@ -1,0 +1,29 @@
+#include "blockstore_config_holder.h"
+
+#include <util/system/yassert.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TBlockstoreConfigHolder::TBlockstoreConfigHolder(
+    IBlockstoreConfigPtr initialConfig)
+{
+    Y_ABORT_UNLESS(initialConfig);
+    Current.AtomicStore(initialConfig);
+}
+
+IBlockstoreConfigConstPtr TBlockstoreConfigHolder::Get() const
+{
+    auto config = Current.AtomicLoad();
+    Y_ABORT_UNLESS(config);
+    return config;
+}
+
+void TBlockstoreConfigHolder::Set(IBlockstoreConfigPtr config)
+{
+    Y_ABORT_UNLESS(config);
+    Current.AtomicStore(config);
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/config/blockstore_config_holder.h
+++ b/cloud/blockstore/libs/config/blockstore_config_holder.h
@@ -1,0 +1,43 @@
+/*******************************************************************************
+
+The atomic publication point for Blockstore configuration snapshots. Construct
+the holder with a non-null initial configuration. A single writer publishes
+replacements; readers load once per logical operation and retain the result.
+
+*******************************************************************************/
+
+#pragma once
+
+#include "blockstore_config.h"
+
+#include <library/cpp/threading/hot_swap/hot_swap.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// The owner of the current Blockstore configuration publication point.
+class TBlockstoreConfigHolder final
+{
+public:
+    explicit TBlockstoreConfigHolder(IBlockstoreConfigPtr initialConfig);
+
+    TBlockstoreConfigHolder(const TBlockstoreConfigHolder&) = delete;
+    TBlockstoreConfigHolder& operator=(const TBlockstoreConfigHolder&) = delete;
+
+    [[nodiscard]] IBlockstoreConfigConstPtr Get() const;
+
+    // Publish a non-null configuration atomically. Only one writer may call
+    // Set().
+    void Set(IBlockstoreConfigPtr config);
+
+private:
+    // The non-null configuration currently visible to new readers.
+    THotSwap<IBlockstoreConfig> Current;
+};
+
+using TBlockstoreConfigHolderPtr = std::shared_ptr<TBlockstoreConfigHolder>;
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/config/blockstore_config_provider.cpp
+++ b/cloud/blockstore/libs/config/blockstore_config_provider.cpp
@@ -1,0 +1,57 @@
+#include "blockstore_config_provider.h"
+
+#include "blockstore_config_provider_private.h"
+
+#include <util/system/yassert.h>
+
+#include <memory>
+#include <utility>
+
+namespace NCloud::NBlockStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TBlockstoreConfigHolderPtr& BlockstoreConfigHolder()
+{
+    static TBlockstoreConfigHolderPtr holder;
+    return holder;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IBlockstoreConfigConstPtr GetCurrentBlockstoreConfig()
+{
+    const auto& holder = BlockstoreConfigHolder();
+    Y_ABORT_UNLESS(
+        holder,
+        "Blockstore configuration provider is not initialized");
+    return holder->Get();
+}
+
+TBlockstoreConfigHolderPtr InitializeBlockstoreConfigProvider(
+    IBlockstoreConfigPtr initialConfig)
+{
+    auto& holder = BlockstoreConfigHolder();
+    Y_ABORT_UNLESS(
+        !holder,
+        "Blockstore configuration provider cannot be reset or rebound");
+    Y_ABORT_UNLESS(
+        initialConfig,
+        "Initial Blockstore configuration must not be null");
+
+    holder =
+        std::make_shared<TBlockstoreConfigHolder>(std::move(initialConfig));
+    return holder;
+}
+
+void ResetBlockstoreConfigProvider()
+{
+    auto& holder = BlockstoreConfigHolder();
+    holder.reset();
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/config/blockstore_config_provider.h
+++ b/cloud/blockstore/libs/config/blockstore_config_provider.h
@@ -1,0 +1,21 @@
+/*******************************************************************************
+
+Process-wide read access to the current Blockstore configuration. Bootstrap
+must initialize the provider in one thread before starting any readers. Each
+call returns a snapshot that remains valid but may stop being current after a
+later publication.
+
+*******************************************************************************/
+
+#pragma once
+
+#include "blockstore_config.h"
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Return the Blockstore configuration published at the time of the call.
+[[nodiscard]] IBlockstoreConfigConstPtr GetCurrentBlockstoreConfig();
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/config/blockstore_config_provider_private.h
+++ b/cloud/blockstore/libs/config/blockstore_config_provider_private.h
@@ -1,0 +1,28 @@
+/*******************************************************************************
+
+Bootstrap-only initialization for the process-wide Blockstore configuration
+provider. Initialize it exactly once in one thread before starting any readers,
+then pass the returned holder to the single runtime writer. Reset it only after
+all readers and the writer have stopped. Rebinding while initialized is
+forbidden.
+
+*******************************************************************************/
+
+#pragma once
+
+#include "blockstore_config_holder.h"
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Initialize the provider with a non-null configuration and return its writer
+// handle. Abort if the provider has already been initialized.
+[[nodiscard]] TBlockstoreConfigHolderPtr InitializeBlockstoreConfigProvider(
+    IBlockstoreConfigPtr initialConfig);
+
+// Reset the provider during test teardown.
+// Do nothing if the provider is not initialized.
+void ResetBlockstoreConfigProvider();
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/config/ut/blockstore_config_ut.cpp
+++ b/cloud/blockstore/libs/config/ut/blockstore_config_ut.cpp
@@ -1,0 +1,476 @@
+#include <cloud/blockstore/libs/config/blockstore_config.h>
+#include <cloud/blockstore/libs/config/blockstore_config_holder.h>
+#include <cloud/blockstore/libs/config/blockstore_config_provider.h>
+#include <cloud/blockstore/libs/config/blockstore_config_provider_private.h>
+
+#include <contrib/ydb/core/control/immediate_control_board_impl.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/scope.h>
+
+#include <atomic>
+#include <thread>
+#include <utility>
+
+namespace NCloud::NBlockStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TBlockstoreConfig MakeConfig(ui32 value)
+{
+    NProto::TBlockstoreConfig config;
+    config.MutableServer()->MutableServerConfig()->SetPort(value);
+    config.MutableStorageService()->SetWriteBlobThreshold(value);
+    return config;
+}
+
+NCloud::NProto::TFeatureConfig* AddFeature(
+    NProto::TBlockstoreConfig& config,
+    const TString& name,
+    const TString& value,
+    const TString& cloudId)
+{
+    auto* feature = config.MutableFeatures()->AddFeatures();
+    feature->SetName(name);
+    feature->SetValue(value);
+    feature->MutableWhitelist()->AddCloudIds(cloudId);
+    return feature;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Aggregate protobuf merge, runtime wrapper, immutable lifetime, atomic
+// publication, and explicit ICB override coverage.
+Y_UNIT_TEST_SUITE(TBlockstoreConfigTest)
+{
+    // Check that the aggregate proto contains 19 top-level configuration
+    // sections, including the representative sections below.
+    Y_UNIT_TEST(ShouldExposeCompleteAggregateSchema)
+    {
+        const auto* descriptor = NProto::TBlockstoreConfig::descriptor();
+
+        UNIT_ASSERT_VALUES_EQUAL(19, descriptor->field_count());
+
+        // Selective check
+        UNIT_ASSERT(descriptor->FindFieldByName("Server"));
+        UNIT_ASSERT(descriptor->FindFieldByName("StorageService"));
+        UNIT_ASSERT(descriptor->FindFieldByName("Features"));
+        UNIT_ASSERT(descriptor->FindFieldByName("LocalNVMe"));
+    }
+
+    // Merge static and dynamic configs. Check that a dynamic scalar overrides
+    // the static value, an omitted scalar stays unchanged, and Features with
+    // different names are kept in source order.
+    Y_UNIT_TEST(ShouldMergePresentFieldsAndAppendDistinctFeatures)
+    {
+        NProto::TBlockstoreConfig staticConfig;
+        staticConfig.MutableStorageService()->SetWriteBlobThreshold(10);
+        staticConfig.MutableStorageService()->SetFlushThreshold(20);
+        auto* staticFeature = staticConfig.MutableFeatures()->AddFeatures();
+        staticFeature->SetName("static");
+
+        NProto::TBlockstoreConfig dynamicConfig;
+        dynamicConfig.MutableStorageService()->SetWriteBlobThreshold(30);
+        auto* dynamicFeature = dynamicConfig.MutableFeatures()->AddFeatures();
+        dynamicFeature->SetName("dynamic");
+
+        const auto result = MergeBlockstoreConfig(staticConfig, dynamicConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            30,
+            result.GetStorageService().GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(
+            20,
+            result.GetStorageService().GetFlushThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(2, result.GetFeatures().FeaturesSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "static",
+            result.GetFeatures().GetFeatures(0).GetName());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "dynamic",
+            result.GetFeatures().GetFeatures(1).GetName());
+    }
+
+    // Merge Features with repeated names. Check that the first record in each
+    // source is used, a dynamic record fully replaces the same-name static
+    // record, and runtime lookups use only the resulting records.
+    Y_UNIT_TEST(ShouldReplaceStaticFeaturesWithDynamicFeatures)
+    {
+        NProto::TBlockstoreConfig staticConfig;
+        auto* staticA =
+            AddFeature(staticConfig, "A", "static-A", "static-A-cloud");
+        staticA->SetCloudProbability(1);
+        AddFeature(staticConfig, "B", "static-B", "static-B-cloud");
+        AddFeature(
+            staticConfig,
+            "B",
+            "duplicate-static-B",
+            "duplicate-static-B-cloud");
+
+        NProto::TBlockstoreConfig dynamicConfig;
+        AddFeature(dynamicConfig, "A", "dynamic-A", "dynamic-A-cloud");
+        AddFeature(dynamicConfig, "C", "dynamic-C", "dynamic-C-cloud");
+        AddFeature(
+            dynamicConfig,
+            "C",
+            "duplicate-dynamic-C",
+            "duplicate-dynamic-C-cloud");
+
+        const auto result = MergeBlockstoreConfig(staticConfig, dynamicConfig);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, result.GetFeatures().FeaturesSize());
+
+        const auto& mergedA = result.GetFeatures().GetFeatures(0);
+        UNIT_ASSERT_VALUES_EQUAL("A", mergedA.GetName());
+        UNIT_ASSERT_VALUES_EQUAL("dynamic-A", mergedA.GetValue());
+        UNIT_ASSERT(!mergedA.HasCloudProbability());
+        UNIT_ASSERT_VALUES_EQUAL(1, mergedA.GetWhitelist().CloudIdsSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "dynamic-A-cloud",
+            mergedA.GetWhitelist().GetCloudIds(0));
+
+        const auto& mergedB = result.GetFeatures().GetFeatures(1);
+        UNIT_ASSERT_VALUES_EQUAL("B", mergedB.GetName());
+        UNIT_ASSERT_VALUES_EQUAL("static-B", mergedB.GetValue());
+
+        const auto& mergedC = result.GetFeatures().GetFeatures(2);
+        UNIT_ASSERT_VALUES_EQUAL("C", mergedC.GetName());
+        UNIT_ASSERT_VALUES_EQUAL("dynamic-C", mergedC.GetValue());
+
+        const auto config = MakeBlockstoreConfig(
+            staticConfig,
+            dynamicConfig,
+            std::make_shared<NStorage::TStorageConfigControls>());
+        const auto& runtimeFeatures = *config->GetFeaturesConfig();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            result.GetFeatures().SerializeAsString(),
+            runtimeFeatures.GetConfigProto().SerializeAsString());
+
+        UNIT_ASSERT(
+            runtimeFeatures.IsFeatureEnabled("dynamic-A-cloud", {}, {}, "A"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "dynamic-A",
+            runtimeFeatures.GetFeatureValue("dynamic-A-cloud", {}, {}, "A"));
+        UNIT_ASSERT(
+            !runtimeFeatures.IsFeatureEnabled("static-A-cloud", {}, {}, "A"));
+        UNIT_ASSERT(
+            !runtimeFeatures.IsFeatureEnabled("other-cloud", {}, {}, "A"));
+
+        UNIT_ASSERT(
+            runtimeFeatures.IsFeatureEnabled("static-B-cloud", {}, {}, "B"));
+        UNIT_ASSERT(
+            !runtimeFeatures
+                 .IsFeatureEnabled("duplicate-static-B-cloud", {}, {}, "B"));
+
+        UNIT_ASSERT(
+            runtimeFeatures.IsFeatureEnabled("dynamic-C-cloud", {}, {}, "C"));
+        UNIT_ASSERT(
+            !runtimeFeatures
+                 .IsFeatureEnabled("duplicate-dynamic-C-cloud", {}, {}, "C"));
+    }
+
+    // Set the ICB value to 100 and rebuild the config with default 300. Check
+    // that the override stays 100 and RestoreDefault switches the value to 300.
+    Y_UNIT_TEST(ShouldKeepExplicitIcbOverrideAcrossConfigs)
+    {
+        auto controls = std::make_shared<NStorage::TStorageConfigControls>();
+        NKikimr::TControlBoard controlBoard;
+        controls->Register(controlBoard);
+
+        auto first =
+            MakeBlockstoreConfig(MakeConfig(100), MakeConfig(200), controls);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            200,
+            first->GetStorageConfig()->GetWriteBlobThreshold());
+
+        TAtomic previous = 0;
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_WriteBlobThreshold",
+            100,
+            previous));
+        UNIT_ASSERT_VALUES_EQUAL(
+            100,
+            first->GetStorageConfig()->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(
+            100,
+            first->GetStorageConfig()
+                ->GetEffectiveStorageConfigProto()
+                .GetWriteBlobThreshold());
+
+        auto second =
+            MakeBlockstoreConfig(MakeConfig(100), MakeConfig(300), controls);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            100,
+            second->GetStorageConfig()->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(
+            100,
+            second->GetStorageConfig()
+                ->GetEffectiveStorageConfigProto()
+                .GetWriteBlobThreshold());
+
+        UNIT_ASSERT(controls->RestoreDefault("WriteBlobThreshold"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            300,
+            second->GetStorageConfig()->GetWriteBlobThreshold());
+
+        auto third = MakeBlockstoreConfig(MakeConfig(100), {}, controls);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            100,
+            third->GetStorageConfig()->GetWriteBlobThreshold());
+    }
+
+    // Publish a config with default 300 while the ICB value is 150. Check that
+    // the override stays 150 and RestoreDefault selects the new default 300.
+    Y_UNIT_TEST(ShouldKeepIcbOverrideWhenCurrentConfigIsUpdated)
+    {
+        auto controls = std::make_shared<NStorage::TStorageConfigControls>();
+        NKikimr::TControlBoard controlBoard;
+        controls->Register(controlBoard);
+
+        TBlockstoreConfigHolder holder(
+            MakeBlockstoreConfig(MakeConfig(100), MakeConfig(200), controls));
+
+        TAtomic previous = 0;
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_WriteBlobThreshold",
+            150,
+            previous));
+
+        holder.Set(
+            MakeBlockstoreConfig(MakeConfig(100), MakeConfig(300), controls));
+
+        const auto currentConfig = holder.Get();
+        UNIT_ASSERT_VALUES_EQUAL(
+            150,
+            currentConfig->GetStorageConfig()->GetWriteBlobThreshold());
+
+        UNIT_ASSERT(controls->RestoreDefault("WriteBlobThreshold"));
+        UNIT_ASSERT_VALUES_EQUAL(
+            300,
+            holder.Get()->GetStorageConfig()->GetWriteBlobThreshold());
+    }
+
+    // Supply Server and Diagnostics fields from both config layers. Check
+    // that their typed runtime wrappers expose every merged value.
+    Y_UNIT_TEST(ShouldExposeMergedTopLevelConfigs)
+    {
+        NProto::TBlockstoreConfig staticConfig;
+        staticConfig.MutableServer()->MutableServerConfig()->SetPort(100);
+        staticConfig.MutableDiagnostics()->SetNbsMonPort(200);
+
+        NProto::TBlockstoreConfig dynamicConfig;
+        dynamicConfig.MutableServer()->MutableServerConfig()->SetDataPort(300);
+        dynamicConfig.MutableDiagnostics()->SetUseAsyncLogger(true);
+
+        auto blockstoreConfig = MakeBlockstoreConfig(
+            staticConfig,
+            dynamicConfig,
+            std::make_shared<NStorage::TStorageConfigControls>());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            100,
+            blockstoreConfig->GetServerConfig()->GetPort());
+        UNIT_ASSERT_VALUES_EQUAL(
+            300,
+            blockstoreConfig->GetServerConfig()->GetDataPort());
+        UNIT_ASSERT_VALUES_EQUAL(
+            200,
+            blockstoreConfig->GetDiagnosticsConfig()->GetNbsMonPort());
+        UNIT_ASSERT(
+            blockstoreConfig->GetDiagnosticsConfig()->GetUseAsyncLogger());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            blockstoreConfig->GetDiskAgentConfig()->GetRack());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            blockstoreConfig->GetDiskAgentConfig()->GetNetworkMbitThroughput());
+    }
+
+    // Build from initialized Storage and DiskAgent adapters. Check that the
+    // aggregate owns independent adapters, preserves DiskAgent host values,
+    // and shares the registered Storage ICB controls.
+    Y_UNIT_TEST(ShouldOwnBootstrapAdaptersAndShareTheirIcbControls)
+    {
+        auto config = MakeConfig(100);
+        config.MutableFeatures()->AddFeatures()->SetName("config-feature");
+        config.MutableDiskAgent()->SetAgentId("merged-agent");
+
+        auto features = std::make_shared<NFeatures::TFeaturesConfig>();
+        auto controls = std::make_shared<NStorage::TStorageConfigControls>();
+        auto storage = std::make_shared<NStorage::TStorageConfig>(
+            config.GetStorageService(),
+            features,
+            controls);
+        NKikimr::TControlBoard controlBoard;
+        storage->Register(controlBoard);
+        NProto::TDiskAgentConfig diskAgentProto;
+        diskAgentProto.SetAgentId("bootstrap-agent");
+        NStorage::TDiskAgentConfig diskAgent(
+            std::move(diskAgentProto),
+            "rack",
+            10'000);
+
+        auto blockstoreConfig =
+            MakeBlockstoreConfig(config, {}, *storage, diskAgent);
+
+        UNIT_ASSERT_UNEQUAL(
+            features.get(),
+            blockstoreConfig->GetFeaturesConfig().get());
+        UNIT_ASSERT_UNEQUAL(
+            storage.get(),
+            blockstoreConfig->GetStorageConfig().get());
+        UNIT_ASSERT_UNEQUAL(
+            &diskAgent,
+            blockstoreConfig->GetDiskAgentConfig().get());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "config-feature",
+            blockstoreConfig->GetFeaturesConfig()
+                ->GetConfigProto()
+                .GetFeatures(0)
+                .GetName());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "bootstrap-agent",
+            blockstoreConfig->GetDiskAgentConfig()->GetAgentId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "rack",
+            blockstoreConfig->GetDiskAgentConfig()->GetRack());
+        UNIT_ASSERT_VALUES_EQUAL(
+            10'000,
+            blockstoreConfig->GetDiskAgentConfig()->GetNetworkMbitThroughput());
+
+        TAtomic previous = 0;
+        UNIT_ASSERT(!controlBoard.SetValue(
+            "BlockStore_WriteBlobThreshold",
+            200,
+            previous));
+        UNIT_ASSERT_VALUES_EQUAL(200, storage->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(
+            200,
+            blockstoreConfig->GetStorageConfig()->GetWriteBlobThreshold());
+    }
+
+    // Store an owning pointer to a top-level configuration section and release
+    // the aggregate config. The section must remain alive and keep its value.
+    Y_UNIT_TEST(ShouldKeepTopLevelSectionAliveAfterAggregateConfigIsReleased)
+    {
+        NServer::TServerAppConfigConstPtr serverConfig;
+        {
+            const auto config = MakeBlockstoreConfig(
+                MakeConfig(100),
+                {},
+                std::make_shared<NStorage::TStorageConfigControls>());
+            serverConfig = config->GetServerConfig();
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(100, serverConfig->GetPort());
+    }
+
+    // Build DiskAgent from a dynamic proto plus rack and throughput parameters.
+    // Check that both the proto value and host-only values reach the wrapper.
+    Y_UNIT_TEST(ShouldPreserveDiskAgentHostContext)
+    {
+        NProto::TBlockstoreConfig dynamicConfig;
+        dynamicConfig.MutableDiskAgent()->SetAgentId("updated-agent");
+        TBlockstoreConfigExtraParameters extraParameters;
+        extraParameters.DiskAgent.Rack = "rack-1";
+        extraParameters.DiskAgent.NetworkMbitThroughput = 42;
+
+        const auto config = MakeBlockstoreConfig(
+            {},
+            dynamicConfig,
+            std::make_shared<NStorage::TStorageConfigControls>(),
+            std::move(extraParameters));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "updated-agent",
+            config->GetDiskAgentConfig()->GetConfigProto().GetAgentId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "rack-1",
+            config->GetDiskAgentConfig()->GetRack());
+        UNIT_ASSERT_VALUES_EQUAL(
+            42,
+            config->GetDiskAgentConfig()->GetNetworkMbitThroughput());
+    }
+
+    // Publish snapshots with matching Server and Storage values while four
+    // threads read them. No reader may combine values from different snapshots,
+    // and a retained old snapshot must remain unchanged.
+    Y_UNIT_TEST(ShouldPublishConfigsAtomically)
+    {
+        auto controls = std::make_shared<NStorage::TStorageConfigControls>();
+        auto initial = MakeBlockstoreConfig(MakeConfig(1), {}, controls);
+        auto retained = IBlockstoreConfigConstPtr(initial);
+        TBlockstoreConfigHolder holder(std::move(initial));
+
+        std::atomic<bool> stop = false;
+        std::atomic<bool> consistent = true;
+        TVector<std::thread> readers;
+
+        for (ui32 i = 0; i != 4; ++i) {
+            readers.emplace_back(
+                [&]
+                {
+                    while (!stop.load()) {
+                        const auto config = holder.Get();
+                        if (config->GetServerConfig()->GetPort() !=
+                            config->GetStorageConfig()->GetWriteBlobThreshold())
+                        {
+                            consistent.store(false);
+                        }
+                    }
+                });
+        }
+
+        for (ui32 value = 2; value != 100; ++value) {
+            holder.Set(MakeBlockstoreConfig(MakeConfig(value), {}, controls));
+        }
+
+        stop.store(true);
+        for (auto& reader: readers) {
+            reader.join();
+        }
+
+        UNIT_ASSERT(consistent.load());
+        UNIT_ASSERT_VALUES_EQUAL(1, retained->GetServerConfig()->GetPort());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            retained->GetStorageConfig()->GetWriteBlobThreshold());
+        UNIT_ASSERT_VALUES_EQUAL(
+            99,
+            holder.Get()->GetStorageConfig()->GetWriteBlobThreshold());
+    }
+
+    // Initialize the process provider with value 100, then publish value 200
+    // through its holder. The getter must return 200 while the retained initial
+    // snapshot must still return 100.
+    Y_UNIT_TEST(ShouldExposeCurrentBlockstoreConfig)
+    {
+        auto controls = std::make_shared<NStorage::TStorageConfigControls>();
+        auto holder = InitializeBlockstoreConfigProvider(
+            MakeBlockstoreConfig(MakeConfig(100), {}, controls));
+        Y_DEFER
+        {
+            ResetBlockstoreConfigProvider();
+        };
+
+        const auto initial = GetCurrentBlockstoreConfig();
+        UNIT_ASSERT_VALUES_EQUAL(100, initial->GetServerConfig()->GetPort());
+
+        holder->Set(MakeBlockstoreConfig(MakeConfig(200), {}, controls));
+
+        const auto current = GetCurrentBlockstoreConfig();
+        UNIT_ASSERT_VALUES_EQUAL(200, current->GetServerConfig()->GetPort());
+        UNIT_ASSERT_VALUES_EQUAL(100, initial->GetServerConfig()->GetPort());
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/config/ut/ya.make
+++ b/cloud/blockstore/libs/config/ut/ya.make
@@ -1,0 +1,14 @@
+# BlockStore configuration and overlay unit tests.
+# The test target also exercises integration with the dynamic control board.
+
+UNITTEST_FOR(cloud/blockstore/libs/config)
+
+SRCS(
+    blockstore_config_ut.cpp
+)
+
+PEERDIR(
+    contrib/ydb/core/control
+)
+
+END()

--- a/cloud/blockstore/libs/config/ya.make
+++ b/cloud/blockstore/libs/config/ya.make
@@ -1,0 +1,38 @@
+# The shared BlockStore configuration, holder, and process provider library.
+# Runtime consumers link this module to read one consistent snapshot.
+
+LIBRARY()
+
+SRCS(
+    blockstore_config.cpp
+    blockstore_config_holder.cpp
+    blockstore_config_provider.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/config
+    cloud/blockstore/libs/cells/iface
+    cloud/blockstore/libs/client
+    cloud/blockstore/libs/diagnostics
+    cloud/blockstore/libs/discovery
+    cloud/blockstore/libs/local_nvme
+    cloud/blockstore/libs/logbroker/iface
+    cloud/blockstore/libs/notify/iface
+    cloud/blockstore/libs/rdma
+    cloud/blockstore/libs/server
+    cloud/blockstore/libs/spdk/iface
+    cloud/blockstore/libs/storage/core
+    cloud/blockstore/libs/storage/disk_agent/model
+    cloud/blockstore/libs/storage/disk_registry_proxy/model
+    cloud/blockstore/libs/ydbstats
+    cloud/storage/core/libs/features
+    cloud/storage/core/libs/iam/iface
+
+    library/cpp/threading/hot_swap
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -299,7 +299,7 @@ void TConfigInitializerYdb::ApplyServerAppConfig(const TString& text)
     }
     if (StorageConfig) {
         ApplyStorageServiceConfig(
-            ProtoToText(StorageConfig->GetStorageConfigProto()));
+            ProtoToText(StorageConfig->GetEffectiveStorageConfigProto()));
     }
     ApplyRootKmsConfig(ProtoToText(RootKmsConfig));
 }

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer_ut.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer_ut.cpp
@@ -686,7 +686,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         ci.InitServerConfig();
         ci.InitStorageConfig();
 
-        const auto& proto = ci.StorageConfig->GetStorageConfigProto();
+        const auto proto = ci.StorageConfig->GetEffectiveStorageConfigProto();
 
         UNIT_ASSERT_VALUES_EQUAL(100, proto.GetNodeRegistrationMaxAttempts());
         UNIT_ASSERT_VALUES_EQUAL(200, proto.GetNodeRegistrationTimeout());
@@ -728,7 +728,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         ci.InitServerConfig();
         ci.InitStorageConfig();
 
-        const auto& proto = ci.StorageConfig->GetStorageConfigProto();
+        const auto proto = ci.StorageConfig->GetEffectiveStorageConfigProto();
 
         UNIT_ASSERT_VALUES_EQUAL(100, proto.GetNodeRegistrationMaxAttempts());
         UNIT_ASSERT_VALUES_EQUAL(200, proto.GetNodeRegistrationTimeout());
@@ -762,7 +762,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
         ci.ApplyCustomCMSConfigs(appCfg);
 
-        const auto& proto = ci.StorageConfig->GetStorageConfigProto();
+        const auto proto = ci.StorageConfig->GetEffectiveStorageConfigProto();
 
         UNIT_ASSERT_VALUES_EQUAL(100, proto.GetNodeRegistrationMaxAttempts());
         UNIT_ASSERT_VALUES_EQUAL(200, proto.GetNodeRegistrationTimeout());
@@ -799,7 +799,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
         ci.ApplyCustomCMSConfigs(appCfg);
 
-        const auto& proto = ci.StorageConfig->GetStorageConfigProto();
+        const auto proto = ci.StorageConfig->GetEffectiveStorageConfigProto();
 
         UNIT_ASSERT_VALUES_EQUAL(100, proto.GetNodeRegistrationMaxAttempts());
         UNIT_ASSERT_VALUES_EQUAL(200, proto.GetNodeRegistrationTimeout());

--- a/cloud/blockstore/libs/diagnostics/config.cpp
+++ b/cloud/blockstore/libs/diagnostics/config.cpp
@@ -178,6 +178,11 @@ TDiagnosticsConfig::TDiagnosticsConfig(NProto::TDiagnosticsConfig diagnosticsCon
     : DiagnosticsConfig(std::move(diagnosticsConfig))
 {}
 
+const NProto::TDiagnosticsConfig& TDiagnosticsConfig::GetConfigProto() const
+{
+    return DiagnosticsConfig;
+}
+
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
 type TDiagnosticsConfig::Get##name() const                                     \
 {                                                                              \

--- a/cloud/blockstore/libs/diagnostics/config.h
+++ b/cloud/blockstore/libs/diagnostics/config.h
@@ -131,6 +131,8 @@ private:
 public:
     TDiagnosticsConfig(NProto::TDiagnosticsConfig diagnosticsConfig = {});
 
+    [[nodiscard]] const NProto::TDiagnosticsConfig& GetConfigProto() const;
+
     NProto::EHostNameScheme GetHostNameScheme() const;
     TString GetBastionNameSuffix() const;
     TString GetViewerHostName() const;

--- a/cloud/blockstore/libs/diagnostics/public.h
+++ b/cloud/blockstore/libs/diagnostics/public.h
@@ -33,6 +33,7 @@ constexpr TDuration UpdateLeakyBucketCountersInterval = TDuration::Seconds(1);
 
 class TDiagnosticsConfig;
 using TDiagnosticsConfigPtr = std::shared_ptr<TDiagnosticsConfig>;
+using TDiagnosticsConfigConstPtr = std::shared_ptr<const TDiagnosticsConfig>;
 
 struct IVolumeInfo;
 using IVolumeInfoPtr = std::shared_ptr<IVolumeInfo>;

--- a/cloud/blockstore/libs/discovery/public.h
+++ b/cloud/blockstore/libs/discovery/public.h
@@ -21,6 +21,7 @@ namespace NDiscovery {
 
 class TDiscoveryConfig;
 using TDiscoveryConfigPtr = std::shared_ptr<TDiscoveryConfig>;
+using TDiscoveryConfigConstPtr = std::shared_ptr<const TDiscoveryConfig>;
 
 struct IDiscoveryService;
 using IDiscoveryServicePtr = std::shared_ptr<IDiscoveryService>;

--- a/cloud/blockstore/libs/disk_agent/config_initializer.cpp
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.cpp
@@ -432,7 +432,7 @@ void TConfigInitializer::ApplyServerAppConfig(const TString& text)
     // Update dependent configs
     if (StorageConfig) {
         ApplyStorageServiceConfig(
-            ProtoToText(StorageConfig->GetStorageConfigProto()));
+            ProtoToText(StorageConfig->GetEffectiveStorageConfigProto()));
     }
 }
 

--- a/cloud/blockstore/libs/disk_agent/config_initializer_ut.cpp
+++ b/cloud/blockstore/libs/disk_agent/config_initializer_ut.cpp
@@ -491,7 +491,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         ci.InitServerConfig();
         ci.InitStorageConfig();
 
-        const auto& proto = ci.StorageConfig->GetStorageConfigProto();
+        const auto proto = ci.StorageConfig->GetEffectiveStorageConfigProto();
 
         UNIT_ASSERT_VALUES_EQUAL(100, proto.GetNodeRegistrationMaxAttempts());
         UNIT_ASSERT_VALUES_EQUAL(200, proto.GetNodeRegistrationTimeout());
@@ -533,7 +533,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         ci.InitServerConfig();
         ci.InitStorageConfig();
 
-        const auto& proto = ci.StorageConfig->GetStorageConfigProto();
+        const auto proto = ci.StorageConfig->GetEffectiveStorageConfigProto();
 
         UNIT_ASSERT_VALUES_EQUAL(100, proto.GetNodeRegistrationMaxAttempts());
         UNIT_ASSERT_VALUES_EQUAL(200, proto.GetNodeRegistrationTimeout());
@@ -567,7 +567,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
         ci.ApplyCustomCMSConfigs(appCfg);
 
-        const auto& proto = ci.StorageConfig->GetStorageConfigProto();
+        const auto proto = ci.StorageConfig->GetEffectiveStorageConfigProto();
 
         UNIT_ASSERT_VALUES_EQUAL(100, proto.GetNodeRegistrationMaxAttempts());
         UNIT_ASSERT_VALUES_EQUAL(200, proto.GetNodeRegistrationTimeout());
@@ -604,7 +604,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
         ci.ApplyCustomCMSConfigs(appCfg);
 
-        const auto& proto = ci.StorageConfig->GetStorageConfigProto();
+        const auto proto = ci.StorageConfig->GetEffectiveStorageConfigProto();
 
         UNIT_ASSERT_VALUES_EQUAL(100, proto.GetNodeRegistrationMaxAttempts());
         UNIT_ASSERT_VALUES_EQUAL(200, proto.GetNodeRegistrationTimeout());
@@ -645,7 +645,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
         UNIT_ASSERT_VALUES_EQUAL(
             "agent-123",
-            ci.StorageConfig->GetStorageConfigProto().GetNodeType());
+            ci.StorageConfig->GetEffectiveStorageConfigProto().GetNodeType());
 
         NKikimrConfig::TAppConfig appCfg;
         auto* serverCfg = appCfg.MutableNamedConfigs()->Add();
@@ -661,7 +661,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
         UNIT_ASSERT_VALUES_EQUAL(
             "agent-123",
-            ci.StorageConfig->GetStorageConfigProto().GetNodeType());
+            ci.StorageConfig->GetEffectiveStorageConfigProto().GetNodeType());
     }
 }
 

--- a/cloud/blockstore/libs/local_nvme/config.cpp
+++ b/cloud/blockstore/libs/local_nvme/config.cpp
@@ -182,6 +182,11 @@ TLocalNVMeConfig::TLocalNVMeConfig(NProto::TLocalNVMeConfig proto)
 
 TLocalNVMeConfig::~TLocalNVMeConfig() = default;
 
+const NProto::TLocalNVMeConfig& TLocalNVMeConfig::GetConfigProto() const
+{
+    return Proto;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \

--- a/cloud/blockstore/libs/local_nvme/config.h
+++ b/cloud/blockstore/libs/local_nvme/config.h
@@ -41,6 +41,8 @@ public:
     explicit TLocalNVMeConfig(NProto::TLocalNVMeConfig proto);
     ~TLocalNVMeConfig();
 
+    [[nodiscard]] const NProto::TLocalNVMeConfig& GetConfigProto() const;
+
     [[nodiscard]] TString GetDevicesSourceUri() const;
     [[nodiscard]] TString GetStateCacheFilePath() const;
     [[nodiscard]] TDuration GetUpdateDevicesInterval() const;

--- a/cloud/blockstore/libs/local_nvme/public.h
+++ b/cloud/blockstore/libs/local_nvme/public.h
@@ -8,6 +8,7 @@ namespace NCloud::NBlockStore {
 
 class TLocalNVMeConfig;
 using TLocalNVMeConfigPtr = std::shared_ptr<TLocalNVMeConfig>;
+using TLocalNVMeConfigConstPtr = std::shared_ptr<const TLocalNVMeConfig>;
 
 struct ILocalNVMeService;
 using ILocalNVMeServicePtr = std::shared_ptr<ILocalNVMeService>;

--- a/cloud/blockstore/libs/logbroker/iface/public.h
+++ b/cloud/blockstore/libs/logbroker/iface/public.h
@@ -11,5 +11,6 @@ using IServicePtr = std::shared_ptr<IService>;
 
 class TLogbrokerConfig;
 using TLogbrokerConfigPtr = std::shared_ptr<TLogbrokerConfig>;
+using TLogbrokerConfigConstPtr = std::shared_ptr<const TLogbrokerConfig>;
 
 }   // namespace NCloud::NBlockStore::NLogbroker

--- a/cloud/blockstore/libs/notify/iface/public.h
+++ b/cloud/blockstore/libs/notify/iface/public.h
@@ -11,5 +11,6 @@ using IServicePtr = std::shared_ptr<IService>;
 
 class TNotifyConfig;
 using TNotifyConfigPtr = std::shared_ptr<TNotifyConfig>;
+using TNotifyConfigConstPtr = std::shared_ptr<const TNotifyConfig>;
 
 }   // namespace NCloud::NBlockStore::NNotify

--- a/cloud/blockstore/libs/rdma/config.h
+++ b/cloud/blockstore/libs/rdma/config.h
@@ -21,6 +21,11 @@ public:
         : Config(std::move(config))
     {}
 
+    [[nodiscard]] const NProto::TRdmaConfig& GetConfigProto() const
+    {
+        return Config;
+    }
+
     auto GetClientEnabled() const
     {
         return Config.GetClientEnabled();
@@ -63,5 +68,6 @@ public:
 };
 
 using TRdmaConfigPtr = std::shared_ptr<TRdmaConfig>;
+using TRdmaConfigConstPtr = std::shared_ptr<const TRdmaConfig>;
 
 }   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -38,6 +38,11 @@ private:
 public:
     TServerAppConfig(NProto::TServerAppConfig appConfig = {});
 
+    [[nodiscard]] const NProto::TServerAppConfig& GetAppConfig() const
+    {
+        return AppConfig;
+    }
+
     const NProto::TServerConfig* GetServerConfig() const
     {
         return ServerConfig;

--- a/cloud/blockstore/libs/server/public.h
+++ b/cloud/blockstore/libs/server/public.h
@@ -14,6 +14,7 @@ namespace NServer {
 
 class TServerAppConfig;
 using TServerAppConfigPtr = std::shared_ptr<TServerAppConfig>;
+using TServerAppConfigConstPtr = std::shared_ptr<const TServerAppConfig>;
 
 struct IServer;
 using IServerPtr = std::shared_ptr<IServer>;

--- a/cloud/blockstore/libs/spdk/iface/config.cpp
+++ b/cloud/blockstore/libs/spdk/iface/config.cpp
@@ -49,6 +49,11 @@ TSpdkEnvConfig::TSpdkEnvConfig(NProto::TSpdkEnvConfig config)
     : Config(std::move(config))
 {}
 
+const NProto::TSpdkEnvConfig& TSpdkEnvConfig::GetConfigProto() const
+{
+    return Config;
+}
+
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
 type TSpdkEnvConfig::Get##name() const                                         \
 {                                                                              \

--- a/cloud/blockstore/libs/spdk/iface/config.h
+++ b/cloud/blockstore/libs/spdk/iface/config.h
@@ -16,6 +16,8 @@ private:
 public:
     explicit TSpdkEnvConfig(NProto::TSpdkEnvConfig config = {});
 
+    [[nodiscard]] const NProto::TSpdkEnvConfig& GetConfigProto() const;
+
     TString GetCpuMask() const;
     TString GetHugeDir() const;
 

--- a/cloud/blockstore/libs/spdk/iface/public.h
+++ b/cloud/blockstore/libs/spdk/iface/public.h
@@ -39,6 +39,7 @@ struct TDeviceRateLimits
 
 class TSpdkEnvConfig;
 using TSpdkEnvConfigPtr = std::shared_ptr<TSpdkEnvConfig>;
+using TSpdkEnvConfigConstPtr = std::shared_ptr<const TSpdkEnvConfig>;
 
 struct ISpdkEnv;
 using ISpdkEnvPtr = std::shared_ptr<ISpdkEnv>;

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -1176,7 +1176,7 @@ bool TStorageConfigControls::RestoreDefault(TStringBuf name)
 struct TStorageConfig::TImpl
 {
     NProto::TStorageServiceConfig StorageServiceConfig;
-    NFeatures::TFeaturesConfigPtr FeaturesConfig;
+    NFeatures::TFeaturesConfigConstPtr FeaturesConfig;
 
     // Non-null ICB controls for all read-write storage fields. The
     // three-argument constructor can reuse a config-independent collection;
@@ -1186,7 +1186,7 @@ struct TStorageConfig::TImpl
 
     TImpl(
         NProto::TStorageServiceConfig storageServiceConfig,
-        NFeatures::TFeaturesConfigPtr featuresConfig,
+        NFeatures::TFeaturesConfigConstPtr featuresConfig,
         TStorageConfigControlsPtr controls)
         : StorageServiceConfig(std::move(storageServiceConfig))
         , FeaturesConfig(std::move(featuresConfig))
@@ -1195,7 +1195,7 @@ struct TStorageConfig::TImpl
         Y_ABORT_UNLESS(Controls);
     }
 
-    void SetFeaturesConfig(NFeatures::TFeaturesConfigPtr featuresConfig)
+    void SetFeaturesConfig(NFeatures::TFeaturesConfigConstPtr featuresConfig)
     {
         FeaturesConfig = std::move(featuresConfig);
     }
@@ -1206,11 +1206,11 @@ struct TStorageConfig::TImpl
         StorageServiceConfig.SetVolumePreemptionType(volumePreemptionType);
     }
 
-    NProto::TStorageServiceConfig GetStorageConfigProto() const
+    NProto::TStorageServiceConfig GetEffectiveStorageConfigProto() const
     {
         NProto::TStorageServiceConfig proto = StorageServiceConfig;
 
-    // Overriding fields with values from ICB
+    // Apply current ICB overrides to the returned proto copy.
 #define BLOCKSTORE_CONFIG_COPY(name, type, ...)                                \
     if (const auto value =                                                     \
             Controls->Impl->ReadOverride(Controls->Impl->Control##name))       \
@@ -1232,7 +1232,7 @@ struct TStorageConfig::TImpl
 
 TStorageConfig::TStorageConfig(
     NProto::TStorageServiceConfig storageServiceConfig,
-    NFeatures::TFeaturesConfigPtr featuresConfig)
+    NFeatures::TFeaturesConfigConstPtr featuresConfig)
     : TStorageConfig(
           std::move(storageServiceConfig),
           std::move(featuresConfig),
@@ -1241,7 +1241,7 @@ TStorageConfig::TStorageConfig(
 
 TStorageConfig::TStorageConfig(
     NProto::TStorageServiceConfig storageServiceConfig,
-    NFeatures::TFeaturesConfigPtr featuresConfig,
+    NFeatures::TFeaturesConfigConstPtr featuresConfig,
     TStorageConfigControlsPtr controls)
 {
     Y_ABORT_UNLESS(!controls || controls->Impl->ConfigIndependent);
@@ -1278,7 +1278,7 @@ TStorageConfig::GetStorageConfigControls() const
 }
 
 void TStorageConfig::SetFeaturesConfig(
-    NFeatures::TFeaturesConfigPtr featuresConfig)
+    NFeatures::TFeaturesConfigConstPtr featuresConfig)
 {
     Impl->SetFeaturesConfig(std::move(featuresConfig));
 }
@@ -1430,7 +1430,7 @@ TStorageConfigPtr TStorageConfig::Merge(
     auto controls = config->GetStorageConfigControls();
     const auto configProto = controls
                                  ? config->Impl->StorageServiceConfig
-                                 : config->GetStorageConfigProto();
+                                 : config->GetEffectiveStorageConfigProto();
     auto patchedConfigProto = configProto;
     patchedConfigProto.MergeFrom(patch);
     if (google::protobuf::util::MessageDifferencer::Equals(
@@ -1516,9 +1516,10 @@ TStorageConfig::TValueByName TStorageConfig::GetValueByName(
     return {value};
 }
 
-NProto::TStorageServiceConfig TStorageConfig::GetStorageConfigProto() const
+NProto::TStorageServiceConfig
+TStorageConfig::GetEffectiveStorageConfigProto() const
 {
-    return Impl->GetStorageConfigProto();
+    return Impl->GetEffectiveStorageConfigProto();
 }
 
 void AdaptNodeRegistrationParams(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/config/server.pb.h>
 #include <cloud/blockstore/config/storage.pb.h>
+#include <cloud/blockstore/libs/kikimr/public.h>
 #include <cloud/storage/core/libs/features/features_config.h>
 #include <cloud/storage/core/protos/media.pb.h>
 
@@ -102,14 +103,14 @@ private:
 public:
     TStorageConfig(
         NProto::TStorageServiceConfig storageServiceConfig,
-        NFeatures::TFeaturesConfigPtr featuresConfig);
+        NFeatures::TFeaturesConfigConstPtr featuresConfig);
 
     // Use the supplied config-independent controls for ICB overrides. If
     // controls is null, create config-bound controls from storageServiceConfig,
     // as the two-argument constructor does.
     TStorageConfig(
         NProto::TStorageServiceConfig storageServiceConfig,
-        NFeatures::TFeaturesConfigPtr featuresConfig,
+        NFeatures::TFeaturesConfigConstPtr featuresConfig,
         TStorageConfigControlsPtr controls);
 
     // Create a raw-proto copy that shares Features and the live ICB controls.
@@ -123,7 +124,7 @@ public:
     // construction.
     TStorageConfigControlsPtr GetStorageConfigControls() const;
 
-    void SetFeaturesConfig(NFeatures::TFeaturesConfigPtr featuresConfig);
+    void SetFeaturesConfig(NFeatures::TFeaturesConfigConstPtr featuresConfig);
 
     void SetVolumePreemptionType(
         NProto::EVolumePreemptionType volumePreemptionType);
@@ -155,7 +156,9 @@ public:
 
     TValueByName GetValueByName(const TString& name) const;
 
-    [[nodiscard]] NProto::TStorageServiceConfig GetStorageConfigProto() const;
+    // Return a proto copy with current ICB overrides applied.
+    [[nodiscard]] NProto::TStorageServiceConfig
+    GetEffectiveStorageConfigProto() const;
 
     TString GetSchemeShardDir() const;
     [[nodiscard]] ui32 GetListVolumesConcurrency() const;

--- a/cloud/blockstore/libs/storage/core/config_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/config_ut.cpp
@@ -249,7 +249,7 @@ Y_UNIT_TEST_SUITE(TConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(1, config->GetMaxMigrationIoDepth());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            config->GetStorageConfigProto().GetMaxMigrationIoDepth());
+            config->GetEffectiveStorageConfigProto().GetMaxMigrationIoDepth());
 
         UNIT_ASSERT(!controlBoard.SetValue(
             "BlockStore_MaxMigrationIoDepth",
@@ -291,7 +291,7 @@ Y_UNIT_TEST_SUITE(TConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(8, config->GetMaxMigrationIoDepth());
         UNIT_ASSERT_VALUES_EQUAL(
             8,
-            config->GetStorageConfigProto().GetMaxMigrationIoDepth());
+            config->GetEffectiveStorageConfigProto().GetMaxMigrationIoDepth());
 
         UNIT_ASSERT(!controlBoard.SetValue(
             "BlockStore_MaxMigrationIoDepth",
@@ -305,7 +305,7 @@ Y_UNIT_TEST_SUITE(TConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(1, config->GetMaxMigrationIoDepth());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            config->GetStorageConfigProto().GetMaxMigrationIoDepth());
+            config->GetEffectiveStorageConfigProto().GetMaxMigrationIoDepth());
     }
 
     Y_UNIT_TEST(ShouldOverrideConfigFields)
@@ -432,6 +432,15 @@ Y_UNIT_TEST_SUITE(TConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(
             maxMigrationIoDepthICB,
             globalConfig->GetMaxMigrationIoDepth());
+
+        const auto effectiveProto =
+            globalConfig->GetEffectiveStorageConfigProto();
+        UNIT_ASSERT_VALUES_EQUAL(
+            maxMigrationBandwidthICB,
+            effectiveProto.GetMaxMigrationBandwidth());
+        UNIT_ASSERT_VALUES_EQUAL(
+            maxMigrationIoDepthICB,
+            effectiveProto.GetMaxMigrationIoDepth());
 
         // Apply a patch with new MaxMigrationIoDepth & ExpectedDiskAgentSize
 

--- a/cloud/blockstore/libs/storage/core/public.h
+++ b/cloud/blockstore/libs/storage/core/public.h
@@ -20,6 +20,7 @@ namespace NStorage {
 
 class TStorageConfig;
 using TStorageConfigPtr = std::shared_ptr<TStorageConfig>;
+using TStorageConfigConstPtr = std::shared_ptr<const TStorageConfig>;
 
 class TStorageConfigControls;
 using TStorageConfigControlsPtr = std::shared_ptr<TStorageConfigControls>;

--- a/cloud/blockstore/libs/storage/disk_agent/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/config.h
@@ -33,6 +33,11 @@ public:
         , NetworkMbitThroughput(networkMbitThroughput)
     {}
 
+    [[nodiscard]] const NProto::TDiskAgentConfig& GetConfigProto() const
+    {
+        return Config;
+    }
+
     bool GetEnabled() const;
     TString GetAgentId() const;
     ui64 GetSeqNumber() const;

--- a/cloud/blockstore/libs/storage/disk_agent/model/public.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/public.h
@@ -13,6 +13,7 @@ using TDeviceClientPtr = std::shared_ptr<TDeviceClient>;
 
 class TDiskAgentConfig;
 using TDiskAgentConfigPtr = std::shared_ptr<TDiskAgentConfig>;
+using TDiskAgentConfigConstPtr = std::shared_ptr<const TDiskAgentConfig>;
 
 class IMultiAgentWriteHandler;
 using IMultiAgentWriteHandlerPtr = std::shared_ptr<IMultiAgentWriteHandler>;

--- a/cloud/blockstore/libs/storage/disk_registry_proxy/model/config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry_proxy/model/config.cpp
@@ -47,6 +47,12 @@ TDiskRegistryProxyConfig::TDiskRegistryProxyConfig(
     : Config(std::move(config))
 {}
 
+const NProto::TDiskRegistryProxyConfig&
+TDiskRegistryProxyConfig::GetConfigProto() const
+{
+    return Config;
+}
+
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
 type TDiskRegistryProxyConfig::Get##name() const                               \
 {                                                                              \

--- a/cloud/blockstore/libs/storage/disk_registry_proxy/model/config.h
+++ b/cloud/blockstore/libs/storage/disk_registry_proxy/model/config.h
@@ -20,6 +20,9 @@ public:
     explicit TDiskRegistryProxyConfig(
             NProto::TDiskRegistryProxyConfig config = {});
 
+    [[nodiscard]] const NProto::TDiskRegistryProxyConfig&
+    GetConfigProto() const;
+
     ui64 GetOwner() const;
     ui64 GetOwnerIdx() const;
 

--- a/cloud/blockstore/libs/storage/disk_registry_proxy/model/public.h
+++ b/cloud/blockstore/libs/storage/disk_registry_proxy/model/public.h
@@ -8,5 +8,7 @@ namespace NCloud::NBlockStore::NStorage {
 
 class TDiskRegistryProxyConfig;
 using TDiskRegistryProxyConfigPtr = std::shared_ptr<TDiskRegistryProxyConfig>;
+using TDiskRegistryProxyConfigConstPtr =
+    std::shared_ptr<const TDiskRegistryProxyConfig>;
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_storage_config.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_storage_config.cpp
@@ -76,7 +76,7 @@ void TGetStorageConfigActor::Bootstrap(const TActorContext& ctx)
     }
 
     if (!proto.GetDiskId()) {
-        HandleSuccess(ctx, StorageConfig->GetStorageConfigProto());
+        HandleSuccess(ctx, StorageConfig->GetEffectiveStorageConfigProto());
         return;
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -877,7 +877,8 @@ void TVolumeActor::HandleGetStorageConfig(
     const TActorContext& ctx)
 {
     auto response = std::make_unique<TEvVolume::TEvGetStorageConfigResponse>();
-    *response->Record.MutableStorageConfig() = Config->GetStorageConfigProto();
+    *response->Record.MutableStorageConfig() =
+        Config->GetEffectiveStorageConfigProto();
 
     NCloud::Reply(
         ctx,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -1587,7 +1587,8 @@ void TVolumeActor::RenderStorageConfig(IOutputStream& out) const
                         TABLEH() { out << "Value"; }
                     }
                 }
-                const auto& protoValues = Config->GetStorageConfigProto();
+                const auto protoValues =
+                    Config->GetEffectiveStorageConfigProto();
                 constexpr i32 expectedNonRepeatedFieldIndex = -1;
                 const auto* descriptor =
                     NProto::TStorageServiceConfig::GetDescriptor();

--- a/cloud/blockstore/libs/ya.make
+++ b/cloud/blockstore/libs/ya.make
@@ -5,6 +5,7 @@ RECURSE(
     client_rdma
     client_spdk
     common
+    config
     daemon
     diagnostics
     discovery

--- a/cloud/blockstore/libs/ydbstats/config.cpp
+++ b/cloud/blockstore/libs/ydbstats/config.cpp
@@ -65,6 +65,11 @@ TYdbStatsConfig::TYdbStatsConfig(NProto::TYdbStatsConfig ydbStatsConfig)
     : YdbStatsConfig(std::move(ydbStatsConfig))
 {}
 
+const NProto::TYdbStatsConfig& TYdbStatsConfig::GetConfigProto() const
+{
+    return YdbStatsConfig;
+}
+
 bool TYdbStatsConfig::IsValid() const
 {
     return

--- a/cloud/blockstore/libs/ydbstats/config.h
+++ b/cloud/blockstore/libs/ydbstats/config.h
@@ -20,6 +20,8 @@ private:
 public:
     TYdbStatsConfig(NProto::TYdbStatsConfig statsUploadConfig = {});
 
+    [[nodiscard]] const NProto::TYdbStatsConfig& GetConfigProto() const;
+
     bool IsValid() const;
 
     TString GetStatsTableName() const;

--- a/cloud/blockstore/libs/ydbstats/public.h
+++ b/cloud/blockstore/libs/ydbstats/public.h
@@ -19,6 +19,7 @@ using IYdbVolumesStatsUploaderPtr = std::shared_ptr<IYdbVolumesStatsUploader>;
 
 class TYdbStatsConfig;
 using TYdbStatsConfigPtr = std::shared_ptr<TYdbStatsConfig>;
+using TYdbStatsConfigConstPtr = std::shared_ptr<const TYdbStatsConfig>;
 
 struct IYdbStorage;
 using IYdbStoragePtr = std::shared_ptr<IYdbStorage>;

--- a/cloud/storage/core/libs/features/features_config.cpp
+++ b/cloud/storage/core/libs/features/features_config.cpp
@@ -33,10 +33,16 @@ TFeaturesConfig::TFeatureInfo::TFeatureInfo(NProto::TFeatureConfig config)
 }
 
 TFeaturesConfig::TFeaturesConfig(NProto::TFeaturesConfig config)
+    : Config(std::move(config))
 {
-    for (const auto& feature: config.GetFeatures()) {
+    for (const auto& feature: Config.GetFeatures()) {
         Features.emplace(feature.GetName(), feature);
     }
+}
+
+const NProto::TFeaturesConfig& TFeaturesConfig::GetConfigProto() const
+{
+    return Config;
 }
 
 bool TFeaturesConfig::IsValid() const

--- a/cloud/storage/core/libs/features/features_config.h
+++ b/cloud/storage/core/libs/features/features_config.h
@@ -30,10 +30,17 @@ class TFeaturesConfig
     };
 
 private:
+    // Source feature definitions owned by this object and used to build the
+    // lookup map.
+    NProto::TFeaturesConfig Config;
+
+    // Parsed feature definitions indexed by feature name.
     THashMap<TString, TFeatureInfo> Features;
 
 public:
     explicit TFeaturesConfig(NProto::TFeaturesConfig config = {});
+
+    [[nodiscard]] const NProto::TFeaturesConfig& GetConfigProto() const;
 
     bool IsValid() const;
 

--- a/cloud/storage/core/libs/features/features_config_ut.cpp
+++ b/cloud/storage/core/libs/features/features_config_ut.cpp
@@ -31,6 +31,23 @@ TVector<TString> RandomStrings(ui32 n)
 
 Y_UNIT_TEST_SUITE(TFeaturesConfigTest)
 {
+    // Construct the wrapper from one Feature and then clear the caller's proto.
+    // GetConfigProto must still expose the original Feature owned by the
+    // wrapper.
+    Y_UNIT_TEST(ShouldExposeSourceConfigProto)
+    {
+        NProto::TFeaturesConfig proto;
+        proto.AddFeatures()->SetName("feature");
+
+        const TFeaturesConfig config(proto);
+        proto.Clear();
+
+        UNIT_ASSERT_VALUES_EQUAL(1, config.GetConfigProto().FeaturesSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "feature",
+            config.GetConfigProto().GetFeatures(0).GetName());
+    }
+
     Y_UNIT_TEST(ShouldMatchCloudsByProbability)
     {
         NProto::TFeaturesConfig fc;

--- a/cloud/storage/core/libs/features/public.h
+++ b/cloud/storage/core/libs/features/public.h
@@ -8,5 +8,6 @@ namespace NCloud::NFeatures {
 
 class TFeaturesConfig;
 using TFeaturesConfigPtr = std::shared_ptr<TFeaturesConfig>;
+using TFeaturesConfigConstPtr = std::shared_ptr<const TFeaturesConfig>;
 
 }   // namespace NCloud::NFeatures

--- a/cloud/storage/core/libs/iam/iface/public.h
+++ b/cloud/storage/core/libs/iam/iface/public.h
@@ -8,6 +8,7 @@ namespace NCloud::NIamClient {
 
 class TIamClientConfig;
 using TIamClientConfigPtr = std::shared_ptr<TIamClientConfig>;
+using TIamClientConfigConstPtr = std::shared_ptr<const TIamClientConfig>;
 
 struct IIamTokenAsyncClient;
 using IIamTokenAsyncClientPtr = std::shared_ptr<IIamTokenAsyncClient>;


### PR DESCRIPTION
### Notes

Introduce the aggregate BlockStore configuration boundary required for dynamic configuration. This preparatory PR defines immutable merged snapshots, atomic snapshot publication, and process-wide read access.

The provider is not yet initialized from bootstrap or used by runtime components, so the existing configuration delivery path remains active. This PR builds on the reusable Storage ICB controls from #6902, which is already merged into `main`.

### Changes

- Add a 19-section aggregate protobuf and `MakeBlockstoreConfig()` factories for regular and bootstrap construction.
- Apply standard protobuf merge rules to ordinary fields. Merge Features by name: the first record within each source wins, a complete dynamic record replaces the matching static record at its existing position, and dynamic-only records are appended in source order.
- Add `IBlockstoreConfig`, which owns const pointers to runtime wrappers and protobuf sections. Readers can retain a complete snapshot or an individual section after a newer snapshot is published.
- Add `TBlockstoreConfigHolder` as the single-writer publication point that atomically replaces the current snapshot.
- Add `GetCurrentBlockstoreConfig()` and bootstrap-only provider initialization. Bootstrap must bind the process-wide holder once, before concurrent reads start; reset and rebind attempts abort.
- Preserve live Storage ICB controls across snapshots in both config-bound and config-independent modes. Rename `GetStorageConfigProto()` to `GetEffectiveStorageConfigProto()` to make its existing ICB-aware serialization behavior explicit.

<details>
<summary>File summaries</summary>

| File or group | Summary |
| --- | --- |
| `cloud/blockstore/config/blockstore.proto` | New aggregate schema for the 19 supported top-level BlockStore configuration sections. |
| `cloud/blockstore/libs/config/blockstore_config.h` | New immutable aggregate interface, factory contracts, merge API, and extra runtime parameters. |
| `cloud/blockstore/libs/config/blockstore_config.cpp` | New snapshot ownership, aggregate merge, wrapper construction, and Feature overlay implementation. |
| `cloud/blockstore/libs/config/blockstore_config_holder.h` | New single-writer, multi-reader holder interface for atomic snapshot publication. |
| `cloud/blockstore/libs/config/blockstore_config_holder.cpp` | New `THotSwap`-based snapshot load and publication implementation. |
| `cloud/blockstore/libs/config/blockstore_config_provider.h` | New process-wide read API for the current BlockStore configuration. |
| `cloud/blockstore/libs/config/blockstore_config_provider_private.h` | New bootstrap-only API for one-time provider initialization. |
| `cloud/blockstore/libs/config/blockstore_config_provider.cpp` | New process-lifetime holder binding and current-snapshot access implementation. |
| `cloud/blockstore/libs/config/ut/blockstore_config_ut.cpp` | New aggregate merge, ownership, ICB, publication, and provider coverage. |
| Runtime wrapper pointer aliases | Add const shared-pointer aliases for wrapper types stored by immutable aggregate snapshots. |
| Proto-backed runtime wrappers | Expose the source protobuf already owned by each wrapper for aggregate configuration assembly. |
| `cloud/blockstore/libs/storage/core/config.{h,cpp}` | Accept const Features ownership and rename the Storage protobuf accessor to clarify its existing ICB-aware behavior. |
| `cloud/blockstore/libs/storage/core/config_ut.cpp` | Update renamed calls and verify that effective protobuf serialization includes live ICB values. |
| Storage configuration accessor call sites | Update YDB and DiskAgent initializers, Storage service and Volume consumers, monitoring, and existing tests for the accessor rename without changing their behavior. |
| `cloud/storage/core/libs/features/features_config.{h,cpp,features_config_ut.cpp}` | Own and expose the source Features protobuf and verify that it remains independent of the caller. |
| Build files | Register the aggregate protobuf, configuration library, and unit-test target. |

</details>

### Issue

#6685
