### PR TITLE
[Disk Manager] Force finish regular task must decrement inflight count

### DIFF
--- a/cloud/tasks/storage/storage_ydb_impl.go
+++ b/cloud/tasks/storage/storage_ydb_impl.go
@@ -1986,6 +1986,13 @@ func (s *storageYDB) forceFinishTask(
 	state.ChangedStateAt = now
 	state.EndedAt = now
 
+	if state.Regular && !IsEnded(lastState.Status) {
+		err = s.decrementRegularTasksInflight(ctx, tx, state.TaskType)
+		if err != nil {
+			return err
+		}
+	}
+
 	transitions := []stateTransition{
 		{
 			lastState: &lastState,

--- a/cloud/tasks/storage/storage_ydb_test.go
+++ b/cloud/tasks/storage/storage_ydb_test.go
@@ -4247,6 +4247,85 @@ func TestStorageYDBCreateRegularTasks(t *testing.T) {
 	require.Equal(t, 2, len(taskInfos))
 }
 
+func TestStorageYDBForceFinishLongRunningRegularTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	metricsRegistry := mocks.NewRegistryMock()
+
+	taskStallingTimeout := "1s"
+	storage, err := newStorage(t, ctx, db, &tasks_config.TasksConfig{
+		TaskStallingTimeout: &taskStallingTimeout,
+	}, metricsRegistry)
+	require.NoError(t, err)
+
+	taskDuration := time.Hour
+	scheduleInterval := time.Second
+	createdAt := time.Now().Add(-taskDuration)
+	task := TaskState{
+		TaskType:     "task",
+		Description:  "Some task",
+		CreatedAt:    createdAt,
+		CreatedBy:    "some_user",
+		ModifiedAt:   createdAt,
+		GenerationID: 0,
+		Status:       TaskStatusReadyToRun,
+		State:        []byte{},
+	}
+	schedule := TaskSchedule{
+		ScheduleInterval: scheduleInterval,
+		MaxTasksInflight: 1,
+	}
+
+	metricsRegistry.GetCounter(
+		"created",
+		map[string]string{"type": task.TaskType},
+	).On("Add", int64(1)).Twice()
+
+	err = storage.CreateRegularTasks(ctx, task, schedule)
+	require.NoError(t, err)
+
+	taskInfos, err := storage.ListTasksReadyToRun(ctx, 100500, nil)
+	require.NoError(t, err)
+	require.Len(t, taskInfos, 1)
+
+	runningTask, err := storage.LockTaskToRun(ctx, taskInfos[0], time.Now(), "host", "runner")
+	require.NoError(t, err)
+	require.Equal(t, TaskStatusRunning, runningTask.Status)
+
+	// Simulate the next scheduling iteration after the task has been running
+	// for much longer than its schedule interval. The unfinished task should
+	// still prevent a new iteration from being scheduled.
+	task.CreatedAt = createdAt.Add(taskDuration)
+	err = storage.CreateRegularTasks(ctx, task, schedule)
+	require.NoError(t, err)
+
+	taskInfos, err = storage.ListTasksReadyToRun(ctx, 100500, nil)
+	require.NoError(t, err)
+	require.Empty(t, taskInfos)
+
+	err = storage.ForceFinishTask(ctx, runningTask.ID)
+	require.NoError(t, err)
+
+	finishedTask, err := storage.GetTask(ctx, runningTask.ID)
+	require.NoError(t, err)
+	require.Equal(t, TaskStatusFinished, finishedTask.Status)
+
+	// Force-finishing the only in-flight regular task should release the
+	// schedule and allow the next iteration to be created.
+	err = storage.CreateRegularTasks(ctx, task, schedule)
+	require.NoError(t, err)
+
+	taskInfos, err = storage.ListTasksReadyToRun(ctx, 100500, nil)
+	require.NoError(t, err)
+	require.Len(t, taskInfos, 1)
+	metricsRegistry.AssertAllExpectations(t)
+}
+
 func TestStorageYDBCreateRegularTasksUsingCrontab(t *testing.T) {
 	ctx, cancel := context.WithCancel(newContext())
 	defer cancel()

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -1649,7 +1649,7 @@ func TestTasksForceFinishLongRunningRegularTask(t *testing.T) {
 	var firstTaskID string
 	select {
 	case firstTaskID = <-started:
-	case <-time.After(5 * time.Second):
+	case <-time.After(100 * time.Second):
 		require.FailNow(t, "regular task was not started")
 	}
 
@@ -1668,7 +1668,7 @@ func TestTasksForceFinishLongRunningRegularTask(t *testing.T) {
 	var secondTaskID string
 	select {
 	case secondTaskID = <-started:
-	case <-time.After(5 * time.Second):
+	case <-time.After(100 * time.Second):
 		require.FailNow(t, "next regular task was not started")
 	}
 	require.NotEqual(t, firstTaskID, secondTaskID)

--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -861,6 +861,53 @@ func (t *regularTask) GetResponse() proto.Message {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+type blockingRegularTask struct {
+	started chan<- string
+}
+
+func (t *blockingRegularTask) Load(_, _ []byte) error {
+	return nil
+}
+
+func (t *blockingRegularTask) Save() ([]byte, error) {
+	return nil, nil
+}
+
+func (t *blockingRegularTask) Run(
+	ctx context.Context,
+	execCtx tasks.ExecutionContext,
+) error {
+
+	select {
+	case t.started <- execCtx.GetTaskID():
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (t *blockingRegularTask) Cancel(
+	ctx context.Context,
+	execCtx tasks.ExecutionContext,
+) error {
+
+	return nil
+}
+
+func (t *blockingRegularTask) GetMetadata(
+	ctx context.Context,
+) (proto.Message, error) {
+
+	return &empty.Empty{}, nil
+}
+
+func (t *blockingRegularTask) GetResponse() proto.Message {
+	return &empty.Empty{}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 var defaultTimeout = 10 * time.Minute
 
 func waitTaskWithTimeout(
@@ -1569,6 +1616,62 @@ func TestTasksRunningRegularTasks(t *testing.T) {
 
 		regularTaskMutex.Unlock()
 	}
+}
+
+func TestTasksForceFinishLongRunningRegularTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db := newYDB(ctx, t)
+	defer db.Close(ctx)
+
+	s := createServices(t, ctx, db, 3)
+
+	const taskType = "forceFinishRegular"
+	started := make(chan string, 2)
+	err := s.registry.RegisterForExecution(taskType, func() tasks.Task {
+		return &blockingRegularTask{started: started}
+	})
+	require.NoError(t, err)
+
+	err = s.startRunners(ctx)
+	require.NoError(t, err)
+
+	s.scheduler.ScheduleRegularTasks(
+		ctx,
+		taskType,
+		tasks.TaskSchedule{
+			ScheduleInterval: time.Millisecond,
+			MaxTasksInflight: 1,
+		},
+	)
+
+	var firstTaskID string
+	select {
+	case firstTaskID = <-started:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "regular task was not started")
+	}
+
+	firstTask, err := s.storage.GetTask(ctx, firstTaskID)
+	require.NoError(t, err)
+	require.True(t, firstTask.Regular)
+	require.Equal(t, tasks_storage.TaskStatusRunning, firstTask.Status)
+
+	err = s.storage.ForceFinishTask(ctx, firstTaskID)
+	require.NoError(t, err)
+
+	firstTask, err = s.storage.GetTask(ctx, firstTaskID)
+	require.NoError(t, err)
+	require.Equal(t, tasks_storage.TaskStatusFinished, firstTask.Status)
+
+	var secondTaskID string
+	select {
+	case secondTaskID = <-started:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "next regular task was not started")
+	}
+	require.NotEqual(t, firstTaskID, secondTaskID)
 }
 
 func newHangingTaskTestConfig() *tasks_config.TasksConfig {


### PR DESCRIPTION
Now regular tasks force finish does not decrement inflight count in the scheduled table. This leads to not re-scheduling the task after force-finish.
