### PR TITLE
[NBS] Separate blocks and blobs counters by channel kind and index kind

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1680,4 +1680,9 @@ message TStorageServiceConfig
     // If false (default), cleanup removes only blobs that were added to the
     // cleanup queue before all checkpoints.
     optional bool CheckpointAwareCleanupEnabled = 526;
+
+    // If true, the legacy mixed/merged blob and block counters are classified
+    // by the data kind of the channel where a blob is stored. If false, both
+    // the legacy and index counter families are classified by index kind.
+    optional bool UseBlobChannelDataKindForCounters = 527;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -732,6 +732,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MixedBlocksFilterRangesToLoadPerTx,         ui64,       100           )\
     xxx(MixedBlocksFilterAllowedCpuTimePerSecond,   TDuration,  MSeconds(10)  )\
     xxx(CheckpointAwareCleanupEnabled,              bool,       false         )\
+    xxx(UseBlobChannelDataKindForCounters,          bool,       false         )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -887,6 +887,8 @@ public:
     [[nodiscard]] TDuration GetMixedBlocksFilterAllowedCpuTimePerSecond() const;
 
     [[nodiscard]] bool GetCheckpointAwareCleanupEnabled() const;
+
+    [[nodiscard]] bool GetUseBlobChannelDataKindForCounters() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -141,6 +141,14 @@ struct TSimpleDiskCounters
         EPublishingPolicy::Repl,
         TSimpleCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
+    TCounter MixedIndexBytesCount{
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
+    TCounter MergedIndexBytesCount{
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
     TCounter FreshBytesCount{
         EPublishingPolicy::Repl,
         TSimpleCounter::ECounterType::Generic,
@@ -266,6 +274,8 @@ struct TSimpleDiskCounters
 
         MakeMeta<&TSimpleDiskCounters::MixedBytesCount>(),
         MakeMeta<&TSimpleDiskCounters::MergedBytesCount>(),
+        MakeMeta<&TSimpleDiskCounters::MixedIndexBytesCount>(),
+        MakeMeta<&TSimpleDiskCounters::MergedIndexBytesCount>(),
         MakeMeta<&TSimpleDiskCounters::FreshBytesCount>(),
         MakeMeta<&TSimpleDiskCounters::UntrimmedFreshBlobBytesCount>(),
         MakeMeta<&TSimpleDiskCounters::UsedBytesCount>(),

--- a/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
+++ b/cloud/blockstore/libs/storage/core/monitoring_utils.cpp
@@ -899,31 +899,84 @@ void DumpPartitionStats(
                             << ")";
                     }
                 }
-                TABLER() {
-                    TABLED() { out << "Mixed blobs count"; }
-                    TABLED() { out << stats.GetMixedBlobsCount(); }
+                TABLER () {
+                    TABLED () {
+                        out << "Mixed channel blobs count";
+                    }
+                    TABLED () {
+                        out << stats.GetMixedBlobsCount();
+                    }
                 }
-                TABLER() {
-                    TABLED() { out << "Mixed blocks count"; }
-                    TABLED() {
+                TABLER () {
+                    TABLED () {
+                        out << "Mixed channel blocks count";
+                    }
+                    TABLED () {
                         out << stats.GetMixedBlocksCount() << " ("
-                            << FormatByteSize(blockSize * stats.GetMixedBlocksCount())
+                            << FormatByteSize(
+                                   blockSize * stats.GetMixedBlocksCount())
                             << ")";
                     }
                 }
-                TABLER() {
-                    TABLED() { out << "Merged blobs count"; }
-                    TABLED() { out << stats.GetMergedBlobsCount(); }
+                TABLER () {
+                    TABLED () {
+                        out << "Merged channel blobs count";
+                    }
+                    TABLED () {
+                        out << stats.GetMergedBlobsCount();
+                    }
                 }
-                TABLER() {
-                    TABLED() { out << "Merged blocks count"; }
-                    TABLED() {
+                TABLER () {
+                    TABLED () {
+                        out << "Merged channel blocks count";
+                    }
+                    TABLED () {
                         out << stats.GetMergedBlocksCount() << " ("
-                            << FormatByteSize(blockSize * stats.GetMergedBlocksCount())
+                            << FormatByteSize(
+                                   blockSize * stats.GetMergedBlocksCount())
                             << ")";
                     }
                 }
-                TABLER() {
+                TABLER () {
+                    TABLED () {
+                        out << "Mixed index blobs count";
+                    }
+                    TABLED () {
+                        out << stats.GetMixedIndexBlobsCount();
+                    }
+                }
+                TABLER () {
+                    TABLED () {
+                        out << "Mixed index blocks count";
+                    }
+                    TABLED () {
+                        out << stats.GetMixedIndexBlocksCount() << " ("
+                            << FormatByteSize(
+                                   blockSize * stats.GetMixedIndexBlocksCount())
+                            << ")";
+                    }
+                }
+                TABLER () {
+                    TABLED () {
+                        out << "Merged index blobs count";
+                    }
+                    TABLED () {
+                        out << stats.GetMergedIndexBlobsCount();
+                    }
+                }
+                TABLER () {
+                    TABLED () {
+                        out << "Merged index blocks count";
+                    }
+                    TABLED () {
+                        out << stats.GetMergedIndexBlocksCount() << " ("
+                            << FormatByteSize(
+                                   blockSize *
+                                   stats.GetMergedIndexBlocksCount())
+                            << ")";
+                    }
+                }
+                TABLER () {
                     TABLED() { out << "Used blocks count"; }
                     TABLED() {
                         out << stats.GetUsedBlocksCount() << " ("

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -474,6 +474,8 @@ private:
         ui64 finalCommitId,
         ui64 mixedBlocksCount,
         ui64 mergedBlocksCount,
+        ui64 mixedChannelBlocksCount,
+        ui64 mergedChannelBlocksCount,
         TDuration retryTimeout);
 
     TBlockBuffer CreateScanDiskBlockBuffer(ui32 blobsPerBatch);

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -209,11 +209,17 @@ private:
                     "Unexpected index kind: %u", static_cast<ui32>(indexKind));
         }
 
-        // Deletion markers do not have a data channel, so classify them by
-        // their index kind even when channel-based counters are enabled.
+        // Deletion markers do not have a data channel.
+        if (IsDeletionMarker(blobId) &&
+            State.ShouldUseBlobChannelDataKindForCounters())
+        {
+            return;
+        }
+
+        // If channel-based counters are enabled, use the channel data kind
+        // otherwise use the index kind
         const auto countersKind =
-            State.ShouldUseBlobChannelDataKindForCounters() &&
-                    !IsDeletionMarker(blobId)
+            State.ShouldUseBlobChannelDataKindForCounters()
                 ? State.GetChannelDataKind(blobId.Channel())
                 : indexKind;
         switch (countersKind) {

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -188,6 +188,50 @@ public:
     }
 
 private:
+    void IncrementBlobCounters(
+        const TPartialBlobId& blobId,
+        EChannelDataKind indexKind, ui64 blocksCount)
+    {
+        // Deletion markers contribute to blob totals, but not block totals.
+        blocksCount = IsDeletionMarker(blobId) ? 0 : blocksCount;
+
+        switch (indexKind) {
+            case EChannelDataKind::Mixed:
+                State.IncrementMixedIndexBlobsCount(1);
+                State.IncrementMixedIndexBlocksCount(blocksCount);
+                break;
+            case EChannelDataKind::Merged:
+                State.IncrementMergedIndexBlobsCount(1);
+                State.IncrementMergedIndexBlocksCount(blocksCount);
+                break;
+            default:
+                Y_ABORT(
+                    "Unexpected index kind: %u", static_cast<ui32>(indexKind));
+        }
+
+        // Deletion markers do not have a data channel, so classify them by
+        // their index kind even when channel-based counters are enabled.
+        const auto countersKind =
+            State.ShouldUseBlobChannelDataKindForCounters() &&
+                    !IsDeletionMarker(blobId)
+                ? State.GetChannelDataKind(blobId.Channel())
+                : indexKind;
+        switch (countersKind) {
+            case EChannelDataKind::Mixed:
+                State.IncrementMixedBlobsCount(1);
+                State.IncrementMixedBlocksCount(blocksCount);
+                break;
+            case EChannelDataKind::Merged:
+                State.IncrementMergedBlobsCount(1);
+                State.IncrementMergedBlocksCount(blocksCount);
+                break;
+            default:
+                Y_ABORT(
+                    "Unexpected blob channel data kind: %u",
+                    static_cast<ui32>(countersKind));
+        }
+    }
+
     void ProcessNewBlob(
         const TActorContext& ctx,
         TPartitionDatabase& db,
@@ -249,10 +293,10 @@ private:
             blob.CompactionRangeCount);
 
         // update counters
-        State.IncrementMixedBlobsCount(1);
-        if (!IsDeletionMarker(blob.BlobId)) {
-            State.IncrementMixedBlocksCount(blob.Blocks.size());
-        }
+        IncrementBlobCounters(
+            blob.BlobId,
+            EChannelDataKind::Mixed,
+            IsDeletionMarker(blob.BlobId) ? 0 : blob.Blocks.size());
     }
 
     void ProcessNewBlob(
@@ -312,10 +356,11 @@ private:
         db.WriteMergedBlocks(blob.BlobId, blob.BlockRange, blob.SkipMask);
 
         // update counters
-        State.IncrementMergedBlobsCount(1);
-        if (!IsDeletionMarker(blob.BlobId)) {
-            State.IncrementMergedBlocksCount(blob.BlockRange.Size() - skipped);
-        }
+        IncrementBlobCounters(
+            blob.BlobId,
+            EChannelDataKind::Merged,
+            IsDeletionMarker(blob.BlobId) ? 0
+                                          : blob.BlockRange.Size() - skipped);
 
         State.ConfirmedBlobsAdded(db, Args.CommitId);
     }
@@ -416,10 +461,10 @@ private:
         }
 
         // update counters
-        State.IncrementMixedBlobsCount(1);
-        if (!IsDeletionMarker(blob.BlobId)) {
-            State.IncrementMixedBlocksCount(blob.Blocks.size());
-        }
+        IncrementBlobCounters(
+            blob.BlobId,
+            EChannelDataKind::Mixed,
+            IsDeletionMarker(blob.BlobId) ? 0 : blob.Blocks.size());
     }
 
     void ProcessOverwrittenBlocks(const TAddFreshBlob& blob)

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -190,10 +190,13 @@ public:
 private:
     void IncrementBlobCounters(
         const TPartialBlobId& blobId,
-        EChannelDataKind indexKind, ui64 blocksCount)
+        EChannelDataKind indexKind,
+        ui64 blocksCount)
     {
         // Deletion markers contribute to blob totals, but not block totals.
-        blocksCount = IsDeletionMarker(blobId) ? 0 : blocksCount;
+        if (IsDeletionMarker(blobId)) {
+            blocksCount = 0;
+        }
 
         switch (indexKind) {
             case EChannelDataKind::Mixed:

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -296,7 +296,7 @@ private:
         IncrementBlobCounters(
             blob.BlobId,
             EChannelDataKind::Mixed,
-            IsDeletionMarker(blob.BlobId) ? 0 : blob.Blocks.size());
+            blob.Blocks.size());
     }
 
     void ProcessNewBlob(
@@ -359,8 +359,7 @@ private:
         IncrementBlobCounters(
             blob.BlobId,
             EChannelDataKind::Merged,
-            IsDeletionMarker(blob.BlobId) ? 0
-                                          : blob.BlockRange.Size() - skipped);
+            blob.BlockRange.Size() - skipped);
 
         State.ConfirmedBlobsAdded(db, Args.CommitId);
     }
@@ -464,7 +463,7 @@ private:
         IncrementBlobCounters(
             blob.BlobId,
             EChannelDataKind::Mixed,
-            IsDeletionMarker(blob.BlobId) ? 0 : blob.Blocks.size());
+            blob.Blocks.size());
     }
 
     void ProcessOverwrittenBlocks(const TAddFreshBlob& blob)

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1384,7 +1384,7 @@ private:
     TriggerRangeCompactionIfNeeded() const
     {
         const auto blobCount =
-            State.GetMixedBlobsCount() + State.GetMergedBlobsCount();
+            State.GetMixedIndexBlobsCount() + State.GetMergedIndexBlobsCount();
         const bool diskBlobCountOverThreshold =
             State.GetMaxBlobsPerDisk() &&
             blobCount >

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -269,7 +269,8 @@ void TPartitionActor::CompleteLoadState(
         SharedState,
         TabletID(),
         mixedBlocksFilterConfig,
-        IsCheckpointAwareCleanupEnabled());
+        IsCheckpointAwareCleanupEnabled(),
+        Config->GetUseBlobChannelDataKindForCounters());
 
     CreateFreshBlocksCompanionClient();
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild.cpp
@@ -150,6 +150,8 @@ NProto::TError TPartitionActor::DoHandleMetadataRebuildBatch(
                     SelfId(),
                     batchSize,
                     State->GetLastCommitId(),
+                    State->GetMixedIndexBlocksCount(),
+                    State->GetMergedIndexBlocksCount(),
                     State->GetMixedBlocksCount(),
                     State->GetMergedBlocksCount(),
                     Config->GetCompactionRetryTimeout()));

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
@@ -176,8 +176,8 @@ TMetadataRebuildBlockCountActor::TMetadataRebuildBlockCountActor(
         const TActorId& tablet,
         ui32 blobsPerBatch,
         ui64 finalCommitId,
-        ui64 mixedBlocksCount,
-        ui64 mergedBlocksCount,
+        ui64 mixedIndexBlocksCount,
+        ui64 mergedIndexBlocksCount,
         ui64 mixedChannelBlocksCount,
         ui64 mergedChannelBlocksCount,
         const TDuration retryTimeout)
@@ -186,8 +186,8 @@ TMetadataRebuildBlockCountActor::TMetadataRebuildBlockCountActor(
     , FinalBlobId(MakePartialBlobId(finalCommitId, Max()))
     , RetryTimeout(retryTimeout)
 {
-    RebuildState.InitialMixedBlocks = mixedBlocksCount;
-    RebuildState.InitialMergedBlocks = mergedBlocksCount;
+    RebuildState.InitialMixedIndexBlocks = mixedIndexBlocksCount;
+    RebuildState.InitialMergedIndexBlocks = mergedIndexBlocksCount;
     RebuildState.InitialMixedChannelBlocks = mixedChannelBlocksCount;
     RebuildState.InitialMergedChannelBlocks = mergedChannelBlocksCount;
 }
@@ -403,8 +403,8 @@ void TPartitionActor::ExecuteMetadataRebuildBlockCount(
     Y_UNUSED(ctx);
 
     State->UpdateRebuildMetadataProgress(args.ReadCount);
-    args.RebuildState.MixedBlocks += args.MixedBlockCount;
-    args.RebuildState.MergedBlocks += args.MergedBlockCount;
+    args.RebuildState.MixedIndexBlocks += args.MixedBlockCount;
+    args.RebuildState.MergedIndexBlocks += args.MergedBlockCount;
     args.RebuildState.MixedChannelBlocks += args.MixedChannelBlockCount;
     args.RebuildState.MergedChannelBlocks += args.MergedChannelBlockCount;
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
@@ -94,12 +94,12 @@ private:
         ui64 blocksCount = 0;
         if (blobMeta.HasMixedBlocks()) {
             blocksCount = blobMeta.GetMixedBlocks().BlocksSize();
-            Args.MixedBlockCount += blocksCount;
+            Args.MixedIndexBlockCount += blocksCount;
         } else {
             const auto& mergedBlocks = blobMeta.GetMergedBlocks();
             blocksCount = mergedBlocks.GetEnd() - mergedBlocks.GetStart() + 1;
             blocksCount -= mergedBlocks.GetSkipped();
-            Args.MergedBlockCount += blocksCount;
+            Args.MergedIndexBlockCount += blocksCount;
         }
 
         const auto channelDataKind =
@@ -403,40 +403,40 @@ void TPartitionActor::ExecuteMetadataRebuildBlockCount(
     Y_UNUSED(ctx);
 
     State->UpdateRebuildMetadataProgress(args.ReadCount);
-    args.RebuildState.MixedIndexBlocks += args.MixedBlockCount;
-    args.RebuildState.MergedIndexBlocks += args.MergedBlockCount;
+    args.RebuildState.MixedIndexBlocks += args.MixedIndexBlockCount;
+    args.RebuildState.MergedIndexBlocks += args.MergedIndexBlockCount;
     args.RebuildState.MixedChannelBlocks += args.MixedChannelBlockCount;
     args.RebuildState.MergedChannelBlocks += args.MergedChannelBlockCount;
 
     if (args.LastReadBlobId == args.FinalBlobId) {
         TPartitionDatabase db(tx.DB);
 
-        auto mixed = State->GetMixedIndexBlocksCount() -
-                     args.RebuildState.InitialMixedBlocks +
-                     args.RebuildState.MixedBlocks;
+        auto mixedIndexBlocks = State->GetMixedIndexBlocksCount() -
+                     args.RebuildState.InitialMixedIndexBlocks +
+                     args.RebuildState.MixedIndexBlocks;
 
-        auto merged = State->GetMergedIndexBlocksCount() -
-                      args.RebuildState.InitialMergedBlocks +
-                      args.RebuildState.MergedBlocks;
+        auto mergedIndexBlocks = State->GetMergedIndexBlocksCount() -
+                      args.RebuildState.InitialMergedIndexBlocks +
+                      args.RebuildState.MergedIndexBlocks;
 
-        auto mixedChannel = State->GetMixedBlocksCount() -
+        auto mixedChannelBlocks = State->GetMixedBlocksCount() -
                             args.RebuildState.InitialMixedChannelBlocks +
                             args.RebuildState.MixedChannelBlocks;
 
-        auto mergedChannel = State->GetMergedBlocksCount() -
+        auto mergedChannelBlocks = State->GetMergedBlocksCount() -
                              args.RebuildState.InitialMergedChannelBlocks +
                              args.RebuildState.MergedChannelBlocks;
 
         if (!State->ShouldUseBlobChannelDataKindForCounters()) {
-            mixedChannel = mixed;
-            mergedChannel = merged;
+            mixedChannelBlocks = mixedIndexBlocks;
+            mergedChannelBlocks = mergedIndexBlocks;
         }
 
         State->UpdateBlocksCountersAfterMetadataRebuild(
-            mixed,
-            merged,
-            mixedChannel,
-            mergedChannel);
+            mixedIndexBlocks,
+            mergedIndexBlocks,
+            mixedChannelBlocks,
+            mergedChannelBlocks);
 
         db.WriteMeta(State->GetMeta());
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
@@ -42,12 +42,16 @@ class TMetadataRebuildBlockCountVisitor final
 {
 private:
     TTxPartition::TMetadataRebuildBlockCount& Args;
+    const TPartitionState& State;
 
     ui32 BlobCount = 0;
 
 public:
-    TMetadataRebuildBlockCountVisitor(TTxPartition::TMetadataRebuildBlockCount& args)
+    TMetadataRebuildBlockCountVisitor(
+        TTxPartition::TMetadataRebuildBlockCount& args,
+        const TPartitionState& state)
         : Args(args)
+        , State(state)
     {}
 
 public:
@@ -82,17 +86,35 @@ private:
     {
         Y_UNUSED(blockMask);
 
-        if (IsDeletionMarker(MakePartialBlobId(commitId, blobId))) {
+        const auto partialBlobId = MakePartialBlobId(commitId, blobId);
+        if (IsDeletionMarker(partialBlobId)) {
             return;
         }
 
+        ui64 blocksCount = 0;
         if (blobMeta.HasMixedBlocks()) {
-            Args.MixedBlockCount += blobMeta.GetMixedBlocks().BlocksSize();
+            blocksCount = blobMeta.GetMixedBlocks().BlocksSize();
+            Args.MixedBlockCount += blocksCount;
         } else {
-            auto delta =
-                blobMeta.GetMergedBlocks().GetEnd() - blobMeta.GetMergedBlocks().GetStart() + 1;
-            delta -= blobMeta.GetMergedBlocks().GetSkipped();
-            Args.MergedBlockCount += delta;
+            const auto& mergedBlocks = blobMeta.GetMergedBlocks();
+            blocksCount = mergedBlocks.GetEnd() - mergedBlocks.GetStart() + 1;
+            blocksCount -= mergedBlocks.GetSkipped();
+            Args.MergedBlockCount += blocksCount;
+        }
+
+        const auto channelDataKind =
+            State.GetChannelDataKind(partialBlobId.Channel());
+        switch (channelDataKind) {
+            case EChannelDataKind::Mixed:
+                Args.MixedChannelBlockCount += blocksCount;
+                break;
+            case EChannelDataKind::Merged:
+                Args.MergedChannelBlockCount += blocksCount;
+                break;
+            default:
+                Y_ABORT(
+                    "Unexpected blob channel data kind: %u",
+                    static_cast<ui32>(channelDataKind));
         }
     }
 };
@@ -119,6 +141,8 @@ public:
         ui64 finalCommitId,
         ui64 mixedBlocksCount,
         ui64 mergedBlocksCount,
+        ui64 mixedChannelBlocksCount,
+        ui64 mergedChannelBlocksCount,
         const TDuration retryTimeout);
 
     void Bootstrap(const TActorContext& ctx);
@@ -154,13 +178,19 @@ TMetadataRebuildBlockCountActor::TMetadataRebuildBlockCountActor(
         ui64 finalCommitId,
         ui64 mixedBlocksCount,
         ui64 mergedBlocksCount,
+        ui64 mixedChannelBlocksCount,
+        ui64 mergedChannelBlocksCount,
         const TDuration retryTimeout)
     : Tablet(tablet)
     , BlobsPerBatch(blobsPerBatch)
     , FinalBlobId(MakePartialBlobId(finalCommitId, Max()))
     , RetryTimeout(retryTimeout)
-    , RebuildState{0, 0, mixedBlocksCount, mergedBlocksCount}
-{}
+{
+    RebuildState.InitialMixedBlocks = mixedBlocksCount;
+    RebuildState.InitialMergedBlocks = mergedBlocksCount;
+    RebuildState.InitialMixedChannelBlocks = mixedChannelBlocksCount;
+    RebuildState.InitialMergedChannelBlocks = mergedChannelBlocksCount;
+}
 
 void TMetadataRebuildBlockCountActor::Bootstrap(const TActorContext& ctx)
 {
@@ -341,7 +371,7 @@ bool TPartitionActor::PrepareMetadataRebuildBlockCount(
     TRequestScope timer(*args.RequestInfo);
     TPartitionDatabase db(tx.DB);
 
-    TMetadataRebuildBlockCountVisitor visitor(args);
+    TMetadataRebuildBlockCountVisitor visitor(args, *State);
 
     auto progress = db.FindBlocksInBlobsIndex(
         visitor,
@@ -375,19 +405,38 @@ void TPartitionActor::ExecuteMetadataRebuildBlockCount(
     State->UpdateRebuildMetadataProgress(args.ReadCount);
     args.RebuildState.MixedBlocks += args.MixedBlockCount;
     args.RebuildState.MergedBlocks += args.MergedBlockCount;
+    args.RebuildState.MixedChannelBlocks += args.MixedChannelBlockCount;
+    args.RebuildState.MergedChannelBlocks += args.MergedChannelBlockCount;
 
     if (args.LastReadBlobId == args.FinalBlobId) {
         TPartitionDatabase db(tx.DB);
 
-        auto mixed = State->GetMixedBlocksCount() -
-            args.RebuildState.InitialMixedBlocks +
-            args.RebuildState.MixedBlocks;
+        auto mixed = State->GetMixedIndexBlocksCount() -
+                     args.RebuildState.InitialMixedBlocks +
+                     args.RebuildState.MixedBlocks;
 
-        auto merged = State->GetMergedBlocksCount() -
-            args.RebuildState.InitialMergedBlocks +
-            args.RebuildState.MergedBlocks;
+        auto merged = State->GetMergedIndexBlocksCount() -
+                      args.RebuildState.InitialMergedBlocks +
+                      args.RebuildState.MergedBlocks;
 
-        State->UpdateBlocksCountersAfterMetadataRebuild(mixed, merged);
+        auto mixedChannel = State->GetMixedBlocksCount() -
+                            args.RebuildState.InitialMixedChannelBlocks +
+                            args.RebuildState.MixedChannelBlocks;
+
+        auto mergedChannel = State->GetMergedBlocksCount() -
+                             args.RebuildState.InitialMergedChannelBlocks +
+                             args.RebuildState.MergedChannelBlocks;
+
+        if (!State->ShouldUseBlobChannelDataKindForCounters()) {
+            mixedChannel = mixed;
+            mergedChannel = merged;
+        }
+
+        State->UpdateBlocksCountersAfterMetadataRebuild(
+            mixed,
+            merged,
+            mixedChannel,
+            mergedChannel);
 
         db.WriteMeta(State->GetMeta());
     }
@@ -419,6 +468,8 @@ IActorPtr TPartitionActor::CreateMetadataRebuildBlockCountActor(
     ui64 finalCommitId,
     ui64 mixedBlocksCount,
     ui64 mergedBlocksCount,
+    ui64 mixedChannelBlocksCount,
+    ui64 mergedChannelBlocksCount,
     TDuration retryTimeout)
 {
     return std::make_unique<TMetadataRebuildBlockCountActor>(
@@ -427,6 +478,8 @@ IActorPtr TPartitionActor::CreateMetadataRebuildBlockCountActor(
         finalCommitId,
         mixedBlocksCount,
         mergedBlocksCount,
+        mixedChannelBlocksCount,
+        mergedChannelBlocksCount,
         retryTimeout);
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_statpartition.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_statpartition.cpp
@@ -30,6 +30,10 @@ void CopyPartitionStats(T1& l, const T2& r)
     COPY_FIELD(l, r, MergedBlobsCount);
     COPY_FIELD(l, r, MixedBlocksCount);
     COPY_FIELD(l, r, MergedBlocksCount);
+    COPY_FIELD(l, r, MixedIndexBlobsCount);
+    COPY_FIELD(l, r, MergedIndexBlobsCount);
+    COPY_FIELD(l, r, MixedIndexBlocksCount);
+    COPY_FIELD(l, r, MergedIndexBlocksCount);
     COPY_FIELD(l, r, UsedBlocksCount);
     COPY_FIELD(l, r, LogicalUsedBlocksCount);
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_stats.cpp
@@ -67,6 +67,12 @@ TPartitionStatisticsCounters TPartitionActor::ExtractPartCounters(
     PartCounters->Simple.MergedBytesCount.Set(
         State->GetMergedBlocksCount() * State->GetBlockSize());
 
+    PartCounters->Simple.MixedIndexBytesCount.Set(
+        State->GetMixedIndexBlocksCount() * State->GetBlockSize());
+
+    PartCounters->Simple.MergedIndexBytesCount.Set(
+        State->GetMergedIndexBlocksCount() * State->GetBlockSize());
+
     PartCounters->Simple.FreshBytesCount.Set(
         State->GetUnflushedFreshBlocksCount() * State->GetBlockSize());
 

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -421,6 +421,8 @@ void ExecuteCleanupTransaction(
             continue;
         }
 
+        EChannelDataKind indexKind = EChannelDataKind::Max;
+        ui64 blockCountInBlob = 0;
         if (blobMeta.HasMixedBlocks()) {
             const auto& mixedBlocks = blobMeta.GetMixedBlocks();
 
@@ -441,24 +443,20 @@ void ExecuteCleanupTransaction(
                 }
             }
 
-            ui64 blockCountInBlob = 0;
-            if (!IsDeletionMarker(item.BlobId)) {
-                if (args.UseRecreatedBlobMeta) {
-                    STORAGE_VERIFY_C(
-                        state.GetBlockSize() > 0 &&
-                            item.BlobId.BlobSize() % state.GetBlockSize() == 0,
-                        TWellKnownEntityTypes::TABLET,
-                        state.GetConfig().GetDiskId(),
-                        "Blob size is not divisible by block size, blob: "
-                            << ToString(MakeBlobId(tabletId, item.BlobId)));
-                    blockCountInBlob =
-                        item.BlobId.BlobSize() / state.GetBlockSize();
-                } else {
-                    blockCountInBlob = mixedBlocks.BlocksSize();
-                }
+            if (args.UseRecreatedBlobMeta) {
+                STORAGE_VERIFY_C(
+                    state.GetBlockSize() > 0 &&
+                        item.BlobId.BlobSize() % state.GetBlockSize() == 0,
+                    TWellKnownEntityTypes::TABLET,
+                    state.GetConfig().GetDiskId(),
+                    "Blob size is not divisible by block size, blob: "
+                        << ToString(MakeBlobId(tabletId, item.BlobId)));
+                blockCountInBlob =
+                    item.BlobId.BlobSize() / state.GetBlockSize();
+            } else {
+                blockCountInBlob = mixedBlocks.BlocksSize();
             }
-            DecrementBlobCounters(
-                state, item.BlobId, EChannelDataKind::Mixed, blockCountInBlob);
+            indexKind = EChannelDataKind::Mixed;
         } else if (blobMeta.HasMergedBlocks()) {
             const auto& mergedBlocks = blobMeta.GetMergedBlocks();
 
@@ -467,13 +465,11 @@ void ExecuteCleanupTransaction(
                 mergedBlocks.GetEnd());
             db.DeleteMergedBlocks(item.BlobId, blockRange);
 
-            ui64 blocksCount = 0;
-            if (!IsDeletionMarker(item.BlobId)) {
-                blocksCount = blockRange.Size() - mergedBlocks.GetSkipped();
-            }
-            DecrementBlobCounters(
-                state, item.BlobId, EChannelDataKind::Merged, blocksCount);
+            indexKind = EChannelDataKind::Merged;
+            blockCountInBlob = blockRange.Size() - mergedBlocks.GetSkipped();
         }
+
+        DecrementBlobCounters(state, item.BlobId, indexKind, blockCountInBlob);
 
         LOG_DEBUG(
             *actorSystem,

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -27,7 +27,9 @@ void DecrementBlobCounters(
     ui64 blocksCount)
 {
     // Deletion markers contribute to blob totals, but not block totals.
-    blocksCount = IsDeletionMarker(blobId) ? 0 : blocksCount;
+    if (IsDeletionMarker(blobId)) {
+        blocksCount = 0;
+    }
 
     switch (indexKind) {
         case EChannelDataKind::Mixed:

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -46,13 +46,18 @@ void DecrementBlobCounters(
             Y_ABORT("Unexpected index kind: %u", static_cast<ui32>(indexKind));
     }
 
-    // Deletion markers do not have a data channel, so classify them by their
-    // index kind even when channel-based counters are enabled.
-    const auto countersKind =
-        state.ShouldUseBlobChannelDataKindForCounters() &&
-                !IsDeletionMarker(blobId)
-            ? state.GetChannelDataKind(blobId.Channel())
-            : indexKind;
+    // Deletion markers do not have a data channel.
+    if (IsDeletionMarker(blobId) &&
+        state.ShouldUseBlobChannelDataKindForCounters())
+    {
+        return;
+    }
+
+    // If channel-based counters are enabled, use the channel data kind
+    // otherwise use the index kind
+    const auto countersKind = state.ShouldUseBlobChannelDataKindForCounters()
+                                  ? state.GetChannelDataKind(blobId.Channel())
+                                  : indexKind;
     switch (countersKind) {
         case EChannelDataKind::Mixed:
             state.DecrementMixedBlobsCount(

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -20,6 +20,61 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void DecrementBlobCounters(
+    TPartitionState& state,
+    const TPartialBlobId& blobId,
+    EChannelDataKind indexKind,
+    ui64 blocksCount)
+{
+    // Deletion markers contribute to blob totals, but not block totals.
+    blocksCount = IsDeletionMarker(blobId) ? 0 : blocksCount;
+
+    switch (indexKind) {
+        case EChannelDataKind::Mixed:
+            state.DecrementMixedIndexBlobsCount(
+                Min<ui64>(1, state.GetMixedIndexBlobsCount()));
+            state.DecrementMixedIndexBlocksCount(
+                Min(blocksCount, state.GetMixedIndexBlocksCount()));
+            break;
+        case EChannelDataKind::Merged:
+            state.DecrementMergedIndexBlobsCount(
+                Min<ui64>(1, state.GetMergedIndexBlobsCount()));
+            state.DecrementMergedIndexBlocksCount(
+                Min(blocksCount, state.GetMergedIndexBlocksCount()));
+            break;
+        default:
+            Y_ABORT("Unexpected index kind: %u", static_cast<ui32>(indexKind));
+    }
+
+    // Deletion markers do not have a data channel, so classify them by their
+    // index kind even when channel-based counters are enabled.
+    const auto countersKind =
+        state.ShouldUseBlobChannelDataKindForCounters() &&
+                !IsDeletionMarker(blobId)
+            ? state.GetChannelDataKind(blobId.Channel())
+            : indexKind;
+    switch (countersKind) {
+        case EChannelDataKind::Mixed:
+            state.DecrementMixedBlobsCount(
+                Min<ui64>(1, state.GetMixedBlobsCount()));
+            state.DecrementMixedBlocksCount(
+                Min(blocksCount, state.GetMixedBlocksCount()));
+            break;
+        case EChannelDataKind::Merged:
+            state.DecrementMergedBlobsCount(
+                Min<ui64>(1, state.GetMergedBlobsCount()));
+            state.DecrementMergedBlocksCount(
+                Min(blocksCount, state.GetMergedBlocksCount()));
+            break;
+        default:
+            Y_ABORT(
+                "Unexpected blob channel data kind: %u",
+                static_cast<ui32>(countersKind));
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 TVerifyBlocksMetaResult VerifyMixedBlocksMeta(
     TPartitionDatabase& db,
     TPartialBlobId originalBlobId,
@@ -337,9 +392,6 @@ void ExecuteCleanupTransaction(
 {
     TRequestScope timer(*args.RequestInfo);
 
-    size_t mixedBlobsCount = 0;
-    size_t mergedBlobsCount = 0;
-
     TVector<TCleanupQueueItem> filteredCleanupQueue;
     filteredCleanupQueue.reserve(args.CleanupQueue.size());
 
@@ -389,9 +441,8 @@ void ExecuteCleanupTransaction(
                 }
             }
 
-            ++mixedBlobsCount;
+            ui64 blockCountInBlob = 0;
             if (!IsDeletionMarker(item.BlobId)) {
-                ui64 blockCountInBlob = 0;
                 if (args.UseRecreatedBlobMeta) {
                     STORAGE_VERIFY_C(
                         state.GetBlockSize() > 0 &&
@@ -405,12 +456,9 @@ void ExecuteCleanupTransaction(
                 } else {
                     blockCountInBlob = mixedBlocks.BlocksSize();
                 }
-                // Mins for block counts are needed due to some
-                // inconsistencies
-                // caused by NBS-1422
-                state.DecrementMixedBlocksCount(
-                    Min(blockCountInBlob, state.GetMixedBlocksCount()));
             }
+            DecrementBlobCounters(
+                state, item.BlobId, EChannelDataKind::Mixed, blockCountInBlob);
         } else if (blobMeta.HasMergedBlocks()) {
             const auto& mergedBlocks = blobMeta.GetMergedBlocks();
 
@@ -419,14 +467,12 @@ void ExecuteCleanupTransaction(
                 mergedBlocks.GetEnd());
             db.DeleteMergedBlocks(item.BlobId, blockRange);
 
-            ++mergedBlobsCount;
+            ui64 blocksCount = 0;
             if (!IsDeletionMarker(item.BlobId)) {
-                // Mins for block counts are needed due to some inconsistencies
-                // caused by NBS-1422
-                ui64 delta = blockRange.Size() - mergedBlocks.GetSkipped();
-                state.DecrementMergedBlocksCount(
-                    Min(delta, state.GetMergedBlocksCount()));
+                blocksCount = blockRange.Size() - mergedBlocks.GetSkipped();
             }
+            DecrementBlobCounters(
+                state, item.BlobId, EChannelDataKind::Merged, blocksCount);
         }
 
         LOG_DEBUG(
@@ -462,10 +508,6 @@ void ExecuteCleanupTransaction(
         Y_DEBUG_ABORT_UNLESS(
             filteredCleanupQueue.size() == args.CleanupQueue.size());
     }
-
-    // Updating counters
-    state.DecrementMixedBlobsCount(mixedBlobsCount);
-    state.DecrementMergedBlobsCount(mergedBlobsCount);
 
     db.WriteMeta(state.GetMeta());
 }

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -84,8 +84,20 @@ TPartitionState MakeState(size_t blockCount = 2048)
         std::move(threadSafeState),
         TTestExecutor::TabletId,
         std::nullopt,  // mixedBlocksFilterConfig
-        false          // checkpointAwareCleanupEnabled
+        false,         // checkpointAwareCleanupEnabled
+        true           // useBlobChannelDataKindForCounters
     );
+}
+
+TPartialBlobId MoveToDataChannel(TPartialBlobId blobId)
+{
+    return TPartialBlobId(
+        blobId.Generation(),
+        blobId.Step(),
+        3,
+        blobId.BlobSize(),
+        blobId.Cookie(),
+        blobId.PartId());
 }
 
 NProto::TBlobMeta MakeMixedBlobMeta(
@@ -135,12 +147,12 @@ TMixedAndMergedBlobsSetup SetupMixedAndMergedBlobs(
     executor.WriteTx(
         [&](TPartitionDatabase db)
         {
-            setup.MixedBlobId = executor.MakeBlobId(3);
+            setup.MixedBlobId = MoveToDataChannel(executor.MakeBlobId(3));
             state.WriteMixedBlocks(db, setup.MixedBlobId, {0, 1, 2}, 1);
             db.WriteBlobMeta(setup.MixedBlobId, setup.MixedBlobMeta);
             db.WriteCleanupQueue(setup.MixedBlobId, deletionCommitId);
 
-            setup.MergedBlobId = executor.MakeBlobId(4);
+            setup.MergedBlobId = MoveToDataChannel(executor.MakeBlobId(4));
             db.WriteMergedBlocks(
                 setup.MergedBlobId,
                 TBlockRange32::MakeClosedInterval(10, 13),
@@ -152,10 +164,12 @@ TMixedAndMergedBlobsSetup SetupMixedAndMergedBlobs(
     state.GetCleanupQueue().Add({setup.MixedBlobId, deletionCommitId, {}});
     state.GetCleanupQueue().Add({setup.MergedBlobId, deletionCommitId, {}});
 
-    state.IncrementMixedBlocksCount(3);
-    state.IncrementMixedBlobsCount(1);
-    state.IncrementMergedBlocksCount(4);
-    state.IncrementMergedBlobsCount(1);
+    state.IncrementMergedBlocksCount(7);
+    state.IncrementMergedBlobsCount(2);
+    state.IncrementMixedIndexBlocksCount(3);
+    state.IncrementMixedIndexBlobsCount(1);
+    state.IncrementMergedIndexBlocksCount(4);
+    state.IncrementMergedIndexBlobsCount(1);
 
     return setup;
 }
@@ -403,7 +417,7 @@ Y_UNIT_TEST_SUITE(TVerifyRecreatedBlobMetaTest)
         executor.WriteTx(
             [&](TPartitionDatabase db)
             {
-                blobId = executor.MakeBlobId(3);
+                blobId = MoveToDataChannel(executor.MakeBlobId(3));
                 db.WriteMixedBlocks(blobId, {0, 1, 2}, 1);
             });
 
@@ -434,7 +448,7 @@ Y_UNIT_TEST_SUITE(TVerifyRecreatedBlobMetaTest)
         executor.WriteTx(
             [&](TPartitionDatabase db)
             {
-                blobId = executor.MakeBlobId(2);
+                blobId = MoveToDataChannel(executor.MakeBlobId(2));
                 db.WriteMixedBlocks(blobId, {5, 7}, 1);
             });
 
@@ -464,7 +478,7 @@ Y_UNIT_TEST_SUITE(TVerifyRecreatedBlobMetaTest)
         executor.WriteTx(
             [&](TPartitionDatabase db)
             {
-                blobId = executor.MakeBlobId(3);
+                blobId = MoveToDataChannel(executor.MakeBlobId(3));
                 db.WriteMixedBlocks(blobId, {0, 1, 2}, 1);
                 db.DeleteMixedBlock(1, blobId.CommitId());
             });
@@ -495,7 +509,7 @@ Y_UNIT_TEST_SUITE(TVerifyRecreatedBlobMetaTest)
         executor.WriteTx(
             [&](TPartitionDatabase db)
             {
-                blobId = executor.MakeBlobId(3);
+                blobId = MoveToDataChannel(executor.MakeBlobId(3));
                 db.WriteMixedBlocks(blobId, {0, 1, 2}, 1);
             });
 
@@ -531,9 +545,9 @@ Y_UNIT_TEST_SUITE(TVerifyRecreatedBlobMetaTest)
         executor.WriteTx(
             [&](TPartitionDatabase db)
             {
-                blobId = executor.MakeBlobId(1);
+                blobId = MoveToDataChannel(executor.MakeBlobId(1));
 
-                auto anotherBlobId = executor.MakeBlobId(1);
+                auto anotherBlobId = MoveToDataChannel(executor.MakeBlobId(1));
                 db.WriteMixedBlock({anotherBlobId, 1, 0, 0, 0});
             });
 
@@ -563,7 +577,7 @@ Y_UNIT_TEST_SUITE(TVerifyRecreatedBlobMetaTest)
         executor.WriteTx(
             [&](TPartitionDatabase db)
             {
-                blobId = executor.MakeBlobId(3);
+                blobId = MoveToDataChannel(executor.MakeBlobId(3));
                 db.WriteMixedBlocks(blobId, {0, 1, 2}, 1);
             });
 
@@ -934,14 +948,14 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         TVector<TPartialBlobId> mixedBlobIds;
 
         for (const auto& tc: mergedTestCases) {
-            mergedBlobIds.push_back(executor.MakeBlobIdWithCommitId(
-                tc.BlobCommitId,
-                tc.EndIndex - tc.StartIndex + 1));
+            mergedBlobIds.push_back(
+                MoveToDataChannel(executor.MakeBlobIdWithCommitId(
+                    tc.BlobCommitId, tc.EndIndex - tc.StartIndex + 1)));
         }
         for (const auto& tc: mixedTestCases) {
-            mixedBlobIds.push_back(executor.MakeBlobIdWithCommitId(
-                tc.BlobCommitId,
-                tc.BlockIndices.size()));
+            mixedBlobIds.push_back(
+                MoveToDataChannel(executor.MakeBlobIdWithCommitId(
+                    tc.BlobCommitId, tc.BlockIndices.size())));
         }
 
         executor.WriteTx(
@@ -1015,10 +1029,13 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             }
         }
 
-        state.IncrementMergedBlocksCount(mergedBlocksCount);
-        state.IncrementMergedBlobsCount(mergedTestCases.size());
-        state.IncrementMixedBlocksCount(mixedBlocksCount);
-        state.IncrementMixedBlobsCount(mixedTestCases.size());
+        state.IncrementMergedBlocksCount(mergedBlocksCount + mixedBlocksCount);
+        state.IncrementMergedBlobsCount(
+            mergedTestCases.size() + mixedTestCases.size());
+        state.IncrementMergedIndexBlocksCount(mergedBlocksCount);
+        state.IncrementMergedIndexBlobsCount(mergedTestCases.size());
+        state.IncrementMixedIndexBlocksCount(mixedBlocksCount);
+        state.IncrementMixedIndexBlobsCount(mixedTestCases.size());
 
         auto args = MakeCleanupArgs(
             state.GetCleanupQueue().GetItems(cleanupCommitId),
@@ -1038,12 +1055,12 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         UNIT_ASSERT_VALUES_EQUAL(
             remainingCount,
             state.GetCleanupQueue().GetCount());
+        UNIT_ASSERT_VALUES_EQUAL(remainingCount, state.GetMergedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, state.GetMixedBlobsCount());
         UNIT_ASSERT_VALUES_EQUAL(
-            remainingMergedBlobs,
-            state.GetMergedBlobsCount());
+            remainingMergedBlobs, state.GetMergedIndexBlobsCount());
         UNIT_ASSERT_VALUES_EQUAL(
-            remainingMixedBlobs,
-            state.GetMixedBlobsCount());
+            remainingMixedBlobs, state.GetMixedIndexBlobsCount());
 
         executor.ReadTx(
             [&](TPartitionDatabase db)

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -243,9 +243,13 @@ struct TBlockCountRebuildState
 {
     ui64 MixedBlocks = 0;
     ui64 MergedBlocks = 0;
+    ui64 MixedChannelBlocks = 0;
+    ui64 MergedChannelBlocks = 0;
 
     ui64 InitialMixedBlocks = 0;
     ui64 InitialMergedBlocks = 0;
+    ui64 InitialMixedChannelBlocks = 0;
+    ui64 InitialMergedChannelBlocks = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -241,13 +241,13 @@ using TReadBlocksRequests = TVector<TReadBlocksRequest>;
 
 struct TBlockCountRebuildState
 {
-    ui64 MixedBlocks = 0;
-    ui64 MergedBlocks = 0;
+    ui64 MixedIndexBlocks = 0;
+    ui64 MergedIndexBlocks = 0;
     ui64 MixedChannelBlocks = 0;
     ui64 MergedChannelBlocks = 0;
 
-    ui64 InitialMixedBlocks = 0;
-    ui64 InitialMergedBlocks = 0;
+    ui64 InitialMixedIndexBlocks = 0;
+    ui64 InitialMergedIndexBlocks = 0;
     ui64 InitialMixedChannelBlocks = 0;
     ui64 InitialMergedChannelBlocks = 0;
 };

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -41,6 +41,51 @@ double BPFeature(const TBackpressureFeatureConfig& c, double x)
     return (1 - nx) + nx * c.MaxValue;
 }
 
+void InitializeMixedMergedBlobsAndBlocksCounts(
+    const TPartitionChannelsState& channelsState,
+    NProto::TPartitionStats& stats,
+    bool useBlobChannelDataKindForCounters)
+{
+    const bool indexCountersInitialized =
+        (stats.GetMixedBlobsCount() || stats.GetMergedBlobsCount()) &&
+        (stats.GetMixedBlocksCount() || stats.GetMergedBlocksCount());
+
+    // if index counters are not set, initialize them from old channel counters.
+    if (!indexCountersInitialized) {
+        stats.SetMixedIndexBlobsCount(stats.GetMixedBlobsCount());
+        stats.SetMergedIndexBlobsCount(stats.GetMergedBlobsCount());
+        stats.SetMixedIndexBlocksCount(stats.GetMixedBlocksCount());
+        stats.SetMergedIndexBlocksCount(stats.GetMergedBlocksCount());
+    }
+
+    // If channel counters are dissabled and index counters are set, that means
+    // that feature was rolled back, so we need to reset the counters to the
+    // index counters.
+    if (!useBlobChannelDataKindForCounters && indexCountersInitialized) {
+        stats.SetMixedBlobsCount(stats.GetMixedIndexBlobsCount());
+        stats.SetMergedBlobsCount(stats.GetMergedIndexBlobsCount());
+        stats.SetMixedBlocksCount(stats.GetMixedIndexBlocksCount());
+        stats.SetMergedBlocksCount(stats.GetMergedIndexBlocksCount());
+        return;
+    }
+
+    // If there are no channels with kind mixed, all blobs from mixed index
+    // table were written to merged channel. If there are some mixed channels,
+    // we are trying to use them for mixed blobs.
+    if (useBlobChannelDataKindForCounters &&
+        !channelsState.GetChannelsByKind(
+            [](EChannelDataKind kind)
+            { return kind == EChannelDataKind::Mixed; }))
+    {
+        stats.SetMergedBlobsCount(
+            stats.GetMergedBlobsCount() + stats.GetMixedBlobsCount());
+        stats.SetMixedBlobsCount(0);
+        stats.SetMergedBlocksCount(
+            stats.GetMergedBlocksCount() + stats.GetMixedBlocksCount());
+        stats.SetMixedBlocksCount(0);
+    }
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -121,42 +166,11 @@ TPartitionState::TPartitionState(
     }
     InitChannels();
 
-    auto& stats = AccessStats();
-    if (!stats.GetMixedIndexBlobsCount() && !stats.GetMergedIndexBlobsCount() &&
-        (stats.GetMixedBlobsCount() || stats.GetMergedBlobsCount()))
-    {
-        stats.SetMixedIndexBlobsCount(stats.GetMixedBlobsCount());
-        stats.SetMergedIndexBlobsCount(stats.GetMergedBlobsCount());
-    }
-    if (!stats.GetMixedIndexBlocksCount() &&
-        !stats.GetMergedIndexBlocksCount() &&
-        (stats.GetMixedBlocksCount() || stats.GetMergedBlocksCount()))
-    {
-        stats.SetMixedIndexBlocksCount(stats.GetMixedBlocksCount());
-        stats.SetMergedIndexBlocksCount(stats.GetMergedBlocksCount());
-    }
-
-    if (!UseBlobChannelDataKindForCounters) {
-        stats.SetMixedBlobsCount(stats.GetMixedIndexBlobsCount());
-        stats.SetMergedBlobsCount(stats.GetMergedIndexBlobsCount());
-        stats.SetMixedBlocksCount(stats.GetMixedIndexBlocksCount());
-        stats.SetMergedBlocksCount(stats.GetMergedIndexBlocksCount());
-    } else if (
-        GetChannelsByKind([](EChannelDataKind kind)
-                          { return kind == EChannelDataKind::Mixed; })
-            .empty())
-    {
-        // If there are no channels with kind mixed, all blobs from mixed index
-        // table were written to merged channel.
-        stats.SetMergedBlobsCount(
-            stats.GetMergedBlobsCount() + stats.GetMixedBlobsCount());
-        stats.SetMixedBlobsCount(0);
-        stats.SetMergedBlocksCount(
-            stats.GetMergedBlocksCount() + stats.GetMixedBlocksCount());
-        stats.SetMixedBlocksCount(0);
-    }
+    InitializeMixedMergedBlobsAndBlocksCounts(
+        *this,
+        AccessStats(),
+        UseBlobChannelDataKindForCounters);
 }
-
 bool TPartitionState::CheckBlockRange(const TBlockRange64& range) const
 {
     Y_DEBUG_ABORT_UNLESS(Config.GetBlocksCount() <= Max<ui32>());

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -67,7 +67,8 @@ TPartitionState::TPartitionState(
         ui64 tabletId,
         const std::optional<TMixedBlocksFilterConfig>
             mixedBlocksFilterConfig,
-        bool checkpointAwareCleanupEnabled)
+        bool checkpointAwareCleanupEnabled,
+        bool useBlobChannelDataKindForCounters)
     : TPartitionChannelsState(
           meta.GetConfig(),
           freeSpaceConfig,
@@ -85,6 +86,7 @@ TPartitionState::TPartitionState(
     , CompactionPolicy(compactionPolicy)
     , BPConfig(bpConfig)
     , FreeSpaceConfig(freeSpaceConfig)
+    , UseBlobChannelDataKindForCounters(useBlobChannelDataKindForCounters)
     , ThreadSafeState(std::move(threadSafeState))
     , Config(*Meta.MutableConfig())
     , MixedIndexCache(mixedIndexCacheSize, &MixedIndexCacheAllocator)
@@ -118,6 +120,40 @@ TPartitionState::TPartitionState(
         }
     }
     InitChannels();
+
+    auto& stats = AccessStats();
+    if (!stats.GetMixedIndexBlobsCount() && !stats.GetMergedIndexBlobsCount() &&
+        (stats.GetMixedBlobsCount() || stats.GetMergedBlobsCount()))
+    {
+        stats.SetMixedIndexBlobsCount(stats.GetMixedBlobsCount());
+        stats.SetMergedIndexBlobsCount(stats.GetMergedBlobsCount());
+    }
+    if (!stats.GetMixedIndexBlocksCount() &&
+        !stats.GetMergedIndexBlocksCount() &&
+        (stats.GetMixedBlocksCount() || stats.GetMergedBlocksCount()))
+    {
+        stats.SetMixedIndexBlocksCount(stats.GetMixedBlocksCount());
+        stats.SetMergedIndexBlocksCount(stats.GetMergedBlocksCount());
+    }
+
+    if (!UseBlobChannelDataKindForCounters) {
+        stats.SetMixedBlobsCount(stats.GetMixedIndexBlobsCount());
+        stats.SetMergedBlobsCount(stats.GetMergedIndexBlobsCount());
+        stats.SetMixedBlocksCount(stats.GetMixedIndexBlocksCount());
+        stats.SetMergedBlocksCount(stats.GetMergedIndexBlocksCount());
+    } else if (GetChannelsByKind([](EChannelDataKind kind)
+                                 { return kind == EChannelDataKind::Mixed; })
+                   .empty())
+    {
+        // If there are no channels with kind mixed, all blobs from mixed index
+        // table were written to merged channel.
+        stats.SetMergedBlobsCount(
+            stats.GetMergedBlobsCount() + stats.GetMixedBlobsCount());
+        stats.SetMixedBlobsCount(0);
+        stats.SetMergedBlocksCount(
+            stats.GetMergedBlocksCount() + stats.GetMixedBlocksCount());
+        stats.SetMixedBlocksCount(0);
+    }
 }
 
 bool TPartitionState::CheckBlockRange(const TBlockRange64& range) const

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -141,9 +141,10 @@ TPartitionState::TPartitionState(
         stats.SetMergedBlobsCount(stats.GetMergedIndexBlobsCount());
         stats.SetMixedBlocksCount(stats.GetMixedIndexBlocksCount());
         stats.SetMergedBlocksCount(stats.GetMergedIndexBlocksCount());
-    } else if (GetChannelsByKind([](EChannelDataKind kind)
-                                 { return kind == EChannelDataKind::Mixed; })
-                   .empty())
+    } else if (
+        GetChannelsByKind([](EChannelDataKind kind)
+                          { return kind == EChannelDataKind::Mixed; })
+            .empty())
     {
         // If there are no channels with kind mixed, all blobs from mixed index
         // table were written to merged channel.

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -65,8 +65,13 @@ using ::NCloud::NBlockStore::NStorage::TPartitionThreadSafeState;
     xxx(MergedBlocksCount)                                                     \
     xxx(MixedBlobsCount)                                                       \
     xxx(MergedBlobsCount)                                                      \
+    xxx(MixedIndexBlocksCount)                                                 \
+    xxx(MergedIndexBlocksCount)                                                \
+    xxx(MixedIndexBlobsCount)                                                  \
+    xxx(MergedIndexBlobsCount)                                                 \
     xxx(UsedBlocksCount)                                                       \
-    xxx(LogicalUsedBlocksCount)                                                \
+    xxx(LogicalUsedBlocksCount)
+
 // BLOCKSTORE_PARTITION_PROTO_COUNTERS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -304,6 +309,7 @@ private:
     const ICompactionPolicyPtr CompactionPolicy;
     const TBackpressureFeaturesConfig BPConfig;
     const TFreeSpaceConfig FreeSpaceConfig;
+    const bool UseBlobChannelDataKindForCounters;
 
     TPartitionThreadSafeStatePtr ThreadSafeState;
 
@@ -329,12 +335,18 @@ public:
         TPartitionThreadSafeStatePtr threadSafeState,
         ui64 tabletId,
         const std::optional<TMixedBlocksFilterConfig> mixedBlocksFilterConfig,
-        bool checkpointAwareCleanupEnabled);
+        bool checkpointAwareCleanupEnabled,
+        bool useBlobChannelDataKindForCounters = false);
 
 private:
     bool LoadStateFinished = false;
 
 public:
+    bool ShouldUseBlobChannelDataKindForCounters() const
+    {
+        return UseBlobChannelDataKindForCounters;
+    }
+
     void FinishLoadState()
     {
         LoadStateFinished = true;
@@ -859,8 +871,7 @@ public:
     void StartRebuildBlockCount()
     {
         RebuildState.StartRebuildBlockCount(
-            GetMixedBlobsCount(),
-            GetMergedBlobsCount());
+            GetMixedIndexBlobsCount(), GetMergedIndexBlobsCount());
     }
 
     TMedatadataRebuildProgress GetMetadataRebuildProgress() const
@@ -878,10 +889,16 @@ public:
         RebuildState.Complete();
     }
 
-    void UpdateBlocksCountersAfterMetadataRebuild(ui64 mixed, ui64 merged)
+    void UpdateBlocksCountersAfterMetadataRebuild(
+        ui64 mixedIndex,
+        ui64 mergedIndex,
+        ui64 mixedChannel,
+        ui64 mergedChannel)
     {
-        AccessStats().SetMixedBlocksCount(mixed);
-        AccessStats().SetMergedBlocksCount(merged);
+        AccessStats().SetMixedIndexBlocksCount(mixedIndex);
+        AccessStats().SetMergedIndexBlocksCount(mergedIndex);
+        AccessStats().SetMixedBlocksCount(mixedChannel);
+        AccessStats().SetMergedBlocksCount(mergedChannel);
     }
 
     //
@@ -905,8 +922,8 @@ public:
     void StartScanDisk()
     {
         ScanDiskState.Start(
-            GetMixedBlobsCount(),
-            GetMergedBlobsCount());
+            GetMixedIndexBlobsCount(),
+            GetMergedIndexBlobsCount());
     }
 
     TScanDiskProgress GetScanDiskProgress() const

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -576,8 +576,8 @@ struct TTxPartition
 
         ui32 ReadCount = 0;
 
-        ui64 MixedBlockCount = 0;
-        ui64 MergedBlockCount = 0;
+        ui64 MixedIndexBlockCount = 0;
+        ui64 MergedIndexBlockCount = 0;
         ui64 MixedChannelBlockCount = 0;
         ui64 MergedChannelBlockCount = 0;
 
@@ -601,8 +601,8 @@ struct TTxPartition
         void Clear()
         {
             ReadCount = 0;
-            MixedBlockCount = 0;
-            MergedBlockCount = 0;
+            MixedIndexBlockCount = 0;
+            MergedIndexBlockCount = 0;
             MixedChannelBlockCount = 0;
             MergedChannelBlockCount = 0;
             LastReadBlobId = {};

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -578,6 +578,8 @@ struct TTxPartition
 
         ui64 MixedBlockCount = 0;
         ui64 MergedBlockCount = 0;
+        ui64 MixedChannelBlockCount = 0;
+        ui64 MergedChannelBlockCount = 0;
 
         TPartialBlobId LastReadBlobId;
 
@@ -601,6 +603,8 @@ struct TTxPartition
             ReadCount = 0;
             MixedBlockCount = 0;
             MergedBlockCount = 0;
+            MixedChannelBlockCount = 0;
+            MergedChannelBlockCount = 0;
             LastReadBlobId = {};
         }
     };

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -1965,7 +1965,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         const auto& stats = response->Record.GetStats();
 
         UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
         UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
 
@@ -9505,7 +9505,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                             event->Get<TEvPartitionPrivate::TEvMetadataRebuildBlockCountResponse>();
                         UNIT_ASSERT_VALUES_UNEQUAL(
                             0,
-                            msg->RebuildState.MixedBlocks + msg->RebuildState.MergedBlocks);
+                            msg->RebuildState.MixedIndexBlocks +
+                                msg->RebuildState.MergedIndexBlocks);
                     }
                 }
                 return TTestActorRuntime::DefaultObserverFunc(event);

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -1339,9 +1339,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         auto response = partition.StatPartition();
         const auto& stats = response->Record.GetStats();
-        UNIT_ASSERT(stats.GetMixedBlobsCount());
-        UNIT_ASSERT_VALUES_EQUAL(blockCount - 1, stats.GetMixedBlocksCount());
-        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        UNIT_ASSERT(stats.GetMixedIndexBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(blockCount - 1, stats.GetMixedIndexBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(blockCount, stats.GetUsedBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1389,9 +1389,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         auto response = partition.StatPartition();
         const auto& stats = response->Record.GetStats();
-        UNIT_ASSERT(stats.GetMixedBlobsCount());
-        UNIT_ASSERT_VALUES_EQUAL(999, stats.GetMixedBlocksCount());
-        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        UNIT_ASSERT(stats.GetMixedIndexBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(999, stats.GetMixedIndexBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(1000, stats.GetUsedBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1458,7 +1458,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         auto response = partition.StatPartition();
         const auto& stats = response->Record.GetStats();
-        UNIT_ASSERT(stats.GetMixedBlobsCount());
+        UNIT_ASSERT(stats.GetMixedIndexBlobsCount());
 
         for (ui32 i = 0; i < maxBlobRangeSize; ++i) {
             const auto block =
@@ -1872,8 +1872,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(6, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
 
             auto partitionInfo = partition.GetPartitionInfo();
             auto value =
@@ -1897,8 +1897,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
 
             UNIT_ASSERT(stats.GetSysWriteCounters().GetExecTime() != 0);
         }
@@ -1914,6 +1914,99 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 TString(),
                 GetBlockContent(partition.ReadBlocks(i)));
         }
+    }
+
+    Y_UNIT_TEST(ShouldFillBothBlobCounterFamiliesByIndexKindByDefault)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+        partition.ZeroBlocks(4);
+        partition.Flush();
+        partition.Flush();
+
+        const auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+
+        UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedIndexBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
+    }
+
+    Y_UNIT_TEST(ShouldClassifyBlobCountersByChannelAndIndexKindWhenEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetUseBlobChannelDataKindForCounters(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+        partition.ZeroBlocks(4);
+        partition.Flush();
+        partition.Flush();
+
+        const auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+
+        UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedIndexBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
+
+        ui64 mixedBytesCount = 0;
+        ui64 mergedBytesCount = 0;
+        ui64 mixedIndexBytesCount = 0;
+        ui64 mergedIndexBytesCount = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    const auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+                    const auto& counters = msg->DiskCounters->Simple;
+                    mixedBytesCount = counters.MixedBytesCount.Value;
+                    mergedBytesCount = counters.MergedBytesCount.Value;
+                    mixedIndexBytesCount = counters.MixedIndexBytesCount.Value;
+                    mergedIndexBytesCount = counters.MergedIndexBytesCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvStatsService::EvVolumePartCounters);
+        runtime->DispatchEvents(options);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, mixedBytesCount);
+        UNIT_ASSERT_VALUES_EQUAL(3 * DefaultBlockSize, mergedBytesCount);
+        UNIT_ASSERT_VALUES_EQUAL(3 * DefaultBlockSize, mixedIndexBytesCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, mergedIndexBytesCount);
     }
 
     Y_UNIT_TEST(ShouldFlushBlocksFromFreshChannelAsNewBlob)
@@ -1939,8 +2032,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(6, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
 
             auto partitionInfo = partition.GetPartitionInfo();
             auto value =
@@ -1960,8 +2053,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
 
             UNIT_ASSERT(stats.GetSysWriteCounters().GetExecTime() != 0);
         }
@@ -1998,8 +2091,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 MaxBlocksCount - 1,
                 stats.GetFreshBlocksCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         partition.WriteBlocks(MaxBlocksCount - 1, 0);
@@ -2011,8 +2104,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(MaxBlocksCount, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(MaxBlocksCount, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -2036,8 +2129,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 MaxBlocksCount - 1,
                 stats.GetFreshBlocksCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         partition.WriteBlocks(MaxBlocksCount - 1, 0);
@@ -2049,8 +2142,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(MaxBlocksCount, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(MaxBlocksCount, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -2081,8 +2174,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 stats.GetFreshBlocksCount()
             );
             UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         partition.WriteBlocks(0, 0);
@@ -2097,9 +2190,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 MaxBlocksCount - 1,
-                stats.GetMixedBlocksCount()
+                stats.GetMixedIndexBlocksCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -2130,8 +2223,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 stats.GetFreshBlocksCount()
             );
             UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
@@ -2146,9 +2239,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 MaxBlocksCount - 1,
-                stats.GetMixedBlocksCount()
+                stats.GetMixedIndexBlocksCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -2290,8 +2383,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         auto response = partition.StatPartition();
         const auto& stats = response->Record.GetStats();
         UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
     }
 
     Y_UNIT_TEST(ShouldAutomaticallyTrimFreshBlobsFromPreviousGeneration)
@@ -2445,8 +2538,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 MaxBlocksCount - 1,
                 stats.GetFreshBlocksCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         constexpr ui32 extraBlocks = 4;
@@ -2462,9 +2555,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(extraBlocks, stats.GetFreshBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 MaxBlocksCount,
-                stats.GetMixedBlocksCount()
+                stats.GetMixedIndexBlocksCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -2489,8 +2582,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 stats.GetFreshBlocksCount()
             );
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         constexpr ui32 extraBlocks = 4;
@@ -2507,9 +2600,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 MaxBlocksCount + extraBlocks,
-                stats.GetMixedBlocksCount()
+                stats.GetMixedIndexBlocksCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -2724,9 +2817,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold - 1,
-                stats.GetMixedBlobsCount()
+                stats.GetMixedIndexBlobsCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         partition.WriteBlocks(0, 0);
@@ -2740,9 +2833,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold,
-                stats.GetMixedBlobsCount()
+                stats.GetMixedIndexBlobsCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         partition.SendToPipe(
@@ -2770,6 +2863,21 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         TPartitionClient partition(*runtime);
         partition.WaitReady();
 
+        ui64 compactionByBlobCount = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    const auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+                    compactionByBlobCount = msg->DiskCounters->Cumulative
+                        .CompactionByBlobCountPerRange.Value;
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
         for (size_t i = 1; i < compactionThreshold; ++i) {
             partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
         }
@@ -2779,8 +2887,13 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold - 1,
-                stats.GetMergedBlobsCount()
-            );
+                stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold - 1,
+                stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
         }
 
         partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
@@ -2793,9 +2906,24 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold + 1,
-                stats.GetMergedBlobsCount()
-            );
+                stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold + 1,
+                stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
         }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_EQUAL(1, compactionByBlobCount);
     }
 
     Y_UNIT_TEST(ShouldRespectCompactionDelay)
@@ -2828,9 +2956,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold,
-                stats.GetMixedBlobsCount()
+                stats.GetMixedIndexBlobsCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         runtime->AdvanceCurrentTime(TDuration::Seconds(10));
@@ -2843,9 +2971,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold,
-                stats.GetMixedBlobsCount()
+                stats.GetMixedIndexBlobsCount()
             );
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -2926,7 +3054,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold + 1,
-                stats.GetMergedBlobsCount()
+                stats.GetMergedIndexBlobsCount()
             );
             delay = TDuration::MilliSeconds(stats.GetCompactionDelay());
             UNIT_ASSERT_VALUES_UNEQUAL(0, delay.MicroSeconds());
@@ -2942,7 +3070,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold + 2,
-                stats.GetMergedBlobsCount()
+                stats.GetMergedIndexBlobsCount()
             );
         }
 
@@ -2958,7 +3086,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT(stats.GetMergedBlobsCount() >= cleanupThreshold);
+            UNIT_ASSERT(stats.GetMergedIndexBlobsCount() >= cleanupThreshold);
             delay = TDuration::MilliSeconds(stats.GetCleanupDelay());
             UNIT_ASSERT_VALUES_UNEQUAL(0, delay.MicroSeconds());
         }
@@ -2971,7 +3099,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -3017,7 +3145,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold + 1,
-                stats.GetMergedBlobsCount()
+                stats.GetMergedIndexBlobsCount()
             );
         }
 
@@ -3030,7 +3158,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -3053,7 +3181,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(512, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(512, stats.GetMixedIndexBlobsCount());
         }
 
         ui64 compactionByBlobCount = -1;
@@ -4062,8 +4190,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount), 1);
@@ -4071,8 +4199,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount), 2);
@@ -4080,8 +4208,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Compaction();
@@ -4089,8 +4217,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Cleanup();
@@ -4098,8 +4226,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -4140,7 +4268,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 expectedSize + 1,
-                stats.GetMergedBlobsCount());
+                stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 expectedSize * MaxBlocksCount * DefaultBlockSize,
                 stats.GetCleanupQueueBytes());
@@ -4220,7 +4348,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 expectedCleanupQueueSize + 1,
-                stats.GetMergedBlobsCount());
+                stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 expectedCleanupQueueSize * MaxBlocksCount * DefaultBlockSize,
                 stats.GetCleanupQueueBytes());
@@ -4909,8 +5037,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         response = partition.StatPartition();
         auto newStats = response->Record.GetStats();
         UNIT_ASSERT_VALUES_EQUAL(
-            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
-            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+            oldStats.GetMixedIndexBlobsCount() + oldStats.GetMergedIndexBlobsCount() + rangesCount,
+            newStats.GetMixedIndexBlobsCount() + newStats.GetMergedIndexBlobsCount()
         );
     }
 
@@ -4960,8 +5088,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         response = partition.StatPartition();
         auto newStats = response->Record.GetStats();
         UNIT_ASSERT_VALUES_EQUAL(
-            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
-            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+            oldStats.GetMixedIndexBlobsCount() + oldStats.GetMergedIndexBlobsCount() + rangesCount - 1,
+            newStats.GetMixedIndexBlobsCount() + newStats.GetMergedIndexBlobsCount()
         );
     }
 
@@ -5001,7 +5129,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         auto response = partition.StatPartition();
         const auto& stats = response->Record.GetStats();
-        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
     }
 
     Y_UNIT_TEST(ShouldMakeUnderlyingBlobsEligibleForCleanupAfterCompaction)
@@ -5033,7 +5161,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -5070,7 +5198,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -5098,7 +5226,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
 
         for (ui32 zero_step = 0; zero_step < 2; ++zero_step) {
@@ -5124,7 +5252,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -5152,7 +5280,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
 
         for (ui32 write_step = 0; write_step < 2; ++write_step) {
@@ -5176,8 +5304,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -5201,7 +5329,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -5772,8 +5900,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Compaction();
@@ -5783,8 +5911,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
         }
 
         partition.ZeroBlocks(TBlockRange32::WithLength(0, 1001));
@@ -5792,8 +5920,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Compaction();
@@ -5803,8 +5931,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -5830,10 +5958,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(6, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(6, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlocksCount());
         }
 
         partition.Compaction();
@@ -5843,10 +5971,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedIndexBlocksCount());
         }
 
         UNIT_ASSERT_VALUES_EQUAL(
@@ -5963,10 +6091,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedIndexBlocksCount());
         }
 
         runtime->DispatchEvents({}, TDuration::Seconds(1));
@@ -5982,10 +6110,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedIndexBlocksCount());
         }
 
         for (ui32 i = 0; i <= 4; ++i) {
@@ -6088,10 +6216,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(31, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(31, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
         }
 
         partition.Compaction();
@@ -6101,10 +6229,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(21, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(21, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedIndexBlocksCount());
         }
 
         for (ui32 i = 11; i <= 22; ++i) {
@@ -6147,10 +6275,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(23, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(23, stats.GetMergedIndexBlocksCount());
         }
 
         partition.Compaction();
@@ -6160,10 +6288,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedIndexBlocksCount());
         }
 
         UNIT_ASSERT_VALUES_EQUAL(
@@ -7451,7 +7579,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             // Other blobs should be collected.
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -7876,8 +8004,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 auto response = partition.StatPartition();
                 const auto& stats = response->Record.GetStats();
                 UNIT_ASSERT_VALUES_EQUAL(255, stats.GetFreshBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
             }
 
             partition.WriteBlocks(TBlockRange32::WithLength(0, 256));
@@ -7886,8 +8014,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 auto response = partition.StatPartition();
                 const auto& stats = response->Record.GetStats();
                 UNIT_ASSERT_VALUES_EQUAL(255, stats.GetFreshBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedIndexBlocksCount());
             }
 
             partition.ZeroBlocks(TBlockRange32::WithLength(0, 255));
@@ -7896,8 +8024,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 auto response = partition.StatPartition();
                 const auto& stats = response->Record.GetStats();
                 UNIT_ASSERT_VALUES_EQUAL(255, stats.GetFreshBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedIndexBlocksCount());
             }
 
             partition.ZeroBlocks(TBlockRange32::WithLength(0, 256));
@@ -7906,8 +8034,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 auto response = partition.StatPartition();
                 const auto& stats = response->Record.GetStats();
                 UNIT_ASSERT_VALUES_EQUAL(255, stats.GetFreshBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedIndexBlocksCount());
             }
         }
 
@@ -7931,8 +8059,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 auto response = partition.StatPartition();
                 const auto& stats = response->Record.GetStats();
                 UNIT_ASSERT_VALUES_EQUAL(31, stats.GetFreshBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
             }
 
             partition.WriteBlocks(TBlockRange32::WithLength(0, 32));
@@ -7941,8 +8069,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 auto response = partition.StatPartition();
                 const auto& stats = response->Record.GetStats();
                 UNIT_ASSERT_VALUES_EQUAL(31, stats.GetFreshBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedIndexBlocksCount());
             }
 
             partition.ZeroBlocks(TBlockRange32::WithLength(0, 31));
@@ -7951,8 +8079,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 auto response = partition.StatPartition();
                 const auto& stats = response->Record.GetStats();
                 UNIT_ASSERT_VALUES_EQUAL(31, stats.GetFreshBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedIndexBlocksCount());
             }
 
             partition.ZeroBlocks(TBlockRange32::WithLength(0, 32));
@@ -7961,8 +8089,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 auto response = partition.StatPartition();
                 const auto& stats = response->Record.GetStats();
                 UNIT_ASSERT_VALUES_EQUAL(31, stats.GetFreshBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedIndexBlocksCount());
             }
         }
     }
@@ -7983,9 +8111,14 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetMergedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
+
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-
             UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetMergedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
         }
@@ -7996,9 +8129,14 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
+
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
         }
@@ -8012,9 +8150,14 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
 
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
+
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
         }
@@ -8025,9 +8168,14 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
+
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
         }
@@ -9289,7 +9437,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
 
         auto stats = partition.StatPartition()->Record.GetStats();
-        UNIT_ASSERT_VALUES_EQUAL(1024 * 11 + 1, stats.GetMergedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(1024 * 11 + 1, stats.GetMergedIndexBlocksCount());
     }
 
     Y_UNIT_TEST(ShouldFailGetMetadataRebuildStatusIfNoOperationRunning)
@@ -9412,7 +9560,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         {
             auto stats = partition.StatPartition()->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedIndexBlobsCount());
         }
 
         {
@@ -9432,7 +9580,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         {
             auto stats = partition.StatPartition()->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         auto progress = partition.GetRebuildMetadataStatus();
@@ -9727,7 +9875,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedIndexBlobsCount());
         }
 
         // blockRange4 and any other 2 ranges should be compacted
@@ -9738,7 +9886,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -9821,7 +9969,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         UNIT_ASSERT(evPatchObserved);
@@ -9958,7 +10106,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         UNIT_ASSERT(evPatchObserved);
@@ -10014,8 +10162,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            // 2 == zeroBlob + dataBlob
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
         }
 
         UNIT_ASSERT(evPatchObserved);
@@ -10085,19 +10232,20 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(1024, 3023));
         partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(5024, 5033));
 
+
         const ui64 mixedBlobsCount = 4;
         const ui64 mergedBlobsCount = 20;
         const ui64 blobsCount = mixedBlobsCount + mergedBlobsCount;
-        const ui64 blobsWithoutDeletionMarkerCount = blobsCount - 2;
+        const ui64 scannableBlobsCount = 22;
 
         {
             const auto stats = partition.StatPartition()->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 mixedBlobsCount,
-                stats.GetMixedBlobsCount());
+                stats.GetMixedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 mergedBlobsCount,
-                stats.GetMergedBlobsCount());
+                stats.GetMergedIndexBlobsCount());
         }
 
         ui32 completionStatus = -1;
@@ -10138,7 +10286,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, completionStatus);
             UNIT_ASSERT_VALUES_EQUAL(
-                blobsWithoutDeletionMarkerCount,
+                scannableBlobsCount,
                 readBlobCount);
 
             const auto progress = partition.GetScanDiskStatus();
@@ -10194,10 +10342,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto stats = partition.StatPartition()->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 mixedBlobsCount,
-                stats.GetMixedBlobsCount());
+                stats.GetMixedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 mergedBlobsCount,
-                stats.GetMergedBlobsCount());
+                stats.GetMergedIndexBlobsCount());
         }
 
         ui32 completionStatus = -1;
@@ -10434,7 +10582,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         {
             const auto stats = partition.StatPartition()->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedIndexBlobsCount());
         }
 
         {
@@ -10454,7 +10602,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         {
             const auto stats = partition.StatPartition()->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         const auto progress = partition.GetScanDiskStatus();
@@ -10666,7 +10814,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetConfirmedBlobCount());
         }
@@ -11289,7 +11437,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
-                stats.GetMergedBlobsCount());
+                stats.GetMergedIndexBlobsCount());
         }
 
         partition.SendToPipe(
@@ -11945,8 +12093,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         // checking that mixed batching has actually worked
         {
             const auto stats = partition.StatPartition()->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(31, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(31, stats.GetMixedIndexBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
         }
@@ -12456,7 +12604,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         TAutoPtr<IEventHandle> compactionRequest;
@@ -12496,7 +12644,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(8, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(8, stats.GetMergedIndexBlobsCount());
         }
 
         runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
@@ -12534,7 +12682,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -12553,7 +12701,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         TVector<size_t> rangeSizes;
@@ -12594,7 +12742,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(9, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(9, stats.GetMergedIndexBlobsCount());
         }
 
         partition.SendCompactRangeRequest(0, 0);
@@ -12638,7 +12786,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -12657,7 +12805,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         const auto blockRange1 = TBlockRange32::WithLength(3 * 1024, 1024);
@@ -12700,8 +12848,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         auto response = partition.StatPartition();
         const auto& stats = response->Record.GetStats();
-        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(blockCount, stats.GetFreshBlocksCount());
 
         // checking that drain-related counters are in a consistent state
@@ -12736,11 +12884,11 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold - 1,
-                stats.GetMixedBlobsCount());
+                stats.GetMixedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold - 1,
-                stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+                stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         partition.WriteBlocks(0, 0);
@@ -12756,11 +12904,11 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold + 1,
-                stats.GetMixedBlobsCount());
+                stats.GetMixedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold * 2,
-                stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+                stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Cleanup();
@@ -12768,11 +12916,11 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold,
-                stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+                stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -12798,8 +12946,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         partition.WriteBlocks(0, 0);
@@ -12810,8 +12958,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         partition.WriteBlocks(TBlockRange32::WithLength(3, 5), 3);
@@ -12823,8 +12971,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Cleanup();
@@ -12832,8 +12980,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -12862,8 +13010,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
         }
 
         // data should be moved to a mixed channel as a result of compaction,
@@ -12874,8 +13022,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Cleanup();
@@ -12884,8 +13032,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         for (int i = 0; i < 4; ++i) {
@@ -12919,8 +13067,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
         }
 
         // data should be moved to a mixed channel as a result of compaction,
@@ -12933,8 +13081,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         const auto checkValue = [&](std::vector<std::tuple<int, int, char>> values)
@@ -12963,8 +13111,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         checkValue({{0, 2, '4'}, {2, 2, '5'}, {5, 5, '1'}, {12, 3, '6'}, {27, 1, '7'}, {35, 20, '3'}});
@@ -13001,9 +13149,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(85, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(85, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
         }
 
         partition.Compaction();
@@ -13013,9 +13161,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(85, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(85, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlocksCount());
         }
 
         for (ui32 i = 12; i < 45; ++i) {
@@ -13068,10 +13216,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedIndexBlocksCount());
         }
 
         {
@@ -13080,10 +13228,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
             const auto statResponse = partition.StatPartition();
             const auto& stats = statResponse->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedIndexBlocksCount());
         }
 
         {
@@ -13091,10 +13239,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
             const auto statResponse = partition.StatPartition();
             const auto& stats = statResponse->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedIndexBlocksCount());
 
             UNIT_ASSERT_VALUES_EQUAL(
                 GetBlockContent(3),
@@ -13127,10 +13275,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedIndexBlocksCount());
         }
 
         {
@@ -13140,10 +13288,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
             const auto statResponse = partition.StatPartition();
             const auto& stats = statResponse->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedIndexBlocksCount());
 
             UNIT_ASSERT_VALUES_EQUAL(
                 GetBlockContent(32),
@@ -13194,10 +13342,10 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(512, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetMergedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(512, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetMergedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -13429,8 +13577,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold,
-                stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+                stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         dropCompaction = false;
@@ -13505,8 +13653,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 compactionThreshold,
-                stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+                stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         dropCompaction = false;
@@ -13774,8 +13922,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         TAutoPtr<IEventHandle> loadCompactionMapEvent;
@@ -13798,8 +13946,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         {
@@ -13815,8 +13963,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
         }
 
         {
@@ -13829,8 +13977,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(100, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(100, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
     }
 
@@ -14102,7 +14250,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
             UNIT_ASSERT_VALUES_EQUAL(4, stats.GetConfirmedBlobCount());
         }
@@ -14147,7 +14295,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetConfirmedBlobCount());
         }
@@ -14770,8 +14918,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         WriteBlocksWithBlockSize(
@@ -14808,8 +14956,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Compaction();
@@ -14817,8 +14965,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 3,
                 stats.GetBlobsProcessedDuringCompaction());
@@ -14851,8 +14999,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Compaction();
@@ -14860,8 +15008,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 5,
                 stats.GetBlobsProcessedDuringCompaction());
@@ -14893,8 +15041,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -14940,8 +15088,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 3,
                 stats.GetBlobsProcessedDuringCompaction());
@@ -15271,8 +15419,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         for (size_t i = 1019; i < 1024; ++i) {
@@ -15284,8 +15432,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Compaction();
@@ -15293,8 +15441,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 1,
                 stats.GetBlobsProcessedDuringCompaction());
@@ -15314,8 +15462,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         for (size_t i = 1019; i < 1030; ++i) {
@@ -15327,8 +15475,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
 
         partition.Compaction();
@@ -15336,8 +15484,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 3,
                 stats.GetBlobsProcessedDuringCompaction());
@@ -15359,8 +15507,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(
                 4,
                 stats.GetBlobsProcessedDuringCompaction());
@@ -15380,8 +15528,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedIndexBlobsCount());
         }
     }
 
@@ -15678,7 +15826,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedIndexBlobsCount());
         }
 
         for (ui32 i = 1022; i < 1024; ++i) {
@@ -15694,7 +15842,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedIndexBlobsCount());
         }
 
         partition.Compaction();
@@ -16142,7 +16290,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             const ui64 blockCount =
-                stats.GetMixedBlocksCount() + stats.GetMergedBlocksCount();
+                stats.GetMixedIndexBlocksCount() + stats.GetMergedIndexBlocksCount();
             UNIT_ASSERT_C(
                 stats.GetUsedBlocksCount() > blockCount,
                 "UsedBlocksCount=" << stats.GetUsedBlocksCount()
@@ -16166,8 +16314,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(128, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128, stats.GetMergedIndexBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(512, stats.GetUsedBlocksCount());
         }
 
@@ -16186,8 +16334,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(128 + 768, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128 + 768, stats.GetMergedIndexBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(512 + 512, stats.GetUsedBlocksCount());
         }
 
@@ -16199,8 +16347,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(128 + 512, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128 + 512, stats.GetMergedIndexBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(512 + 512, stats.GetUsedBlocksCount());
         }
 
@@ -16210,8 +16358,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(128 + 512, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128 + 512, stats.GetMergedIndexBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(128 + 512, stats.GetUsedBlocksCount());
         }
     }

--- a/cloud/blockstore/libs/storage/protos/part.proto
+++ b/cloud/blockstore/libs/storage/protos/part.proto
@@ -92,11 +92,11 @@ message TPartitionStats
     TIOCounters SysWriteCounters = 4;
     TIOCounters SysChecksumCounters = 14;
 
-    // Numbers of stored blobs.
+    // Numbers of stored blobs (classified by channel).
     uint64 MixedBlobsCount = 5;
     uint64 MergedBlobsCount = 6;
 
-    // Numbers of stored blocks.
+    // Numbers of stored blocks (classified by channel).
     uint64 FreshBlocksCount = 7;
     uint64 MixedBlocksCount = 8;
     uint64 MergedBlocksCount = 9;
@@ -131,6 +131,14 @@ message TPartitionStats
     // Triggers counters for compaction by garbage ignoring zeroed blocks.
     uint64 CompactionByIgnoringZeroedPerRange = 24;
     uint64 CompactionByIgnoringZeroedPerDisk = 25;
+
+    // Numbers of blobs classified by the index they are stored in.
+    uint64 MixedIndexBlobsCount = 26;
+    uint64 MergedIndexBlobsCount = 27;
+
+    // Numbers of blocks classified by the index they are stored in.
+    uint64 MixedIndexBlocksCount = 28;
+    uint64 MergedIndexBlocksCount = 29;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
@@ -76,10 +76,14 @@ void Merge(const NProto::TVolumeStats& source, NProto::TVolumeStats& target)
 
     MERGE_FIELD(MixedBlobsCount);
     MERGE_FIELD(MergedBlobsCount);
+    MERGE_FIELD(MixedIndexBlobsCount);
+    MERGE_FIELD(MergedIndexBlobsCount);
 
     MERGE_FIELD(FreshBlocksCount);
     MERGE_FIELD(MixedBlocksCount);
     MERGE_FIELD(MergedBlocksCount);
+    MERGE_FIELD(MixedIndexBlocksCount);
+    MERGE_FIELD(MergedIndexBlocksCount);
     MERGE_FIELD(UsedBlocksCount);
     MERGE_FIELD(LogicalUsedBlocksCount);
     MERGE_FIELD(GarbageBlocksCount);

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -348,11 +348,11 @@ message TVolumeStats
     TIOCounters SysReadCounters = 3;
     TIOCounters SysWriteCounters = 4;
 
-    // Numbers of stored blobs.
+    // Numbers of stored blobs (classified by channel).
     uint64 MixedBlobsCount = 5;
     uint64 MergedBlobsCount = 6;
 
-    // Numbers of stored blocks.
+    // Numbers of stored blocks (classified by channel).
     uint64 FreshBlocksCount = 7;
     uint64 MixedBlocksCount = 8;
     uint64 MergedBlocksCount = 9;
@@ -422,6 +422,14 @@ message TVolumeStats
 
     // Number of garbage blocks in the most dirty range ignoring zeroed blocks.
     uint32 CompactionIgnoringZeroedScore = 32;
+
+    // Numbers of blobs classified by the index they are stored in.
+    uint64 MixedIndexBlobsCount = 33;
+    uint64 MergedIndexBlobsCount = 34;
+
+    // Numbers of blocks classified by the index they are stored in.
+    uint64 MixedIndexBlocksCount = 35;
+    uint64 MergedIndexBlocksCount = 36;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tests/loadtest/compaction/test.py
+++ b/cloud/blockstore/tests/loadtest/compaction/test.py
@@ -84,7 +84,7 @@ def nbs_server_start(kikimr_cluster, configurator, storage):
     return nbs, server_app_config, storage
 
 
-def data_count_by_channels(nbs_client_binary_path, nbs_port):
+def data_count_by_indexes(nbs_client_binary_path, nbs_port):
     partition_info = check_output([
         nbs_client_binary_path, "ExecuteAction",
         "--action", "getpartitioninfo",
@@ -96,11 +96,11 @@ def data_count_by_channels(nbs_client_binary_path, nbs_port):
     if "Stats" not in json_data:
         return 0, 0, 0, 0, 0
     stats = json_data["Stats"]
-    fresh_blocks = 0 if "FreshBlocksCount" not in stats else stats["FreshBlocksCount"]
-    mixed_blocks = 0 if "MixedBlocksCount" not in stats else stats["MixedBlocksCount"]
-    mixed_blobs = 0 if "MixedBlobsCount" not in stats else stats["MixedBlobsCount"]
-    merged_blocks = 0 if "MergedBlocksCount" not in stats else stats["MergedBlocksCount"]
-    merged_blobs = 0 if "MergedBlobsCount" not in stats else stats["MergedBlobsCount"]
+    fresh_blocks = stats.get("FreshBlocksCount", 0)
+    mixed_blocks = stats.get("MixedIndexBlocksCount", 0)
+    mixed_blobs = stats.get("MixedIndexBlobsCount", 0)
+    merged_blocks = stats.get("MergedIndexBlocksCount", 0)
+    merged_blobs = stats.get("MergedIndexBlobsCount", 0)
     return fresh_blocks, mixed_blocks, mixed_blobs, merged_blocks, merged_blobs
 
 
@@ -156,7 +156,7 @@ def check_data(nbs_client_binary_path,
                expected_merged_blobs,
                written_data):
     fresh_blocks, mixed_blocks, mixed_blobs, merged_blocks, merged_blobs = \
-        data_count_by_channels(nbs_client_binary_path, nbs_port)
+        data_count_by_indexes(nbs_client_binary_path, nbs_port)
 
     logging.info(f"fresh_blocks={fresh_blocks}")
     logging.info(f"mixed_blocks={mixed_blocks} -> expected={expected_mixed_blocks}")


### PR DESCRIPTION
### Notes
We currently write mixed blobs to mixed channels and merged blobs to merged channels. However, if we start writing mixed-index blobs to merged channels—for example, when flushing a large, dense blob on an HDD—the existing counters will no longer accurately represent channel usage.

This change adds a feature flag that makes the existing MixedBytesCount and MergedBytesCount metrics report bytes by channel kind (SSD and HDD, respectively). It also introduces MixedIndexBytesCount and MergedIndexBytesCount, which report bytes by index kind.

### Issue
Put links to the related issues here
