### PR TITLE
[Filestore] Avoid recursive queued operation processing in write-back cache

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/queued_operations.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/queued_operations.cpp
@@ -118,10 +118,26 @@ void TQueuedOperations::Acquire()
 
 void TQueuedOperations::Release()
 {
-    auto events = std::exchange(Events, {});
-    Lock.Release();
-    for (auto& event: events) {
-        std::visit([](auto& ev) { ev.Invoke(); }, event);
+    if (ProcessingEvents) {
+        Lock.Release();
+        return;
+    }
+
+    ProcessingEvents = true;
+    while (true) {
+        auto events = std::exchange(Events, {});
+        Lock.Release();
+
+        for (auto& event: events) {
+            std::visit([](auto& ev) { ev.Invoke(); }, event);
+        }
+
+        Lock.Acquire();
+        if (Events.empty()) {
+            ProcessingEvents = false;
+            Lock.Release();
+            return;
+        }
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/queued_operations.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/queued_operations.h
@@ -32,6 +32,10 @@ private:
     TVector<TEvent> Events;
     IQueuedOperationsProcessor& Processor;
 
+    // Only the outermost Release call processes events to avoid a recursive
+    // call chain.
+    bool ProcessingEvents = false;
+
 public:
     explicit TQueuedOperations(IQueuedOperationsProcessor& processor);
     ~TQueuedOperations();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/queued_operations_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/queued_operations_ut.cpp
@@ -1,0 +1,62 @@
+#include "queued_operations.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NFileStore::NFuse::NWriteBackCache {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TProcessor final: public IQueuedOperationsProcessor
+{
+private:
+    TQueuedOperations Operations{*this};
+    ui32 CurrentDepth = 0;
+
+public:
+    ui32 MaxDepth = 0;
+    ui32 ProcessedCount = 0;
+
+    void Start(ui64 operationCount)
+    {
+        Operations.Acquire();
+        Operations.ScheduleFlushNode(operationCount);
+        Operations.Release();
+    }
+
+private:
+    void ScheduleFlushNode(ui64 remainingOperationCount) override
+    {
+        ++CurrentDepth;
+        MaxDepth = Max(MaxDepth, CurrentDepth);
+        ++ProcessedCount;
+
+        if (remainingOperationCount > 1) {
+            Operations.Acquire();
+            Operations.ScheduleFlushNode(remainingOperationCount - 1);
+            Operations.Release();
+        }
+
+        --CurrentDepth;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TQueuedOperationsTest)
+{
+    Y_UNIT_TEST(ShouldProcessQueuedOperationsWithoutRecursion)
+    {
+        TProcessor processor;
+
+        processor.Start(100'000);
+
+        UNIT_ASSERT_VALUES_EQUAL(100'000, processor.ProcessedCount);
+        UNIT_ASSERT_VALUES_EQUAL(1, processor.MaxDepth);
+    }
+}
+
+}   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/ut/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/ut/ya.make
@@ -11,6 +11,7 @@ SRCS(
     node_state_holder_ut.cpp
     overlapping_interval_set_ut.cpp
     persistent_storage_ut.cpp
+    queued_operations_ut.cpp
     read_response_builder_ut.cpp
     test/test_persistent_storage.cpp
     utils_ut.cpp


### PR DESCRIPTION
### Notes

Prevent reentrant `TQueuedOperations::Release` calls from recursively invoking the next queued operation.

#### How it worked before

The old `Release()` implementation took all accumulated events, released the lock, and immediately invoked them:

```cpp
auto events = std::exchange(Events, {});
Lock.Release();

for (auto& event: events) {
    std::visit([](auto& ev) { ev.Invoke(); }, event);
}
```

The problem occurred when `event.Invoke()` synchronously scheduled another operation:

```text
Release
└─ Invoke
   └─ ScheduleFlushNode
      └─ Release
         └─ Invoke
            └─ ScheduleFlushNode
               └─ Release
                  └─ ...
```

Each newly scheduled flush was executed before the previous callback returned. In the failing test, this produced the following recursive call chain:

```text
CompleteFlush → FlushSucceeded → ScheduleFlushNode → ExecuteFlush
```

With enough queued operations, every new flush added another stack frame until ASAN reported a stack overflow.

---

#### What changed

A `ProcessingEvents` flag was added to indicate that an outer `Release()` call is already processing the queue.

Nested `Release()` calls now only release the lock and return, leaving newly added events in the queue. The outer call processes them iteratively in batches:

1. Take the queued events under the lock
2. Release the lock and invoke them
3. Reacquire the lock and process any newly queued events

This prevents recursive callback chains and makes the stack depth independent of the number of flush operations.

`ProcessingEvents` does not need to be atomic because it is accessed only while holding the lock. 

Callbacks are still invoked without holding the spin lock.

### Issue

ASAN test `cloud/filestore/libs/vfs_fuse/write_back_cache/ut` failed

`ShouldMaintainVisibilityOrderWhenFlushWritesInParallelDisabled`

```
Test crashed (return code: 100)
==941175==ERROR: AddressSanitizer: stack-overflow on address 0x7b69b2dfeec8 (pc 0x0000017b39aa bp 0x7b69b2dff6f0 sp 0x7b69b2dfeec0 T21)
    #0 0x0000017b39aa in StackTrace /-S/contrib/libs/clang20-rt/lib/sanitizer_common/sanitizer_stacktrace.h:53:45
    #1 0x0000017b39aa in BufferedStackTrace /-S/contrib/libs/clang20-rt/lib/sanitizer_common/sanitizer_stacktrace.h:113:26
    #2 0x0000017b39aa in operator new(unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:86:3
    #3 0x000003fcbe04 in __libcpp_operator_new<unsigned long> /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:37:10
    #4 0x000003fcbe04 in __libcpp_allocate<NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::TEvent> /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:64:28
    #5 0x000003fcbe04 in allocate /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:105:14
    #6 0x000003fcbe04 in __allocate_at_least<std::__y1::allocator<NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::TEvent> > /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocate_at_least.h:41:19
    #7 0x000003fcbe04 in __split_buffer /-S/contrib/libs/cxxsupp/libcxx/include/__split_buffer:330:25
    #8 0x000003fcbe04 in NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::TEvent* std::__y1::vector<NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::TEvent, std::__y1::allocator<NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::TEvent>>::__emplace_back_slow_path<NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::TEvent>(NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::TEvent&&) /-S/contrib/libs/cxxsupp/libcxx/include/__vector/vector.h:1169:47
    #9 0x000003fc7b17 in emplace_back<NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::TEvent> /-S/contrib/libs/cxxsupp/libcxx/include/__vector/vector.h:1191:13
    #10 0x000003fc7b17 in push_back /-S/contrib/libs/cxxsupp/libcxx/include/__vector/vector.h:456:90
    #11 0x000003fc7b17 in NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::ScheduleFlushNode(unsigned long) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/queued_operations.cpp:130:12
    #12 0x000003ffc02d in NCloud::NFileStore::NFuse::NWriteBackCache::TWriteBackCacheState::UpdateFlushStatus(unsigned long, NCloud::NFileStore::NFuse::NWriteBackCache::TNodeState&) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp:652:30
    #13 0x0000040002f6 in NCloud::NFileStore::NFuse::NWriteBackCache::TWriteBackCacheState::FlushSucceeded(unsigned long, unsigned long) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp:339:5
    #14 0x000003ff4202 in NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::CompleteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:561:19
    #15 0x000003ff2d6b in auto NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ExecuteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>)::'lambda'(auto const&)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse>>(auto const&) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:535:35
    #16 0x000003ff0dc4 in Subscribe<(lambda at /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:525:29)> /-S/library/cpp/threading/future/core/future-inl.h:623:13
    #17 0x000003ff0dc4 in NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ExecuteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:545:18
    #18 0x000003feff92 in NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ScheduleFlushNode(unsigned long) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:479:9
    #19 0x000003fc763f in __visit_alt<std::__y1::__variant_detail::__visitation::__variant::__value_visitor<(lambda at /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/queued_operations.cpp:124:20)>, std::__y1::__variant_detail::__impl<NC
..[snippet truncated]..
shState>) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:561:19
    #575 0x000003ff2d6b in auto NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ExecuteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>)::'lambda'(auto const&)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse>>(auto const&) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:535:35
SUMMARY: AddressSanitizer: stack-overflow /-S/contrib/libs/clang20-rt/lib/sanitizer_common/sanitizer_stacktrace.h:53:45 in StackTrace
Thread T21 (cloud-fi.Timer) created by T0 here:
    #0 0x00000175e141 in pthread_create /-S/contrib/libs/clang20-rt/lib/asan/asan_interceptors.cpp:250:3
    #1 0x000001ae83f5 in Start /-S/util/system/thread.cpp:230:27
    #2 0x000001ae83f5 in TThread::Start() /-S/util/system/thread.cpp:315:34
    #3 0x00000152a9a5 in NCloud::NFileStore::NFuse::(anonymous namespace)::TBootstrap::TBootstrap(NCloud::NFileStore::NFuse::(anonymous namespace)::TBootstrapArgs const&) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:245:20
    #4 0x00000161485a in TShouldMaintainVisibilityOrderWhenFlushWritesInParallelDisabledTest /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:2472:15
    #5 0x00000161485a in NCloud::NFileStore::NFuse::NTestSuiteTWriteBackCacheTest::TTestCaseShouldMaintainVisibilityOrderWhenFlushWritesInParallelDisabled::Execute_(NUnitTest::TTestContext&) /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:2540:77
    #6 0x000001631281 in operator() /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:843:1
    #7 0x000001631281 in __invoke<(lambda at /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:843:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #8 0x000001631281 in __call<(lambda at /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:843:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #9 0x000001631281 in __invoke_r<void, (lambda at /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:843:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #10 0x000001631281 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:167:12
    #11 0x000001631281 in std::__y1::__function::__func<NCloud::NFileStore::NFuse::NTestSuiteTWriteBackCacheTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::NTestSuiteTWriteBackCacheTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:319:10
    #12 0x000001b717fb in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:436:12
    #13 0x000001b717fb in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:995:10
    #14 0x000001b717fb in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #15 0x000001b467d7 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #16 0x00000163046a in NCloud::NFileStore::NFuse::NTestSuiteTWriteBackCacheTest::TCurrentTest::Execute() /-S/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp:843:1
    #17 0x000001b47fdf in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #18 0x000001b6addc in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:895:44
    #19 0x7f69b689d082 in __libc_start_main /build/glibc-B3wQXB/glibc-2.31/csu/../csu/libc-start.c:308:16
==941175==ABORTING
```