### PR TITLE
[NBS] prevent conflicting volume operations

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
@@ -42,6 +42,11 @@ private:
     const ui64 NewBlocksCount = 0;
     const TString DiskId;
     ui32 ConfigVersion = 0;
+    const bool CheckVolumeOperationRestriction = false;
+
+    TString Path;
+    ui64 PathId = 0;
+    ui64 PathVersion = 0;
 
     NPrivateProto::TVolumeChannelsToPoolsKinds VolumeChannelsToPoolsKinds;
     bool SetupChannelsRequested = false;
@@ -122,6 +127,8 @@ private:
 
     void DescribeVolume(const TActorContext& ctx);
 
+    void StatVolume(const TActorContext& ctx);
+
     void AlterVolume(
         const TActorContext& ctx,
         TString path,
@@ -134,11 +141,16 @@ private:
 
 private:
     STFUNC(StateDescribeVolume);
+    STFUNC(StateStatVolume);
     STFUNC(StateAlterVolume);
     STFUNC(StateWaitReady);
 
     void HandleDescribeVolumeResponse(
         const TEvSSProxy::TEvDescribeVolumeResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleStatVolumeResponse(
+        const TEvService::TEvStatVolumeResponse::TPtr& ev,
         const TActorContext& ctx);
 
     void HandleAlterVolumeResponse(
@@ -165,6 +177,7 @@ TAlterVolumeActor::TAlterVolumeActor(
     , NewBlocksCount(request.GetBlocksCount())
     , DiskId(request.GetDiskId())
     , ConfigVersion(request.GetConfigVersion())
+    , CheckVolumeOperationRestriction(true)
 {}
 
 TAlterVolumeActor::TAlterVolumeActor(
@@ -177,6 +190,7 @@ TAlterVolumeActor::TAlterVolumeActor(
     , Config(std::move(config))
     , DiskId(request.GetDiskId())
     , ConfigVersion(request.GetConfigVersion())
+    , CheckVolumeOperationRestriction(true)
 {
     VolumeConfig.SetProjectId(request.GetProjectId());
     VolumeConfig.SetFolderId(request.GetFolderId());
@@ -226,6 +240,18 @@ void TAlterVolumeActor::DescribeVolume(const TActorContext& ctx)
             /*exactDiskIdMatch=*/false));
 }
 
+void TAlterVolumeActor::StatVolume(const TActorContext& ctx)
+{
+    Become(&TThis::StateStatVolume);
+
+    auto request = std::make_unique<TEvService::TEvStatVolumeRequest>();
+    request->Record.MutableHeaders()->SetExactDiskIdMatch(false);
+    request->Record.SetDiskId(DiskId);
+    request->Record.SetNoPartition(true);
+
+    NCloud::Send(ctx, MakeVolumeProxyServiceId(), std::move(request));
+}
+
 void TAlterVolumeActor::AlterVolume(
     const TActorContext& ctx,
     TString path,
@@ -237,6 +263,8 @@ void TAlterVolumeActor::AlterVolume(
     LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
         "Sending alter request for %s",
         path.Quote().c_str());
+
+    VolumeConfig.SetAlterTs(ctx.Now().MicroSeconds());
 
     auto request = CreateModifySchemeRequestForAlterVolume(
         path, pathId, version, VolumeConfig);
@@ -443,13 +471,44 @@ void TAlterVolumeActor::HandleDescribeVolumeResponse(
         VolumeConfig.SetVersion(ConfigVersion);
     }
 
-    VolumeConfig.SetAlterTs(ctx.Now().MicroSeconds());
+    if (CheckVolumeOperationRestriction) {
+        Path = path;
+        PathId = pathDescription.GetSelf().GetPathId();
+        PathVersion = pathDescription.GetSelf().GetPathVersion();
+        StatVolume(ctx);
+    } else {
+        AlterVolume(
+            ctx,
+            path,
+            pathDescription.GetSelf().GetPathId(),
+            pathDescription.GetSelf().GetPathVersion());
+    }
+}
 
-    AlterVolume(
-        ctx,
-        path,
-        pathDescription.GetSelf().GetPathId(),
-        pathDescription.GetSelf().GetPathVersion());
+void TAlterVolumeActor::HandleStatVolumeResponse(
+    const TEvService::TEvStatVolumeResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        Error = msg->GetError();
+        ReplyAndDie(ctx);
+        return;
+    }
+
+    if (msg->Record.GetIsVolumeOperationRestricted()) {
+        Error = MakeError(
+            E_TRY_AGAIN,
+            TStringBuilder()
+                << GetOperationString()
+                << "Volume is not allowed while another exclusive volume "
+                   "operation is in progress");
+        ReplyAndDie(ctx);
+        return;
+    }
+
+    AlterVolume(ctx, std::move(Path), PathId, PathVersion);
 }
 
 void TAlterVolumeActor::HandleAlterVolumeResponse(
@@ -508,6 +567,20 @@ STFUNC(TAlterVolumeActor::StateDescribeVolume)
 {
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvSSProxy::TEvDescribeVolumeResponse, HandleDescribeVolumeResponse);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::SERVICE,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+}
+
+STFUNC(TAlterVolumeActor::StateStatVolume)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvService::TEvStatVolumeResponse, HandleStatVolumeResponse);
 
         default:
             HandleUnexpectedEvent(

--- a/cloud/blockstore/libs/storage/service/service_ut_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_alter.cpp
@@ -976,7 +976,7 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldDisableExactDiskIdMatchOnAlterVolume)
+    Y_UNIT_TEST(ShouldDisableExactDiskIdMatchOnAlterVolumeRequests)
     {
         TTestEnv env;
         NProto::TStorageServiceConfig config;
@@ -993,7 +993,9 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
             "test_cloud");
 
         bool describeRequestObserved = false;
+        bool statRequestObserved = false;
         bool describeExactDiskIdMatch = true;
+        bool statExactDiskIdMatch = true;
 
         runtime.SetEventFilter(
             [&](auto& runtime, TAutoPtr<IEventHandle>& event)
@@ -1007,6 +1009,14 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
                         describeExactDiskIdMatch = msg.ExactDiskIdMatch;
                         break;
                     }
+                    case TEvService::EvStatVolumeRequest: {
+                        const auto& msg =
+                            *event->Get<TEvService::TEvStatVolumeRequest>();
+                        statRequestObserved = true;
+                        statExactDiskIdMatch =
+                            msg.Record.GetHeaders().GetExactDiskIdMatch();
+                        break;
+                    }
                 }
 
                 return false;
@@ -1016,6 +1026,8 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
 
         UNIT_ASSERT_VALUES_EQUAL(true, describeRequestObserved);
         UNIT_ASSERT_VALUES_EQUAL(false, describeExactDiskIdMatch);
+        UNIT_ASSERT_VALUES_EQUAL(true, statRequestObserved);
+        UNIT_ASSERT_VALUES_EQUAL(false, statExactDiskIdMatch);
     }
 
     Y_UNIT_TEST(ShouldAlterAndResizeSecondaryDiskUsingPrimaryDiskId)

--- a/cloud/blockstore/libs/storage/service/service_ut_link_volume.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_link_volume.cpp
@@ -2,6 +2,9 @@
 
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
+#include <cloud/blockstore/private/api/protos/checkpoints.pb.h>
+#include <cloud/blockstore/private/api/protos/volume.pb.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -216,6 +219,397 @@ Y_UNIT_TEST_SUITE(TServiceLinkVolumeTest)
             NProto::ELinkStatus::LINK_STATUS_PREPARING,
             linkStatus.GetStatus(),
             linkStatus.ShortDebugString());
+    }
+
+    Y_UNIT_TEST(ShouldReportVolumeOperationRestrictionWhileLinkIsActive)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateVolume("vol-1", DefaultBlocksCount);
+        service.CreateVolume("vol-2", DefaultBlocksCount);
+
+        auto isOperationRestricted = [&](const TString& diskId)
+        {
+            auto request = service.CreateStatVolumeRequest(diskId);
+            request->Record.MutableHeaders()->SetExactDiskIdMatch(true);
+            request->Record.SetNoPartition(true);
+            service.SendRequest(MakeStorageServiceId(), std::move(request));
+
+            auto response = service.RecvStatVolumeResponse();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            return response->Record.GetIsVolumeOperationRestricted();
+        };
+
+        UNIT_ASSERT(!isOperationRestricted("vol-1"));
+        UNIT_ASSERT(!isOperationRestricted("vol-2"));
+
+        service.CreateVolumeLink("vol-1", "vol-2");
+
+        UNIT_ASSERT(isOperationRestricted("vol-1"));
+        UNIT_ASSERT(isOperationRestricted("vol-2"));
+    }
+
+    Y_UNIT_TEST(ShouldRejectAlterAndResizeVolumeWhileLinkIsActive)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateVolume("vol-1", DefaultBlocksCount);
+        service.CreateVolume("vol-2", DefaultBlocksCount);
+        service.CreateVolumeLink("vol-1", "vol-2");
+
+        for (const auto& diskId: {TString("vol-1"), TString("vol-2")}) {
+            service
+                .SendAlterVolumeRequest(diskId, "project", "folder", "cloud");
+            auto response = service.RecvAlterVolumeResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                response->GetStatus(),
+                response->GetErrorReason());
+
+            service.SendResizeVolumeRequest(
+                diskId,
+                DefaultBlocksCount * 2);
+            auto resizeResponse = service.RecvResizeVolumeResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                resizeResponse->GetStatus(),
+                resizeResponse->GetErrorReason());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRejectCheckpointWhileLinkIsActive)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateVolume("vol-1", DefaultBlocksCount);
+        service.CreateVolume("vol-2", DefaultBlocksCount);
+        service.CreateVolumeLink("vol-1", "vol-2");
+
+        for (const auto& diskId: {TString("vol-1"), TString("vol-2")}) {
+            service.SendCreateCheckpointRequest(diskId, "checkpoint");
+            auto response = service.RecvCreateCheckpointResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldAllowMultipleActiveCheckpoints)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateVolume("vol-1", DefaultBlocksCount);
+
+        service.CreateCheckpoint("vol-1", "checkpoint-1");
+        service.CreateCheckpoint("vol-1", "checkpoint-2");
+    }
+
+    Y_UNIT_TEST(ShouldRejectExclusiveOperationsWhileCheckpointDataIsPresent)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+        auto& runtime = env.GetRuntime();
+
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateVolume("vol-1", DefaultBlocksCount);
+        service.CreateVolume("vol-2", DefaultBlocksCount);
+
+        service.CreateCheckpoint("vol-1", "leader-checkpoint");
+
+        service.SendAlterVolumeRequest(
+            "vol-1",
+            "project",
+            "folder",
+            "cloud");
+        auto alterResponse = service.RecvAlterVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_TRY_AGAIN,
+            alterResponse->GetStatus(),
+            alterResponse->GetErrorReason());
+
+        service.SendResizeVolumeRequest("vol-1", DefaultBlocksCount * 2);
+        auto resizeResponse = service.RecvResizeVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_TRY_AGAIN,
+            resizeResponse->GetStatus(),
+            resizeResponse->GetErrorReason());
+
+        service.SendCreateVolumeLinkRequest("vol-1", "vol-2");
+        auto response = service.RecvCreateVolumeLinkResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_TRY_AGAIN,
+            response->GetStatus(),
+            response->GetErrorReason());
+        service.DeleteCheckpoint("vol-1", "leader-checkpoint");
+
+        service.CreateCheckpoint("vol-2", "follower-checkpoint");
+
+        bool linkRejectedByFollower = false;
+        TTestActorRuntimeBase::TEventFilter previousFilter;
+        previousFilter = runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() ==
+                    TEvVolume::EvUpdateLinkOnFollowerResponse)
+                {
+                    const auto* msg = ev->Get<
+                        TEvVolume::TEvUpdateLinkOnFollowerResponse>();
+                    if (msg->GetError().GetCode() == E_REJECTED) {
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            "CreateVolumeLink is not allowed while another "
+                            "exclusive volume operation is in progress on "
+                            "the follower volume",
+                            msg->GetError().GetMessage());
+                        linkRejectedByFollower = true;
+                    }
+                }
+                return previousFilter(runtime, ev);
+            });
+
+        service.SendCreateVolumeLinkRequest("vol-1", "vol-2");
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] { return linkRejectedByFollower; };
+        runtime.DispatchEvents(options);
+
+        service.DeleteCheckpoint("vol-2", "follower-checkpoint");
+
+        response = service.RecvCreateVolumeLinkResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->GetStatus(),
+            response->GetErrorReason());
+
+        runtime.SetEventFilter(previousFilter);
+    }
+
+    Y_UNIT_TEST(ShouldAllowExclusiveOperationsAfterCheckpointDataDeletion)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateVolume("vol-1", DefaultBlocksCount);
+        service.CreateVolume("vol-2", DefaultBlocksCount * 2);
+
+        for (const auto& diskId: {TString("vol-1"), TString("vol-2")}) {
+            service.CreateCheckpoint(diskId, "checkpoint");
+
+            NPrivateProto::TDeleteCheckpointDataRequest request;
+            request.SetDiskId(diskId);
+            request.SetCheckpointId("checkpoint");
+
+            TString input;
+            google::protobuf::util::MessageToJsonString(request, &input);
+            auto response =
+                service.ExecuteAction("deletecheckpointdata", input);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        service.SendAlterVolumeRequest("vol-1", "project", "folder", "cloud");
+        auto alterResponse = service.RecvAlterVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            alterResponse->GetStatus(),
+            alterResponse->GetErrorReason());
+
+        service.SendResizeVolumeRequest("vol-1", DefaultBlocksCount * 2);
+        auto resizeResponse = service.RecvResizeVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            resizeResponse->GetStatus(),
+            resizeResponse->GetErrorReason());
+
+        service.SendCreateVolumeLinkRequest("vol-1", "vol-2");
+        auto linkResponse = service.RecvCreateVolumeLinkResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            linkResponse->GetStatus(),
+            linkResponse->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ShouldRejectExclusiveOperationsWhileFillIsInProgress)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        auto request = service.CreateCreateVolumeRequest(
+            "vol-1",
+            DefaultBlocksCount);
+        request->Record.SetFillGeneration(1);
+        service.SendRequest(MakeStorageServiceId(), std::move(request));
+        auto createResponse = service.RecvCreateVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createResponse->GetStatus(),
+            createResponse->GetErrorReason());
+        service.CreateVolume("vol-2", DefaultBlocksCount);
+
+        service.SendAlterVolumeRequest(
+            "vol-1",
+            "project",
+            "folder",
+            "cloud");
+        auto alterResponse = service.RecvAlterVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_TRY_AGAIN,
+            alterResponse->GetStatus(),
+            alterResponse->GetErrorReason());
+
+        service.SendResizeVolumeRequest("vol-1", DefaultBlocksCount * 2);
+        auto resizeResponse = service.RecvResizeVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_TRY_AGAIN,
+            resizeResponse->GetStatus(),
+            resizeResponse->GetErrorReason());
+
+        service.SendCreateVolumeLinkRequest("vol-1", "vol-2");
+        auto linkResponse = service.RecvCreateVolumeLinkResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_TRY_AGAIN,
+            linkResponse->GetStatus(),
+            linkResponse->GetErrorReason());
+
+        service.SendCreateCheckpointRequest("vol-1", "checkpoint");
+        auto checkpointResponse = service.RecvCreateCheckpointResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            checkpointResponse->GetStatus(),
+            checkpointResponse->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ShouldAllowExclusiveOperationsAfterFillIsFinished)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        auto request =
+            service.CreateCreateVolumeRequest("vol-1", DefaultBlocksCount);
+        request->Record.SetFillGeneration(1);
+        service.SendRequest(MakeStorageServiceId(), std::move(request));
+        auto createResponse = service.RecvCreateVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createResponse->GetStatus(),
+            createResponse->GetErrorReason());
+        service.CreateVolume("vol-2", DefaultBlocksCount * 2);
+
+        auto isOperationRestricted = [&]
+        {
+            auto request = service.CreateStatVolumeRequest("vol-1");
+            request->Record.MutableHeaders()->SetExactDiskIdMatch(true);
+            request->Record.SetNoPartition(true);
+            service.SendRequest(MakeStorageServiceId(), std::move(request));
+
+            auto response = service.RecvStatVolumeResponse();
+            UNIT_ASSERT_C(
+                SUCCEEDED(response->GetStatus()),
+                response->GetErrorReason());
+            return response->Record.GetIsVolumeOperationRestricted();
+        };
+
+        UNIT_ASSERT(isOperationRestricted());
+
+        const auto volumeConfig = GetVolumeConfig(service, "vol-1");
+        NPrivateProto::TFinishFillDiskRequest finishRequest;
+        finishRequest.SetDiskId("vol-1");
+        finishRequest.SetConfigVersion(volumeConfig.GetVersion());
+        finishRequest.SetFillGeneration(1);
+
+        TString input;
+        google::protobuf::util::MessageToJsonString(finishRequest, &input);
+        auto finishResponse = service.ExecuteAction("finishfilldisk", input);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            finishResponse->GetStatus(),
+            finishResponse->GetErrorReason());
+
+        UNIT_ASSERT(!isOperationRestricted());
+
+        service.SendAlterVolumeRequest("vol-1", "project", "folder", "cloud");
+        auto alterResponse = service.RecvAlterVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            alterResponse->GetStatus(),
+            alterResponse->GetErrorReason());
+
+        service.SendResizeVolumeRequest("vol-1", DefaultBlocksCount * 2);
+        auto resizeResponse = service.RecvResizeVolumeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            resizeResponse->GetStatus(),
+            resizeResponse->GetErrorReason());
+
+        service.SendCreateVolumeLinkRequest("vol-1", "vol-2");
+        auto linkResponse = service.RecvCreateVolumeLinkResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            linkResponse->GetStatus(),
+            linkResponse->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ShouldKeepRepeatedLinkRequestIdempotentWhileCreating)
+    {
+        TTestEnv env(1, 1, 4);
+        ui32 nodeIdx = SetupTestEnv(env);
+        auto& runtime = env.GetRuntime();
+
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateVolume("vol-1", DefaultBlocksCount);
+        service.CreateVolume("vol-2", DefaultBlocksCount);
+
+        TAutoPtr<IEventHandle> delayedRequest;
+        bool requestDelayed = false;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (!requestDelayed &&
+                    ev->GetTypeRewrite() ==
+                        TEvVolumePrivate::EvUpdateFollowerStateRequest)
+                {
+                    const auto* msg = ev->Get<
+                        TEvVolumePrivate::TEvUpdateFollowerStateRequest>();
+                    if (msg->Follower.State ==
+                        TFollowerDiskInfo::EState::Created)
+                    {
+                        requestDelayed = true;
+                        delayedRequest = ev.Release();
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        service.SendCreateVolumeLinkRequest("vol-1", "vol-2");
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] { return bool(delayedRequest); };
+        runtime.DispatchEvents(options);
+
+        service.SendCreateVolumeLinkRequest("vol-1", "vol-2");
+        runtime.Send(delayedRequest.Release(), nodeIdx);
+
+        for (ui32 i = 0; i != 2; ++i) {
+            auto response = service.RecvCreateVolumeLinkResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -5128,8 +5128,17 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             response->GetErrorReason()
         );
 
-        // Resize volume request updates volume config
-        service.ResizeVolume(DefaultDiskId, DefaultBlocksCount * 2);
+        NPrivateProto::TModifyTagsRequest modifyTagsRequest;
+        modifyTagsRequest.SetDiskId(DefaultDiskId);
+        *modifyTagsRequest.AddTagsToAdd() = "fill-seq-number-test";
+
+        TString input;
+        google::protobuf::util::MessageToJsonString(modifyTagsRequest, &input);
+        auto modifyTagsResponse = service.ExecuteAction("ModifyTags", input);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            modifyTagsResponse->GetStatus(),
+            modifyTagsResponse->GetErrorReason());
 
         service.SendMountVolumeRequest(
             DefaultDiskId,
@@ -5141,8 +5150,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
             mountFlags,
             mountSeqNumber++,
             NProto::TEncryptionDesc(),
-            0,  // fillSeqNumber
-            1   // fillGeneration
+            0,   // fillSeqNumber
+            1    // fillGeneration
         );
 
         {

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -236,8 +236,7 @@ bool TCheckpointStore::HasCheckpointCreationRequest() const
 {
     for (const auto& [_, request]: CheckpointRequests) {
         const bool isCreationRequest =
-            request.ReqType == ECheckpointRequestType::Create ||
-            request.ReqType == ECheckpointRequestType::CreateWithoutData;
+            request.ReqType == ECheckpointRequestType::Create;
         const bool isPending =
             request.State == ECheckpointRequestState::Received ||
             request.State == ECheckpointRequestState::Saved;

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.cpp
@@ -232,6 +232,24 @@ bool TCheckpointStore::IsCheckpointBeingCreated() const
     return CheckpointBeingCreated;
 }
 
+bool TCheckpointStore::HasCheckpointCreationRequest() const
+{
+    for (const auto& [_, request]: CheckpointRequests) {
+        const bool isCreationRequest =
+            request.ReqType == ECheckpointRequestType::Create ||
+            request.ReqType == ECheckpointRequestType::CreateWithoutData;
+        const bool isPending =
+            request.State == ECheckpointRequestState::Received ||
+            request.State == ECheckpointRequestState::Saved;
+
+        if (isCreationRequest && isPending) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool TCheckpointStore::DoesCheckpointBlockingWritesExist() const
 {
     return CheckpointBlockingWritesBeingCreated ||

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -189,6 +189,7 @@ public:
 
     [[nodiscard]] bool IsRequestInProgress() const;
     [[nodiscard]] bool IsCheckpointBeingCreated() const;
+    [[nodiscard]] bool HasCheckpointCreationRequest() const;
     [[nodiscard]] bool DoesCheckpointBlockingWritesExist() const;
 
     [[nodiscard]] bool IsCheckpointDeleted(const TString& checkpointId) const;

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint.h
@@ -189,6 +189,8 @@ public:
 
     [[nodiscard]] bool IsRequestInProgress() const;
     [[nodiscard]] bool IsCheckpointBeingCreated() const;
+    // CreateWithoutData requests are intentionally ignored because they do not
+    // retain checkpoint data and therefore do not restrict volume operations.
     [[nodiscard]] bool HasCheckpointCreationRequest() const;
     [[nodiscard]] bool DoesCheckpointBlockingWritesExist() const;
 

--- a/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/checkpoint_ut.cpp
@@ -16,6 +16,7 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
 
         UNIT_ASSERT_VALUES_EQUAL(false, store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointBeingCreated());
+        UNIT_ASSERT_VALUES_EQUAL(false, store.HasCheckpointCreationRequest());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsRequestInProgress());
         UNIT_ASSERT_VALUES_EQUAL(0, store.GetRequestIdsToProcess().size());
     }
@@ -226,6 +227,7 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
 
         UNIT_ASSERT_VALUES_EQUAL(false, store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointBeingCreated());
+        UNIT_ASSERT_VALUES_EQUAL(true, store.HasCheckpointCreationRequest());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsRequestInProgress());
         ui64 requestId = 0;
         UNIT_ASSERT_VALUES_EQUAL(1, store.GetRequestIdsToProcess().size());
@@ -236,6 +238,7 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         store.SetCheckpointRequestSaved(request.RequestId);
         UNIT_ASSERT_VALUES_EQUAL(false, store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointBeingCreated());
+        UNIT_ASSERT_VALUES_EQUAL(true, store.HasCheckpointCreationRequest());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsRequestInProgress());
         UNIT_ASSERT_VALUES_EQUAL(1, store.GetRequestIdsToProcess().size());
         UNIT_ASSERT_VALUES_EQUAL(request.RequestId, requestId);
@@ -244,6 +247,7 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         store.SetCheckpointRequestInProgress(requestId);
         UNIT_ASSERT_VALUES_EQUAL(true, store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(true, store.IsCheckpointBeingCreated());
+        UNIT_ASSERT_VALUES_EQUAL(true, store.HasCheckpointCreationRequest());
         UNIT_ASSERT_VALUES_EQUAL(true, store.IsRequestInProgress());
         UNIT_ASSERT_VALUES_EQUAL(1, store.GetRequestIdsToProcess().size());
         UNIT_ASSERT_VALUES_EQUAL(request.RequestId, requestId);
@@ -258,6 +262,7 @@ Y_UNIT_TEST_SUITE(TCheckpointStore)
         UNIT_ASSERT_VALUES_EQUAL(0, checkpoints.size());
         UNIT_ASSERT_VALUES_EQUAL(false, store.DoesCheckpointBlockingWritesExist());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointBeingCreated());
+        UNIT_ASSERT_VALUES_EQUAL(false, store.HasCheckpointCreationRequest());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsRequestInProgress());
         UNIT_ASSERT_VALUES_EQUAL(0, store.GetRequestIdsToProcess().size());
         UNIT_ASSERT_VALUES_EQUAL(false, store.IsCheckpointDeleted("checkpoint"));

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -1247,6 +1247,16 @@ void TVolumeActor::HandleCheckpointRequest<TCreateCheckpointMethod>(
         ev->Cookie,
         msg.CallContext);
 
+    if (State->IsCreateCheckpointOperationRestricted()) {
+        auto response = std::make_unique<TCreateCheckpointMethod::TResponse>(
+            MakeError(
+                E_TRY_AGAIN,
+                "CreateCheckpoint is not allowed while another exclusive "
+                "volume operation is in progress"));
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+        return;
+    }
+
     const auto& checkpointRequest =
         State->GetCheckpointStore().MakeCreateCheckpointRequest(
             msg.Record.GetCheckpointId(),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_follower.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_follower.cpp
@@ -52,6 +52,10 @@ void TVolumeActor::CompleteUpdateLeader(
     const TActorContext& ctx,
     TTxVolume::TUpdateLeader& args)
 {
+    if (args.Leader.State == TLeaderDiskInfo::EState::Following) {
+        State->FinishCreateLeaderRequest();
+    }
+
     auto response =
         std::make_unique<TEvVolume::TEvUpdateLinkOnFollowerResponse>(
             MakeError(S_OK));
@@ -120,6 +124,20 @@ void TVolumeActor::CreateLeaderLink(
                 MakeError(S_ALREADY)));
         return;
     }
+
+    if (State->IsVolumeOperationRestricted()) {
+        // Link propagation retries E_REJECTED responses with backoff.
+        auto response =
+            std::make_unique<TEvVolume::TEvUpdateLinkOnFollowerResponse>(
+                MakeError(
+                    E_REJECTED,
+                    "CreateVolumeLink is not allowed while another exclusive "
+                    "volume operation is in progress on the follower volume"));
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+        return;
+    }
+
+    State->StartCreateLeaderRequest();
 
     auto leaderInfo = TLeaderDiskInfo{
         .Link = std::move(link),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_leader.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_leader.cpp
@@ -145,6 +145,28 @@ void TVolumeActor::HandleLinkLeaderVolumeToFollower(
         }
     }
 
+    if (auto* request = State->FindCreateFollowerRequestInfo(link)) {
+        request->Requests.push_back(requestInfo);
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "%s Link %s creation already in progress",
+            LogTitle.GetWithTime().c_str(),
+            request->Link.Describe().c_str());
+        return;
+    }
+
+    if (State->IsVolumeOperationRestricted()) {
+        auto response =
+            std::make_unique<TEvVolume::TEvLinkLeaderVolumeToFollowerResponse>(
+                MakeError(
+                    E_TRY_AGAIN,
+                    "CreateVolumeLink is not allowed while another exclusive "
+                    "volume operation is in progress on the leader volume"));
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+        return;
+    }
+
     // Save create link request.
     auto& createFollowerRequest = State->AccessCreateFollowerRequestInfo(link);
     createFollowerRequest.Requests.push_back(requestInfo);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_statvolume.cpp
@@ -249,6 +249,7 @@ void TVolumeActor::HandleStatVolume(
     }
 
     NProto::TStatVolumeResponse record;
+    record.SetIsVolumeOperationRestricted(State->IsVolumeOperationRestricted());
     auto& protoFieldsToValues = *record.MutableStorageConfigFieldsToValues();
 
     for (const auto& field: msg->Record.GetStorageConfigFields()) {

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -1295,23 +1295,13 @@ bool TVolumeState::IsVolumeOperationRestricted() const
 
 bool TVolumeState::IsCreateCheckpointOperationRestricted() const
 {
-    if (CreateLeaderRequestInProgress || !CreateFollowerRequests.empty()) {
+    const bool createFollowerRequestInProgress =
+        !CreateFollowerRequests.empty();
+    if (CreateLeaderRequestInProgress || createFollowerRequestInProgress) {
         return true;
     }
 
-    for (const auto& follower: FollowerDisks) {
-        if (follower.State != TFollowerDiskInfo::EState::Error) {
-            return true;
-        }
-    }
-
-    for (const auto& leader: LeaderDisks) {
-        if (leader.State == TLeaderDiskInfo::EState::Following) {
-            return true;
-        }
-    }
-
-    return false;
+    return HasActiveLink();
 }
 
 bool TVolumeState::CanPreemptClient(
@@ -1539,6 +1529,23 @@ void TVolumeState::MarkBlocksAsDirtyInCheckpointLight(const TBlockRange64& block
     // local mounted client has read only access
     return !LocalMountClientId.empty() &&
             LocalMountClientId != ReadWriteAccessClientId;
+}
+
+[[nodiscard]] bool TVolumeState::HasActiveLink() const
+{
+    for (const auto& follower: FollowerDisks) {
+        if (follower.State != TFollowerDiskInfo::EState::Error) {
+            return true;
+        }
+    }
+
+    for (const auto& leader: LeaderDisks) {
+        if (leader.State == TLeaderDiskInfo::EState::Following) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -1058,14 +1058,24 @@ TVolumeState::GetDevicesForAcquireOrRelease() const
 TCreateFollowerRequestInfo& TVolumeState::AccessCreateFollowerRequestInfo(
     const TLeaderFollowerLink& link)
 {
-    for (auto& requestInfo: CreateFollowerRequests) {
-        if (requestInfo.Link.Match(link)) {
-            return requestInfo;
-        }
+    if (auto* requestInfo = FindCreateFollowerRequestInfo(link)) {
+        return *requestInfo;
     }
 
     CreateFollowerRequests.push_back(TCreateFollowerRequestInfo{.Link = link});
     return CreateFollowerRequests.back();
+}
+
+TCreateFollowerRequestInfo* TVolumeState::FindCreateFollowerRequestInfo(
+    const TLeaderFollowerLink& link)
+{
+    for (auto& requestInfo: CreateFollowerRequests) {
+        if (requestInfo.Link.Match(link)) {
+            return &requestInfo;
+        }
+    }
+
+    return nullptr;
 }
 
 void TVolumeState::DeleteCreateFollowerRequestInfo(
@@ -1075,6 +1085,18 @@ void TVolumeState::DeleteCreateFollowerRequestInfo(
         CreateFollowerRequests,
         [&](const TCreateFollowerRequestInfo& requestInfo)
         { return requestInfo.Link.Match(link); });
+}
+
+void TVolumeState::StartCreateLeaderRequest()
+{
+    Y_DEBUG_ABORT_UNLESS(!CreateLeaderRequestInProgress);
+    CreateLeaderRequestInProgress = true;
+}
+
+void TVolumeState::FinishCreateLeaderRequest()
+{
+    Y_DEBUG_ABORT_UNLESS(CreateLeaderRequestInProgress);
+    CreateLeaderRequestInProgress = false;
 }
 
 std::optional<TFollowerDiskInfo> TVolumeState::FindFollower(
@@ -1251,6 +1273,45 @@ void TVolumeState::UpdateScrubberCounters(TScrubbingInfo counters)
     ScrubbingInfo.FixedPartial.insert(
         counters.FixedPartial.begin(),
         counters.FixedPartial.end());
+}
+
+bool TVolumeState::IsVolumeOperationRestricted() const
+{
+    if (IsCreateCheckpointOperationRestricted() ||
+        GetCheckpointStore().HasCheckpointCreationRequest() ||
+        !GetCheckpointStore().GetCheckpointsWithData().empty())
+    {
+        return true;
+    }
+
+    if (const auto& config = Meta.GetVolumeConfig();
+        config.GetFillGeneration() != 0 && !config.GetIsFillFinished())
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool TVolumeState::IsCreateCheckpointOperationRestricted() const
+{
+    if (CreateLeaderRequestInProgress || !CreateFollowerRequests.empty()) {
+        return true;
+    }
+
+    for (const auto& follower: FollowerDisks) {
+        if (follower.State != TFollowerDiskInfo::EState::Error) {
+            return true;
+        }
+    }
+
+    for (const auto& leader: LeaderDisks) {
+        if (leader.State == TLeaderDiskInfo::EState::Following) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool TVolumeState::CanPreemptClient(

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -275,6 +275,7 @@ private:
     TLeaderDisks LeaderDisks;
     TString PrincipalDiskId;   // Set when in ELeadershipStatus::Outdated
     ELeadershipStatus LeadershipStatus = ELeadershipStatus::Principal;
+    bool CreateLeaderRequestInProgress = false;
 
     struct TLaggingAgentMigrationInfo
     {
@@ -850,6 +851,8 @@ public:
 
     TCreateFollowerRequestInfo& AccessCreateFollowerRequestInfo(
         const TLeaderFollowerLink& link);
+    TCreateFollowerRequestInfo* FindCreateFollowerRequestInfo(
+        const TLeaderFollowerLink& link);
     void DeleteCreateFollowerRequestInfo(const TLeaderFollowerLink& link);
 
     std::optional<TFollowerDiskInfo> FindFollower(
@@ -857,6 +860,9 @@ public:
     void AddOrUpdateFollower(TFollowerDiskInfo follower);
     void RemoveFollower(const TLeaderFollowerLink& link);
     const TFollowerDisks& GetAllFollowers() const;
+
+    void StartCreateLeaderRequest();
+    void FinishCreateLeaderRequest();
 
     std::optional<TLeaderDiskInfo> FindLeader(
         const TLeaderFollowerLink& link) const;
@@ -877,6 +883,16 @@ public:
     }
 
     void UpdateScrubberCounters(TScrubbingInfo counters);
+
+    // Volume configuration and link operations must not overlap with disk
+    // copying, checkpoint creation, snapshot fill, or checkpoints whose data
+    // is still present.
+    bool IsVolumeOperationRestricted() const;
+
+    // Checkpoint creation must not overlap with link creation or disk copying.
+    // Other checkpoint requests are serialized by the checkpoint queue;
+    // existing checkpoints and snapshot fill do not conflict with creation.
+    bool IsCreateCheckpointOperationRestricted() const;
 
 private:
     bool CanPreemptClient(

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -913,6 +913,8 @@ private:
     void UpdateLeadershipStatus();
 
     [[nodiscard]] bool IsVolumeClientMigrationInProgress() const;
+
+    [[nodiscard]] bool HasActiveLink() const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -2661,6 +2661,40 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
         UNIT_ASSERT(!volumeState.IsCreateCheckpointOperationRestricted());
         UNIT_ASSERT(!volumeState.IsVolumeOperationRestricted());
     }
+
+    Y_UNIT_TEST(ShouldNotRestrictOperationsForCheckpointWithoutData)
+    {
+        auto volumeState = CreateVolumeState();
+        auto& store = volumeState.GetCheckpointStore();
+
+        const auto& request = store.MakeCreateCheckpointRequest(
+            "checkpoint",
+            TInstant::Now(),
+            ECheckpointRequestType::CreateWithoutData,
+            ECheckpointType::Normal,
+            false);
+
+        UNIT_ASSERT(!store.HasCheckpointCreationRequest());
+        UNIT_ASSERT(!volumeState.IsVolumeOperationRestricted());
+
+        store.SetCheckpointRequestSaved(request.RequestId);
+        UNIT_ASSERT(!store.HasCheckpointCreationRequest());
+        UNIT_ASSERT(!volumeState.IsVolumeOperationRestricted());
+
+        store.SetCheckpointRequestInProgress(request.RequestId);
+        UNIT_ASSERT(!store.HasCheckpointCreationRequest());
+        UNIT_ASSERT(!volumeState.IsVolumeOperationRestricted());
+
+        store.SetCheckpointRequestFinished(
+            request.RequestId,
+            true,
+            {},
+            EShadowDiskState::None);
+
+        UNIT_ASSERT(!store.HasCheckpointCreationRequest());
+        UNIT_ASSERT(store.GetCheckpointsWithData().empty());
+        UNIT_ASSERT(!volumeState.IsVolumeOperationRestricted());
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -2603,6 +2603,64 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
             UNIT_ASSERT_VALUES_EQUAL(res.Error.GetCode(), E_INVALID_STATE);
         }
     }
+
+    Y_UNIT_TEST(ShouldRestrictOperationsWhileLeaderLinkCreationIsPending)
+    {
+        auto volumeState = CreateVolumeState();
+
+        UNIT_ASSERT(!volumeState.IsVolumeOperationRestricted());
+
+        volumeState.StartCreateLeaderRequest();
+        UNIT_ASSERT(volumeState.IsVolumeOperationRestricted());
+
+        volumeState.FinishCreateLeaderRequest();
+        UNIT_ASSERT(!volumeState.IsVolumeOperationRestricted());
+    }
+
+    Y_UNIT_TEST(ShouldRestrictOperationsUntilCheckpointDataIsDeleted)
+    {
+        auto volumeState = CreateVolumeState();
+        auto& store = volumeState.GetCheckpointStore();
+
+        const auto& request = store.MakeCreateCheckpointRequest(
+            "checkpoint",
+            TInstant::Now(),
+            ECheckpointRequestType::Create,
+            ECheckpointType::Normal,
+            false);
+
+        UNIT_ASSERT(!volumeState.IsCreateCheckpointOperationRestricted());
+        UNIT_ASSERT(volumeState.IsVolumeOperationRestricted());
+
+        store.SetCheckpointRequestInProgress(request.RequestId);
+        store.SetCheckpointRequestSaved(request.RequestId);
+        store.SetCheckpointRequestFinished(
+            request.RequestId,
+            true,
+            {},
+            EShadowDiskState::None);
+
+        UNIT_ASSERT(!volumeState.IsCreateCheckpointOperationRestricted());
+        UNIT_ASSERT(volumeState.IsVolumeOperationRestricted());
+
+        const auto& deleteDataRequest = store.MakeDeleteCheckpointDataRequest(
+            "checkpoint",
+            TInstant::Now());
+        store.SetCheckpointRequestInProgress(deleteDataRequest.RequestId);
+        store.SetCheckpointRequestSaved(deleteDataRequest.RequestId);
+        store.SetCheckpointRequestFinished(
+            deleteDataRequest.RequestId,
+            true,
+            {},
+            EShadowDiskState::None);
+
+        const auto checkpoint = store.GetCheckpoint("checkpoint");
+        UNIT_ASSERT(checkpoint);
+        UNIT_ASSERT(checkpoint->Data == ECheckpointData::DataDeleted);
+        UNIT_ASSERT(store.GetCheckpointsWithData().empty());
+        UNIT_ASSERT(!volumeState.IsCreateCheckpointOperationRestricted());
+        UNIT_ASSERT(!volumeState.IsVolumeOperationRestricted());
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -5666,6 +5666,39 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
         UNIT_ASSERT(seenReleaseShadowDiskForAnyReader);
         UNIT_ASSERT(seenReleaseShadowDiskForAnyWriter);
     }
+
+    Y_UNIT_TEST(ShouldQueueConcurrentCreateCheckpointRequests)
+    {
+        NProto::TStorageServiceConfig config;
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TVolumeClient volume(*runtime);
+        volume.UpdateVolumeConfig();
+        volume.WaitReady();
+
+        volume.SendCreateCheckpointRequest("c1");
+        volume.SendCreateCheckpointRequest("c2");
+        volume.SendCreateCheckpointRequest("c1");
+
+        ui32 successCount = 0;
+        ui32 alreadyCount = 0;
+        for (ui32 i = 0; i < 3; ++i) {
+            auto response = volume.RecvCreateCheckpointResponse();
+            switch (response->GetStatus()) {
+                case S_OK:
+                    ++successCount;
+                    break;
+                case S_ALREADY:
+                    ++alreadyCount;
+                    break;
+                default:
+                    UNIT_FAIL(response->GetErrorReason());
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(2, successCount);
+        UNIT_ASSERT_VALUES_EQUAL(1, alreadyCount);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_linked.cpp
@@ -29,19 +29,18 @@ using namespace NTestVolume;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-enum class ECheckpointBehaviour
-{
-    None,
-    CreateBeforeLink,
-    CreateAfterLink,
-    CreateThenDelete,
-};
-
 enum class ERebootBehaviour
 {
     RebootLeader,
     RebootFollower,
     RebootBoth,
+};
+
+enum class ECheckpointBeforeLink
+{
+    None,
+    DataPresent,
+    Deleted,
 };
 
 namespace {
@@ -738,9 +737,9 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
         TFixture& fixture,
         NProto::EStorageMediaKind leaderMediaType,
         NProto::EStorageMediaKind followerMediaType,
-        ECheckpointBehaviour checkpoint,
         bool isMultipartition = false,
-        bool verifySourcePartitionStopped = false)
+        bool verifySourcePartitionStopped = false,
+        ECheckpointBeforeLink checkpoint = ECheckpointBeforeLink::None)
     {
         TActorId latestSourcePartitionActor;
         TActorId migrationSourcePartitionActor;
@@ -864,8 +863,11 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
                 'a');
         }
 
-        if (checkpoint == ECheckpointBehaviour::CreateBeforeLink) {
+        if (checkpoint != ECheckpointBeforeLink::None) {
             fixture.CreateCheckpoint(leaderMediaType);
+        }
+        if (checkpoint == ECheckpointBeforeLink::Deleted) {
+            fixture.DeleteCheckpoint();
         }
 
         // Link volumes
@@ -876,7 +878,21 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             .FollowerDiskId = "vol2",
             .FollowerShardId = "su2"};
         {
-            auto response = volume1.LinkLeaderVolumeToFollower(link);
+            volume1.SendLinkLeaderVolumeToFollowerRequest(link);
+            auto response = volume1.RecvLinkLeaderVolumeToFollowerResponse();
+
+            if (checkpoint == ECheckpointBeforeLink::DataPresent) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    E_TRY_AGAIN,
+                    response->GetStatus(),
+                    response->GetErrorReason());
+                return;
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
             link.LinkUUID = response->Record.GetLinkUUID();
 
             UNIT_ASSERT_EQUAL(
@@ -888,15 +904,6 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             volume1.ReconnectPipe();
             volume1.AddClient(clientInfo1);
         };
-
-        if (checkpoint == ECheckpointBehaviour::CreateAfterLink) {
-            fixture.CreateCheckpoint(leaderMediaType);
-        }
-
-        if (checkpoint == ECheckpointBehaviour::CreateThenDelete) {
-            fixture.CreateCheckpoint(leaderMediaType);
-            fixture.DeleteCheckpoint();
-        }
 
         // Send WriteBlocks and ZeroBlocks to leader during migration
         size_t writtenBlockCount = 0;
@@ -923,12 +930,6 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             // when the volume was restarted.
             volume1.ReconnectPipe();
             volume1.WaitReady();
-        }
-
-        if (checkpoint == ECheckpointBehaviour::CreateBeforeLink ||
-            checkpoint == ECheckpointBehaviour::CreateAfterLink)
-        {
-            fixture.WaitCheckpointReady();
         }
 
         // Check volumes content match.
@@ -959,8 +960,29 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
         DoShouldPrepareFollowerVolume(
             *this,
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            NProto::STORAGE_MEDIA_SSD);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectLinkWhileCheckpointDataIsPresent, TFixture)
+    {
+        DoShouldPrepareFollowerVolume(
+            *this,
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             NProto::STORAGE_MEDIA_SSD,
-            ECheckpointBehaviour::None);
+            false,
+            false,
+            ECheckpointBeforeLink::DataPresent);
+    }
+
+    Y_UNIT_TEST_F(ShouldPrepareFollowerVolumeAfterCheckpointDeletion, TFixture)
+    {
+        DoShouldPrepareFollowerVolume(
+            *this,
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            NProto::STORAGE_MEDIA_SSD,
+            false,
+            false,
+            ECheckpointBeforeLink::Deleted);
     }
 
     Y_UNIT_TEST_F(ShouldPrepareFollowerVolume_SSD_NRD, TFixture)
@@ -968,8 +990,7 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
         DoShouldPrepareFollowerVolume(
             *this,
             NProto::STORAGE_MEDIA_SSD,
-            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-            ECheckpointBehaviour::None);
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
     }
 
     Y_UNIT_TEST_F(ShouldPrepareFollowerVolume_NRD_NRD, TFixture)
@@ -977,8 +998,7 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
         DoShouldPrepareFollowerVolume(
             *this,
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-            ECheckpointBehaviour::None);
+            NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
     }
 
     Y_UNIT_TEST_F(ShouldPrepareFollowerVolume_SSD_MIRROR, TFixture)
@@ -986,8 +1006,7 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
         DoShouldPrepareFollowerVolume(
             *this,
             NProto::STORAGE_MEDIA_SSD,
-            NProto::STORAGE_MEDIA_SSD_MIRROR3,
-            ECheckpointBehaviour::None);
+            NProto::STORAGE_MEDIA_SSD_MIRROR3);
     }
 
     Y_UNIT_TEST_F(ShouldPrepareFollowerVolume_MIRROR_SSD, TFixture)
@@ -995,8 +1014,7 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
         DoShouldPrepareFollowerVolume(
             *this,
             NProto::STORAGE_MEDIA_SSD_MIRROR3,
-            NProto::STORAGE_MEDIA_SSD,
-            ECheckpointBehaviour::None);
+            NProto::STORAGE_MEDIA_SSD);
     }
 
     Y_UNIT_TEST_F(ShouldPrepareFollowerVolume_SSD_MultiPartition_NRD, TFixture)
@@ -1005,7 +1023,6 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             *this,
             NProto::STORAGE_MEDIA_SSD,
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-            ECheckpointBehaviour::None,
             true);
     }
 
@@ -1015,7 +1032,6 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             *this,
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             NProto::STORAGE_MEDIA_SSD,
-            ECheckpointBehaviour::None,
             true);
     }
 
@@ -1026,50 +1042,6 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             NProto::STORAGE_MEDIA_SSD,
             NProto::STORAGE_MEDIA_SSD);
         */
-    }
-
-    Y_UNIT_TEST_F(
-        ShouldPrepareFollowerVolume_NRD_SSD_WithCheckpointBefore,
-        TFixture)
-    {
-        DoShouldPrepareFollowerVolume(
-            *this,
-            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-            NProto::STORAGE_MEDIA_SSD,
-            ECheckpointBehaviour::CreateBeforeLink);
-    }
-
-    Y_UNIT_TEST_F(
-        ShouldPrepareFollowerVolume_NRD_SSD_WithCheckpointAfter,
-        TFixture)
-    {
-        DoShouldPrepareFollowerVolume(
-            *this,
-            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-            NProto::STORAGE_MEDIA_SSD,
-            ECheckpointBehaviour::CreateAfterLink);
-    }
-
-    Y_UNIT_TEST_F(
-        ShouldPrepareFollowerVolume_NRD_SSD_WithCheckpointCreateThenDelete,
-        TFixture)
-    {
-        DoShouldPrepareFollowerVolume(
-            *this,
-            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-            NProto::STORAGE_MEDIA_SSD,
-            ECheckpointBehaviour::CreateThenDelete);
-    }
-
-    Y_UNIT_TEST_F(
-        ShouldPrepareFollowerVolume_SSD_NRD_WithCheckpointAfter,
-        TFixture)
-    {
-        DoShouldPrepareFollowerVolume(
-            *this,
-            NProto::STORAGE_MEDIA_SSD,
-            NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
-            ECheckpointBehaviour::CreateAfterLink);
     }
 
     void DoShouldPrepareFollowerVolumeWithReboot(
@@ -1334,7 +1306,6 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             *this,
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
             NProto::STORAGE_MEDIA_SSD,
-            ECheckpointBehaviour::None,
             false,   // isMultipartition
             true     // verifySourcePartitionStopped
         );
@@ -1346,7 +1317,6 @@ Y_UNIT_TEST_SUITE(TLinkedVolumeTest)
             *this,
             NProto::STORAGE_MEDIA_SSD_MIRROR3,
             NProto::STORAGE_MEDIA_SSD,
-            ECheckpointBehaviour::None,
             false,   // isMultipartition
             true     // verifySourcePartitionStopped
         );

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -744,6 +744,9 @@ message TStatVolumeResponse
     // applied to this volume via VolumeThrottlingManager
     TVolumeVolatileThrottlingInfo VolatileThrottlingInfo = 12;
 
+    // Potentially dangerous volume operations must not be performed while set.
+    bool IsVolumeOperationRestricted = 13;
+
     // Optional response headers.
     TResponseHeaders Headers = 1000;
 }


### PR DESCRIPTION
## Problem

Potentially unsafe volume operations could run concurrently with disk copying, snapshot fill, or checkpoint-related operations.
In particular, AlterVolume and ResizeVolume relied on SchemeShard state and did not query the Volume tablet, which owns the actual runtime state. Concurrent configuration changes could therefore interfere with copying or produce an inconsistent volume state.

## Solution

- Added `IsVolumeOperationRestricted` to `StatVolume`.
- AlterVolume and ResizeVolume now call StatVolume before sending `ModifyScheme` and return `E_TRY_AGAIN` when another conflicting operation is active.
- Added local checks before starting volume link and checkpoint creation.
- Added in-memory state covering the window between follower link validation and transaction completion.
- Temporary follower conflicts return `E_REJECTED` and are handled by the existing link propagation retry mechanism.
- Preserved idempotency for repeated link creation requests.
- Kept checkpoint semantics unchanged where operations do not conflict:
  - multiple checkpoints are allowed;
  - checkpoint creation during snapshot fill is allowed.
- AlterVolume Describe and Stat requests use `ExactDiskIdMatch=false`, preserving fallback to the copy disk after the original disk has been removed.
