### PR TITLE
fix: allowed labels should be treated as json list, not a string

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -74,6 +74,7 @@ act pull_request --bind \
   --pull=false
 ```
 
+`LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS` must be a JSON array of exact label names.
 The allowed-label case should run `check-running-allowed`:
 
 ```bash
@@ -111,7 +112,7 @@ act pull_request --bind \
   -e /tmp/act-pr-event-large-tests.json \
   -P self-hosted=ghcr.io/catthehacker/ubuntu:act-latest \
   -P runner_light=ghcr.io/catthehacker/ubuntu:act-latest \
-  --var LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS="['large-tests']" \
+  --var LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS='["large-tests"]' \
   --pull=false
 ```
 
@@ -152,6 +153,6 @@ act pull_request --bind \
   -e /tmp/act-pr-event-doc-label.json \
   -P self-hosted=ghcr.io/catthehacker/ubuntu:act-latest \
   -P runner_light=ghcr.io/catthehacker/ubuntu:act-latest \
-  --var LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS="['large-tests']" \
+  --var LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS='["large-tests"]' \
   --pull=false
 ```

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -52,8 +52,8 @@ concurrency:
       (
         github.event.action != 'labeled' ||
         contains(
-          vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS,
-          format('''{0}''', github.event.label.name)
+          fromJSON(vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS || '[]'),
+          github.event.label.name
         )
       ) && 'tests' || 'ignored'
     }}
@@ -66,8 +66,8 @@ jobs:
         (
           github.event.action != 'labeled' ||
           contains(
-            vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS,
-            format('''{0}''', github.event.label.name)
+            fromJSON(vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS || '[]'),
+            github.event.label.name
           )
         ) &&
         (

--- a/.github/workflows/pr-vscode-yatool-extension.yaml
+++ b/.github/workflows/pr-vscode-yatool-extension.yaml
@@ -30,8 +30,8 @@ jobs:
         (
           github.event.action != 'labeled' ||
           contains(
-            vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS,
-            format('''{0}''', github.event.label.name)
+            fromJSON(vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS || '[]'),
+            github.event.label.name
           )
         ) &&
         (

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,8 +29,8 @@ concurrency:
       (
         github.event.action != 'labeled' ||
         contains(
-          vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS,
-          format('''{0}''', github.event.label.name)
+          fromJSON(vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS || '[]'),
+          github.event.label.name
         )
       ) && 'tests' || 'ignored'
     }}
@@ -66,8 +66,8 @@ jobs:
         (
           github.event.action != 'labeled' ||
           contains(
-            vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS,
-            format('''{0}''', github.event.label.name)
+            fromJSON(vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS || '[]'),
+            github.event.label.name
           )
         ) &&
         (

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -27,8 +27,8 @@ concurrency:
       (
         github.event.action != 'labeled' ||
         contains(
-          vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS,
-          format('''{0}''', github.event.label.name)
+          fromJSON(vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS || '[]'),
+          github.event.label.name
         )
       ) && 'pre-commit' || 'ignored'
     }}
@@ -41,8 +41,8 @@ jobs:
         (
           github.event.action != 'labeled' ||
           contains(
-            vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS,
-            format('''{0}''', github.event.label.name)
+            fromJSON(vars.LABELS_ALLOWED_TO_TRIGGER_PR_CHECKS || '[]'),
+            github.event.label.name
           )
         ) &&
         (


### PR DESCRIPTION
Once again, shot myself in the foot by assuming how github actions syntax works...

