### PR TITLE
issue-5895: fastshard - added logging context for all requests: logging NodeId/Handle/Name/Pages when possible

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -1282,7 +1282,7 @@ public:
             lc.NodeId = request.GetNodeId();
 
             NProto::TNodeAttr attr;
-            auto error = GetNodeAttr(request.GetNodeId(), name, &attr);
+            auto error = GetNodeAttr(lc, request.GetNodeId(), name, &attr);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
@@ -1300,8 +1300,11 @@ public:
         return response;
     }
 
-    NProto::TError
-    GetNodeAttr(ui64 nodeId, const TString& name, NProto::TNodeAttr* attr)
+    NProto::TError GetNodeAttr(
+        TLoggingContext& lc,
+        ui64 nodeId,
+        const TString& name,
+        NProto::TNodeAttr* attr)
     {
         std::lock_guard g(Mutex);
 
@@ -1312,7 +1315,8 @@ public:
             }
         }
 
-        SILK_DEBUG("GetNodeAttr name=%s ino=%lu", name.c_str(), nodeId);
+        lc.NodeId = nodeId;
+        SILK_DEBUG("[%s] GetNodeAttr", lc.Describe().c_str());
 
         return Nodes.GetNode(nodeId, attr);
     }
@@ -1335,7 +1339,8 @@ public:
         lc.NodeId = request.GetNodeId();
 
         NProto::TNodeAttr attr;
-        auto error = GetNodeAttr(request.GetNodeId(), request.GetName(), &attr);
+        auto error =
+            GetNodeAttr(lc, request.GetNodeId(), request.GetName(), &attr);
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
@@ -1633,6 +1638,7 @@ public:
                 }
 
                 storagePageClusterIds.push_back(slot.StoragePageClusterId);
+                lc.StoragePageClusterIds.push_back(slot.StoragePageClusterId);
             }
 
             error = PageAllocator.Deallocate(

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -724,6 +724,59 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TLoggingContext
+{
+    TString Name;
+    ui64 NodeId = 0;
+    ui64 Handle = 0;
+    TVector<ui64> PageClusterIds;
+    TVector<ui64> StoragePageClusterIds;
+
+    TString Describe() const
+    {
+        TStringBuilder s;
+        if (Name) {
+            s << "N=" << Name;
+        }
+
+        if (NodeId) {
+            if (s) {
+                s << " ";
+            }
+
+            s << "I=" << NodeId;
+        }
+
+        if (Handle) {
+            if (s) {
+                s << " ";
+            }
+
+            s << "H=" << Handle;
+        }
+
+        for (const ui64 pageClusterId: PageClusterIds) {
+            if (s) {
+                s << " ";
+            }
+
+            s << "P=" << pageClusterId;
+        }
+
+        for (const ui64 storagePageClusterId: StoragePageClusterIds) {
+            if (s) {
+                s << " ";
+            }
+
+            s << "S=" << storagePageClusterId;
+        }
+
+        return s;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TPageAllocator
 {
 private:
@@ -776,6 +829,7 @@ public:
     }
 
     NProto::TError Allocate(
+        const TLoggingContext& lc,
         ui64 pageClusterCount,
         TVector<ui64>* storagePageClusterIds,
         TWriteContext& writeContext)
@@ -787,6 +841,11 @@ public:
                 &(*storagePageClusterIds)[i],
                 writeContext.PageGroups);
             if (HasError(error)) {
+                SILK_WARN(
+                    "[%s] TPageAllocator.Allocate error=%s",
+                    lc.Describe().c_str(),
+                    FormatError(error).c_str());
+
                 for (ui64 j = 0; j < i; ++j) {
                     auto error2 = Bitmap->Reset(
                         writeContext.Lsn,
@@ -807,12 +866,18 @@ public:
 
         for (ui64& storagePageClusterId: *storagePageClusterIds) {
             storagePageClusterId += FirstStoragePageClusterId;
+
+            SILK_DEBUG(
+                "[%s] TPageAllocator.Allocate storagePageCluster=%lu",
+                lc.Describe().c_str(),
+                storagePageClusterId);
         }
 
         return {};
     }
 
     NProto::TError Deallocate(
+        const TLoggingContext& lc,
         const TVector<ui64>& storagePageClusterIds,
         TWriteContext& writeContext)
     {
@@ -824,6 +889,11 @@ public:
                 storagePageClusterIds[i] - FirstStoragePageClusterId,
                 writeContext.PageGroups);
             if (HasError(error)) {
+                SILK_WARN(
+                    "[%s] TPageAllocator.Deallocate error=%s",
+                    lc.Describe().c_str(),
+                    FormatError(error).c_str());
+
                 for (ui64 j = 0; j < i; ++j) {
                     auto error2 = Bitmap->Set(
                         writeContext.Lsn,
@@ -841,10 +911,18 @@ public:
             }
         }
 
+        for (ui64 storagePageClusterId: storagePageClusterIds) {
+            SILK_DEBUG(
+                "[%s] TPageAllocator.Deallocate storagePageCluster=%lu",
+                lc.Describe().c_str(),
+                storagePageClusterId);
+        }
+
         return {};
     }
 
     void RollbackAllocation(
+        const TLoggingContext& lc,
         const TVector<ui64>& storagePageClusterIds,
         const TWriteContext& writeContext)
     {
@@ -861,6 +939,11 @@ public:
             //
 
             Y_ABORT_UNLESS(!HasError(error));
+
+            SILK_DEBUG(
+                "[%s] TPageAllocator.RollbackAllocation storagePageCluster=%lu",
+                lc.Describe().c_str(),
+                clusterId);
         }
     }
 
@@ -1194,12 +1277,17 @@ public:
         }
 
         for (const auto& name: request.GetNames()) {
+            TLoggingContext lc;
+            lc.Name = name;
+            lc.NodeId = request.GetNodeId();
+
             NProto::TNodeAttr attr;
             auto error = GetNodeAttr(request.GetNodeId(), name, &attr);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "GetNodeAttrBatch::GetNodeAttr error=%s",
+                    "[%s] GetNodeAttrBatch::GetNodeAttr error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
                 return response;
@@ -1242,12 +1330,17 @@ public:
             return response;
         }
 
+        TLoggingContext lc;
+        lc.Name = request.GetName();
+        lc.NodeId = request.GetNodeId();
+
         NProto::TNodeAttr attr;
         auto error = GetNodeAttr(request.GetNodeId(), request.GetName(), &attr);
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "GetNodeAttr::GetNodeAttr error=%s",
+                "[%s] GetNodeAttr::GetNodeAttr error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
         } else {
@@ -1265,6 +1358,9 @@ public:
             return response;
         }
 
+        TLoggingContext lc;
+        lc.NodeId = request.GetNodeId();
+
         TWriteContext writeContext;
         TWriteContextGuard wcg(writeContext, *PageStore);
 
@@ -1281,7 +1377,8 @@ public:
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "SetNodeAttr::Nodes.UpdateNode error=%s",
+                    "[%s] SetNodeAttr::Nodes.UpdateNode error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
             }
@@ -1295,7 +1392,8 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "SetNodeAttr::WriteLogRecord error=%s",
+                "[%s] SetNodeAttr::WriteLogRecord error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             PageStore->RollbackPages(pages);
@@ -1304,14 +1402,15 @@ public:
         }
 
         SILK_DEBUG(
-            "SetNodeAttr ino=%lu update=%s",
-            request.GetNodeId(),
+            "[%s] SetNodeAttr complete, update=%s",
+            lc.Describe().c_str(),
             request.GetUpdate().ShortUtf8DebugString().Quote().c_str());
 
         return response;
     }
 
     NProto::TError CreateNodeImpl(
+        TLoggingContext& lc,
         const TString& name,
         ui32 mode,
         ui64 uid,
@@ -1329,25 +1428,35 @@ public:
             return error;
         }
 
-        *attr = CreateAttrs(
-            ShardedId(nodeId, ShardNo),
-            mode,
-            0 /* size */,
-            uid,
-            gid);
+        nodeId = ShardedId(nodeId, ShardNo);
+        *attr = CreateAttrs(nodeId, mode, 0 /* size */, uid, gid);
 
         error = Nodes.PutNode(*attr, writeContext);
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "CreateNodeImpl::Nodes.PutNode error=%s",
+                "[%s] CreateNodeImpl::Nodes.PutNode error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             return error;
         }
 
-        SILK_DEBUG("CreateNodeImpl name=%s ino=%lu", name.c_str(), nodeId);
+        error = Names.Put(name, attr->GetId(), writeContext);
+        if (HasError(error)) {
+            SILK_LOG(
+                LogLevel(error),
+                "[%s] CreateNodeImpl::Names.Put error=%s",
+                lc.Describe().c_str(),
+                FormatError(error).c_str());
+            return error;
+        }
 
-        return Names.Put(name, attr->GetId(), writeContext);
+        SILK_DEBUG(
+            "[%s] CreateNodeImpl complete, ino=%lu",
+            lc.Describe().c_str(),
+            nodeId);
+        lc.NodeId = nodeId;
+        return {};
     }
 
     NProto::TCreateNodeResponse CreateNode(NProto::TCreateNodeRequest request)
@@ -1369,6 +1478,10 @@ public:
             return response;
         }
 
+        TLoggingContext lc;
+        lc.Name = request.GetName();
+        lc.NodeId = request.GetNodeId();
+
         TWriteContext writeContext;
         TWriteContextGuard wcg(writeContext, *PageStore);
 
@@ -1378,6 +1491,7 @@ public:
             std::lock_guard g(Mutex);
             wcg.Init();
             error = CreateNodeImpl(
+                lc,
                 request.GetName(),
                 request.GetFile().GetMode(),
                 request.GetUid(),
@@ -1389,7 +1503,8 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "CreateNode::CreateNodeImpl error=%s",
+                "[%s] CreateNode::CreateNodeImpl error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             return response;
@@ -1403,17 +1518,15 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "CreateNode::WriteLogRecord error=%s",
+                "[%s] CreateNode::WriteLogRecord error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             PageStore->RollbackPages(pages);
             return response;
         }
 
-        SILK_DEBUG(
-            "CreateNode name=%s ino=%lu",
-            request.GetName().c_str(),
-            attr.GetId());
+        SILK_DEBUG("[%s] CreateNode complete", lc.Describe().c_str());
 
         PageStore->CommitPages(pages);
         *response.MutableNode() = std::move(attr);
@@ -1432,6 +1545,9 @@ public:
             return response;
         }
 
+        TLoggingContext lc;
+        lc.Name = request.GetName();
+
         TWriteContext writeContext;
         TWriteContextGuard wcg(writeContext, *PageStore);
 
@@ -1448,17 +1564,21 @@ public:
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "UnlinkNode::Names.Get error=%s",
+                    "[%s] UnlinkNode::Names.Get error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
                 return response;
             }
 
+            lc.NodeId = nodeId;
+
             error = Names.Delete(request.GetName(), writeContext);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "UnlinkNode::Names.Delete error=%s",
+                    "[%s] UnlinkNode::Names.Delete error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
                 return response;
@@ -1469,7 +1589,8 @@ public:
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "UnlinkNode::Nodes.DeleteNode error=%s",
+                    "[%s] UnlinkNode::Nodes.DeleteNode error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
                 return response;
@@ -1479,11 +1600,14 @@ public:
             for (ui64 offset = 0; offset < slot.Size;
                     offset += PageClusterSize)
             {
+                const ui64 pageClusterId = offset / PageClusterSize;
+                lc.PageClusterIds.push_back(pageClusterId);
+
                 TNodePageClusterSlot slot{};
                 error = PageIndex.Delete(
                     {
                         .NodeId = nodeId,
-                        .PageClusterId = offset / PageClusterSize
+                        .PageClusterId = pageClusterId,
                     },
                     writeContext,
                     &slot);
@@ -1493,13 +1617,16 @@ public:
                     // This page cluster is not allocated.
                     //
 
+                    lc.StoragePageClusterIds.push_back(
+                        InvalidStoragePageClusterId);
                     continue;
                 }
 
                 if (HasError(error)) {
                     SILK_LOG(
                         LogLevel(error),
-                        "UnlinkNode::PageIndex.Delete error=%s",
+                        "[%s] UnlinkNode::PageIndex.Delete error=%s",
+                        lc.Describe().c_str(),
                         FormatError(error).c_str());
                     *response.MutableError() = std::move(error);
                     return response;
@@ -1508,12 +1635,15 @@ public:
                 storagePageClusterIds.push_back(slot.StoragePageClusterId);
             }
 
-            error =
-                PageAllocator.Deallocate(storagePageClusterIds, writeContext);
+            error = PageAllocator.Deallocate(
+                lc,
+                storagePageClusterIds,
+                writeContext);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "UnlinkNode::PageAllocator.Deallocate error=%s",
+                    "[%s] UnlinkNode::PageAllocator.Deallocate error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
                 return response;
@@ -1528,17 +1658,15 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "UnlinkNode::WriteLogRecord error=%s",
+                "[%s] UnlinkNode::WriteLogRecord error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             PageStore->RollbackPages(pages);
             return response;
         }
 
-        SILK_DEBUG(
-            "UnlinkNode name=%s ino=%lu",
-            request.GetName().c_str(),
-            nodeId);
+        SILK_DEBUG("[%s] UnlinkNode complete", lc.Describe().c_str());
 
         PageStore->CommitPages(pages);
         return response;
@@ -1557,6 +1685,10 @@ public:
             return response;
         }
 
+        TLoggingContext lc;
+        lc.Name = request.GetName();
+        lc.NodeId = request.GetNodeId();
+
         const ui32 flags = request.GetFlags();
         const auto createFlag = NProto::TCreateHandleRequest::E_CREATE;
         const auto exclFlag = NProto::TCreateHandleRequest::E_EXCLUSIVE;
@@ -1574,7 +1706,8 @@ public:
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "CreateHandle::Nodes.GetNode error=%s",
+                    "[%s] CreateHandle::Nodes.GetNode error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
             }
@@ -1583,6 +1716,7 @@ public:
             if (error.GetCode() == E_FS_NOENT) {
                 if (HasFlag(flags, createFlag)) {
                     auto error = CreateNodeImpl(
+                        lc,
                         request.GetName(),
                         request.GetMode(),
                         request.GetUid(),
@@ -1592,7 +1726,8 @@ public:
                     if (HasError(error)) {
                         SILK_LOG(
                             LogLevel(error),
-                            "CreateHandle::CreateNodeImpl error=%s",
+                            "[%s] CreateHandle::CreateNodeImpl error=%s",
+                            lc.Describe().c_str(),
                             FormatError(error).c_str());
                         *response.MutableError() = std::move(error);
                     }
@@ -1606,20 +1741,21 @@ public:
             } else if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "CreateHandle::Names.Get error=%s",
+                    "[%s] CreateHandle::Names.Get error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
+            } else if (HasFlag(flags, createFlag) && HasFlag(flags, exclFlag)) {
+                *response.MutableError() =
+                    ErrorAlreadyExists(request.GetName());
             } else {
-                if (HasFlag(flags, createFlag) && HasFlag(flags, exclFlag)) {
-                    *response.MutableError() =
-                        ErrorAlreadyExists(request.GetName());
-                }
-
+                lc.NodeId = nodeId;
                 auto error = Nodes.GetNode(nodeId, &attr);
                 if (HasError(error)) {
                     SILK_LOG(
                         LogLevel(error),
-                        "CreateHandle::Nodes.GetNode error=%s",
+                        "[%s] CreateHandle::Nodes.GetNode error=%s",
+                        lc.Describe().c_str(),
                         FormatError(error).c_str());
                     *response.MutableError() = std::move(error);
                 }
@@ -1629,7 +1765,8 @@ public:
         if (HasError(response.GetError())) {
             SILK_LOG(
                 LogLevel(response.GetError()),
-                "CreateHandle error=%s",
+                "[%s] CreateHandle error=%s",
+                lc.Describe().c_str(),
                 FormatError(response.GetError()).c_str());
             return response;
         }
@@ -1640,19 +1777,22 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "CreateHandle::Handles.AllocateHandle error=%s",
+                "[%s] CreateHandle::Handles.AllocateHandle error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             return response;
         }
 
         handle = ShardedId(handle, ShardNo);
+        lc.Handle = handle;
 
         error = Handles.Put({.Handle = handle, .NodeId = nodeId}, writeContext);
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "CreateHandle::Handles.Put error=%s",
+                "[%s] CreateHandle::Handles.Put error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             return response;
@@ -1668,18 +1808,15 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "CreateHandle::WriteLogRecord error=%s",
+                "[%s] CreateHandle::WriteLogRecord error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             PageStore->RollbackPages(pages);
             return response;
         }
 
-        SILK_DEBUG(
-            "CreateHandle name=%s ino=%lu handle=%lu",
-            request.GetName().c_str(),
-            nodeId,
-            handle);
+        SILK_DEBUG("[%s] CreateHandle complete", lc.Describe().c_str());
 
         PageStore->CommitPages(pages);
 
@@ -1696,6 +1833,9 @@ public:
             return response;
         }
 
+        TLoggingContext lc;
+        lc.Handle = request.GetHandle();
+
         TWriteContext writeContext;
         TWriteContextGuard wcg(writeContext, *PageStore);
 
@@ -1707,7 +1847,8 @@ public:
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "DestroyHandle::Handles.Delete error=%s",
+                    "[%s] DestroyHandle::Handles.Delete error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
             }
@@ -1720,7 +1861,8 @@ public:
         if (HasError(response.GetError())) {
             SILK_LOG(
                 LogLevel(response.GetError()),
-                "DestroyHandle error=%s",
+                "[%s] DestroyHandle error=%s",
+                lc.Describe().c_str(),
                 FormatError(response.GetError()).c_str());
             return response;
         }
@@ -1733,14 +1875,15 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "DestroyHandle::WriteLogRecord error=%s",
+                "[%s] DestroyHandle::WriteLogRecord error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             PageStore->RollbackPages(pages);
             return response;
         }
 
-        SILK_DEBUG("DestroyHandle handle=%lu", request.GetHandle());
+        SILK_DEBUG("[%s] DestroyHandle complete", lc.Describe().c_str());
 
         PageStore->CommitPages(pages);
 
@@ -1754,6 +1897,9 @@ public:
             return response;
         }
 
+        TLoggingContext lc;
+        lc.Handle = request.GetHandle();
+
         std::unique_lock l(Mutex);
 
         ui64 nodeId = 0;
@@ -1761,11 +1907,14 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "WriteData::Handles.Get error=%s",
+                "[%s] WriteData::Handles.Get error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             return response;
         }
+
+        lc.NodeId = nodeId;
 
         //
         // Figuring out how many page clusters we need to allocate.
@@ -1780,6 +1929,8 @@ public:
                 bufferOffset - request.GetBufferOffset() + request.GetOffset();
             const ui64 pageClusterId = fileOffset / PageClusterSize;
 
+            lc.PageClusterIds.push_back(pageClusterId);
+
             ui64 storagePageClusterId = 0;
             error = PageIndex.Get(
                 {.NodeId = nodeId, .PageClusterId = pageClusterId},
@@ -1792,12 +1943,16 @@ public:
             } else if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "WriteData::PageIndex.Get error=%s",
+                    "[%s] WriteData::PageIndex.Get error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 break;
             } else {
                 storagePageClusterIdsToWrite.push_back(storagePageClusterId);
             }
+
+            lc.StoragePageClusterIds.push_back(
+                storagePageClusterIdsToWrite.back());
 
             const ui64 nextFileOffset =
                 RoundDown(fileOffset + PageClusterSize, PageClusterSize);
@@ -1807,7 +1962,8 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "WriteData error=%s",
+                "[%s] WriteData error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             return response;
@@ -1826,13 +1982,15 @@ public:
         TVector<ui64> newStoragePageClusterIds;
         if (pageClusterIdsToAllocate) {
             error = PageAllocator.Allocate(
+                lc,
                 pageClusterIdsToAllocate,
                 &newStoragePageClusterIds,
                 writeContext);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "WriteData::PageAllocator.Allocate error=%s",
+                    "[%s] WriteData::PageAllocator.Allocate error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
                 return response;
@@ -1853,6 +2011,7 @@ public:
         bufferOffset = request.GetBufferOffset();
 
         auto storagePageClusterIdIt = storagePageClusterIdsToWrite.begin();
+        auto lcStoragePageClusterIdIt = lc.StoragePageClusterIds.begin();
         auto newStoragePageClusterIdIt = newStoragePageClusterIds.begin();
         while (bufferOffset < request.GetBuffer().size()) {
             //
@@ -1865,11 +2024,14 @@ public:
 
             Y_ABORT_UNLESS(
                 storagePageClusterIdIt != storagePageClusterIdsToWrite.end());
+            Y_ABORT_UNLESS(
+                lcStoragePageClusterIdIt != lc.StoragePageClusterIds.end());
             if (*storagePageClusterIdIt == InvalidStoragePageClusterId) {
                 Y_ABORT_UNLESS(
                     newStoragePageClusterIdIt !=
                     newStoragePageClusterIds.end());
                 *storagePageClusterIdIt = *newStoragePageClusterIdIt;
+                *lcStoragePageClusterIdIt = *newStoragePageClusterIdIt;
                 ++newStoragePageClusterIdIt;
 
                 TNodePageClusterSlot slot;
@@ -1880,7 +2042,8 @@ public:
                 if (HasError(error)) {
                     SILK_LOG(
                         LogLevel(error),
-                        "WriteData::PageIndex.Put error=%s",
+                        "[%s] WriteData::PageIndex.Put error=%s",
+                        lc.Describe().c_str(),
                         FormatError(error).c_str());
                     break;
                 }
@@ -1921,7 +2084,8 @@ public:
                     if (HasError(error)) {
                         SILK_LOG(
                             LogLevel(error),
-                            "WriteData::PageStore.ReadPage error=%s",
+                            "[%s] WriteData::PageStore.ReadPage error=%s",
+                            lc.Describe().c_str(),
                             FormatError(error).c_str());
                         break;
                     }
@@ -1947,15 +2111,15 @@ public:
                     writeContext.PageGroups);
 
                 SILK_DEBUG(
-                    "WriteData ino=%lu handle=%lu storagePage=%lu",
-                    nodeId,
-                    request.GetHandle(),
+                    "[%s] WriteData storagePage=%lu",
+                    lc.Describe().c_str(),
                     storagePageNo);
 
                 if (HasError(error)) {
                     SILK_LOG(
                         LogLevel(error),
-                        "WriteData::PageStore.WritePage error=%s",
+                        "[%s] WriteData::PageStore.WritePage error=%s",
+                        lc.Describe().c_str(),
                         FormatError(error).c_str());
                     break;
                 }
@@ -1967,21 +2131,25 @@ public:
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "WriteData error=%s",
+                    "[%s] WriteData error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 break;
             }
 
             ++storagePageClusterIdIt;
+            ++lcStoragePageClusterIdIt;
         }
 
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "WriteData error=%s",
+                "[%s] WriteData error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
 
             PageAllocator.RollbackAllocation(
+                lc,
                 newStoragePageClusterIds,
                 writeContext);
 
@@ -1999,10 +2167,12 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "WriteData::Nodes.ResizeNode error=%s",
+                "[%s] WriteData::Nodes.ResizeNode error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
 
             PageAllocator.RollbackAllocation(
+                lc,
                 newStoragePageClusterIds,
                 writeContext);
 
@@ -2024,7 +2194,8 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "WriteData::WriteLogRecord error=%s",
+                "[%s] WriteData::WriteLogRecord error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
 
@@ -2036,6 +2207,7 @@ public:
 
             l.lock();
             PageAllocator.RollbackAllocation(
+                lc,
                 newStoragePageClusterIds,
                 writeContext);
             l.unlock();
@@ -2045,7 +2217,7 @@ public:
             return response;
         }
 
-        SILK_DEBUG("WriteData ino=%lu handle=%lu", nodeId, request.GetHandle());
+        SILK_DEBUG("[%s] WriteData complete", lc.Describe().c_str());
 
         PageStore->CommitPages(pages);
 
@@ -2059,6 +2231,9 @@ public:
             return response;
         }
 
+        TLoggingContext lc;
+        lc.Handle = request.GetHandle();
+
         std::lock_guard l(Mutex);
 
         ui64 nodeId = 0;
@@ -2066,11 +2241,14 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "ReadData::Handles.Get error=%s",
+                "[%s] ReadData::Handles.Get error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
             return response;
         }
+
+        lc.NodeId = request.GetNodeId();
 
         auto& buffer = *response.MutableBuffer();
         buffer.resize(request.GetLength(), 0);
@@ -2086,6 +2264,8 @@ public:
             const ui64 fileOffset = bufferOffset + request.GetOffset();
             const ui64 pageClusterId = fileOffset / PageClusterSize;
             const ui64 pageClusterOffset = fileOffset % PageClusterSize;
+
+            lc.PageClusterIds.push_back(pageClusterId);
 
             ui64 storagePageClusterId = 0;
             error = PageIndex.Get(
@@ -2103,16 +2283,22 @@ public:
                 memset(buffer.begin() + bufferOffset, 0, toSet);
                 bufferOffset += toSet;
                 error = {};
+
+                lc.StoragePageClusterIds.push_back(InvalidStoragePageClusterId);
+
                 continue;
             }
 
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "ReadData::PageIndex.Get error=%s",
+                    "[%s] ReadData::PageIndex.Get error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 break;
             }
+
+            lc.StoragePageClusterIds.push_back(storagePageClusterId);
 
             //
             // Page cluster mapping found - reading the pages into the buffer.
@@ -2138,15 +2324,15 @@ public:
                 error = PageStore->ReadPage(0 /* lsn */, storagePageNo, &page);
 
                 SILK_DEBUG(
-                    "ReadData ino=%lu handle=%lu storagePage=%lu",
-                    nodeId,
-                    request.GetHandle(),
+                    "[%s] ReadData storagePage=%lu",
+                    lc.Describe().c_str(),
                     storagePageNo);
 
                 if (HasError(error)) {
                     SILK_LOG(
                         LogLevel(error),
-                        "ReadData::PageStore.ReadPage error=%s",
+                        "[%s] ReadData::PageStore.ReadPage error=%s",
+                        lc.Describe().c_str(),
                         FormatError(error).c_str());
                     break;
                 }
@@ -2169,7 +2355,8 @@ public:
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "ReadData error=%s",
+                    "[%s] ReadData error=%s",
+                    lc.Describe().c_str(),
                     FormatError(error).c_str());
                 break;
             }
@@ -2178,13 +2365,14 @@ public:
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
-                "ReadData error=%s",
+                "[%s] ReadData error=%s",
+                lc.Describe().c_str(),
                 FormatError(error).c_str());
             buffer.clear();
             *response.MutableError() = std::move(error);
         }
 
-        SILK_DEBUG("ReadData ino=%lu handle=%lu", nodeId, request.GetHandle());
+        SILK_DEBUG("[%s] ReadData complete", lc.Describe().c_str());
 
         return response;
     }


### PR DESCRIPTION
### Notes
Logging NodeId, Name, Handle, PageClusterIds, StoragePageClusterIds everywhere where possible. If some of those items are not applicable, they are not logged. Introduced a `TLoggingContext` class for that and using it in all requests. Adds a little bit of overhead but doesn't look like a big deal for now.

### Issue
https://github.com/ydb-platform/nbs/issues/5895
