### PR TITLE
[filestore] support  forced flush, flush_bytes,  collect_garbage operations

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -102,6 +102,7 @@ namespace NCloud::NFileStore{
     xxx(ListNodesInternalFailedToAddNodeRef)                                   \
     xxx(InMemoryIndexStateNotInitialized)                                      \
     xxx(WriteDataRequestWithBufferAndPayload)                                  \
+    xxx(ForcedOperationUnexpectedState)                                        \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -1500,6 +1500,102 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
                 ->GetCounter("Count")->GetAtomic());
     }
 
+    void TestForcedTabletOperationAction(
+        NProtoPrivate::TForcedOperationRequest::EForcedOperationType operation)
+    {
+        using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
+
+        TTestEnv env;
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore("test", 1'000);
+
+        bool operationCompleted = false;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+
+                if (event->GetTypeRewrite() ==
+                    TEvIndexTabletPrivate::EvForcedTabletOperationCompleted)
+                {
+                    operationCompleted = true;
+                }
+
+                return false;
+            });
+
+        NProtoPrivate::TForcedOperationRequest request;
+        request.SetFileSystemId("test");
+        request.SetOpType(operation);
+
+        TString input;
+        google::protobuf::util::MessageToJsonString(request, &input);
+        auto actionResponse = service.ExecuteAction("forcedoperation", input);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            actionResponse->GetStatus(),
+            actionResponse->GetErrorReason());
+
+        NProtoPrivate::TForcedOperationResponse response;
+        UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                        actionResponse->Record.GetOutput(),
+                        &response)
+                        .ok());
+        UNIT_ASSERT_VALUES_UNEQUAL(TString(), response.GetOperationId());
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return operationCompleted;
+        };
+        env.GetRuntime().DispatchEvents(options);
+
+        NProtoPrivate::TForcedOperationStatusRequest statusRequest;
+        statusRequest.SetFileSystemId("test");
+        statusRequest.SetOperationId(response.GetOperationId());
+
+        TString statusInput;
+        google::protobuf::util::MessageToJsonString(
+            statusRequest,
+            &statusInput);
+        actionResponse =
+            service.ExecuteAction("forcedoperationstatus", statusInput);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            actionResponse->GetStatus(),
+            actionResponse->GetErrorReason());
+
+        NProtoPrivate::TForcedOperationStatusResponse statusResponse;
+        UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                        actionResponse->Record.GetOutput(),
+                        &statusResponse)
+                        .ok());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(TStatus::E_COMPLETED),
+            static_cast<int>(statusResponse.GetStatus()));
+    }
+
+    Y_UNIT_TEST(ShouldRunForcedFlushAction)
+    {
+        TestForcedTabletOperationAction(
+            NProtoPrivate::TForcedOperationRequest::E_FLUSH);
+    }
+
+    Y_UNIT_TEST(ShouldRunForcedFlushBytesAction)
+    {
+        TestForcedTabletOperationAction(
+            NProtoPrivate::TForcedOperationRequest::E_FLUSH_BYTES);
+    }
+
+    Y_UNIT_TEST(ShouldRunForcedCollectGarbageAction)
+    {
+        TestForcedTabletOperationAction(
+            NProtoPrivate::TForcedOperationRequest::E_COLLECT_GARBAGE);
+    }
+
     Y_UNIT_TEST(ShouldMarkNodeRefsExhaustive)
     {
         NProto::TStorageConfig config;

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -1352,6 +1352,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
 
     Y_UNIT_TEST(ShouldRunForcedOperation)
     {
+        using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
+
         NProto::TStorageConfig config;
         config.SetCompactionThreshold(1000);
         TTestEnv env({}, config);
@@ -1437,6 +1439,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 1177944066,
                 response.GetLastProcessedRangeId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(TStatus::E_RUNNING),
+                static_cast<int>(response.GetStatus()));
         }
 
         UNIT_ASSERT(completion);
@@ -1469,6 +1474,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
                 jsonResponse->Record.GetOutput(), &response).ok());
             UNIT_ASSERT_VALUES_EQUAL(4, response.GetRangeCount());
             UNIT_ASSERT_VALUES_EQUAL(4, response.GetProcessedRangeCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(TStatus::E_COMPLETED),
+                static_cast<int>(response.GetStatus()));
         }
 
         env.GetRegistry()->Update(env.GetRuntime().GetCurrentTime());

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -37,6 +37,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(Flush,                                  __VA_ARGS__)                   \
     xxx(FlushBytes,                             __VA_ARGS__)                   \
     xxx(ForcedRangeOperation,                   __VA_ARGS__)                   \
+    xxx(ForcedTabletOperation,                  __VA_ARGS__)                   \
     xxx(Truncate,                               __VA_ARGS__)                   \
     xxx(ReadBlob,                               __VA_ARGS__)                   \
     xxx(WriteBlob,                              __VA_ARGS__)                   \
@@ -636,6 +637,33 @@ struct TEvIndexTabletPrivate
         {
         }
     };
+
+    //
+    // ForcedTabletOperation
+    //
+
+    enum EForcedTabletOperationMode
+    {
+        Flush = 0,
+        FlushBytes = 1,
+        CollectGarbage = 2,
+    };
+
+    struct TForcedTabletOperationRequest
+    {
+        EForcedTabletOperationMode Mode;
+        TString OperationId;
+
+        TForcedTabletOperationRequest(
+                EForcedTabletOperationMode mode,
+                TString operationId)
+            : Mode(mode)
+            , OperationId(std::move(operationId))
+        {}
+    };
+
+    using TForcedTabletOperationResponse = TEmpty;
+    using TForcedTabletOperationCompleted = TEmpty;
 
     //
     // NodeCreatedInShard

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1184,7 +1184,8 @@ TIndexTabletActor::ProcessForcedRangeOperationRequest(
     }
 
     if (e.GetCode() == S_OK && IsForcedOperationRunning()) {
-        const auto* state = std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
+        const auto* state =
+            std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
         if (state) {
             const auto currentMode = state->Mode;
             if (currentMode == mode) {
@@ -1249,7 +1250,8 @@ TIndexTabletActor::ProcessForcedTabletOperationRequest(
     }
 
     if (e.GetCode() == S_OK && IsForcedOperationRunning()) {
-        const auto* state = std::get_if<TForcedTabletOperationState>(GetForcedOperationState());
+        const auto* state =
+            std::get_if<TForcedTabletOperationState>(GetForcedOperationState());
         if (state) {
             const auto currentMode = state->Mode;
             if (currentMode == mode) {
@@ -1285,23 +1287,26 @@ void TIndexTabletActor::EnqueueForcedOperationIfNeeded(
         return;
     }
 
-    std::visit(TOverloaded{
-        [&](TPendingForcedRangeOperation& state) {
-            auto request =
-                    std::make_unique<TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
-                        std::move(state.Ranges),
-                        state.Mode,
-                        std::move(state.OperationId));
-            ctx.Send(ctx.SelfID, request.release());
-        },
-        [&](TPendingForcedTabletOperation& state) {
-            auto request =
-                    std::make_unique<TEvIndexTabletPrivate::TEvForcedTabletOperationRequest>(
-                        state.Mode,
-                        std::move(state.OperationId));
-            ctx.Send(ctx.SelfID, request.release());
-        }
-    }, *pendingRequest.Get());
+    std::visit(
+        TOverloaded{
+            [&](TPendingForcedRangeOperation& state)
+            {
+                auto request = std::make_unique<
+                    TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
+                    std::move(state.Ranges),
+                    state.Mode,
+                    std::move(state.OperationId));
+                ctx.Send(ctx.SelfID, request.release());
+            },
+            [&](TPendingForcedTabletOperation& state)
+            {
+                auto request = std::make_unique<
+                    TEvIndexTabletPrivate::TEvForcedTabletOperationRequest>(
+                    state.Mode,
+                    std::move(state.OperationId));
+                ctx.Send(ctx.SelfID, request.release());
+            }},
+        *pendingRequest.Get());
 }
 
 void TIndexTabletActor::HandleForcedOperationStatus(
@@ -1320,7 +1325,8 @@ void TIndexTabletActor::HandleForcedOperationStatus(
         if (rangeState) {
             response->Record.SetRangeCount(rangeState->RangesToCompact.size());
             response->Record.SetProcessedRangeCount(rangeState->Current);
-            response->Record.SetLastProcessedRangeId(rangeState->GetCurrentRange());
+            response->Record.SetLastProcessedRangeId(
+                rangeState->GetCurrentRange());
             response->Record.SetStatus(
                 rangeState->Current < rangeState->RangesToCompact.size()
                     ? TStatus::E_RUNNING

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1137,6 +1137,31 @@ void TIndexTabletActor::HandleForcedOperation(
     const TActorContext& ctx)
 {
     const auto& request = ev->Get()->Record;
+    using TResponse = TEvIndexTablet::TEvForcedOperationResponse;
+    std::unique_ptr<TResponse> response;
+    switch (request.GetOpType()) {
+    case NProtoPrivate::TForcedOperationRequest::E_COMPACTION:
+    case NProtoPrivate::TForcedOperationRequest::E_CLEANUP:
+    case NProtoPrivate::TForcedOperationRequest::E_DELETE_EMPTY_RANGES:
+        response = ProcessForcedRangeOperationRequest(request, ctx);
+        break;
+    case NProtoPrivate::TForcedOperationRequest::E_FLUSH:
+    case NProtoPrivate::TForcedOperationRequest::E_FLUSH_BYTES:
+    case NProtoPrivate::TForcedOperationRequest::E_COLLECT_GARBAGE:
+        response = ProcessForcedTabletOperationRequest(request, ctx);
+        break;
+    default:
+        response = std::make_unique<TResponse>(
+            MakeError(E_ARGUMENT, "unsupported mode"));
+    }
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+std::unique_ptr<TEvIndexTablet::TEvForcedOperationResponse>
+TIndexTabletActor::ProcessForcedRangeOperationRequest(
+    const NProtoPrivate::TForcedOperationRequest& request,
+    const TActorContext& ctx)
+{
     using EMode = TEvIndexTabletPrivate::EForcedRangeOperationMode;
     EMode mode{};
     NProto::TError e;
@@ -1145,33 +1170,30 @@ void TIndexTabletActor::HandleForcedOperation(
             mode = EMode::Compaction;
             break;
         }
-
         case NProtoPrivate::TForcedOperationRequest::E_CLEANUP: {
             mode = EMode::Cleanup;
             break;
         }
-
         case NProtoPrivate::TForcedOperationRequest::E_DELETE_EMPTY_RANGES: {
             mode = EMode::DeleteZeroCompactionRanges;
             break;
         }
-
         default: {
             e = MakeError(E_ARGUMENT, "unsupported mode");
         }
     }
 
     if (e.GetCode() == S_OK && IsForcedOperationRunning()) {
-        const auto* rangeState = std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
-        if (rangeState) {
-            const auto currentMode = rangeState->Mode;
+        const auto* state = std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
+        if (state) {
+            const auto currentMode = state->Mode;
             if (currentMode == mode) {
                 e = MakeError(S_ALREADY, "already launched");
-            } else {
-                e = MakeError(E_TRY_AGAIN, TStringBuilder() << "mode mismatch: "
-                    << static_cast<int>(mode)
-                    << " != " << static_cast<int>(currentMode));
             }
+        } else {
+            e = MakeError(E_TRY_AGAIN, TStringBuilder() << "mode mismatch: "
+                << static_cast<int>(mode));
+                // << " != " << static_cast<int>(currentMode));
         }
     }
 
@@ -1197,8 +1219,58 @@ void TIndexTabletActor::HandleForcedOperation(
         response->Record.SetOperationId(std::move(operationId));
         EnqueueForcedOperationIfNeeded(ctx);
     }
+    return response;
+}
 
-    NCloud::Reply(ctx, *ev, std::move(response));
+std::unique_ptr<TEvIndexTablet::TEvForcedOperationResponse>
+TIndexTabletActor::ProcessForcedTabletOperationRequest(
+    const NProtoPrivate::TForcedOperationRequest& request,
+    const TActorContext& ctx)
+{
+    using EMode = TEvIndexTabletPrivate::EForcedTabletOperationMode;
+    EMode mode{};
+    NProto::TError e;
+    switch (request.GetOpType()) {
+        case NProtoPrivate::TForcedOperationRequest::E_FLUSH: {
+            mode = EMode::Flush;
+            break;
+        }
+        case NProtoPrivate::TForcedOperationRequest::E_FLUSH_BYTES: {
+            mode = EMode::FlushBytes;
+            break;
+        }
+        case NProtoPrivate::TForcedOperationRequest::E_COLLECT_GARBAGE: {
+            mode = EMode::CollectGarbage;
+            break;
+        }
+        default: {
+            e = MakeError(E_ARGUMENT, "unsupported mode");
+        }
+    }
+
+    if (e.GetCode() == S_OK && IsForcedOperationRunning()) {
+        const auto* state = std::get_if<TForcedTabletOperationState>(GetForcedOperationState());
+        if (state) {
+            const auto currentMode = state->Mode;
+            if (currentMode == mode) {
+                e = MakeError(S_ALREADY, "already launched");
+            }
+        } else {
+            e = MakeError(E_TRY_AGAIN, TStringBuilder() << "mode mismatch: "
+                << static_cast<int>(mode));
+                // << " != " << static_cast<int>(currentMode));
+        }
+    }
+
+    using TResponse = TEvIndexTablet::TEvForcedOperationResponse;
+    auto code = e.GetCode();
+    auto response = std::make_unique<TResponse>(std::move(e));
+    if (code == S_OK) {
+        auto operationId = EnqueueForcedTabletOperation(mode);
+        response->Record.SetOperationId(std::move(operationId));
+        EnqueueForcedOperationIfNeeded(ctx);
+    }
+    return response;
 }
 
 void TIndexTabletActor::EnqueueForcedOperationIfNeeded(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1161,14 +1161,17 @@ void TIndexTabletActor::HandleForcedOperation(
         }
     }
 
-    if (e.GetCode() == S_OK && IsForcedRangeOperationRunning()) {
-        const auto currentMode = GetForcedRangeOperationState()->Mode;
-        if (currentMode == mode) {
-            e = MakeError(S_ALREADY, "already launched");
-        } else {
-            e = MakeError(E_TRY_AGAIN, TStringBuilder() << "mode mismatch: "
-                << static_cast<int>(mode)
-                << " != " << static_cast<int>(currentMode));
+    if (e.GetCode() == S_OK && IsForcedOperationRunning()) {
+        const auto* rangeState = std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
+        if (rangeState) {
+            const auto currentMode = rangeState->Mode;
+            if (currentMode == mode) {
+                e = MakeError(S_ALREADY, "already launched");
+            } else {
+                e = MakeError(E_TRY_AGAIN, TStringBuilder() << "mode mismatch: "
+                    << static_cast<int>(mode)
+                    << " != " << static_cast<int>(currentMode));
+            }
         }
     }
 
@@ -1192,7 +1195,7 @@ void TIndexTabletActor::HandleForcedOperation(
         response->Record.SetRangeCount(ranges.size());
         auto operationId = EnqueueForcedRangeOperation(mode, std::move(ranges));
         response->Record.SetOperationId(std::move(operationId));
-        EnqueueForcedRangeOperationIfNeeded(ctx);
+        EnqueueForcedOperationIfNeeded(ctx);
     }
 
     NCloud::Reply(ctx, *ev, std::move(response));
@@ -1205,14 +1208,28 @@ void TIndexTabletActor::HandleForcedOperationStatus(
     const auto& request = ev->Get()->Record;
 
     using TResponse = TEvIndexTablet::TEvForcedOperationStatusResponse;
+    using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
     auto response = std::make_unique<TResponse>();
 
-    const auto* state = FindForcedRangeOperation(request.GetOperationId());
+    const auto* state = FindForcedOperation(request.GetOperationId());
     if (state) {
-        response->Record.SetRangeCount(state->RangesToCompact.size());
-        response->Record.SetProcessedRangeCount(state->Current);
-        response->Record.SetLastProcessedRangeId(state->GetCurrentRange());
+        const auto* rangeState = std::get_if<TForcedRangeOperationState>(state);
+        if (rangeState) {
+            response->Record.SetRangeCount(rangeState->RangesToCompact.size());
+            response->Record.SetProcessedRangeCount(rangeState->Current);
+            response->Record.SetLastProcessedRangeId(rangeState->GetCurrentRange());
+            response->Record.SetStatus(
+                rangeState->Current < rangeState->RangesToCompact.size()
+                    ? TStatus::E_RUNNING
+                    : TStatus::E_COMPLETED);
+        } else {
+            response->Record.SetStatus(
+                state == GetForcedOperationState()
+                    ? TStatus::E_RUNNING
+                    : TStatus::E_COMPLETED);
+        }
     } else {
+        response->Record.SetStatus(TStatus::E_UNKNOWN);
         response->Record.MutableError()->CopyFrom(MakeError(
             E_NOT_FOUND,
             TStringBuilder() << "forced operation with id "

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1201,6 +1201,37 @@ void TIndexTabletActor::HandleForcedOperation(
     NCloud::Reply(ctx, *ev, std::move(response));
 }
 
+void TIndexTabletActor::EnqueueForcedOperationIfNeeded(
+    const TActorContext& ctx)
+{
+    if (IsForcedOperationRunning()) {
+        return;
+    }
+
+    auto pendingRequest = DequeueForcedOperation();
+    if (!pendingRequest) {
+        return;
+    }
+
+    std::visit(TOverloaded{
+        [&](TPendingForcedRangeOperation& state) {
+            auto request =
+                    std::make_unique<TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
+                        std::move(state.Ranges),
+                        state.Mode,
+                        std::move(state.OperationId));
+            ctx.Send(ctx.SelfID, request.release());
+        },
+        [&](TPendingForcedTabletOperation& state) {
+            auto request =
+                    std::make_unique<TEvIndexTabletPrivate::TEvForcedTabletOperationRequest>(
+                        state.Mode,
+                        std::move(state.OperationId));
+            ctx.Send(ctx.SelfID, request.release());
+        }
+    }, *pendingRequest.Get());
+}
+
 void TIndexTabletActor::HandleForcedOperationStatus(
     const TEvIndexTablet::TEvForcedOperationStatusRequest::TPtr& ev,
     const TActorContext& ctx)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1186,15 +1186,10 @@ TIndexTabletActor::ProcessForcedRangeOperationRequest(
     if (e.GetCode() == S_OK && IsForcedOperationRunning()) {
         const auto* state =
             std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
-        if (state) {
-            const auto currentMode = state->Mode;
-            if (currentMode == mode) {
-                e = MakeError(S_ALREADY, "already launched");
-            }
+        if (state && state->Mode == mode) {
+            e = MakeError(S_ALREADY, "already launched");
         } else {
-            e = MakeError(E_TRY_AGAIN, TStringBuilder() << "mode mismatch: "
-                << static_cast<int>(mode));
-                // << " != " << static_cast<int>(currentMode));
+            e = MakeError(E_TRY_AGAIN, "another operation is running");
         }
     }
 
@@ -1252,15 +1247,10 @@ TIndexTabletActor::ProcessForcedTabletOperationRequest(
     if (e.GetCode() == S_OK && IsForcedOperationRunning()) {
         const auto* state =
             std::get_if<TForcedTabletOperationState>(GetForcedOperationState());
-        if (state) {
-            const auto currentMode = state->Mode;
-            if (currentMode == mode) {
-                e = MakeError(S_ALREADY, "already launched");
-            }
+        if (state && state->Mode == mode) {
+            e = MakeError(S_ALREADY, "already launched");
         } else {
-            e = MakeError(E_TRY_AGAIN, TStringBuilder() << "mode mismatch: "
-                << static_cast<int>(mode));
-                // << " != " << static_cast<int>(currentMode));
+            e = MakeError(E_TRY_AGAIN, "another operation is running");
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1140,19 +1140,19 @@ void TIndexTabletActor::HandleForcedOperation(
     using TResponse = TEvIndexTablet::TEvForcedOperationResponse;
     std::unique_ptr<TResponse> response;
     switch (request.GetOpType()) {
-    case NProtoPrivate::TForcedOperationRequest::E_COMPACTION:
-    case NProtoPrivate::TForcedOperationRequest::E_CLEANUP:
-    case NProtoPrivate::TForcedOperationRequest::E_DELETE_EMPTY_RANGES:
-        response = ProcessForcedRangeOperationRequest(request, ctx);
-        break;
-    case NProtoPrivate::TForcedOperationRequest::E_FLUSH:
-    case NProtoPrivate::TForcedOperationRequest::E_FLUSH_BYTES:
-    case NProtoPrivate::TForcedOperationRequest::E_COLLECT_GARBAGE:
-        response = ProcessForcedTabletOperationRequest(request, ctx);
-        break;
-    default:
-        response = std::make_unique<TResponse>(
-            MakeError(E_ARGUMENT, "unsupported mode"));
+        case NProtoPrivate::TForcedOperationRequest::E_COMPACTION:
+        case NProtoPrivate::TForcedOperationRequest::E_CLEANUP:
+        case NProtoPrivate::TForcedOperationRequest::E_DELETE_EMPTY_RANGES:
+            response = ProcessForcedRangeOperationRequest(request, ctx);
+            break;
+        case NProtoPrivate::TForcedOperationRequest::E_FLUSH:
+        case NProtoPrivate::TForcedOperationRequest::E_FLUSH_BYTES:
+        case NProtoPrivate::TForcedOperationRequest::E_COLLECT_GARBAGE:
+            response = ProcessForcedTabletOperationRequest(request, ctx);
+            break;
+        default:
+            response = std::make_unique<TResponse>(
+                MakeError(E_ARGUMENT, "unsupported mode"));
     }
     NCloud::Reply(ctx, *ev, std::move(response));
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1296,7 +1296,7 @@ void TIndexTabletActor::EnqueueForcedOperationIfNeeded(
                     std::move(state.OperationId));
                 ctx.Send(ctx.SelfID, request.release());
             }},
-        *pendingRequest.Get());
+        *pendingRequest);
 }
 
 void TIndexTabletActor::HandleForcedOperationStatus(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -344,7 +344,7 @@ private:
         const TCleanupInfo& cleanupInfo);
     void EnqueueCollectGarbageIfNeeded(const NActors::TActorContext& ctx);
     void EnqueueTruncateIfNeeded(const NActors::TActorContext& ctx);
-    void EnqueueForcedRangeOperationIfNeeded(const NActors::TActorContext& ctx);
+    void EnqueueForcedOperationIfNeeded(const NActors::TActorContext& ctx);
     void LoadNextCompactionMapChunkIfNeeded(const NActors::TActorContext& ctx);
     void ScheduleEnqueueBlobIndexOpIfNeeded(const NActors::TActorContext& ctx);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -902,6 +902,16 @@ private:
     std::unique_ptr<IIndexTabletDatabase> CreateIndexTabletDatabaseProxy(
         NKikimr::NTable::TDatabase& database,
         TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
+
+    std::unique_ptr<TEvIndexTablet::TEvForcedOperationResponse>
+    ProcessForcedRangeOperationRequest(
+        const NProtoPrivate::TForcedOperationRequest& request,
+        const NActors::TActorContext& ctx);
+
+    std::unique_ptr<TEvIndexTablet::TEvForcedOperationResponse>
+    ProcessForcedTabletOperationRequest(
+        const NProtoPrivate::TForcedOperationRequest& request,
+        const NActors::TActorContext& ctx);
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -264,24 +264,35 @@ using TDeleteRangesWithEmptyScoreActor = TForcedOperationActor<
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TIndexTabletActor::EnqueueForcedRangeOperationIfNeeded(
+void TIndexTabletActor::EnqueueForcedOperationIfNeeded(
     const TActorContext& ctx)
 {
-    if (IsForcedRangeOperationRunning()) {
+    if (IsForcedOperationRunning()) {
         return;
     }
 
-    auto pendingRequest = DequeueForcedRangeOperation();
-    if (pendingRequest.Ranges.empty()) {
+    auto pendingRequest = DequeueForcedOperation();
+    if (!pendingRequest) {
         return;
     }
 
-    auto request =
-        std::make_unique<TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
-            std::move(pendingRequest.Ranges),
-            pendingRequest.Mode,
-            std::move(pendingRequest.OperationId));
-    ctx.Send(ctx.SelfID, request.release());
+    std::visit(TOverloaded{
+        [&](TPendingForcedRangeOperation& state) {
+            auto request =
+                    std::make_unique<TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
+                        std::move(state.Ranges),
+                        state.Mode,
+                        std::move(state.OperationId));
+            ctx.Send(ctx.SelfID, request.release());
+        },
+        [&](TPendingForcedTabletOperation& state) {
+            auto request =
+                    std::make_unique<TEvIndexTabletPrivate::TEvForcedTabletOperationRequest>(
+                        state.Mode,
+                        std::move(state.OperationId));
+            ctx.Send(ctx.SelfID, request.release());
+        }
+    }, *pendingRequest.Get());
 }
 
 void TIndexTabletActor::HandleForcedRangeOperation(
@@ -319,7 +330,7 @@ void TIndexTabletActor::HandleForcedRangeOperation(
     requestInfo->StartedTs = ctx.Now();
 
     // will lose original request info in case of enqueueing external request
-    if (IsForcedRangeOperationRunning()) {
+    if (IsForcedOperationRunning()) {
         EnqueueForcedRangeOperation(msg->Mode, std::move(msg->Ranges));
         return;
     }
@@ -329,6 +340,10 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         std::move(msg->Ranges),
         std::move(msg->OperationId));
 
+
+    const auto* state = std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
+    TABLET_VERIFY(state);
+
     std::unique_ptr<IActor> actor;
 
     switch (msg->Mode) {
@@ -337,7 +352,7 @@ void TIndexTabletActor::HandleForcedRangeOperation(
                 ctx.SelfID,
                 LogTag,
                 Config->GetCompactionRetryTimeout(),
-                *GetForcedRangeOperationState(),
+                *state,
                 std::move(requestInfo));
             break;
 
@@ -346,7 +361,7 @@ void TIndexTabletActor::HandleForcedRangeOperation(
                 ctx.SelfID,
                 LogTag,
                 Config->GetCompactionRetryTimeout(),
-                *GetForcedRangeOperationState(),
+                *state,
                 std::move(requestInfo));
             break;
         case TEvIndexTabletPrivate::EForcedRangeOperationMode::DeleteZeroCompactionRanges:
@@ -354,12 +369,55 @@ void TIndexTabletActor::HandleForcedRangeOperation(
                 ctx.SelfID,
                 LogTag,
                 Config->GetCompactionRetryTimeout(),
-                *GetForcedRangeOperationState(),
+                *state,
                 std::move(requestInfo));
             break;
 
         default:
             TABLET_VERIFY_C(false, "unexpected forced compaction mode");
+    }
+
+    auto actorId = ctx.Register(actor.release());
+    WorkerActors.insert(actorId);
+}
+
+void TIndexTabletActor::HandleForcedTabletOperation(
+    const TEvIndexTabletPrivate::TEvForcedTabletOperationRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s ForcedTabletOperation request",
+        LogTag.c_str());
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
+
+    // will lose original request info in case of enqueueing external request
+    if (IsForcedOperationRunning()) {
+        EnqueueForcedTabletOperation(msg->Mode);
+        return;
+    }
+
+    StartForcedTabletOperation(
+        msg->Mode,
+        std::move(msg->OperationId));
+
+    std::unique_ptr<IActor> actor;
+
+    switch (msg->Mode) {
+        case TEvIndexTabletPrivate::EForcedTabletOperationMode::Flush:
+            break;
+        case TEvIndexTabletPrivate::EForcedTabletOperationMode::FlushBytes:
+            break;
+        case TEvIndexTabletPrivate::EForcedTabletOperationMode::CollectGarbage:
+            break;
+        default:
+            TABLET_VERIFY_C(false, "unexpected forced tablet operation mode");
     }
 
     auto actorId = ctx.Register(actor.release());
@@ -376,11 +434,11 @@ void TIndexTabletActor::HandleForcedRangeOperationCompleted(
         LogTag.c_str(),
         FormatError(msg->GetError()).c_str());
 
-    TABLET_VERIFY(IsForcedRangeOperationRunning());
+    TABLET_VERIFY(IsForcedOperationRunning());
     WorkerActors.erase(ev->Sender);
 
     CompleteForcedRangeOperation();
-    EnqueueForcedRangeOperationIfNeeded(ctx);
+    EnqueueForcedOperationIfNeeded(ctx);
 }
 
 void TIndexTabletActor::HandleForcedRangeOperationProgress(
@@ -389,9 +447,26 @@ void TIndexTabletActor::HandleForcedRangeOperationProgress(
 {
     Y_UNUSED(ctx);
 
-    if (IsForcedRangeOperationRunning()) {
+    if (IsForcedOperationRunning()) {
         UpdateForcedRangeOperationProgress(ev->Get()->Current);
     }
+}
+
+void TIndexTabletActor::HandleForcedTabletOperationCompleted(
+    const TEvIndexTabletPrivate::TEvForcedTabletOperationCompleted::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s ForcedTabletOperation completed (%s)",
+        LogTag.c_str(),
+        FormatError(msg->GetError()).c_str());
+
+    TABLET_VERIFY(IsForcedOperationRunning());
+    WorkerActors.erase(ev->Sender);
+
+    CompleteForcedTabletOperation();
+    EnqueueForcedOperationIfNeeded(ctx);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
@@ -264,37 +264,6 @@ using TDeleteRangesWithEmptyScoreActor = TForcedOperationActor<
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TIndexTabletActor::EnqueueForcedOperationIfNeeded(
-    const TActorContext& ctx)
-{
-    if (IsForcedOperationRunning()) {
-        return;
-    }
-
-    auto pendingRequest = DequeueForcedOperation();
-    if (!pendingRequest) {
-        return;
-    }
-
-    std::visit(TOverloaded{
-        [&](TPendingForcedRangeOperation& state) {
-            auto request =
-                    std::make_unique<TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
-                        std::move(state.Ranges),
-                        state.Mode,
-                        std::move(state.OperationId));
-            ctx.Send(ctx.SelfID, request.release());
-        },
-        [&](TPendingForcedTabletOperation& state) {
-            auto request =
-                    std::make_unique<TEvIndexTabletPrivate::TEvForcedTabletOperationRequest>(
-                        state.Mode,
-                        std::move(state.OperationId));
-            ctx.Send(ctx.SelfID, request.release());
-        }
-    }, *pendingRequest.Get());
-}
-
 void TIndexTabletActor::HandleForcedRangeOperation(
     const TEvIndexTabletPrivate::TEvForcedRangeOperationRequest::TPtr& ev,
     const TActorContext& ctx)
@@ -381,49 +350,6 @@ void TIndexTabletActor::HandleForcedRangeOperation(
     WorkerActors.insert(actorId);
 }
 
-void TIndexTabletActor::HandleForcedTabletOperation(
-    const TEvIndexTabletPrivate::TEvForcedTabletOperationRequest::TPtr& ev,
-    const TActorContext& ctx)
-{
-    auto* msg = ev->Get();
-
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ForcedTabletOperation request",
-        LogTag.c_str());
-
-    auto requestInfo = CreateRequestInfo(
-        ev->Sender,
-        ev->Cookie,
-        msg->CallContext);
-    requestInfo->StartedTs = ctx.Now();
-
-    // will lose original request info in case of enqueueing external request
-    if (IsForcedOperationRunning()) {
-        EnqueueForcedTabletOperation(msg->Mode);
-        return;
-    }
-
-    StartForcedTabletOperation(
-        msg->Mode,
-        std::move(msg->OperationId));
-
-    std::unique_ptr<IActor> actor;
-
-    switch (msg->Mode) {
-        case TEvIndexTabletPrivate::EForcedTabletOperationMode::Flush:
-            break;
-        case TEvIndexTabletPrivate::EForcedTabletOperationMode::FlushBytes:
-            break;
-        case TEvIndexTabletPrivate::EForcedTabletOperationMode::CollectGarbage:
-            break;
-        default:
-            TABLET_VERIFY_C(false, "unexpected forced tablet operation mode");
-    }
-
-    auto actorId = ctx.Register(actor.release());
-    WorkerActors.insert(actorId);
-}
-
 void TIndexTabletActor::HandleForcedRangeOperationCompleted(
     const TEvIndexTabletPrivate::TEvForcedRangeOperationCompleted::TPtr& ev,
     const TActorContext& ctx)
@@ -450,23 +376,6 @@ void TIndexTabletActor::HandleForcedRangeOperationProgress(
     if (IsForcedOperationRunning()) {
         UpdateForcedRangeOperationProgress(ev->Get()->Current);
     }
-}
-
-void TIndexTabletActor::HandleForcedTabletOperationCompleted(
-    const TEvIndexTabletPrivate::TEvForcedTabletOperationCompleted::TPtr& ev,
-    const TActorContext& ctx)
-{
-    auto* msg = ev->Get();
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ForcedTabletOperation completed (%s)",
-        LogTag.c_str(),
-        FormatError(msg->GetError()).c_str());
-
-    TABLET_VERIFY(IsForcedOperationRunning());
-    WorkerActors.erase(ev->Sender);
-
-    CompleteForcedTabletOperation();
-    EnqueueForcedOperationIfNeeded(ctx);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
@@ -311,6 +311,7 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         std::move(msg->OperationId));
     if (!state) {
         replyError(MakeError(E_INVALID_STATE, "could not start the operation"));
+        return;
     }
 
     std::unique_ptr<IActor> actor;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
@@ -72,9 +72,7 @@ private:
         const TEvents::TEvPoisonPill::TPtr& ev,
         const TActorContext& ctx);
 
-    void ReplyAndDie(
-        const TActorContext& ctx,
-        const NProto::TError& error);
+    void ReplyAndDie(const TActorContext& ctx, const NProto::TError& error);
 
     void ReportProgress(const TActorContext& ctx);
 };
@@ -120,8 +118,7 @@ void TForcedOperationActor<TResponseType, TRequestConstructor>::
 }
 
 template <typename TResponseType, typename TRequestConstructor>
-STFUNC(
-    (TForcedOperationActor<TResponseType, TRequestConstructor>::StateWork))
+STFUNC((TForcedOperationActor<TResponseType, TRequestConstructor>::StateWork))
 {
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvents::TEvWakeup, HandleWakeUp);
@@ -164,8 +161,9 @@ void TForcedOperationActor<TResponseType, TRequestConstructor>::
 }
 
 template <typename TResponseType, typename TRequestConstructor>
-void TForcedOperationActor<TResponseType, TRequestConstructor>::
-    HandleWakeUp(const TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx)
+void TForcedOperationActor<TResponseType, TRequestConstructor>::HandleWakeUp(
+    const TEvents::TEvWakeup::TPtr& ev,
+    const TActorContext& ctx)
 {
     Y_UNUSED(ev);
     SendRangeOperationRequest(ctx);
@@ -182,8 +180,9 @@ void TForcedOperationActor<TResponseType, TRequestConstructor>::
 }
 
 template <typename TResponseType, typename TRequestConstructor>
-void TForcedOperationActor<TResponseType, TRequestConstructor>::
-    ReplyAndDie(const TActorContext& ctx, const NProto::TError& error)
+void TForcedOperationActor<TResponseType, TRequestConstructor>::ReplyAndDie(
+    const TActorContext& ctx,
+    const NProto::TError& error)
 {
     {
         // notify tablet
@@ -208,8 +207,8 @@ void TForcedOperationActor<TResponseType, TRequestConstructor>::
 }
 
 template <typename TResponseType, typename TRequestConstructor>
-void TForcedOperationActor<TResponseType, TRequestConstructor>::
-    ReportProgress(const TActorContext& ctx)
+void TForcedOperationActor<TResponseType, TRequestConstructor>::ReportProgress(
+    const TActorContext& ctx)
 {
     using TEvent = TEvIndexTabletPrivate::TEvForcedRangeOperationProgress;
     NCloud::Send(ctx, Tablet, std::make_unique<TEvent>(State.Current));
@@ -270,14 +269,15 @@ void TIndexTabletActor::HandleForcedRangeOperation(
 {
     auto* msg = ev->Get();
 
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
         "%s ForcedRangeOperation request mode=%u for %lu ranges",
         LogTag.c_str(),
         msg->Mode,
         msg->Ranges.size());
 
-    auto replyError = [&] (
-        const NProto::TError& error)
+    auto replyError = [&](const NProto::TError& error)
     {
         if (ev->Sender == ctx.SelfID) {
             return;
@@ -293,10 +293,8 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         return;
     }
 
-    auto requestInfo = CreateRequestInfo(
-        ev->Sender,
-        ev->Cookie,
-        msg->CallContext);
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
     if (IsForcedOperationRunning()) {
@@ -307,14 +305,13 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         return;
     }
 
-    StartForcedRangeOperation(
+    const auto* state = StartForcedRangeOperation(
         msg->Mode,
         std::move(msg->Ranges),
         std::move(msg->OperationId));
-
-    const auto* state =
-        std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
-    TABLET_VERIFY(state);
+    if (!state) {
+        replyError(MakeError(E_INVALID_STATE, "could not start the operation"));
+    }
 
     std::unique_ptr<IActor> actor;
 
@@ -355,12 +352,24 @@ void TIndexTabletActor::HandleForcedRangeOperationCompleted(
     const TEvIndexTabletPrivate::TEvForcedRangeOperationCompleted::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (!IsForcedOperationRunning()) {
+        ReportForcedOperationUnexpectedState(
+            "got ForcedRangeOperationCompleted but no current op");
+        return;
+    }
+
     auto* msg = ev->Get();
-    TABLET_VERIFY(IsForcedOperationRunning());
     const auto* state =
         std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
-    TABLET_VERIFY(state);
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+    if (!state) {
+        ReportForcedOperationUnexpectedState(
+            "got ForcedRangeOperationCompleted but current op is a tablet op");
+        return;
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
         "%s ForcedRangeOperation mode=%u completed (%s)",
         LogTag.c_str(),
         state->Mode,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
@@ -310,8 +310,8 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         std::move(msg->Ranges),
         std::move(msg->OperationId));
 
-
-    const auto* state = std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
+    const auto* state =
+        std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
     TABLET_VERIFY(state);
 
     std::unique_ptr<IActor> actor;
@@ -334,7 +334,8 @@ void TIndexTabletActor::HandleForcedRangeOperation(
                 *state,
                 std::move(requestInfo));
             break;
-        case TEvIndexTabletPrivate::EForcedRangeOperationMode::DeleteZeroCompactionRanges:
+        case TEvIndexTabletPrivate::EForcedRangeOperationMode::
+            DeleteZeroCompactionRanges:
             actor = std::make_unique<TDeleteRangesWithEmptyScoreActor>(
                 ctx.SelfID,
                 LogTag,
@@ -357,7 +358,8 @@ void TIndexTabletActor::HandleForcedRangeOperationCompleted(
 {
     auto* msg = ev->Get();
     TABLET_VERIFY(IsForcedOperationRunning());
-    const auto* state = std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
+    const auto* state =
+        std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
     TABLET_VERIFY(state);
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
         "%s ForcedRangeOperation mode=%u completed (%s)",

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
@@ -299,9 +299,11 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    // will lose original request info in case of enqueueing external request
     if (IsForcedOperationRunning()) {
-        EnqueueForcedRangeOperation(msg->Mode, std::move(msg->Ranges));
+        EnqueueForcedRangeOperation(
+            msg->Mode,
+            std::move(msg->Ranges),
+            std::move(msg->OperationId));
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
@@ -345,9 +345,6 @@ void TIndexTabletActor::HandleForcedRangeOperation(
                 *state,
                 std::move(requestInfo));
             break;
-
-        default:
-            TABLET_VERIFY_C(false, "unexpected forced compaction mode");
     }
 
     auto actorId = ctx.Register(actor.release());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_range_operation.cpp
@@ -271,8 +271,9 @@ void TIndexTabletActor::HandleForcedRangeOperation(
     auto* msg = ev->Get();
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ForcedRangeOperation request for %lu ranges",
+        "%s ForcedRangeOperation request mode=%u for %lu ranges",
         LogTag.c_str(),
+        msg->Mode,
         msg->Ranges.size());
 
     auto replyError = [&] (
@@ -355,12 +356,14 @@ void TIndexTabletActor::HandleForcedRangeOperationCompleted(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ForcedRangeOperation completed (%s)",
-        LogTag.c_str(),
-        FormatError(msg->GetError()).c_str());
-
     TABLET_VERIFY(IsForcedOperationRunning());
+    const auto* state = std::get_if<TForcedRangeOperationState>(GetForcedOperationState());
+    TABLET_VERIFY(state);
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s ForcedRangeOperation mode=%u completed (%s)",
+        LogTag.c_str(),
+        state->Mode,
+        FormatError(msg->GetError()).c_str());
     WorkerActors.erase(ev->Sender);
 
     CompleteForcedRangeOperation();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -1,15 +1,7 @@
 #include "tablet_actor.h"
 
-#include <cloud/filestore/libs/diagnostics/profile_log.h>
-#include <cloud/filestore/libs/storage/model/block_buffer.h>
-#include <cloud/filestore/libs/storage/tablet/model/blob_builder.h>
-#include <cloud/filestore/libs/storage/tablet/tablet_state.h>
-
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
-#include <util/generic/algorithm.h>
-#include <util/generic/hash.h>
-#include <util/generic/vector.h>
 
 namespace NCloud::NFileStore::NStorage {
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -264,8 +264,6 @@ void TIndexTabletActor::HandleForcedTabletOperation(
                     Config->GetCompactionRetryTimeout(),
                     std::move(requestInfo));
             break;
-        default:
-            TABLET_VERIFY_C(false, "unexpected forced tablet operation mode");
     }
 
     auto actorId = ctx.Register(actor.release());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -220,8 +220,9 @@ void TIndexTabletActor::HandleForcedTabletOperation(
     auto* msg = ev->Get();
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ForcedTabletOperation request",
-        LogTag.c_str());
+        "%s ForcedTabletOperation mode=%u request",
+        LogTag.c_str(),
+        msg->Mode);
 
     auto requestInfo = CreateRequestInfo(
         ev->Sender,
@@ -276,12 +277,18 @@ void TIndexTabletActor::HandleForcedTabletOperationCompleted(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s ForcedTabletOperation completed (%s)",
-        LogTag.c_str(),
-        FormatError(msg->GetError()).c_str());
 
     TABLET_VERIFY(IsForcedOperationRunning());
+    const auto* state =
+        std::get_if<TForcedTabletOperationState>(GetForcedOperationState());
+    TABLET_VERIFY(state);
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s ForcedTabletOperation mode=%u completed (%s)",
+        LogTag.c_str(),
+        state->Mode,
+        FormatError(msg->GetError()).c_str());
+
     WorkerActors.erase(ev->Sender);
 
     CompleteForcedTabletOperation();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -23,11 +23,8 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * @brief An actor that performs forced compaction or forced cleanup. It is
- * implemented as a template class to avoid code duplication.
- *
- * @tparam TRequestType A functor that constructs a unique_ptr to a
- * request that is necessary to be performed to passed range.
+ * @brief An actor that performs forced flush, flush_bytes, collect_garbage ops.
+ * It is implemented as a template class to avoid code duplication.
  */
 template <typename TResponseType, typename TRequestType>
 class TForcedOperationActor final
@@ -56,7 +53,7 @@ public:
 private:
     STFUNC(StateWork);
 
-    void SendRangeOperationRequest(const TActorContext& ctx);
+    void SendOperationRequest(const TActorContext& ctx);
 
     void HandleOperationResponse(
         const TResponseType::TPtr& ev,
@@ -99,14 +96,14 @@ void TForcedOperationActor<TResponseType, TRequestType>::Bootstrap(
     FILESTORE_TRACK(
         RequestReceived_TabletWorker,
         RequestInfo->CallContext,
-        "ForcedRangeOperation");
+        "ForcedTabletOperation");
 
-    SendRangeOperationRequest(ctx);
+    SendOperationRequest(ctx);
 }
 
 template <typename TResponseType, typename TRequestType>
 void TForcedOperationActor<TResponseType, TRequestType>::
-    SendRangeOperationRequest(const TActorContext& ctx)
+    SendOperationRequest(const TActorContext& ctx)
 {
     auto request = std::make_unique<TRequestType>();
     ctx.Send(Tablet, request.release());
@@ -156,7 +153,7 @@ void TForcedOperationActor<TResponseType, TRequestType>::
     HandleWakeUp(const TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    SendRangeOperationRequest(ctx);
+    SendOperationRequest(ctx);
 }
 
 template <typename TResponseType, typename TRequestType>
@@ -176,19 +173,19 @@ void TForcedOperationActor<TResponseType, TRequestType>::
     {
         // notify tablet
         auto response = std::make_unique<
-            TEvIndexTabletPrivate::TEvForcedRangeOperationCompleted>(error);
+            TEvIndexTabletPrivate::TEvForcedTabletOperationCompleted>(error);
         NCloud::Send(ctx, Tablet, std::move(response));
     }
 
     FILESTORE_TRACK(
         ResponseSent_TabletWorker,
         RequestInfo->CallContext,
-        "ForcedRangeOperation");
+        "ForcedTabletOperation");
 
     if (RequestInfo->Sender != Tablet) {
         // reply to caller
         auto response = std::make_unique<
-            TEvIndexTabletPrivate::TEvForcedRangeOperationResponse>(error);
+            TEvIndexTabletPrivate::TEvForcedTabletOperationResponse>(error);
         NCloud::Reply(ctx, *RequestInfo, std::move(response));
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -246,6 +246,7 @@ void TIndexTabletActor::HandleForcedTabletOperation(
         StartForcedTabletOperation(msg->Mode, std::move(msg->OperationId));
     if (!state) {
         replyError(MakeError(E_INVALID_STATE, "could not start the operation"));
+        return;
     }
 
     std::unique_ptr<IActor> actor;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -136,6 +136,8 @@ void TForcedOperationActor<TResponseType, TRequestType>::
 {
     auto* msg = ev->Get();
 
+    // Note that collect_garbage returns S_ALREAdY instead of E_TRY_AGAIN
+    // so it will be treated as success and the operation won't be restarted
     if (HasError(msg->Error)) {
         if (msg->Error.GetCode() == E_TRY_AGAIN) {
             ctx.Schedule(RetryTimeout, new TEvents::TEvWakeup());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -18,6 +18,201 @@ using namespace NActors;
 using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief An actor that performs forced compaction or forced cleanup. It is
+ * implemented as a template class to avoid code duplication.
+ *
+ * @tparam TRequestType A functor that constructs a unique_ptr to a
+ * request that is necessary to be performed to passed range.
+ */
+template <typename TResponseType, typename TRequestType>
+class TForcedOperationActor final
+    : public TActorBootstrapped<
+          TForcedOperationActor<TResponseType, TRequestType>>
+{
+private:
+    using TBase = NActors::TActorBootstrapped<
+        TForcedOperationActor<TResponseType, TRequestType>>;
+
+    const TActorId Tablet;
+    const TString LogTag;
+    const TDuration RetryTimeout;
+
+    const TRequestInfoPtr RequestInfo;
+
+public:
+    TForcedOperationActor(
+        TActorId tablet,
+        TString logTag,
+        TDuration retry,
+        TRequestInfoPtr requestInfo);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void SendRangeOperationRequest(const TActorContext& ctx);
+
+    void HandleOperationResponse(
+        const TResponseType::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleWakeUp(
+        const TEvents::TEvWakeup::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        const NProto::TError& error);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TResponseType, typename TRequestType>
+TForcedOperationActor<TResponseType, TRequestType>::
+    TForcedOperationActor(
+        TActorId tablet,
+        TString logTag,
+        TDuration retry,
+        TRequestInfoPtr requestInfo)
+    : Tablet(tablet)
+    , LogTag(std::move(logTag))
+    , RetryTimeout(retry)
+    , RequestInfo(std::move(requestInfo))
+{}
+
+template <typename TResponseType, typename TRequestType>
+void TForcedOperationActor<TResponseType, TRequestType>::Bootstrap(
+    const TActorContext& ctx)
+{
+    TBase::Become(&TBase::TThis::StateWork);
+
+    FILESTORE_TRACK(
+        RequestReceived_TabletWorker,
+        RequestInfo->CallContext,
+        "ForcedRangeOperation");
+
+    SendRangeOperationRequest(ctx);
+}
+
+template <typename TResponseType, typename TRequestType>
+void TForcedOperationActor<TResponseType, TRequestType>::
+    SendRangeOperationRequest(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TRequestType>();
+    ctx.Send(Tablet, request.release());
+}
+
+template <typename TResponseType, typename TRequestType>
+STFUNC(
+    (TForcedOperationActor<TResponseType, TRequestType>::StateWork))
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvWakeup, HandleWakeUp);
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(TResponseType, HandleOperationResponse);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TFileStoreComponents::TABLET_WORKER,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+}
+
+template <typename TResponseType, typename TRequestType>
+void TForcedOperationActor<TResponseType, TRequestType>::
+    HandleOperationResponse(
+        const TResponseType::TPtr& ev,
+        const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->Error)) {
+        if (msg->Error.GetCode() == E_TRY_AGAIN) {
+            ctx.Schedule(RetryTimeout, new TEvents::TEvWakeup());
+            return;
+        }
+
+        return ReplyAndDie(ctx, msg->Error);
+    }
+
+    return ReplyAndDie(ctx, {});
+}
+
+template <typename TResponseType, typename TRequestType>
+void TForcedOperationActor<TResponseType, TRequestType>::
+    HandleWakeUp(const TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    SendRangeOperationRequest(ctx);
+}
+
+template <typename TResponseType, typename TRequestType>
+void TForcedOperationActor<TResponseType, TRequestType>::
+    HandlePoisonPill(
+        const TEvents::TEvPoison::TPtr& ev,
+        const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    ReplyAndDie(ctx, MakeError(E_FAIL, "actor killed"));
+}
+
+template <typename TResponseType, typename TRequestType>
+void TForcedOperationActor<TResponseType, TRequestType>::
+    ReplyAndDie(const TActorContext& ctx, const NProto::TError& error)
+{
+    {
+        // notify tablet
+        auto response = std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedRangeOperationCompleted>(error);
+        NCloud::Send(ctx, Tablet, std::move(response));
+    }
+
+    FILESTORE_TRACK(
+        ResponseSent_TabletWorker,
+        RequestInfo->CallContext,
+        "ForcedRangeOperation");
+
+    if (RequestInfo->Sender != Tablet) {
+        // reply to caller
+        auto response = std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedRangeOperationResponse>(error);
+        NCloud::Reply(ctx, *RequestInfo, std::move(response));
+    }
+
+    TBase::Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TForcedFlushActor = TForcedOperationActor<
+    TEvIndexTabletPrivate::TEvFlushResponse,
+    TEvIndexTabletPrivate::TEvFlushRequest>;
+
+using TForcedFlushBytesActor = TForcedOperationActor<
+    TEvIndexTabletPrivate::TEvFlushBytesResponse,
+    TEvIndexTabletPrivate::TEvFlushBytesRequest>;
+
+using TForcedCollectGarbageActor = TForcedOperationActor<
+    TEvIndexTabletPrivate::TEvCollectGarbageResponse,
+    TEvIndexTabletPrivate::TEvCollectGarbageRequest>;
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TIndexTabletActor::HandleForcedTabletOperation(
     const TEvIndexTabletPrivate::TEvForcedTabletOperationRequest::TPtr& ev,
     const TActorContext& ctx)
@@ -48,10 +243,25 @@ void TIndexTabletActor::HandleForcedTabletOperation(
 
     switch (msg->Mode) {
         case TEvIndexTabletPrivate::EForcedTabletOperationMode::Flush:
+            actor = std::make_unique<TForcedFlushActor>(
+                ctx.SelfID,
+                LogTag,
+                Config->GetCompactionRetryTimeout(),
+                std::move(requestInfo));
             break;
         case TEvIndexTabletPrivate::EForcedTabletOperationMode::FlushBytes:
+            actor = std::make_unique<TForcedFlushBytesActor>(
+                    ctx.SelfID,
+                    LogTag,
+                    Config->GetCompactionRetryTimeout(),
+                    std::move(requestInfo));
             break;
         case TEvIndexTabletPrivate::EForcedTabletOperationMode::CollectGarbage:
+            actor = std::make_unique<TForcedCollectGarbageActor>(
+                    ctx.SelfID,
+                    LogTag,
+                    Config->GetCompactionRetryTimeout(),
+                    std::move(requestInfo));
             break;
         default:
             TABLET_VERIFY_C(false, "unexpected forced tablet operation mode");

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -229,9 +229,10 @@ void TIndexTabletActor::HandleForcedTabletOperation(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    // will lose original request info in case of enqueueing external request
     if (IsForcedOperationRunning()) {
-        EnqueueForcedTabletOperation(msg->Mode);
+        EnqueueForcedTabletOperation(
+            msg->Mode,
+            std::move(msg->OperationId));
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -67,20 +67,17 @@ private:
         const TEvents::TEvPoisonPill::TPtr& ev,
         const TActorContext& ctx);
 
-    void ReplyAndDie(
-        const TActorContext& ctx,
-        const NProto::TError& error);
+    void ReplyAndDie(const TActorContext& ctx, const NProto::TError& error);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TResponseType, typename TRequestType>
-TForcedOperationActor<TResponseType, TRequestType>::
-    TForcedOperationActor(
-        TActorId tablet,
-        TString logTag,
-        TDuration retry,
-        TRequestInfoPtr requestInfo)
+TForcedOperationActor<TResponseType, TRequestType>::TForcedOperationActor(
+    TActorId tablet,
+    TString logTag,
+    TDuration retry,
+    TRequestInfoPtr requestInfo)
     : Tablet(tablet)
     , LogTag(std::move(logTag))
     , RetryTimeout(retry)
@@ -102,16 +99,15 @@ void TForcedOperationActor<TResponseType, TRequestType>::Bootstrap(
 }
 
 template <typename TResponseType, typename TRequestType>
-void TForcedOperationActor<TResponseType, TRequestType>::
-    SendOperationRequest(const TActorContext& ctx)
+void TForcedOperationActor<TResponseType, TRequestType>::SendOperationRequest(
+    const TActorContext& ctx)
 {
     auto request = std::make_unique<TRequestType>();
     ctx.Send(Tablet, request.release());
 }
 
 template <typename TResponseType, typename TRequestType>
-STFUNC(
-    (TForcedOperationActor<TResponseType, TRequestType>::StateWork))
+STFUNC((TForcedOperationActor<TResponseType, TRequestType>::StateWork))
 {
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvents::TEvWakeup, HandleWakeUp);
@@ -151,26 +147,27 @@ void TForcedOperationActor<TResponseType, TRequestType>::
 }
 
 template <typename TResponseType, typename TRequestType>
-void TForcedOperationActor<TResponseType, TRequestType>::
-    HandleWakeUp(const TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx)
+void TForcedOperationActor<TResponseType, TRequestType>::HandleWakeUp(
+    const TEvents::TEvWakeup::TPtr& ev,
+    const TActorContext& ctx)
 {
     Y_UNUSED(ev);
     SendOperationRequest(ctx);
 }
 
 template <typename TResponseType, typename TRequestType>
-void TForcedOperationActor<TResponseType, TRequestType>::
-    HandlePoisonPill(
-        const TEvents::TEvPoison::TPtr& ev,
-        const TActorContext& ctx)
+void TForcedOperationActor<TResponseType, TRequestType>::HandlePoisonPill(
+    const TEvents::TEvPoison::TPtr& ev,
+    const TActorContext& ctx)
 {
     Y_UNUSED(ev);
     ReplyAndDie(ctx, MakeError(E_FAIL, "actor killed"));
 }
 
 template <typename TResponseType, typename TRequestType>
-void TForcedOperationActor<TResponseType, TRequestType>::
-    ReplyAndDie(const TActorContext& ctx, const NProto::TError& error)
+void TForcedOperationActor<TResponseType, TRequestType>::ReplyAndDie(
+    const TActorContext& ctx,
+    const NProto::TError& error)
 {
     {
         // notify tablet
@@ -218,27 +215,38 @@ void TIndexTabletActor::HandleForcedTabletOperation(
 {
     auto* msg = ev->Get();
 
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
         "%s ForcedTabletOperation mode=%u request",
         LogTag.c_str(),
         msg->Mode);
 
-    auto requestInfo = CreateRequestInfo(
-        ev->Sender,
-        ev->Cookie,
-        msg->CallContext);
+    auto replyError = [&](const NProto::TError& error)
+    {
+        if (ev->Sender == ctx.SelfID) {
+            return;
+        }
+
+        auto response = std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedRangeOperationResponse>(error);
+        NCloud::Reply(ctx, *ev, std::move(response));
+    };
+
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
     if (IsForcedOperationRunning()) {
-        EnqueueForcedTabletOperation(
-            msg->Mode,
-            std::move(msg->OperationId));
+        EnqueueForcedTabletOperation(msg->Mode, std::move(msg->OperationId));
         return;
     }
 
-    StartForcedTabletOperation(
-        msg->Mode,
-        std::move(msg->OperationId));
+    const auto* state =
+        StartForcedTabletOperation(msg->Mode, std::move(msg->OperationId));
+    if (!state) {
+        replyError(MakeError(E_INVALID_STATE, "could not start the operation"));
+    }
 
     std::unique_ptr<IActor> actor;
 
@@ -252,17 +260,17 @@ void TIndexTabletActor::HandleForcedTabletOperation(
             break;
         case TEvIndexTabletPrivate::EForcedTabletOperationMode::FlushBytes:
             actor = std::make_unique<TForcedFlushBytesActor>(
-                    ctx.SelfID,
-                    LogTag,
-                    Config->GetCompactionRetryTimeout(),
-                    std::move(requestInfo));
+                ctx.SelfID,
+                LogTag,
+                Config->GetCompactionRetryTimeout(),
+                std::move(requestInfo));
             break;
         case TEvIndexTabletPrivate::EForcedTabletOperationMode::CollectGarbage:
             actor = std::make_unique<TForcedCollectGarbageActor>(
-                    ctx.SelfID,
-                    LogTag,
-                    Config->GetCompactionRetryTimeout(),
-                    std::move(requestInfo));
+                ctx.SelfID,
+                LogTag,
+                Config->GetCompactionRetryTimeout(),
+                std::move(requestInfo));
             break;
     }
 
@@ -274,14 +282,24 @@ void TIndexTabletActor::HandleForcedTabletOperationCompleted(
     const TEvIndexTabletPrivate::TEvForcedTabletOperationCompleted::TPtr& ev,
     const TActorContext& ctx)
 {
-    auto* msg = ev->Get();
+    if (!IsForcedOperationRunning()) {
+        ReportForcedOperationUnexpectedState(
+            "got ForcedTabletOperationCompleted but no current op");
+        return;
+    }
 
-    TABLET_VERIFY(IsForcedOperationRunning());
+    auto* msg = ev->Get();
     const auto* state =
         std::get_if<TForcedTabletOperationState>(GetForcedOperationState());
-    TABLET_VERIFY(state);
+    if (!state) {
+        ReportForcedOperationUnexpectedState(
+            "got ForcedTabletOperationCompleted but current op is a range op");
+        return;
+    }
 
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
         "%s ForcedTabletOperation mode=%u completed (%s)",
         LogTag.c_str(),
         state->Mode,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_forced_tablet_operation.cpp
@@ -1,0 +1,81 @@
+#include "tablet_actor.h"
+
+#include <cloud/filestore/libs/diagnostics/profile_log.h>
+#include <cloud/filestore/libs/storage/model/block_buffer.h>
+#include <cloud/filestore/libs/storage/tablet/model/blob_builder.h>
+#include <cloud/filestore/libs/storage/tablet/tablet_state.h>
+
+#include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <util/generic/algorithm.h>
+#include <util/generic/hash.h>
+#include <util/generic/vector.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+void TIndexTabletActor::HandleForcedTabletOperation(
+    const TEvIndexTabletPrivate::TEvForcedTabletOperationRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s ForcedTabletOperation request",
+        LogTag.c_str());
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
+
+    // will lose original request info in case of enqueueing external request
+    if (IsForcedOperationRunning()) {
+        EnqueueForcedTabletOperation(msg->Mode);
+        return;
+    }
+
+    StartForcedTabletOperation(
+        msg->Mode,
+        std::move(msg->OperationId));
+
+    std::unique_ptr<IActor> actor;
+
+    switch (msg->Mode) {
+        case TEvIndexTabletPrivate::EForcedTabletOperationMode::Flush:
+            break;
+        case TEvIndexTabletPrivate::EForcedTabletOperationMode::FlushBytes:
+            break;
+        case TEvIndexTabletPrivate::EForcedTabletOperationMode::CollectGarbage:
+            break;
+        default:
+            TABLET_VERIFY_C(false, "unexpected forced tablet operation mode");
+    }
+
+    auto actorId = ctx.Register(actor.release());
+    WorkerActors.insert(actorId);
+}
+
+void TIndexTabletActor::HandleForcedTabletOperationCompleted(
+    const TEvIndexTabletPrivate::TEvForcedTabletOperationCompleted::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s ForcedTabletOperation completed (%s)",
+        LogTag.c_str(),
+        FormatError(msg->GetError()).c_str());
+
+    TABLET_VERIFY(IsForcedOperationRunning());
+    WorkerActors.erase(ev->Sender);
+
+    CompleteForcedTabletOperation();
+    EnqueueForcedOperationIfNeeded(ctx);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -342,9 +342,13 @@ void DumpCompactionInfo(
     IOutputStream& out,
     const TIndexTabletState::TForcedOperationState& state)
 {
-    const auto* rangeOpState = std::get_if<TIndexTabletState::TForcedRangeOperationState>(&state);
+    const auto* rangeOpState =
+        std::get_if<TIndexTabletState::TForcedRangeOperationState>(&state);
     if (rangeOpState) {
-        DumpProgress(out, rangeOpState->Current, rangeOpState->RangesToCompact.size());
+        DumpProgress(
+            out,
+            rangeOpState->Current,
+            rangeOpState->RangesToCompact.size());
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -340,9 +340,12 @@ void DumpOperationState(
 
 void DumpCompactionInfo(
     IOutputStream& out,
-    const TIndexTabletState::TForcedRangeOperationState& state)
+    const TIndexTabletState::TForcedOperationState& state)
 {
-    DumpProgress(out, state.Current, state.RangesToCompact.size());
+    const auto* rangeOpState = std::get_if<TIndexTabletState::TForcedRangeOperationState>(&state);
+    if (rangeOpState) {
+        DumpProgress(out, rangeOpState->Current, rangeOpState->RangesToCompact.size());
+    }
 }
 
 void DumpRangeId(IOutputStream& out, ui64 tabletId, ui32 rangeId)
@@ -1255,14 +1258,14 @@ void TIndexTabletActor::RenderHttpInfo_OverviewTab(
 #undef DUMP_INFO_FIELD
 
         TAG(TH3) {
-            if (!IsForcedRangeOperationRunning()) {
+            if (!IsForcedOperationRunning()) {
                 BuildMenuButton(out, "compact-all");
             }
             out << "CompactionQueue";
         }
 
-        if (IsForcedRangeOperationRunning()) {
-            DumpCompactionInfo(out, *GetForcedRangeOperationState());
+        if (IsForcedOperationRunning()) {
+            DumpCompactionInfo(out, *GetForcedOperationState());
         } else {
             out << "<div class='collapse form-group' id='compact-all'>";
             BuildForceCompactionButton(out, TabletID());
@@ -1424,7 +1427,7 @@ void TIndexTabletActor::HandleHttpInfo_ForceOperation(
     const TCgiParameters& params,
     TRequestInfoPtr requestInfo)
 {
-    if (IsForcedRangeOperationRunning()) {
+    if (IsForcedOperationRunning()) {
         SendHttpResponse(
             ctx,
             TabletID(),
@@ -1481,7 +1484,7 @@ void TIndexTabletActor::HandleHttpInfo_ForceOperation(
     }
 
     EnqueueForcedRangeOperation(mode, std::move(ranges));
-    EnqueueForcedRangeOperationIfNeeded(ctx);
+    EnqueueForcedOperationIfNeeded(ctx);
 
     SendHttpResponse(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1519,14 +1519,16 @@ public:
 protected:
     struct TPendingForcedRangeOperation
     {
-        TEvIndexTabletPrivate::EForcedRangeOperationMode Mode;
+        TEvIndexTabletPrivate::EForcedRangeOperationMode Mode =
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction;
         TVector<ui32> Ranges;
         TString OperationId;
     };
 
     struct TPendingForcedTabletOperation
     {
-        TEvIndexTabletPrivate::EForcedTabletOperationMode Mode;
+        TEvIndexTabletPrivate::EForcedTabletOperationMode Mode =
+            TEvIndexTabletPrivate::EForcedTabletOperationMode::Flush;
         TString OperationId;
     };
 
@@ -1565,7 +1567,7 @@ public:
     }
 
     // TODO: FindForcedOperation does not perform lookup in pending
-    // requests queue
+    // requests queue (https://github.com/ydb-platform/nbs/issues/6977)
     const TForcedOperationState* FindForcedOperation(
         const TString& operationId) const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1541,9 +1541,11 @@ private:
 public:
     TString EnqueueForcedRangeOperation(
         TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
-        TVector<ui32> ranges);
+        TVector<ui32> ranges,
+        TString operationId = {});
     TString EnqueueForcedTabletOperation(
-        TEvIndexTabletPrivate::EForcedTabletOperationMode mode);
+        TEvIndexTabletPrivate::EForcedTabletOperationMode mode,
+        TString operationId = {});
     TMaybe<TPendingForcedOperation> DequeueForcedOperation();
 
     void StartForcedRangeOperation(

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1463,7 +1463,7 @@ public:
     void LoadCompactionMap(const TVector<TCompactionRangeInfo>& compactionMap);
 
     //
-    // Forced Compaction
+    // Forced operations
     //
 
 public:
@@ -1499,7 +1499,23 @@ public:
         }
     };
 
-private:
+    struct TForcedTabletOperationState
+    {
+        const TEvIndexTabletPrivate::EForcedTabletOperationMode Mode;
+        const TString OperationId;
+        TInstant StartTime = TInstant::Now();
+
+        TForcedTabletOperationState(
+                TEvIndexTabletPrivate::EForcedTabletOperationMode mode,
+                const TString& operationId)
+            : Mode(mode)
+            , OperationId(operationId)
+        {}
+    };
+
+    using TForcedOperationState = std::variant<TForcedRangeOperationState, TForcedTabletOperationState>;
+
+protected:
     struct TPendingForcedRangeOperation
     {
         TEvIndexTabletPrivate::EForcedRangeOperationMode Mode;
@@ -1507,40 +1523,58 @@ private:
         TString OperationId;
     };
 
-    TVector<TPendingForcedRangeOperation> PendingForcedRangeOperations;
-    TMaybe<TForcedRangeOperationState> ForcedRangeOperationState;
-    TVector<TForcedRangeOperationState> CompletedForcedRangeOperations;
+    struct TPendingForcedTabletOperation
+    {
+        TEvIndexTabletPrivate::EForcedTabletOperationMode Mode;
+        TString OperationId;
+    };
+
+    using TPendingForcedOperation = std::variant<TPendingForcedRangeOperation, TPendingForcedTabletOperation>;
+
+private:
+    TVector<TPendingForcedOperation> PendingForcedOperations;
+    TMaybe<TForcedOperationState> ForcedOperationState;
+    TVector<TForcedOperationState> CompletedForcedOperations;
 
 public:
     TString EnqueueForcedRangeOperation(
         TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
         TVector<ui32> ranges);
-    TPendingForcedRangeOperation DequeueForcedRangeOperation();
+    TString EnqueueForcedTabletOperation(
+        TEvIndexTabletPrivate::EForcedTabletOperationMode mode);
+    TMaybe<TPendingForcedOperation> DequeueForcedOperation();
 
     void StartForcedRangeOperation(
         TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
         TVector<ui32> ranges,
         TString operationId);
+    void StartForcedTabletOperation(
+        TEvIndexTabletPrivate::EForcedTabletOperationMode mode,
+        TString operationId);
 
     void CompleteForcedRangeOperation();
+    void CompleteForcedTabletOperation();
 
-    const TForcedRangeOperationState* GetForcedRangeOperationState() const
+    const TForcedOperationState* GetForcedOperationState() const
     {
-        return ForcedRangeOperationState.Get();
+        return ForcedOperationState.Get();
     }
 
-    const TForcedRangeOperationState* FindForcedRangeOperation(
+    // TODO: FindForcedOperation does not perform lookup in pending
+    // requests queue
+    const TForcedOperationState* FindForcedOperation(
         const TString& operationId) const;
 
     void UpdateForcedRangeOperationProgress(ui32 current)
     {
-        ForcedRangeOperationState->Current =
-            Max(ForcedRangeOperationState->Current, current);
+        auto* state = std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
+        TABLET_VERIFY(state);
+        state->Current = Max(state->Current, current);
     }
 
-    bool IsForcedRangeOperationRunning() const
+    bool IsForcedOperationRunning() const
     {
-        return ForcedRangeOperationState.Defined();
+        return ForcedOperationState.Defined();
     }
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1513,7 +1513,8 @@ public:
         {}
     };
 
-    using TForcedOperationState = std::variant<TForcedRangeOperationState, TForcedTabletOperationState>;
+    using TForcedOperationState =
+        std::variant<TForcedRangeOperationState, TForcedTabletOperationState>;
 
 protected:
     struct TPendingForcedRangeOperation
@@ -1529,7 +1530,8 @@ protected:
         TString OperationId;
     };
 
-    using TPendingForcedOperation = std::variant<TPendingForcedRangeOperation, TPendingForcedTabletOperation>;
+    using TPendingForcedOperation = std::
+        variant<TPendingForcedRangeOperation, TPendingForcedTabletOperation>;
 
 private:
     TVector<TPendingForcedOperation> PendingForcedOperations;
@@ -1567,7 +1569,8 @@ public:
 
     void UpdateForcedRangeOperationProgress(ui32 current)
     {
-        auto* state = std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
+        auto* state =
+            std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
         TABLET_VERIFY(state);
         state->Current = Max(state->Current, current);
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1550,11 +1550,11 @@ public:
         TString operationId = {});
     TMaybe<TPendingForcedOperation> DequeueForcedOperation();
 
-    void StartForcedRangeOperation(
+    TForcedRangeOperationState* StartForcedRangeOperation(
         TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
         TVector<ui32> ranges,
         TString operationId);
-    void StartForcedTabletOperation(
+    TForcedTabletOperationState* StartForcedTabletOperation(
         TEvIndexTabletPrivate::EForcedTabletOperationMode mode,
         TString operationId);
 
@@ -1571,13 +1571,7 @@ public:
     const TForcedOperationState* FindForcedOperation(
         const TString& operationId) const;
 
-    void UpdateForcedRangeOperationProgress(ui32 current)
-    {
-        auto* state =
-            std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
-        TABLET_VERIFY(state);
-        state->Current = Max(state->Current, current);
-    }
+    void UpdateForcedRangeOperationProgress(ui32 current);
 
     bool IsForcedOperationRunning() const
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1451,9 +1451,12 @@ void TIndexTabletState::LoadCompactionMap(
 
 TString TIndexTabletState::EnqueueForcedRangeOperation(
     TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
-    TVector<ui32> ranges)
+    TVector<ui32> ranges,
+    TString operationId)
 {
-    auto operationId = CreateGuidAsString();
+    if (!operationId) {
+        operationId = CreateGuidAsString();
+    }
     PendingForcedOperations.emplace_back(TPendingForcedRangeOperation(
         mode,
         std::move(ranges),
@@ -1462,9 +1465,12 @@ TString TIndexTabletState::EnqueueForcedRangeOperation(
 }
 
 TString TIndexTabletState::EnqueueForcedTabletOperation(
-    TEvIndexTabletPrivate::EForcedTabletOperationMode mode)
+    TEvIndexTabletPrivate::EForcedTabletOperationMode mode,
+    TString operationId)
 {
-    auto operationId = CreateGuidAsString();
+    if (!operationId) {
+        operationId = CreateGuidAsString();
+    }
     PendingForcedOperations.emplace_back(TPendingForcedTabletOperation(
         mode,
         operationId));

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1532,14 +1532,12 @@ void TIndexTabletState::CompleteForcedTabletOperation()
 auto TIndexTabletState::FindForcedOperation(
     const TString& operationId) const -> const TForcedOperationState*
 {
-    auto checkId = [operationId](const TForcedOperationState& state) {
-        const auto& opId = std::visit(
-            [] (const auto& state)
-            {
-                return state.OperationId;
-            },
+    auto checkId = [operationId](const TForcedOperationState& state)
+    {
+        return std::visit(
+            [operationId](const auto& state)
+            { return state.OperationId == operationId; },
             state);
-        return opId == operationId;
     };
 
     if (ForcedOperationState && checkId(*ForcedOperationState.Get()))

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1576,10 +1576,10 @@ void TIndexTabletState::CompleteForcedTabletOperation()
 auto TIndexTabletState::FindForcedOperation(
     const TString& operationId) const -> const TForcedOperationState*
 {
-    auto checkId = [operationId](const TForcedOperationState& state)
+    auto checkId = [&operationId](const TForcedOperationState& state)
     {
         return std::visit(
-            [operationId](const auto& state)
+            [&operationId](const auto& state)
             { return state.OperationId == operationId; },
             state);
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1490,33 +1490,63 @@ TMaybe<TIndexTabletState::TPendingForcedOperation> TIndexTabletState::
     return op;
 }
 
-void TIndexTabletState::StartForcedRangeOperation(
+TIndexTabletState::TForcedRangeOperationState*
+TIndexTabletState::StartForcedRangeOperation(
     TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
     TVector<ui32> ranges,
     TString operationId)
 {
-    TABLET_VERIFY(!ForcedOperationState.Defined());
+    if (ForcedOperationState.Defined()) {
+        ReportForcedOperationUnexpectedState("operation already running");
+        return nullptr;
+    }
     ForcedOperationState.ConstructInPlace(TForcedRangeOperationState(
         mode,
         std::move(ranges),
         std::move(operationId)));
+    return std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
 }
 
-void TIndexTabletState::StartForcedTabletOperation(
-        TEvIndexTabletPrivate::EForcedTabletOperationMode mode,
-        TString operationId)
+TIndexTabletState::TForcedTabletOperationState*
+TIndexTabletState::StartForcedTabletOperation(
+    TEvIndexTabletPrivate::EForcedTabletOperationMode mode,
+    TString operationId)
 {
-    TABLET_VERIFY(!ForcedOperationState.Defined());
-    ForcedOperationState.ConstructInPlace(TForcedTabletOperationState(
-        mode,
-        std::move(operationId)));
+    if (ForcedOperationState.Defined()) {
+        ReportForcedOperationUnexpectedState("operation already running");
+        return nullptr;
+    }
+    ForcedOperationState.ConstructInPlace(
+        TForcedTabletOperationState(mode, std::move(operationId)));
+    return std::get_if<TForcedTabletOperationState>(ForcedOperationState.Get());
+}
+
+void TIndexTabletState::UpdateForcedRangeOperationProgress(ui32 current)
+{
+    auto* state =
+        std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
+    if (!state) {
+        ReportForcedOperationUnexpectedState("range state expected");
+        return;
+    }
+    state->Current = Max(state->Current, current);
 }
 
 void TIndexTabletState::CompleteForcedRangeOperation()
 {
-    Y_DEBUG_ABORT_UNLESS(ForcedOperationState);
-    auto* rangeState = std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
-    TABLET_VERIFY(rangeState);
+    if (!ForcedOperationState) {
+        ReportForcedOperationUnexpectedState("no current operation");
+        return;
+    }
+
+    auto* rangeState =
+        std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
+    if (!rangeState) {
+        ReportForcedOperationUnexpectedState(
+            "current state is not a range state");
+        return;
+    }
+
     if (rangeState->OperationId) {
         rangeState->Current = rangeState->RangesToCompact.size();
         CompletedForcedOperations.push_back(*ForcedOperationState);
@@ -1526,9 +1556,17 @@ void TIndexTabletState::CompleteForcedRangeOperation()
 
 void TIndexTabletState::CompleteForcedTabletOperation()
 {
-    Y_DEBUG_ABORT_UNLESS(ForcedOperationState);
+    if (!ForcedOperationState) {
+        ReportForcedOperationUnexpectedState("no current operation");
+        return;
+    }
+
     auto* tabletState = std::get_if<TForcedTabletOperationState>(ForcedOperationState.Get());
-    TABLET_VERIFY(tabletState);
+    if (!tabletState) {
+        ReportForcedOperationUnexpectedState(
+            "current state is not a tablet state");
+        return;
+    }
     if (tabletState->OperationId) {
         CompletedForcedOperations.push_back(*ForcedOperationState);
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1454,22 +1454,32 @@ TString TIndexTabletState::EnqueueForcedRangeOperation(
     TVector<ui32> ranges)
 {
     auto operationId = CreateGuidAsString();
-    PendingForcedRangeOperations.emplace_back(
+    PendingForcedOperations.emplace_back(TPendingForcedRangeOperation(
         mode,
         std::move(ranges),
-        operationId);
+        operationId));
     return operationId;
 }
 
-TIndexTabletState::TPendingForcedRangeOperation TIndexTabletState::
-    DequeueForcedRangeOperation()
+TString TIndexTabletState::EnqueueForcedTabletOperation(
+    TEvIndexTabletPrivate::EForcedTabletOperationMode mode)
 {
-    if (PendingForcedRangeOperations.empty()) {
+    auto operationId = CreateGuidAsString();
+    PendingForcedOperations.emplace_back(TPendingForcedTabletOperation(
+        mode,
+        operationId));
+    return operationId;
+}
+
+TMaybe<TIndexTabletState::TPendingForcedOperation> TIndexTabletState::
+    DequeueForcedOperation()
+{
+    if (PendingForcedOperations.empty()) {
         return {};
     }
 
-    auto op = std::move(PendingForcedRangeOperations.back());
-    PendingForcedRangeOperations.pop_back();
+    auto op = std::move(PendingForcedOperations.back());
+    PendingForcedOperations.pop_back();
 
     return op;
 }
@@ -1479,35 +1489,66 @@ void TIndexTabletState::StartForcedRangeOperation(
     TVector<ui32> ranges,
     TString operationId)
 {
-    TABLET_VERIFY(!ForcedRangeOperationState.Defined());
-    ForcedRangeOperationState.ConstructInPlace(
+    TABLET_VERIFY(!ForcedOperationState.Defined());
+    ForcedOperationState.ConstructInPlace(TForcedRangeOperationState(
         mode,
         std::move(ranges),
-        std::move(operationId));
+        std::move(operationId)));
+}
+
+void TIndexTabletState::StartForcedTabletOperation(
+        TEvIndexTabletPrivate::EForcedTabletOperationMode mode,
+        TString operationId)
+{
+    TABLET_VERIFY(!ForcedOperationState.Defined());
+    ForcedOperationState.ConstructInPlace(TForcedTabletOperationState(
+        mode,
+        std::move(operationId)));
 }
 
 void TIndexTabletState::CompleteForcedRangeOperation()
 {
-    Y_DEBUG_ABORT_UNLESS(ForcedRangeOperationState);
-    if (ForcedRangeOperationState && ForcedRangeOperationState->OperationId) {
-        ForcedRangeOperationState->Current =
-            ForcedRangeOperationState->RangesToCompact.size();
-        CompletedForcedRangeOperations.push_back(*ForcedRangeOperationState);
+    Y_DEBUG_ABORT_UNLESS(ForcedOperationState);
+    auto* rangeState = std::get_if<TForcedRangeOperationState>(ForcedOperationState.Get());
+    TABLET_VERIFY(rangeState);
+    if (rangeState->OperationId) {
+        rangeState->Current = rangeState->RangesToCompact.size();
+        CompletedForcedOperations.push_back(*ForcedOperationState);
     }
-    ForcedRangeOperationState.Clear();
+    ForcedOperationState.Clear();
 }
 
-auto TIndexTabletState::FindForcedRangeOperation(
-    const TString& operationId) const -> const TForcedRangeOperationState*
+void TIndexTabletState::CompleteForcedTabletOperation()
 {
-    if (ForcedRangeOperationState
-            && ForcedRangeOperationState->OperationId == operationId)
+    Y_DEBUG_ABORT_UNLESS(ForcedOperationState);
+    auto* tabletState = std::get_if<TForcedTabletOperationState>(ForcedOperationState.Get());
+    TABLET_VERIFY(tabletState);
+    if (tabletState->OperationId) {
+        CompletedForcedOperations.push_back(*ForcedOperationState);
+    }
+    ForcedOperationState.Clear();
+}
+
+auto TIndexTabletState::FindForcedOperation(
+    const TString& operationId) const -> const TForcedOperationState*
+{
+    auto checkId = [operationId](const TForcedOperationState& state) {
+        const auto& opId = std::visit(
+            [] (const auto& state)
+            {
+                return state.OperationId;
+            },
+            state);
+        return opId == operationId;
+    };
+
+    if (ForcedOperationState && checkId(*ForcedOperationState.Get()))
     {
-        return ForcedRangeOperationState.Get();
+        return ForcedOperationState.Get();
     }
 
-    for (const auto& op: CompletedForcedRangeOperations) {
-        if (op.OperationId == operationId) {
+    for (const auto& op: CompletedForcedOperations) {
+        if (checkId(op)) {
             return &op;
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -4663,40 +4663,37 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         TVector<std::unique_ptr<IEventHandle>> scheduledRequests;
         std::unique_ptr<IEventHandle> flushBytesRequest;
 
-        env.GetRuntime().SetEventFilter(
-            [&](auto& runtime, auto& event)
-            {
-                Y_UNUSED(runtime);
+        auto filter = [&](auto& runtime, auto& event)
+        {
+            Y_UNUSED(runtime);
 
-                switch (event->GetTypeRewrite()) {
-                    case TEvIndexTabletPrivate ::EvForcedTabletOperationRequest:
-                    case TEvIndexTabletPrivate ::
-                        EvForcedRangeOperationRequest: {
-                        if (captureScheduledRequests) {
-                            scheduledRequests.emplace_back(event.Release());
-                            return true;
-                        }
-                        break;
+            switch (event->GetTypeRewrite()) {
+                case TEvIndexTabletPrivate ::EvForcedTabletOperationRequest:
+                case TEvIndexTabletPrivate ::EvForcedRangeOperationRequest: {
+                    if (captureScheduledRequests) {
+                        scheduledRequests.emplace_back(event.Release());
+                        return true;
                     }
-                    case TEvIndexTabletPrivate::EvFlushBytesRequest: {
-                        if (captureFlushBytesRequest) {
-                            captureFlushBytesRequest = false;
-                            flushBytesRequest.reset(event.Release());
-                            return true;
-                        }
-                        break;
-                    }
-                    case TEvIndexTabletPrivate ::
-                        EvForcedRangeOperationCompleted:
-                    case TEvIndexTabletPrivate ::
-                        EvForcedTabletOperationCompleted: {
-                        ++completedOperations;
-                        break;
-                    }
+                    break;
                 }
+                case TEvIndexTabletPrivate::EvFlushBytesRequest: {
+                    if (captureFlushBytesRequest) {
+                        captureFlushBytesRequest = false;
+                        flushBytesRequest.reset(event.Release());
+                        return true;
+                    }
+                    break;
+                }
+                case TEvIndexTabletPrivate ::EvForcedRangeOperationCompleted:
+                case TEvIndexTabletPrivate ::EvForcedTabletOperationCompleted: {
+                    ++completedOperations;
+                    break;
+                }
+            }
 
-                return false;
-            });
+            return false;
+        };
+        env.GetRuntime().SetEventFilter(filter);
 
         // Initialize all operations and capture their operationIds
         for (const auto operation: operations) {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -4626,6 +4626,145 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             testEnvConfig);
     }
 
+    TABLET_TEST(ShouldPreserveIdsOfQueuedForcedOperations)
+    {
+        using EOperation =
+            NProtoPrivate::TForcedOperationRequest::EForcedOperationType;
+        using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
+
+        const TVector<EOperation> operations = {
+            NProtoPrivate::TForcedOperationRequest::E_FLUSH_BYTES,
+            NProtoPrivate::TForcedOperationRequest::E_FLUSH,
+            NProtoPrivate::TForcedOperationRequest::E_COMPACTION,
+        };
+
+        TTestEnv env(testEnvConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        NProtoPrivate::TCompactionRangeStats range;
+        range.SetRangeId(0);
+        range.SetBlobCount(1);
+        tablet.WriteCompactionMap(
+            TVector<NProtoPrivate::TCompactionRangeStats>{range});
+        tablet.RebootTablet();
+
+        bool captureScheduledRequests = true;
+        ui32 completedOperations = 0;
+        bool captureFlushBytesRequest = true;
+        TVector<std::unique_ptr<IEventHandle>> scheduledRequests;
+        std::unique_ptr<IEventHandle> flushBytesRequest;
+
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTabletPrivate ::EvForcedTabletOperationRequest:
+                    case TEvIndexTabletPrivate ::
+                        EvForcedRangeOperationRequest: {
+                        if (captureScheduledRequests) {
+                            scheduledRequests.emplace_back(event.Release());
+                            return true;
+                        }
+                        break;
+                    }
+                    case TEvIndexTabletPrivate::EvFlushBytesRequest: {
+                        if (captureFlushBytesRequest) {
+                            captureFlushBytesRequest = false;
+                            flushBytesRequest.reset(event.Release());
+                            return true;
+                        }
+                        break;
+                    }
+                    case TEvIndexTabletPrivate ::
+                        EvForcedRangeOperationCompleted:
+                    case TEvIndexTabletPrivate ::
+                        EvForcedTabletOperationCompleted: {
+                        ++completedOperations;
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        // Initialize all operations and capture their operationIds
+        for (const auto operation: operations) {
+            tablet.SendForcedOperationRequest(operation);
+        }
+
+        TVector<TString> operationIds;
+        for (ui32 i = 0; i < operations.size(); ++i) {
+            auto response = tablet.RecvForcedOperationResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_UNEQUAL(
+                TString(),
+                response->Record.GetOperationId());
+            operationIds.push_back(response->Record.GetOperationId());
+        }
+
+        // Wait until all private tablet/range events are sent
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return scheduledRequests.size() == operations.size();
+        };
+        env.GetRuntime().DispatchEvents(options);
+
+        // Send first request and wait until it is convered into a
+        // real operation event (flush_bytes).
+        captureScheduledRequests = false;
+        env.GetRuntime().Send(scheduledRequests.front().release(), nodeIdx);
+
+        options.CustomFinalCondition = [&]
+        {
+            return !!flushBytesRequest;
+        };
+        env.GetRuntime().DispatchEvents(options);
+
+        // Send all other tablet/range op requests. Here is the window between
+        // flush_bytes event is sent but the operation is not yet started,
+        // hence all the new concrete op events are queued.
+        for (ui32 i = 1; i < scheduledRequests.size(); ++i) {
+            env.GetRuntime().Send(scheduledRequests[i].release(), nodeIdx);
+        }
+        // Resend flush_bytes request. After it is handled, the operation
+        // is started and new requests are rejected.
+        env.GetRuntime().Send(flushBytesRequest.release(), nodeIdx);
+
+        // Wait until all events complete
+        options.CustomFinalCondition = [&]
+        {
+            return completedOperations == operations.size();
+        };
+        env.GetRuntime().DispatchEvents(options);
+
+        // Ensure that we can check operation status also if it was queued.
+        for (const auto& operationId: operationIds) {
+            auto status = GetForcedOperationStatus(tablet, operationId);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                status->GetStatus(),
+                status->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(TStatus::E_COMPLETED),
+                static_cast<int>(status->Record.GetStatus()));
+        }
+    }
+
     TABLET_TEST(ShouldDumpCompactionRangeBlobs)
     {
         TTestEnv env(testEnvConfig);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -4375,6 +4375,257 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL(lastCompactionMapRangeId, 79);
     }
 
+    std::unique_ptr<TEvIndexTablet::TEvForcedOperationStatusResponse>
+    GetForcedOperationStatus(
+        TIndexTabletClient & tablet,
+        const TString& operationId)
+    {
+        auto request =
+            std::make_unique<TEvIndexTablet::TEvForcedOperationStatusRequest>();
+        request->Record.SetOperationId(operationId);
+
+        tablet.SendRequest(std::move(request));
+        return tablet.RecvForcedOperationStatusResponse();
+    }
+
+    template <typename TOperationResponse>
+    struct TForcedTabletOperationTestConfig
+    {
+        using EOperation =
+            NProtoPrivate::TForcedOperationRequest::EForcedOperationType;
+        using EMode = TEvIndexTabletPrivate::EForcedTabletOperationMode;
+        using TResponse = TOperationResponse;
+
+        EOperation Type;
+        EMode Mode;
+        ui32 RequestEventType;
+    };
+
+    template <typename TOperationResponse>
+    void TestForcedTabletOperation(
+        const TForcedTabletOperationTestConfig<TOperationResponse>& operation,
+        TFileSystemConfig tabletConfig,
+        TTestEnvConfig testEnvConfig)
+    {
+        using EMode =
+            typename TForcedTabletOperationTestConfig<TOperationResponse>::EMode;
+        using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
+
+        TTestEnv env(testEnvConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        if (operation.Mode != EMode::CollectGarbage) {
+            auto id =
+                CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+            auto handle = CreateHandle(tablet, id);
+            tablet.WriteData(handle, 0, tabletConfig.BlockSize, 'a');
+
+            if (operation.Mode == EMode::FlushBytes) {
+                tablet.WriteData(handle, 100, 10, 'b');
+            }
+        }
+
+        bool operationRequestObserved = false;
+        bool forcedOperationCompleted = false;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+
+                if (event->GetTypeRewrite() == operation.RequestEventType) {
+                    operationRequestObserved = true;
+                } else if (
+                    event->GetTypeRewrite() ==
+                    TEvIndexTabletPrivate::EvForcedTabletOperationCompleted)
+                {
+                    forcedOperationCompleted = true;
+                }
+
+                return false;
+            });
+
+        auto response = tablet.ForcedOperation(operation.Type);
+        const auto operationId = response->Record.GetOperationId();
+        UNIT_ASSERT_VALUES_UNEQUAL(TString(), operationId);
+
+        NActors::TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return forcedOperationCompleted;
+        };
+        env.GetRuntime().DispatchEvents(options);
+
+        UNIT_ASSERT(operationRequestObserved);
+
+        auto status = GetForcedOperationStatus(tablet, operationId);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            status->GetStatus(),
+            status->GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(TStatus::E_COMPLETED),
+            static_cast<int>(status->Record.GetStatus()));
+
+        if (operation.Mode == EMode::Flush) {
+            auto stats = tablet.GetStorageStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats->Record.GetStats().GetFreshBlocksCount());
+        } else if (operation.Mode == EMode::FlushBytes) {
+            auto stats = tablet.GetStorageStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats->Record.GetStats().GetFreshBytesCount());
+        }
+    }
+
+    template <typename TOperationResponse>
+    void TestForcedTabletOperationError(
+        const TForcedTabletOperationTestConfig<TOperationResponse>& operation,
+        TFileSystemConfig tabletConfig,
+        TTestEnvConfig testEnvConfig)
+    {
+        using TResponse = typename TForcedTabletOperationTestConfig<
+            TOperationResponse>::TResponse;
+
+        TTestEnv env(testEnvConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        const TString errorMessage = "injected forced operation error";
+        bool operationRequestObserved = false;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                if (event->GetTypeRewrite() != operation.RequestEventType) {
+                    return false;
+                }
+
+                operationRequestObserved = true;
+                const auto error = MakeError(E_REJECTED, errorMessage);
+                const auto sendForcedOperationError = [&](auto response)
+                {
+                    auto responseHandle =
+                        std::make_unique<NActors::IEventHandle>(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0,
+                            event->Cookie);
+
+                    runtime.Send(responseHandle.release(), nodeIdx);
+                };
+                sendForcedOperationError(std::make_unique<TResponse>(error));
+
+                return true;
+            });
+
+        auto request = std::make_unique<
+            TEvIndexTabletPrivate::TEvForcedTabletOperationRequest>(
+            operation.Mode,
+            CreateGuidAsString());
+        tablet.SendRequest(std::move(request));
+
+        auto response = tablet.RecvForcedTabletOperationResponse();
+        UNIT_ASSERT(operationRequestObserved);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            response->GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(errorMessage, response->GetErrorReason());
+    }
+
+    static const TForcedTabletOperationTestConfig<
+        TEvIndexTabletPrivate::TEvFlushResponse>
+        ForcedFlushOperation = {
+            NProtoPrivate::TForcedOperationRequest::E_FLUSH,
+            TEvIndexTabletPrivate::EForcedTabletOperationMode::Flush,
+            TEvIndexTabletPrivate::EvFlushRequest,
+        };
+
+    const TForcedTabletOperationTestConfig<
+        TEvIndexTabletPrivate::TEvFlushBytesResponse>
+        ForcedFlushBytesOperation = {
+            NProtoPrivate::TForcedOperationRequest::E_FLUSH_BYTES,
+            TEvIndexTabletPrivate::EForcedTabletOperationMode::FlushBytes,
+            TEvIndexTabletPrivate::EvFlushBytesRequest,
+        };
+
+    const TForcedTabletOperationTestConfig<
+        TEvIndexTabletPrivate::TEvCollectGarbageResponse>
+        ForcedCollectGarbageOperation = {
+            NProtoPrivate::TForcedOperationRequest::E_COLLECT_GARBAGE,
+            TEvIndexTabletPrivate::EForcedTabletOperationMode::CollectGarbage,
+            TEvIndexTabletPrivate::EvCollectGarbageRequest,
+        };
+
+    TABLET_TEST(ShouldDoForcedFlush)
+    {
+        TestForcedTabletOperation(
+            ForcedFlushOperation,
+            tabletConfig,
+            testEnvConfig);
+    }
+
+    TABLET_TEST(ShouldDoForcedFlushBytes)
+    {
+        TestForcedTabletOperation(
+            ForcedFlushBytesOperation,
+            tabletConfig,
+            testEnvConfig);
+    }
+
+    TABLET_TEST(ShouldDoForcedCollectGarbage)
+    {
+        TestForcedTabletOperation(
+            ForcedCollectGarbageOperation,
+            tabletConfig,
+            testEnvConfig);
+    }
+
+    // So far there is no proper error reporting in public api, so
+    // using private api here.
+    TABLET_TEST(ShouldReportForcedFlushError)
+    {
+        TestForcedTabletOperationError(
+            ForcedFlushOperation,
+            tabletConfig,
+            testEnvConfig);
+    }
+
+    TABLET_TEST(ShouldReportForcedFlushBytesError)
+    {
+        TestForcedTabletOperationError(
+            ForcedFlushBytesOperation,
+            tabletConfig,
+            testEnvConfig);
+    }
+
+    TABLET_TEST(ShouldReportForcedCollectGarbageError)
+    {
+        TestForcedTabletOperationError(
+            ForcedCollectGarbageOperation,
+            tabletConfig,
+            testEnvConfig);
+    }
+
     TABLET_TEST(ShouldDumpCompactionRangeBlobs)
     {
         TTestEnv env(testEnvConfig);

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -27,7 +27,6 @@ SRCS(
     tablet_actor_collectgarbage.cpp
     tablet_actor_confirmblobs.cpp
     tablet_actor_compaction.cpp
-    tablet_actor_compactionforced.cpp
     tablet_actor_counters.cpp
     tablet_actor_createcheckpoint.cpp
     tablet_actor_createhandle.cpp
@@ -43,6 +42,8 @@ SRCS(
     tablet_actor_filteralivenodes.cpp
     tablet_actor_flush.cpp
     tablet_actor_flush_bytes.cpp
+    tablet_actor_forced_range_operation.cpp
+    tablet_actor_forced_tablet_operation.cpp
     tablet_actor_generatecommitid.cpp
     tablet_actor_getnodeattr.cpp
     tablet_actor_getnodexattr.cpp

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -702,6 +702,15 @@ message TForcedOperationStatusResponse
     // Last processed range id. Can be used to skip processed range ids upon
     // operation restart via the MinRangeId parameter.
     uint32 LastProcessedRangeId = 4;
+
+    // Provides status both range and non-range operations.
+    enum EStatus
+    {
+        E_UNKNOWN = 0;
+        E_RUNNING = 1;
+        E_COMPLETED = 2;
+    }
+    EStatus Status = 5;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -660,11 +660,11 @@ message TForcedOperationRequest
     EForcedOperationType OpType = 3;
 
     // Enables processing of all ranges - even the ranges whose compaction
-    // stats are zero. Used for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES
+    // stats are zero. Used for E_COMPACTION, E_CLEANUP, E_DELETE_EMPTY_RANGES
     bool ProcessAllRanges = 4;
 
     // Starts from the min RangeId whose value is >= MinRangeId.
-    // Used for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES
+    // Used for E_COMPACTION, E_CLEANUP, E_DELETE_EMPTY_RANGES
     uint32 MinRangeId = 5;
 }
 
@@ -674,7 +674,7 @@ message TForcedOperationResponse
     NCloud.NProto.TError Error = 1;
 
     // Affected range count.
-    // Set for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES
+    // Set for E_COMPACTION, E_CLEANUP, E_DELETE_EMPTY_RANGES
     uint64 RangeCount = 2;
 
     // Can be used to query operation status.
@@ -699,16 +699,16 @@ message TForcedOperationStatusResponse
     NCloud.NProto.TError Error = 1;
 
     // Affected range count.
-    // Set for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES.
+    // Set for E_COMPACTION, E_CLEANUP, E_DELETE_EMPTY_RANGES.
     uint64 RangeCount = 2;
 
     // Processed range count.
-    // Set for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES.
+    // Set for E_COMPACTION, E_CLEANUP, E_DELETE_EMPTY_RANGES.
     uint64 ProcessedRangeCount = 3;
 
     // Last processed range id. Can be used to skip processed range ids upon
     // operation restart via the MinRangeId parameter.
-    // Set for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES.
+    // Set for E_COMPACTION, E_CLEANUP, E_DELETE_EMPTY_RANGES.
     uint32 LastProcessedRangeId = 4;
 
     // Provides status both range and non-range operations.

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -715,8 +715,10 @@ message TForcedOperationStatusResponse
     enum EStatus
     {
         E_UNKNOWN = 0;
-        E_RUNNING = 1;
-        E_COMPLETED = 2;
+        E_PENDING = 1; // unused https://github.com/ydb-platform/nbs/issues/6977
+        E_RUNNING = 2;
+        E_COMPLETED = 3;
+        E_FAILED = 4; // unused, https://github.com/ydb-platform/nbs/issues/6979
     }
     EStatus Status = 5;
 }

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -645,6 +645,9 @@ message TForcedOperationRequest
         E_COMPACTION = 0;
         E_CLEANUP = 1;
         E_DELETE_EMPTY_RANGES = 2;
+        E_FLUSH = 3;
+        E_FLUSH_BYTES = 4;
+        E_COLLECT_GARBAGE = 5;
     };
 
     // Optional request headers.
@@ -657,10 +660,11 @@ message TForcedOperationRequest
     EForcedOperationType OpType = 3;
 
     // Enables processing of all ranges - even the ranges whose compaction
-    // stats are zero.
+    // stats are zero. Used for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES
     bool ProcessAllRanges = 4;
 
     // Starts from the min RangeId whose value is >= MinRangeId.
+    // Used for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES
     uint32 MinRangeId = 5;
 }
 
@@ -670,6 +674,7 @@ message TForcedOperationResponse
     NCloud.NProto.TError Error = 1;
 
     // Affected range count.
+    // Set for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES
     uint64 RangeCount = 2;
 
     // Can be used to query operation status.
@@ -694,13 +699,16 @@ message TForcedOperationStatusResponse
     NCloud.NProto.TError Error = 1;
 
     // Affected range count.
+    // Set for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES.
     uint64 RangeCount = 2;
 
     // Processed range count.
+    // Set for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES.
     uint64 ProcessedRangeCount = 3;
 
     // Last processed range id. Can be used to skip processed range ids upon
     // operation restart via the MinRangeId parameter.
+    // Set for E_COMPACTION, E_FLUSH, E_DELETE_EMPTY_RANGES.
     uint32 LastProcessedRangeId = 4;
 
     // Provides status both range and non-range operations.


### PR DESCRIPTION
### Notes
This change implements initial changes for supporting new types of forced operations on a tablet.

Before this change only "range" forced operations (cleanup, compaction, )  were supported. The linked issue requires support of other operations such as flush, flush_bytes and collect_garbage which naturally operate on whole tablet state, not on a specific range. New operation types do not map well on existing range-based logic.

Some notes:
- "non-range" operations are called "tablet" operations
-  only one forced operation can be running at the same time. This also prevents Flush from running in parallel with other ops (which is normally allowed).
-  there are still some issues (e.g. no way to query queued op state or reliably determine if op has failed), some of which will be fixed in future commits.   
- new mode will be tested with implementation of operations .

### Issue
https://github.com/ydb-platform/nbs/issues/4115
