### PR TITLE
RDMA: derive send/recv queue sizes at Validate, not construction

### DIFF
--- a/cloud/storage/core/libs/rdma/iface/client.cpp
+++ b/cloud/storage/core/libs/rdma/iface/client.cpp
@@ -6,7 +6,9 @@ namespace NCloud::NStorage::NRdma {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TClientConfig::TClientConfig()
+TClientConfig::TClientConfig() = default;
+
+void TClientConfig::Validate(TLog& log)
 {
     // Compatibility with the old config.
     if (SendQueueSize == 0 && QueueSize > 0) {
@@ -15,10 +17,7 @@ TClientConfig::TClientConfig()
     if (RecvQueueSize == 0 && QueueSize > 0) {
         RecvQueueSize = QueueSize;
     }
-}
 
-void TClientConfig::Validate(TLog& log)
-{
     BufferPool.Validate(log);
     constexpr ui8 ThreeBitsMax = 7;
     constexpr ui8 FiveBitsMax = 31;

--- a/cloud/storage/core/libs/rdma/iface/server.cpp
+++ b/cloud/storage/core/libs/rdma/iface/server.cpp
@@ -6,19 +6,18 @@ namespace NCloud::NStorage::NRdma {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TServerConfig::TServerConfig()
+TServerConfig::TServerConfig() = default;
+
+void TServerConfig::Validate(TLog& log)
 {
-    // Compatibility with old config.
+    // Compatibility with the old config.
     if (SendQueueSize == 0 && QueueSize > 0) {
         SendQueueSize = QueueSize;
     }
     if (RecvQueueSize == 0 && QueueSize > 0) {
         RecvQueueSize = QueueSize;
     }
-}
 
-void TServerConfig::Validate(TLog& log)
-{
     BufferPool.Validate(log);
     constexpr ui8 ThreeBitsMax = 7;
     constexpr ui8 FiveBitsMax = 31;

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -5,6 +5,7 @@
 
 #include <cloud/storage/core/libs/rdma/iface/protobuf.h>
 #include <cloud/storage/core/libs/rdma/iface/protocol.h>
+#include <cloud/storage/core/libs/rdma/iface/server.h>
 
 #include <cloud/storage/core/libs/common/context.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -131,6 +132,25 @@ TEST(TRdmaClientTest, ShouldStartEndpointWithToS)
 
     client->StartEndpoint("::", 10020);
     ASSERT_EQ(42, testContext->ToS);
+}
+
+TEST(TRdmaClientTest, ShouldDeriveQueueSizesFromQueueSizeAtValidate)
+{
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+    auto log = logging->CreateLog("TEST");
+
+    TClientConfig clientConfig;
+    clientConfig.QueueSize = 256;
+    clientConfig.Validate(log);
+    EXPECT_EQ(256u, clientConfig.SendQueueSize);
+    EXPECT_EQ(256u, clientConfig.RecvQueueSize);
+
+    TServerConfig serverConfig;
+    serverConfig.QueueSize = 512;
+    serverConfig.Validate(log);
+    EXPECT_EQ(512u, serverConfig.SendQueueSize);
+    EXPECT_EQ(512u, serverConfig.RecvQueueSize);
 }
 
 TEST(TRdmaClientTest, ShouldUseConfiguredResolveTimeoutAndQpParamsOnConnect)


### PR DESCRIPTION
### Notes
Queue sizing, SendQueueSize/RecvQueueSize derivation moved from the config constructors to Validate(), fixing the silent behavior for every config that assigns QueueSize after construction. 

Added ShouldDeriveQueueSizesFromQueueSizeAtValidate

### Issue
#5388
