### PR TITLE
RDMA: apply the QP ACK timeout via RDMA_OPTION_ID_ACK_TIMEOUT

### DIFF
--- a/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
@@ -109,6 +109,11 @@ public:
         (override));
     MOCK_METHOD(
         void,
+        SetAckTimeout,
+        (rdma_cm_id * id, ui8 timeout),
+        (override));
+    MOCK_METHOD(
+        void,
         ResolveAddress,
         (rdma_cm_id * id, sockaddr* src, sockaddr* dst, TDuration timeout),
         (override));

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -746,10 +746,6 @@ void TClientEndpoint::SetupQP()
 {
     ibv_qp_attr qpAttr{};
     int mask = 0;
-    if (Config.QpTimeout > 0) {
-        qpAttr.timeout = Config.QpTimeout;
-        mask |= IBV_QP_TIMEOUT;
-    }
     if (Config.QpMinRnrTimer > 0) {
         qpAttr.min_rnr_timer = Config.QpMinRnrTimer;
         mask |= IBV_QP_MIN_RNR_TIMER;
@@ -2276,6 +2272,11 @@ void TClient::BeginConnect(TClientEndpoint* endpoint) noexcept
             EEndpointState::Connecting);
 
         endpoint->CreateQP();
+        if (Config->QpTimeout > 0) {
+            Verbs->SetAckTimeout(
+                endpoint->Connection.get(),
+                Config->QpTimeout);
+        }
         endpoint->Poller->Attach(endpoint);
         endpoint->Reconnect.Schedule(MIN_CONNECT_TIMEOUT);
 

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -156,6 +156,7 @@ TEST(TRdmaClientTest, ShouldUseConfiguredResolveTimeoutAndQpParamsOnConnect)
     std::atomic<int> connectRnrRetryCount = -1;
 
     std::atomic<bool> modifyCalled = false;
+    std::atomic<bool> ackTimeoutCalled = false;
 
     testContext->HandleResolveAddress =
         [&](rdma_cm_id* id, sockaddr* srcAddr, sockaddr* dstAddr, TDuration t)
@@ -180,13 +181,20 @@ TEST(TRdmaClientTest, ShouldUseConfiguredResolveTimeoutAndQpParamsOnConnect)
     {
         Y_UNUSED(qp);
 
-        const int expectedMask = IBV_QP_TIMEOUT | IBV_QP_MIN_RNR_TIMER;
-
-        EXPECT_EQ(expectedMask, mask);
-        EXPECT_EQ(clientConfig->QpTimeout, attr->timeout);
+        EXPECT_EQ(IBV_QP_MIN_RNR_TIMER, mask);
         EXPECT_EQ(clientConfig->QpMinRnrTimer, attr->min_rnr_timer);
 
         modifyCalled.store(true);
+    };
+
+    testContext->SetAckTimeout = [&](rdma_cm_id* id, ui8 timeout)
+    {
+        Y_UNUSED(id);
+
+        EXPECT_EQ(clientConfig->QpTimeout, timeout);
+        EXPECT_FALSE(connectCalled.load());
+
+        ackTimeoutCalled.store(true);
     };
 
     testContext->HandleConnect = [&](rdma_cm_id* id, rdma_conn_param* param)
@@ -233,6 +241,7 @@ TEST(TRdmaClientTest, ShouldUseConfiguredResolveTimeoutAndQpParamsOnConnect)
     ASSERT_EQ(clientConfig->QpRnrRetryCount, connectRnrRetryCount.load());
 
     ASSERT_TRUE(modifyCalled.load());
+    ASSERT_TRUE(ackTimeoutCalled.load());
 }
 
 TEST(TRdmaClientTest, ShouldDetachFromPoller)

--- a/cloud/storage/core/libs/rdma/impl/server.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server.cpp
@@ -522,10 +522,6 @@ void TServerSession::SetupQP()
 {
     ibv_qp_attr qpAttr{};
     int mask = 0;
-    if (Config->QpTimeout > 0) {
-        qpAttr.timeout = Config->QpTimeout;
-        mask |= IBV_QP_TIMEOUT;
-    }
     if (Config->QpMinRnrTimer > 0) {
         qpAttr.min_rnr_timer = Config->QpMinRnrTimer;
         mask |= IBV_QP_MIN_RNR_TIMER;
@@ -1981,6 +1977,10 @@ void TServer::Accept(
             .retry_count = Config->QpRetryCount,
             .rnr_retry_count = Config->QpRnrRetryCount,
         };
+
+        if (Config->QpTimeout > 0) {
+            Verbs->SetAckTimeout(event->id, Config->QpTimeout);
+        }
 
         RDMA_DEBUG("accept " << Verbs->GetPeer(event->id));
         Verbs->Accept(event->id, &acceptParams);

--- a/cloud/storage/core/libs/rdma/impl/server_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server_ut.cpp
@@ -192,6 +192,7 @@ TEST(TRdmaServerTest, ShouldUseConfiguredQpParamsOnAcceptAndSetupQp)
     std::atomic<int> acceptRetryCount = -1;
     std::atomic<int> acceptRnrRetryCount = -1;
     std::atomic<bool> modifyCalled = false;
+    std::atomic<bool> ackTimeoutCalled = false;
 
     testContext->HandleAccept = [&](rdma_cm_id* id, rdma_conn_param* param)
     {
@@ -210,13 +211,20 @@ TEST(TRdmaServerTest, ShouldUseConfiguredQpParamsOnAcceptAndSetupQp)
             return;
         }
 
-        const int expectedMask = IBV_QP_TIMEOUT | IBV_QP_MIN_RNR_TIMER;
-
-        EXPECT_EQ(expectedMask, mask);
-        EXPECT_EQ(serverConfig->QpTimeout, attr->timeout);
+        EXPECT_EQ(IBV_QP_MIN_RNR_TIMER, mask);
         EXPECT_EQ(serverConfig->QpMinRnrTimer, attr->min_rnr_timer);
 
         modifyCalled.store(true);
+    };
+
+    testContext->SetAckTimeout = [&](rdma_cm_id* id, ui8 timeout)
+    {
+        Y_UNUSED(id);
+
+        EXPECT_EQ(serverConfig->QpTimeout, timeout);
+        EXPECT_FALSE(acceptCalled.load());
+
+        ackTimeoutCalled.store(true);
     };
 
     auto logging =
@@ -244,6 +252,7 @@ TEST(TRdmaServerTest, ShouldUseConfiguredQpParamsOnAcceptAndSetupQp)
     ASSERT_EQ(serverConfig->QpRnrRetryCount, acceptRnrRetryCount.load());
 
     ASSERT_TRUE(modifyCalled.load());
+    ASSERT_TRUE(ackTimeoutCalled.load());
 }
 
 TEST(TRdmaServerTest, StartEndpointShouldNotThrow)

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -422,6 +422,13 @@ struct TTestVerbs
         };
     }
 
+    void SetAckTimeout(rdma_cm_id* id, ui8 timeout) override
+    {
+        if (TestContext->SetAckTimeout) {
+            TestContext->SetAckTimeout(id, timeout);
+        }
+    }
+
     void BindAddress(rdma_cm_id* id, sockaddr* addr) override
     {
         Y_UNUSED(id);

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.h
@@ -49,6 +49,7 @@ struct TTestContext: TAtomicRefCount<TTestContext>
         GetAddressInfo;
     std::function<void(rdma_cm_id* id)> DestroyQP;
     std::function<void(ibv_qp* qp, ibv_qp_attr* attr, int mask)> ModifyQP;
+    std::function<void(rdma_cm_id* id, ui8 timeout)> SetAckTimeout;
     std::function<void(ibv_pd* pd, void* addr, size_t length, int flags)>
         RegisterMemoryRegion;
 

--- a/cloud/storage/core/libs/rdma/impl/verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/verbs.cpp
@@ -258,6 +258,20 @@ struct TVerbs
         return WrapPtr(id);
     }
 
+    void SetAckTimeout(rdma_cm_id* id, ui8 timeout) override
+    {
+        int res = rdma_set_option(
+            id,
+            RDMA_OPTION_ID,
+            RDMA_OPTION_ID_ACK_TIMEOUT,
+            &timeout,
+            sizeof(timeout));
+
+        if (res < 0) {
+            RDMA_THROW_ERROR("rdma_set_option RDMA_OPTION_ID_ACK_TIMEOUT");
+        }
+    }
+
     void BindAddress(rdma_cm_id* id, sockaddr* addr) override
     {
         int res = rdma_bind_addr(id, addr);

--- a/cloud/storage/core/libs/rdma/impl/verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/verbs.h
@@ -108,6 +108,8 @@ struct IVerbs
         rdma_port_space ps,
         ui8 tos) = 0;
 
+    virtual void SetAckTimeout(rdma_cm_id* id, ui8 timeout) = 0;
+
     virtual void BindAddress(rdma_cm_id* id, sockaddr* addr) = 0;
     virtual void ResolveAddress(
         rdma_cm_id* id,


### PR DESCRIPTION
### Notes
The QpTimeout config field (RC local ACK timeout exponent) has never worked. It was applied via ibv_modify_qp(IBV_QP_TIMEOUT) in SetupQP, which runs on the CM ESTABLISHED event, but the QP is already in RTS there, and IBV_QP_TIMEOUT is only modifiable during the RTR -> RTS transition. The kernel rejects the call with EINVAL, ModifyQP throws, and the error handler disconnects the endpoint.

Fix
Set the timeout with rdma_set_option(RDMA_OPTION_ID_ACK_TIMEOUT) on the cm_id before rdma_connect / rdma_accept (a new IVerbs::SetAckTimeout); the CM then installs it during its own RTR -> RTS transition. SetupQP keeps only min_rnr_timer, which is legal to modify in RTS.

### Issue
#5388
