### PR TITLE
issue-5895: fastshard - fixing page allocator bitmap inconsistency

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
@@ -119,7 +119,13 @@ NProto::TError TPersistentBitmap::Get(ui64 bit, bool* result) const
     }
 
     const ui64 bitmapPageNo = bit / BitsPerPage;
-    *result = GetBit(BitmapPages[bitmapPageNo], bit % BitsPerPage);
+    TBuffer page;
+    error = ReadPage(0 /* lsn */, bitmapPageNo, &page);
+    if (HasError(error)) {
+        return error;
+    }
+
+    *result = GetBit(page, bit % BitsPerPage);
     return {};
 }
 
@@ -137,11 +143,16 @@ TPersistentBitmap::Set(ui64 lsn, ui64 bit, TVector<TPageGroup>& pageGroups)
     }
 
     const ui64 bitmapPageNo = bit / BitsPerPage;
-    SetBit(BitmapPages[bitmapPageNo], bit % BitsPerPage, false /* isReset */);
+    TBuffer page;
+    error = ReadPage(lsn, bitmapPageNo, &page);
+    if (HasError(error)) {
+        return error;
+    }
+
+    SetBit(page, bit % BitsPerPage, false /* isReset */);
 
     const ui64 pageNo = FirstPageNo + bitmapPageNo;
-    return PageStore
-        ->WritePage(lsn, pageNo, BitmapPages[bitmapPageNo], pageGroups);
+    return PageStore->WritePage(lsn, pageNo, page, pageGroups);
 }
 
 NProto::TError
@@ -158,7 +169,12 @@ TPersistentBitmap::Reset(ui64 lsn, ui64 bit, TVector<TPageGroup>& pageGroups)
     }
 
     const ui64 bitmapPageNo = bit / BitsPerPage;
-    auto& page = BitmapPages[bitmapPageNo];
+    TBuffer page;
+    error = ReadPage(lsn, bitmapPageNo, &page);
+    if (HasError(error)) {
+        return error;
+    }
+
     const bool wasFull = IsFull(page);
     SetBit(page, bit % BitsPerPage, true /* isReset */);
 
@@ -167,23 +183,22 @@ TPersistentBitmap::Reset(ui64 lsn, ui64 bit, TVector<TPageGroup>& pageGroups)
     }
 
     const ui64 pageNo = FirstPageNo + bitmapPageNo;
-    return PageStore
-        ->WritePage(lsn, pageNo, BitmapPages[bitmapPageNo], pageGroups);
+    return PageStore->WritePage(lsn, pageNo, page, pageGroups);
 }
 
-NProto::TError TPersistentBitmap::Allocate(
+NProto::TError TPersistentBitmap::AllocateImpl(
     ui64 lsn,
     ui64* bit,
     TVector<TPageGroup>& pageGroups)
 {
-    auto error = InitIfNeeded();
-    if (HasError(error)) {
-        return error;
-    }
-
     while (!BitmapPagesWithFreeBits.empty()) {
         const ui64 bitmapPageNo = BitmapPagesWithFreeBits.top();
-        auto& page = BitmapPages[bitmapPageNo];
+        TBuffer page;
+        auto error = ReadPage(lsn, bitmapPageNo, &page);
+        if (HasError(error)) {
+            return error;
+        }
+
         const ui64 pageBit = FindFirstFreeBit(page);
         if (pageBit == InvalidBitNo) {
             //
@@ -208,6 +223,37 @@ NProto::TError TPersistentBitmap::Allocate(
     return MakeError(E_FS_OUT_OF_SPACE, "bitmap full");
 }
 
+NProto::TError TPersistentBitmap::Allocate(
+    ui64 lsn,
+    ui64* bit,
+    TVector<TPageGroup>& pageGroups)
+{
+    auto error = InitIfNeeded();
+    if (HasError(error)) {
+        return error;
+    }
+
+    error = AllocateImpl(lsn, bit, pageGroups);
+    if (error.GetCode() == E_FS_OUT_OF_SPACE) {
+        //
+        // Not guaranteeing that BitmapPagesWithFreeBits is perfectly up to date
+        // to avoid having complex rollback logic in case of errors.
+        //
+        // Rebuilding free page stack once to ensure that the next loop operates
+        // on an up to date stack.
+        //
+
+        error = UpdateFreeStack();
+        if (HasError(error)) {
+            return error;
+        }
+
+        error = AllocateImpl(lsn, bit, pageGroups);
+    }
+
+    return error;
+}
+
 [[nodiscard]] NProto::TError TPersistentBitmap::CountBits(ui64* bits) const
 {
     auto e = InitIfNeeded();
@@ -216,7 +262,13 @@ NProto::TError TPersistentBitmap::Allocate(
     }
 
     *bits = 0;
-    for (const auto& page: BitmapPages) {
+    for (ui64 i = 0; i < GetPageCount(); ++i) {
+        TBuffer page;
+        e = ReadPage(0 /* lsn */, i, &page);
+        if (HasError(e)) {
+            return e;
+        }
+
         *bits += PopCount(page);
     }
 
@@ -230,45 +282,71 @@ NProto::TError TPersistentBitmap::Allocate(
     return {};
 }
 
-NProto::TError TPersistentBitmap::InitIfNeeded() const
+NProto::TError TPersistentBitmap::ReadPage(
+    ui64 lsn,
+    ui64 relPageNo,
+    TBuffer* page) const
 {
-    if (!BitmapPages.empty()) {
-        return {};
+    const ui64 bitsPerPage = CalcBitsPerPage(PageSize);
+    const ui64 pageNo = FirstPageNo + relPageNo;
+    auto error = PageStore->ReadPage(lsn, pageNo, page);
+    if (HasError(error)) {
+        return error;
     }
 
-    const ui64 bitsPerPage = CalcBitsPerPage(PageSize);
-    BitmapPages.resize(GetPageCount());
+    Y_ABORT_UNLESS(page->Size() == PageSize);
 
-    for (ui64 i = 0; i < BitmapPages.size(); ++i) {
-        const ui64 pageNo = FirstPageNo + i;
-        auto error = PageStore->ReadPage(0 /* lsn */, pageNo, &BitmapPages[i]);
+    if (relPageNo == GetPageCount() - 1) {
+        const ui64 endBit = MaxBits % bitsPerPage;
+        if (endBit) {
+            if (endBit % 8 != 0) {
+                SILK_WARN("unaligned max bit count: %lu", MaxBits);
+            }
+
+            const ui64 endByte = endBit / 8;
+            memset(
+                page->data() + endByte,
+                0xFF,
+                PageSize - endByte);
+            UnusedBits = (PageSize - endByte) * 8;
+        }
+    }
+
+    return {};
+}
+
+NProto::TError TPersistentBitmap::UpdateFreeStack() const
+{
+    BitmapPagesWithFreeBits = {};
+    TVector<TBuffer> bitmapPages(GetPageCount());
+
+    for (ui64 i = 0; i < bitmapPages.size(); ++i) {
+        auto error = ReadPage(0 /* lsn */, i, &bitmapPages[i]);
         if (HasError(error)) {
-            BitmapPages.clear();
+            bitmapPages.clear();
             return error;
         }
 
-        Y_ABORT_UNLESS(BitmapPages[i].Size() == PageSize);
-
-        if (i == BitmapPages.size() - 1) {
-            const ui64 endBit = MaxBits % bitsPerPage;
-            if (endBit) {
-                if (endBit % 8 != 0) {
-                    SILK_WARN("unaligned max bit count: %lu", MaxBits);
-                }
-
-                const ui64 endByte = endBit / 8;
-                memset(
-                    BitmapPages[i].data() + endByte,
-                    0xFF,
-                    PageSize - endByte);
-                UnusedBits = (PageSize - endByte) * 8;
-            }
-        }
-
-        if (!IsFull(BitmapPages[i])) {
+        if (!IsFull(bitmapPages[i])) {
             BitmapPagesWithFreeBits.push(i);
         }
     }
+
+    return {};
+}
+
+NProto::TError TPersistentBitmap::InitIfNeeded() const
+{
+    if (Initialized) {
+        return {};
+    }
+
+    auto error = UpdateFreeStack();
+    if (HasError(error)) {
+        return error;
+    }
+
+    Initialized = true;
 
     return {};
 }

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
@@ -20,7 +20,7 @@ private:
     const ui64 BitsPerPage;
     IPageStorePtr PageStore;
 
-    mutable TVector<TBuffer> BitmapPages;
+    mutable bool Initialized = false;
     mutable TStack<ui64> BitmapPagesWithFreeBits;
     mutable ui64 UnusedBits = 0;
 
@@ -59,6 +59,13 @@ public:
 private:
     [[nodiscard]] bool Validate(ui64 bit, NProto::TError* error) const;
     [[nodiscard]] NProto::TError InitIfNeeded() const;
+    [[nodiscard]] NProto::TError ReadPage(
+        ui64 lsn,
+        ui64 relPageNo,
+        TBuffer* page) const;
+    [[nodiscard]] NProto::TError UpdateFreeStack() const;
+    NProto::TError
+    AllocateImpl(ui64 lsn, ui64* bit, TVector<TPageGroup>& pageGroups);
 
     [[nodiscard]] static ui64 CalcBitsPerPage(ui64 pageSize)
     {

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -921,32 +921,6 @@ public:
         return {};
     }
 
-    void RollbackAllocation(
-        const TLoggingContext& lc,
-        const TVector<ui64>& storagePageClusterIds,
-        const TWriteContext& writeContext)
-    {
-        TVector<TPageGroup> pageGroups;
-        for (const ui64 clusterId: storagePageClusterIds) {
-            Y_ABORT_UNLESS(clusterId >= FirstStoragePageClusterId);
-            auto error = Bitmap->Reset(
-                writeContext.Lsn,
-                clusterId - FirstStoragePageClusterId,
-                pageGroups);
-
-            //
-            // Errors aren't expected if allocation has already happened.
-            //
-
-            Y_ABORT_UNLESS(!HasError(error));
-
-            SILK_DEBUG(
-                "[%s] TPageAllocator.RollbackAllocation storagePageCluster=%lu",
-                lc.Describe().c_str(),
-                clusterId);
-        }
-    }
-
     [[nodiscard]] NProto::TError CollectStats(
         TFileSystemShardStats* stats) const
     {
@@ -2154,11 +2128,6 @@ public:
                 lc.Describe().c_str(),
                 FormatError(error).c_str());
 
-            PageAllocator.RollbackAllocation(
-                lc,
-                newStoragePageClusterIds,
-                writeContext);
-
             *response.MutableError() = std::move(error);
             return response;
         }
@@ -2176,11 +2145,6 @@ public:
                 "[%s] WriteData::Nodes.ResizeNode error=%s",
                 lc.Describe().c_str(),
                 FormatError(error).c_str());
-
-            PageAllocator.RollbackAllocation(
-                lc,
-                newStoragePageClusterIds,
-                writeContext);
 
             *response.MutableError() = std::move(error);
             return response;
@@ -2204,19 +2168,6 @@ public:
                 lc.Describe().c_str(),
                 FormatError(error).c_str());
             *response.MutableError() = std::move(error);
-
-            //
-            // We should first rollback the allocation - we should do it while
-            // the bitmap pages are still marked as dirty at our lsn. And only
-            // after that we can rollback the pages.
-            //
-
-            l.lock();
-            PageAllocator.RollbackAllocation(
-                lc,
-                newStoragePageClusterIds,
-                writeContext);
-            l.unlock();
 
             PageStore->RollbackPages(pages);
 


### PR DESCRIPTION
### Notes
Getting rid of a separate page cache in `TPersistentBitmap` - all caching should be done by `PageStore`. Simplifies the code a lot - no need to do separate rollbacks in page allocator bitmap upon errors. Also fixes this kind of alloc/dealloc race that eventually leads to data corruption:
```
2026-08-26 21:05:12.569 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:2123: [I=144136275822334939 H=144127642848360097 P=0 S=2160] WriteData storagePage=17280
2026-08-26 21:05:12.570 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:2227: [I=144136275822334939 H=144127642848360097 P=0 S=2160] WriteData complete
2026-08-26 21:05:13.824 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:1462: [N=44b1b4d5-5ac593d-85fe6c2e-924b6e4f I=1] CreateNodeImpl complete, ino=144217953438370253
2026-08-26 21:05:13.825 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:1534: [N=44b1b4d5-5ac593d-85fe6c2e-924b6e4f I=144217953438370253] CreateNode complete
2026-08-26 21:05:13.829 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:1826: [N=44b1b4d5-5ac593d-85fe6c2e-924b6e4f I=144217953438370253 H=144130296001590212] CreateHandle complete
2026-08-26 21:05:13.830 [WARN ] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:895: [N=f3fddd8c-25e1fb9c-2ce5a296-360a1dc2 I=144136275822334939 P=0 S=2160] TPageAllocator.Deallocate error=E_REJECTED dirty page (7650) with different lsn (6447 != 6448)
2026-08-26 21:05:13.830 [WARN ] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:1654: [N=f3fddd8c-25e1fb9c-2ce5a296-360a1dc2 I=144136275822334939 P=0 S=2160] UnlinkNode::PageAllocator.Deallocate error=E_REJECTED dirty page (7650) with different lsn (6447 != 6448)
2026-08-26 21:05:13.831 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:873: [I=144217953438370253 H=144130296001590212 P=0 S=18446744073709551615] TPageAllocator.Allocate storagePageCluster=216
0
2026-08-26 21:05:13.831 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:2123: [I=144217953438370253 H=144130296001590212 P=0 S=2160] WriteData storagePage=17280
2026-08-26 21:05:13.832 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:2227: [I=144217953438370253 H=144130296001590212 P=0 S=2160] WriteData complete
2026-08-26 21:05:13.835 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:918: [N=f3fddd8c-25e1fb9c-2ce5a296-360a1dc2 I=144136275822334939 P=0 S=2160] TPageAllocator.Deallocate storagePageCluster=2160
2026-08-26 21:05:13.836 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:1676: [N=f3fddd8c-25e1fb9c-2ce5a296-360a1dc2 I=144136275822334939 P=0 S=2160] UnlinkNode complete
2026-08-26 21:05:13.839 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:1319: [I=144217953438370253] GetNodeAttr
2026-08-26 21:05:13.852 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:2123: [I=144365409814264298 H=144315740897089479 P=0 S=2160] WriteData storagePage=17280
2026-08-26 21:05:13.853 [DEBUG] /mnt/shared/astr/git/nbs/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp:2227: [I=144365409814264298 H=144315740897089479 P=0 S=2160] WriteData complete

```
^^^ here we see the following sequence of events:
1. attempt to delete inode 144136275822334939
2. marked page cluster 2160 as free
3. inode deletion failed because of an attempt to update a dirty page
4. 2160 remains deallocated (the code didn't roll back the deallocation in page allocator's bitmap)
5. that's why we then allocated 2160 for another inode - 144217953438370253
6. inode 144136275822334939 deletion was retried and we once again deallocated 2160 even though it was already allocated for a different inode

### Issue
https://github.com/ydb-platform/nbs/issues/5895
