### PR TITLE
Remove deprecated TraceInfo and ThrottlerDelay fields from protos

### DIFF
--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -80,12 +80,10 @@ void ProcessThrottleTime(
 {
     NProto::TThrottlerInfo& throttler =
         *localResponse.MutableHeaders()->MutableThrottler();
-    const ui64 throttlerDelay =
-        Max(localResponse.GetDeprecatedThrottlerDelay(), throttler.GetDelay());
+    const ui64 throttlerDelay = throttler.GetDelay();
     callContext->AddTime(
         EProcessingStage::Postponed,
         TDuration::MicroSeconds(throttlerDelay));
-    localResponse.SetDeprecatedThrottlerDelay(0);
     throttler.SetDelay(0);
     callContext->SetPossiblePostponeDuration(TDuration::Zero());
 
@@ -192,13 +190,10 @@ public:
 
         if (CallContext->LWOrbit.HasShuttles()) {
             TraceSerializer->HandleTraceInfo(
-                responseMsg.GetHeaders().HasTrace()
-                    ? responseMsg.GetHeaders().GetTrace()
-                    : responseMsg.GetDeprecatedTrace(),
+                responseMsg.GetHeaders().GetTrace(),
                 CallContext->LWOrbit,
                 StartTime,
                 GetCycleCount());
-            responseMsg.ClearDeprecatedTrace();
             responseMsg.MutableHeaders()->ClearTrace();
         }
 
@@ -370,13 +365,10 @@ public:
 
         if (CallContext->LWOrbit.HasShuttles()) {
             TraceSerializer->HandleTraceInfo(
-                responseMsg.GetHeaders().HasTrace()
-                    ? responseMsg.GetHeaders().GetTrace()
-                    : responseMsg.GetDeprecatedTrace(),
+                responseMsg.GetHeaders().GetTrace(),
                 CallContext->LWOrbit,
                 StartTime,
                 GetCycleCount());
-            responseMsg.ClearDeprecatedTrace();
             responseMsg.MutableHeaders()->ClearTrace();
         }
 
@@ -474,14 +466,11 @@ public:
         auto& responseMsg = static_cast<TResponse&>(*response.Proto);
 
         TraceSerializer->HandleTraceInfo(
-            responseMsg.GetHeaders().HasTrace()
-                ? responseMsg.GetHeaders().GetTrace()
-                : responseMsg.GetDeprecatedTrace(),
+            responseMsg.GetHeaders().GetTrace(),
             CallContext->LWOrbit,
             StartTime,
             GetCycleCount());
         responseMsg.MutableHeaders()->ClearTrace();
-        responseMsg.ClearDeprecatedTrace();
 
         ProcessThrottleTime(CallContext, responseMsg);
 

--- a/cloud/blockstore/libs/common/split_request_helpers.cpp
+++ b/cloud/blockstore/libs/common/split_request_helpers.cpp
@@ -26,13 +26,10 @@ TResponse MergeReadBlocksResponsesImpl(std::span<TResponse> responsesToMerge)
         }
         allZeros &= response.GetAllZeroes();
         allBlocksEmpty &= response.GetBlocks().BuffersSize() == 0;
-        throttlerDelaySum +=
-            Max(response.GetDeprecatedThrottlerDelay(),
-                response.GetHeaders().GetThrottler().GetDelay());
+        throttlerDelaySum += response.GetHeaders().GetThrottler().GetDelay();
         checksums.push_back(response.GetChecksum());
     }
 
-    result.SetDeprecatedThrottlerDelay(throttlerDelaySum);
     result.MutableHeaders()->MutableThrottler()->SetDelay(throttlerDelaySum);
     result.SetAllZeroes(allZeros);
     if (NProto::TChecksum checksum = CombineChecksums(checksums);

--- a/cloud/blockstore/libs/common/split_request_helpers_ut.cpp
+++ b/cloud/blockstore/libs/common/split_request_helpers_ut.cpp
@@ -291,7 +291,6 @@ Y_UNIT_TEST_SUITE(TSplitRequestTest)
                 map.Flip();
             }
 
-            response.SetDeprecatedThrottlerDelay(blocksCount);
             response.MutableHeaders()->MutableThrottler()->SetDelay(
                 blocksCount);
             throttlerDelaySum += blocksCount;
@@ -301,9 +300,6 @@ Y_UNIT_TEST_SUITE(TSplitRequestTest)
 
         auto mergedResponse = MergeReadResponses(responses);
         UNIT_ASSERT(!HasError(mergedResponse.GetError()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            throttlerDelaySum,
-            mergedResponse.GetDeprecatedThrottlerDelay());
         UNIT_ASSERT_VALUES_EQUAL(
             throttlerDelaySum,
             mergedResponse.GetHeaders().GetThrottler().GetDelay());

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -624,16 +624,11 @@ TFuture<NProto::TZeroBlocksResponse> TEncryptionClient::ZeroBlocks(
             const auto& response = f.GetValue();
 
             NProto::TZeroBlocksResponse zeroResponse;
-            const auto& trace = response.GetHeaders().HasTrace()
-                                    ? response.GetHeaders().GetTrace()
-                                    : response.GetDeprecatedTrace();
+            const auto& trace = response.GetHeaders().GetTrace();
             const ui64 throttlerDelay =
-                Max(response.GetDeprecatedThrottlerDelay(),
-                    response.GetHeaders().GetThrottler().GetDelay());
+                response.GetHeaders().GetThrottler().GetDelay();
             zeroResponse.MutableError()->CopyFrom(response.GetError());
-            zeroResponse.MutableDeprecatedTrace()->CopyFrom(trace);
             zeroResponse.MutableHeaders()->MutableTrace()->CopyFrom(trace);
-            zeroResponse.SetDeprecatedThrottlerDelay(throttlerDelay);
             zeroResponse.MutableHeaders()->MutableThrottler()->SetDelay(
                 throttlerDelay);
             return zeroResponse;

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -434,12 +434,10 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
         NProto::TWriteBlocksLocalResponse wResponse;
         wResponse.MutableError()->SetMessage("testMessage");
-        wResponse.MutableDeprecatedTrace()->SetRequestStartTime(42);
         wResponse.MutableHeaders()->MutableTrace()->SetRequestStartTime(42);
-        wResponse.SetDeprecatedThrottlerDelay(13);
         wResponse.MutableHeaders()->MutableThrottler()->SetDelay(13);
         UNIT_ASSERT_VALUES_EQUAL(
-            4,
+            2,
             GetFieldCount<NProto::TWriteBlocksResponse>());
 
         testClient->MountVolumeHandler =
@@ -499,22 +497,16 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             wResponse.GetError().GetMessage(),
             zResponse.GetError().GetMessage());
         UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetDeprecatedTrace().GetRequestStartTime(),
-            zResponse.GetDeprecatedTrace().GetRequestStartTime());
-        UNIT_ASSERT_VALUES_EQUAL(
             wResponse.GetHeaders().GetTrace().GetRequestStartTime(),
             zResponse.GetHeaders().GetTrace().GetRequestStartTime());
-        UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetDeprecatedThrottlerDelay(),
-            zResponse.GetDeprecatedThrottlerDelay());
         UNIT_ASSERT_VALUES_EQUAL(
             wResponse.GetHeaders().GetThrottler().GetDelay(),
             zResponse.GetHeaders().GetThrottler().GetDelay());
         UNIT_ASSERT_VALUES_EQUAL(
-            4,
+            2,
             GetFieldCount<NProto::TWriteBlocksResponse>());
         UNIT_ASSERT_VALUES_EQUAL(
-            4,
+            2,
             GetFieldCount<NProto::TZeroBlocksResponse>());
 
         for (size_t i = 0; i < storageBlocksCount; ++i) {
@@ -607,7 +599,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto zResponse = future.GetValue(TDuration::Seconds(5));
         UNIT_ASSERT(!HasError(zResponse));
         UNIT_ASSERT_VALUES_EQUAL(
-            4,
+            2,
             GetFieldCount<NProto::TZeroBlocksResponse>());
         UNIT_ASSERT_VALUES_EQUAL(1, zRequestCount);
     }

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -71,7 +71,6 @@ void FillResponse(const TCallContextPtr& callContext, TResponse& response)
 {
     const ui64 postponeTime =
         callContext->Time(EProcessingStage::Postponed).MicroSeconds();
-    response.SetDeprecatedThrottlerDelay(postponeTime);
     response.MutableHeaders()->MutableThrottler()->SetDelay(postponeTime);
 
     const ui64 shapingTime =
@@ -293,7 +292,6 @@ private:
                             // TODO: consider variable length proto size
                             // or switch from lwtrace to open telemetry like
                             // solution to avoid sending traces between nodes
-                            response.MutableDeprecatedTrace()->Clear();
                             response.MutableHeaders()->ClearTrace();
                         }
 
@@ -396,7 +394,6 @@ private:
                             // TODO: consider variable length proto size
                             // or switch from lwtrace to open telemetry like
                             // solution to avoid sending traces between nodes
-                            response.MutableDeprecatedTrace()->Clear();
                             response.MutableHeaders()->ClearTrace();
                         }
 
@@ -475,7 +472,6 @@ private:
                     // TODO: consider variable length proto size
                     // or switch from lwtrace to open telemetry like
                     // solution to avoid sending traces between nodes
-                    response.MutableDeprecatedTrace()->Clear();
                     response.MutableHeaders()->ClearTrace();
                 }
 

--- a/cloud/blockstore/libs/storage/protos/volume.proto
+++ b/cloud/blockstore/libs/storage/protos/volume.proto
@@ -12,7 +12,6 @@ import "cloud/blockstore/public/api/protos/volume.proto";
 
 import "cloud/storage/core/protos/error.proto";
 import "cloud/storage/core/protos/media.proto";
-import "cloud/storage/core/protos/trace.proto";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Follower volume link update action
@@ -121,6 +120,8 @@ message TAddClientRequest
 
 message TAddClientResponse
 {
+    reserved 5;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
@@ -132,9 +133,6 @@ message TAddClientResponse
 
     // Volume information.
     TVolume Volume = 4;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 5;
 
     // Expected pipe generation. Deprecated.
     uint32 ExpectedPipeGeneration = 6;
@@ -167,6 +165,8 @@ message TRemoveClientRequest
 
 message TRemoveClientResponse
 {
+    reserved 5;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
@@ -178,9 +178,6 @@ message TRemoveClientResponse
 
     // Client identifier.
     string ClientId = 4;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 5;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -200,14 +197,13 @@ message TWaitReadyRequest
 
 message TWaitReadyResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     // Volume information.
     TVolume Volume = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -231,11 +227,10 @@ message TUsedBlockData {
 }
 
 message TGetUsedBlocksResponse {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     repeated TUsedBlockData UsedBlocks = 3;
 
@@ -259,14 +254,13 @@ message TGetPartitionInfoRequest
 
 message TGetPartitionInfoResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     // Partition info data in JSON format.
     string Payload = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -298,14 +292,13 @@ message TCompactRangeRequest
 
 message TCompactRangeResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     // Compact operation reference
     string OperationId = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -331,6 +324,8 @@ message TGetCompactionStatusRequest
 
 message TGetCompactionStatusResponse
 {
+    reserved 5;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
@@ -342,9 +337,6 @@ message TGetCompactionStatusResponse
 
     // Flag if operation completed.
     bool IsCompleted = 4;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 5;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -364,11 +356,10 @@ message TReallocateDiskRequest
 
 message TReallocateDiskResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Outdated lagging devices of the volume.
     repeated TLaggingDevice OutdatedLaggingDevices = 3;
@@ -398,11 +389,10 @@ message TUpdateUsedBlocksRequest
 
 message TUpdateUsedBlocksResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -483,13 +473,12 @@ message TGetVolumeLoadInfoRequest
 
 message TGetVolumeLoadInfoResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     TVolumeBalancerDiskStats Stats = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -512,11 +501,10 @@ message TDeleteCheckpointDataRequest
 
 message TDeleteCheckpointDataResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -548,11 +536,10 @@ message TRebuildMetadataRequest
 
 message TRebuildMetadataResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -583,13 +570,12 @@ message TGetRebuildMetadataStatusRequest
 
 message TGetRebuildMetadataStatusResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     TMetadataRebuildProgress Progress = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -612,11 +598,10 @@ message TScanDiskRequest
 
 message TScanDiskResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -636,11 +621,10 @@ message TGetVolumeInfoRequest
 
 message TGetVolumeInfoResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     TVolume Volume = 3;
 
@@ -669,9 +653,9 @@ message TUpdateVolumeParamsRequest
 
 message TUpdateVolumeParamsResponse
 {
-    NCloud.NProto.TError Error = 1;
+    reserved 2;
 
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
+    NCloud.NProto.TError Error = 1;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -697,11 +681,10 @@ message TChangeStorageConfigRequest
 
 message TChangeStorageConfigResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Result Storage config.
     NProto.TStorageServiceConfig StorageConfig = 3;
@@ -725,11 +708,10 @@ message TGetStorageConfigRequest
 
 message TGetStorageConfigResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Result Storage config.
     NProto.TStorageServiceConfig StorageConfig = 3;
@@ -752,11 +734,10 @@ message TGracefulShutdownRequest
 
 message TGracefulShutdownResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -797,7 +778,7 @@ message TMirrorInconsistentChecksums
 
 message TCheckRangeResponse
 {
-    reserved 2, 3;
+    reserved 2, 3, 4;
 
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
@@ -812,9 +793,6 @@ message TCheckRangeResponse
         TChecksums DiskChecksums = 5;
         TMirrorInconsistentChecksums InconsistentChecksums = 6;
     };
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 4;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -843,14 +821,13 @@ message TLinkLeaderVolumeToFollowerRequest
 
 message TLinkLeaderVolumeToFollowerResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     // Uuid of created link.
     string LinkUUID = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -882,11 +859,10 @@ message TUpdateLinkOnFollowerRequest
 
 message TUpdateLinkOnFollowerResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -915,6 +891,8 @@ message TGetLinkStatusRequest
 
 message TGetLinkStatusResponse
 {
+    reserved 999;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
@@ -926,9 +904,6 @@ message TGetLinkStatusResponse
 
     // Error message when link in error state.
     string ErrorMessage = 4;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 999;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -958,11 +933,10 @@ message TUnlinkLeaderVolumeFromFollowerRequest
 
 message TUnlinkLeaderVolumeFromFollowerResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;

--- a/cloud/blockstore/libs/storage/protos_ydb/volume.proto
+++ b/cloud/blockstore/libs/storage/protos_ydb/volume.proto
@@ -8,7 +8,6 @@ import "cloud/blockstore/libs/storage/protos/volume.proto";
 import "cloud/blockstore/public/api/protos/headers.proto";
 import "cloud/blockstore/public/api/protos/volume.proto";
 import "cloud/storage/core/protos/error.proto";
-import "cloud/storage/core/protos/trace.proto";
 
 import "contrib/ydb/core/protos/base.proto";
 import "contrib/ydb/core/protos/blockstore_config.proto";
@@ -147,17 +146,13 @@ message TBlobPiece
 
 message TDescribeBlocksResponse
 {
+    reserved 4, 5;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     repeated TFreshBlockRange FreshBlockRanges = 2;
     repeated TBlobPiece BlobPieces = 3;
-
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 4;
-
-    // Throttler delay. Deprecated. Use Headers.Throttler.Delay instead.
-    uint64 DeprecatedThrottlerDelay = 5;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -262,13 +257,12 @@ message TGetScanDiskStatusRequest
 
 message TGetScanDiskStatusResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     TScanDiskProgress Progress = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_compact_range.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_compact_range.cpp
@@ -163,7 +163,6 @@ void TCompactRangeActionActor::HandleCompactRangeResponse(
         HandleError(ctx, error);
         return;
     }
-    msg->Record.ClearDeprecatedTrace();
     msg->Record.MutableHeaders()->ClearTrace();
 
     TString response;

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_describe_blocks.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_describe_blocks.cpp
@@ -189,7 +189,6 @@ void TDescribeBlocksActionActor::HandleDescribeBlocksResponse(
         // Fresh block information is only needed for index-only requests.
         msg->Record.ClearFreshBlockRanges();
     }
-    msg->Record.ClearDeprecatedTrace();
     msg->Record.MutableHeaders()->ClearTrace();
 
     TString response;

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_compaction_status.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_compaction_status.cpp
@@ -148,7 +148,6 @@ void TGetCompactionStatusActionActor::HandleGetCompactionStatusResponse(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-    msg->Record.ClearDeprecatedTrace();
     msg->Record.MutableHeaders()->ClearTrace();
 
     TString response;

--- a/cloud/blockstore/libs/storage/service/service_ut_read_write.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_read_write.cpp
@@ -614,9 +614,6 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 0,
                 response->Record.GetHeaders().GetThrottler().GetDelay());
-            UNIT_ASSERT_VALUES_EQUAL(
-                0,
-                response->Record.GetDeprecatedThrottlerDelay());
         }
 
         runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
@@ -624,7 +621,6 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
                     case TEvService::EvWriteBlocksResponse: {
                         auto* msg =
                             event->Get<TEvService::TEvWriteBlocksResponse>();
-                        msg->Record.SetDeprecatedThrottlerDelay(1e6);
                         msg->Record.MutableHeaders()
                             ->MutableThrottler()
                             ->SetDelay(1e6);
@@ -633,7 +629,6 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
                     case TEvService::EvReadBlocksResponse: {
                         auto* msg =
                             event->Get<TEvService::TEvReadBlocksResponse>();
-                        msg->Record.SetDeprecatedThrottlerDelay(1e6);
                         msg->Record.MutableHeaders()
                             ->MutableThrottler()
                             ->SetDelay(1e6);
@@ -642,7 +637,6 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
                     case TEvVolume::EvDescribeBlocksResponse: {
                         auto* msg =
                             event->Get<TEvVolume::TEvDescribeBlocksResponse>();
-                        msg->Record.SetDeprecatedThrottlerDelay(1e6);
                         msg->Record.MutableHeaders()
                             ->MutableThrottler()
                             ->SetDelay(1e6);
@@ -662,9 +656,6 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
                 callContext->GetPossiblePostponeDuration());
             service.SendRequest(MakeStorageServiceId(), std::move(request));
             auto response = service.RecvReadBlocksResponse();
-            UNIT_ASSERT_VALUES_EQUAL(
-                1e6,
-                response->Record.GetDeprecatedThrottlerDelay());
             UNIT_ASSERT_VALUES_EQUAL(
                 1e6,
                 response->Record.GetHeaders().GetThrottler().GetDelay());
@@ -689,9 +680,6 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
                 callContext->GetPossiblePostponeDuration());
             service.SendRequest(MakeStorageServiceId(), std::move(request));
             auto response = service.RecvWriteBlocksResponse();
-            UNIT_ASSERT_VALUES_EQUAL(
-                1e6,
-                response->Record.GetDeprecatedThrottlerDelay());
             UNIT_ASSERT_VALUES_EQUAL(
                 1e6,
                 response->Record.GetHeaders().GetThrottler().GetDelay());

--- a/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_client_actor.cpp
@@ -35,10 +35,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Y_HAS_MEMBER(GetDeprecatedThrottlerDelay);
-
-////////////////////////////////////////////////////////////////////////////////
-
 NTabletPipe::TClientConfig CreateTabletPipeClientConfig(
     const TStorageConfig& config)
 {
@@ -50,20 +46,6 @@ NTabletPipe::TClientConfig CreateTabletPipeClientConfig(
     };
     return clientConfig;
 }
-
-template <typename TProtoMessage>
-const NProto::TTraceInfo& GetTraceInfo(const TProtoMessage& msg)
-{
-    if (msg.Record.GetHeaders().HasTrace()) {
-        return msg.Record.GetHeaders().GetTrace();
-    }
-    if constexpr (requires { msg.Record.MutableDeprecatedTrace(); }) {
-        return msg.Record.GetDeprecatedTrace();
-    }
-    return msg.Record.GetHeaders().GetTrace();
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 class TVolumeClientActor final
     : public TActor<TVolumeClientActor>
@@ -376,31 +358,20 @@ void TVolumeClientActor::HandleResponse(
 
     if (it->second.CallContext->LWOrbit.HasShuttles()) {
         TraceSerializer->HandleTraceInfo(
-            GetTraceInfo(*msg),
+            msg->Record.GetHeaders().GetTrace(),
             it->second.CallContext->LWOrbit,
             it->second.SendTime,
             GetCycleCount());
-        if constexpr (requires { msg->Record.MutableDeprecatedTrace(); }) {
-            msg->Record.ClearDeprecatedTrace();
-        }
         msg->Record.MutableHeaders()->ClearTrace();
     }
-
-    using TProtoType = decltype(TMethod::TResponse::Record);
-    static_assert(
-        RequiresThrottling<TMethod> ==
-        THasGetDeprecatedThrottlerDelay<TProtoType>::value);
 
     if constexpr (RequiresThrottling<TMethod>) {
         NProto::TThrottlerInfo& throttler =
             *msg->Record.MutableHeaders()->MutableThrottler();
-        const ui64 throttlerDelay =
-            Max(msg->Record.GetDeprecatedThrottlerDelay(),
-                throttler.GetDelay());
+        const ui64 throttlerDelay = throttler.GetDelay();
         it->second.CallContext->AddTime(
             EProcessingStage::Postponed,
             TDuration::MicroSeconds(throttlerDelay));
-        msg->Record.SetDeprecatedThrottlerDelay(0);
         throttler.SetDelay(0);
         it->second.CallContext->SetPossiblePostponeDuration(TDuration::Zero());
 

--- a/cloud/blockstore/libs/storage/volume/actors/multi_partition_requests.h
+++ b/cloud/blockstore/libs/storage/volume/actors/multi_partition_requests.h
@@ -454,8 +454,6 @@ void TMultiPartitionRequestActor<TMethod>::HandlePartitionResponse(
                 RequestInfo->CallContext->LWOrbit,
                 TraceInfo.ReceiveTime,
                 GetCycleCount());
-            response->Record.MutableDeprecatedTrace()->CopyFrom(
-                response->Record.GetHeaders().GetTrace());
         }
 
         LWTRACK(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -440,8 +440,6 @@ void TCheckpointActor<TMethod>::ReplyAndDie(const TActorContext& ctx)
             RequestInfo->CallContext->LWOrbit,
             TraceInfo.ReceiveTime,
             GetCycleCount());
-        response->Record.MutableDeprecatedTrace()->CopyFrom(
-            response->Record.GetHeaders().GetTrace());
     }
 
     LWTRACK(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -30,20 +30,13 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Y_HAS_MEMBER(SetDeprecatedThrottlerDelay);
-
 template <typename TMethod>
 void StoreThrottlerDelay(
     typename TMethod::TResponse& response,
     TDuration delay,
     TDuration shapingDelay)
 {
-    using TProtoType = decltype(TMethod::TResponse::Record);
-    static_assert(
-        THasSetDeprecatedThrottlerDelay<TProtoType>::value ==
-        RequiresThrottling<TMethod>);
     if constexpr (RequiresThrottling<TMethod>) {
-        response.Record.SetDeprecatedThrottlerDelay(delay.MicroSeconds());
         response.Record.MutableHeaders()->MutableThrottler()->SetDelay(
             delay.MicroSeconds());
         response.Record.MutableHeaders()->MutableThrottler()->SetShapingDelay(
@@ -328,10 +321,6 @@ void TVolumeActor::FillResponse(
             callContext.LWOrbit,
             startTime,
             GetCycleCount());
-        if constexpr (requires { response.Record.MutableDeprecatedTrace(); }) {
-            response.Record.MutableDeprecatedTrace()->CopyFrom(
-                response.Record.GetHeaders().GetTrace());
-        }
     }
 
     StoreThrottlerDelay<TMethod>(

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -6433,9 +6433,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         auto response = volume.RecvWriteBlocksResponse();
 
         CheckForkJoin(
-            response->Record.GetDeprecatedTrace().GetLWTrace().GetTrace(),
-            true);
-        CheckForkJoin(
             response->Record.GetHeaders().GetTrace().GetLWTrace().GetTrace(),
             true);
     }
@@ -6488,18 +6485,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         UNIT_ASSERT(FAILED(response->GetStatus()));
 
-        const auto& deprecatedTrace = response->Record.GetDeprecatedTrace()
-                                          .GetLWTrace()
-                                          .GetTrace()
-                                          .GetEvents();
-        UNIT_ASSERT_C(
-            FindIf(
-                deprecatedTrace.begin(),
-                deprecatedTrace.end(),
-                [](const auto& e)
-                { return e.GetName() == "Join"; }) != deprecatedTrace.end(),
-            "No Join found");
-
         const auto& trace = response->Record.GetHeaders()
                                 .GetTrace()
                                 .GetLWTrace()
@@ -6543,9 +6528,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         auto response = volume.RecvWriteBlocksResponse();
 
         CheckForkJoin(
-            response->Record.GetDeprecatedTrace().GetLWTrace().GetTrace(),
-            true);
-        CheckForkJoin(
             response->Record.GetHeaders().GetTrace().GetLWTrace().GetTrace(),
             true);
     }
@@ -6577,13 +6559,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         auto response = volume.RecvWriteBlocksResponse();
 
-        UNIT_ASSERT_VALUES_UNEQUAL(
-            0,
-            response->Record.GetDeprecatedTrace()
-                .GetLWTrace()
-                .GetTrace()
-                .GetEvents()
-                .size());
         UNIT_ASSERT_VALUES_UNEQUAL(
             0,
             response->Record.GetHeaders()
@@ -6634,13 +6609,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             UNIT_ASSERT(response);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
 
-            UNIT_ASSERT_VALUES_UNEQUAL(
-                0,
-                response->Record.GetDeprecatedTrace()
-                    .GetLWTrace()
-                    .GetTrace()
-                    .GetEvents()
-                    .size());
             UNIT_ASSERT_VALUES_UNEQUAL(
                 0,
                 response->Record.GetHeaders()
@@ -6755,7 +6723,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             UNIT_ASSERT(response);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
 
-            UNIT_ASSERT_VALUES_UNEQUAL(0, response->Record.GetDeprecatedThrottlerDelay());
             UNIT_ASSERT_VALUES_UNEQUAL(
                 0,
                 response->Record.GetHeaders().GetThrottler().GetDelay());
@@ -6768,7 +6735,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             UNIT_ASSERT(response);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
 
-            UNIT_ASSERT_VALUES_UNEQUAL(0, response->Record.GetDeprecatedThrottlerDelay());
             UNIT_ASSERT_VALUES_UNEQUAL(
                 0,
                 response->Record.GetHeaders().GetThrottler().GetDelay());
@@ -6781,7 +6747,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             UNIT_ASSERT(response);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
 
-            UNIT_ASSERT_VALUES_UNEQUAL(0, response->Record.GetDeprecatedThrottlerDelay());
             UNIT_ASSERT_VALUES_UNEQUAL(
                 0,
                 response->Record.GetHeaders().GetThrottler().GetDelay());
@@ -9274,11 +9239,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         auto duplicateResponse = volume.RecvWriteBlocksResponse();
         auto response = volume.RecvWriteBlocksResponse();
 
-        UNIT_ASSERT(HasProbe(
-            duplicateResponse->Record.GetDeprecatedTrace()
-                .GetLWTrace()
-                .GetTrace(),
-            "DuplicatedRequestReceived_Volume"));
         UNIT_ASSERT(HasProbe(
             duplicateResponse->Record.GetHeaders()
                 .GetTrace()

--- a/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_checkpoint.cpp
@@ -2165,7 +2165,6 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
 
             auto response = volume.RecvCreateCheckpointResponse();
 
-            CheckForkJoin(response->Record.GetDeprecatedTrace().GetLWTrace().GetTrace(), true);
             CheckForkJoin(response->Record.GetHeaders().GetTrace().GetLWTrace().GetTrace(), true);
         }
 
@@ -2177,7 +2176,6 @@ Y_UNIT_TEST_SUITE(TVolumeCheckpointTest)
 
             auto response = volume.RecvDeleteCheckpointResponse();
 
-            CheckForkJoin(response->Record.GetDeprecatedTrace().GetLWTrace().GetTrace(), true);
             CheckForkJoin(response->Record.GetHeaders().GetTrace().GetLWTrace().GetTrace(), true);
         }
     }

--- a/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
+++ b/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
@@ -34,10 +34,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Y_HAS_MEMBER(GetDeprecatedThrottlerDelay);
-
-////////////////////////////////////////////////////////////////////////////////
-
 std::unique_ptr<NTabletPipe::IClientCache> CreateTabletPipeClientCache(
     const TStorageConfig& config)
 {
@@ -60,20 +56,6 @@ constexpr bool IsDataPlaneMethod =
     std::is_same_v<TMethod, TEvService::TZeroBlocksMethod> ||
     std::is_same_v<TMethod, TEvService::TReadBlocksLocalMethod> ||
     std::is_same_v<TMethod, TEvService::TWriteBlocksLocalMethod>;
-
-template <typename TProtoMessage>
-const NProto::TTraceInfo& GetTraceInfo(const TProtoMessage& msg)
-{
-    if (msg.Record.GetHeaders().HasTrace()) {
-        return msg.Record.GetHeaders().GetTrace();
-    }
-    if constexpr (requires { msg.Record.MutableDeprecatedTrace(); }) {
-        return msg.Record.GetDeprecatedTrace();
-    }
-    return msg.Record.GetHeaders().GetTrace();
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 // VolumeProxy discovers the volume specified in the DiskId field of request,
 // establishes a connection to the tablet of this volume and redirects the
@@ -843,30 +825,20 @@ void TVolumeProxyActor::HandleResponse(
 
     if (it->second.CallContext->LWOrbit.HasShuttles()) {
         TraceSerializer->HandleTraceInfo(
-            GetTraceInfo(*msg),
+            msg->Record.GetHeaders().GetTrace(),
             it->second.CallContext->LWOrbit,
             it->second.SendTime,
             GetCycleCount());
-        if constexpr (requires { msg->Record.MutableDeprecatedTrace(); }) {
-            msg->Record.ClearDeprecatedTrace();
-        }
         msg->Record.MutableHeaders()->ClearTrace();
     }
 
-    using TProtoType = decltype(TMethod::TResponse::Record);
-    static_assert(
-        THasGetDeprecatedThrottlerDelay<TProtoType>::value ==
-        RequiresThrottling<TMethod>);
     if constexpr (RequiresThrottling<TMethod>) {
         NProto::TThrottlerInfo& throttler =
             *msg->Record.MutableHeaders()->MutableThrottler();
-        const ui64 throttlerDelay =
-            Max(msg->Record.GetDeprecatedThrottlerDelay(),
-                throttler.GetDelay());
+        const ui64 throttlerDelay = throttler.GetDelay();
         it->second.CallContext->AddTime(
             EProcessingStage::Postponed,
             TDuration::MicroSeconds(throttlerDelay));
-        msg->Record.SetDeprecatedThrottlerDelay(0);
         throttler.SetDelay(0);
         it->second.CallContext->SetPossiblePostponeDuration(TDuration::Zero());
 

--- a/cloud/blockstore/public/api/protos/checkpoints.proto
+++ b/cloud/blockstore/public/api/protos/checkpoints.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 import "cloud/blockstore/public/api/protos/headers.proto";
 import "cloud/storage/core/protos/error.proto";
-import "cloud/storage/core/protos/trace.proto";
 
 package NCloud.NBlockStore.NProto;
 
@@ -40,11 +39,10 @@ message TCreateCheckpointRequest
 
 message TCreateCheckpointResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -67,11 +65,10 @@ message TDeleteCheckpointRequest
 
 message TDeleteCheckpointResponse
 {
+    reserved 2;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -106,14 +103,13 @@ message TGetChangedBlocksRequest
 
 message TGetChangedBlocksResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     // Bit mask where bit is set if block has changed between checkpoints.
     bytes Mask = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -149,14 +145,13 @@ message TGetCheckpointStatusRequest
 
 message TGetCheckpointStatusResponse
 {
+    reserved 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     // Checkpoint status
     ECheckpointStatus CheckpointStatus = 2;
-
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;

--- a/cloud/blockstore/public/api/protos/io.proto
+++ b/cloud/blockstore/public/api/protos/io.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 import "cloud/blockstore/public/api/protos/headers.proto";
 import "cloud/storage/core/protos/error.proto";
-import "cloud/storage/core/protos/trace.proto";
 
 package NCloud.NBlockStore.NProto;
 
@@ -64,20 +63,16 @@ message TReadBlocksRequest
 
 message TReadBlocksResponse
 {
+    reserved 3, 5;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
     // Requested blocks.
     TIOVector Blocks = 2;
 
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 3;
-
     // Bitmask for unencrypted blocks
     bytes UnencryptedBlockMask = 4;
-
-    // Throttler delay. Deprecated. Use Headers.Throttler.Delay instead.
-    uint64 DeprecatedThrottlerDelay = 5;
 
     // If true, it means that all the data read was zeros.
     // It's a hint, false negatives are allowed.
@@ -123,14 +118,10 @@ message TWriteBlocksRequest
 
 message TWriteBlocksResponse
 {
+    reserved 2, 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
-
-    // Throttler delay.
-    uint64 DeprecatedThrottlerDelay = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;
@@ -162,14 +153,10 @@ message TZeroBlocksRequest
 
 message TZeroBlocksResponse
 {
+    reserved 2, 3;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
-
-    // Request traces.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 2;
-
-    // Throttler delay. Deprecated. Use Headers.Throttler.Delay instead.
-    uint64 DeprecatedThrottlerDelay = 3;
 
     // Optional response headers.
     TResponseHeaders Headers = 1000;

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -6,7 +6,6 @@ import "cloud/blockstore/public/api/protos/rdma.proto";
 import "cloud/blockstore/public/api/protos/volume_throttling.proto";
 import "cloud/storage/core/protos/error.proto";
 import "cloud/storage/core/protos/media.proto";
-import "cloud/storage/core/protos/trace.proto";
 
 package NCloud.NBlockStore.NProto;
 
@@ -706,6 +705,8 @@ message TVolumeVolatileThrottlingInfo
 
 message TStatVolumeResponse
 {
+    reserved 5;
+
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
@@ -717,9 +718,6 @@ message TStatVolumeResponse
 
     // Volume Mount seq number.
     uint64 MountSeqNumber = 4;
-
-    // Request traces. Deprecated. Use Headers.Trace instead.
-    NCloud.NProto.TTraceInfo DeprecatedTrace = 5;
 
     // List of checkpoints.
     repeated string Checkpoints = 6;


### PR DESCRIPTION
### Notes
This is cleanup after https://github.com/ydb-platform/nbs/pull/5127. After 6 month it is time to remove old proto fields and use only new ones (headers)
