### PR TITLE
fix request resources deallocation race

### DIFF
--- a/cloud/storage/core/libs/rdma/iface/protobuf.cpp
+++ b/cloud/storage/core/libs/rdma/iface/protobuf.cpp
@@ -191,6 +191,19 @@ size_t SerializeError(ui32 code, TStringBuf message, TStringBuf buffer)
     return 0;   // will be interpreted as E_FAIL by ParseError
 }
 
+TString SerializeError(ui32 code, TStringBuf message)
+{
+    auto error = MakeError(code, TString(message));
+
+    TString result;
+    result.resize(error.ByteSizeLong());
+
+    bool succeeded = error.SerializeToArray(result.Detach(), result.size());
+    Y_ENSURE(succeeded, "could not serialize protobuf message");
+
+    return result;
+}
+
 NProto::TError ParseError(TStringBuf buffer)
 {
     NProto::TError error;

--- a/cloud/storage/core/libs/rdma/iface/protobuf.cpp
+++ b/cloud/storage/core/libs/rdma/iface/protobuf.cpp
@@ -198,8 +198,9 @@ TString SerializeError(ui32 code, TStringBuf message)
     TString result;
     result.resize(error.ByteSizeLong());
 
-    bool succeeded = error.SerializeToArray(result.Detach(), result.size());
-    Y_ENSURE(succeeded, "could not serialize protobuf message");
+    Y_ABORT_UNLESS(
+        error.SerializeToArray(result.Detach(), result.size()),
+        "could not serialize protobuf message");
 
     return result;
 }

--- a/cloud/storage/core/libs/rdma/iface/protobuf.h
+++ b/cloud/storage/core/libs/rdma/iface/protobuf.h
@@ -101,6 +101,7 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 size_t SerializeError(ui32 code, TStringBuf message, TStringBuf buffer);
+TString SerializeError(ui32 code, TStringBuf message);
 
 NProto::TError ParseError(TStringBuf buffer);
 

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -164,6 +164,8 @@ struct TRequest
     NVerbs::TMemoryWindowPtr InMemoryWindow = NVerbs::NullPtr;
     NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
 
+    ui64 BufferPoolGeneration = 0;
+
     ERequestState State = ERequestState::Init;
 
     TRequest(
@@ -597,6 +599,7 @@ private:
 
     TBufferPool SendBuffers;
     TBufferPool RecvBuffers;
+    std::atomic<ui64> BufferPoolGeneration = 0;
     TMutex AllocationLock;
 
     TPooledBuffer SendBuffer {};
@@ -800,6 +803,8 @@ void TClientEndpoint::ChangeState(
 
 void TClientEndpoint::CreateQP()
 {
+    ++BufferPoolGeneration;
+
     CompletionChannel = Verbs->CreateCompletionChannel(Connection->verbs);
     SetNonBlock(CompletionChannel->fd, true);
 
@@ -987,6 +992,7 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         shared_from_this(),
         std::move(handler),
         std::move(context));
+    req->BufferPoolGeneration = BufferPoolGeneration.load();
 
     try {
         with_lock (AllocationLock) {
@@ -1033,6 +1039,15 @@ ui64 TClientEndpoint::SendRequest(
 
     auto clientReqId = GetNewReqId();
     req->ClientReqId = clientReqId;
+
+    if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
+        // Endpoint reconnected between AllocateRequest() and SendRequest():
+        // req->OutBuffer/OutMemoryWindow may belong to an already torn down
+        // pool generation/PD.
+        auto* handler = req->Handler.get();
+        handler->HandleResponse(std::move(req), RDMA_PROTO_FAIL, 0);
+        return clientReqId;
+    }
 
     if (!CheckState(EEndpointState::Connected)) {
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
@@ -1957,6 +1972,19 @@ bool TClientEndpoint::FlushHanging() const
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
 {
     with_lock (AllocationLock) {
+        const bool sameBufferPoolGeneration =
+            req->BufferPoolGeneration == BufferPoolGeneration.load();
+
+        if (!sameBufferPoolGeneration) {
+            // Late request destruction after reconnect: buffers/windows
+            // belong to an older pool generation and cannot be safely
+            // released via the current pool/PD, so just drop them without
+            // touching SendBuffers/RecvBuffers or calling ibv_dealloc_mw.
+            req->InMemoryWindow.release();
+            req->OutMemoryWindow.release();
+            return;
+        }
+
         // destroy memory windows that haven't been properly invalidated
         if (req->InMemoryWindow) {
             req->InMemoryWindow.reset();

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -867,13 +867,13 @@ void TClientEndpoint::CreateQP()
         ++BufferPoolGeneration;
         SendBuffers.Init(Verbs, Connection->pd, sendFlags);
         RecvBuffers.Init(Verbs, Connection->pd, recvFlags);
+
+        SendBuffer = SendBuffers.AcquireBuffer(
+            Config.SendQueueSize * sizeof(TRequestMessage), true);
+
+        RecvBuffer = RecvBuffers.AcquireBuffer(
+            Config.RecvQueueSize * sizeof(TResponseMessage), true);
     }
-
-    SendBuffer = SendBuffers.AcquireBuffer(
-        Config.SendQueueSize * sizeof(TRequestMessage), true);
-
-    RecvBuffer = RecvBuffers.AcquireBuffer(
-        Config.RecvQueueSize * sizeof(TResponseMessage), true);
 
     SendWrs.resize(Config.SendQueueSize);
     RecvWrs.resize(Config.RecvQueueSize);

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -1135,6 +1135,16 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
         Y_ABORT_UNLESS(req);
         Counters->RequestDequeued();
 
+        if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
+            // The caller's thread could have been preempted between the
+            // generation check in SendRequest() and InputRequests.Enqueue()
+            // for the whole duration of a reconnect cycle - req->InBuffer/
+            // OutBuffer may already belong to a torn down pool generation.
+            SendQueue.Push(send);
+            RejectStaleGenerationRequest(std::move(req));
+            continue;
+        }
+
         if (req->State != ERequestState::Enqueued) {
             RDMA_ERROR(
                 "request " << req->ReqId << " has unexpected state "
@@ -1147,16 +1157,6 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
             Counters->Error();
             Disconnect();
             return;
-        }
-
-        if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
-            // The caller's thread could have been preempted between the
-            // generation check in SendRequest() and InputRequests.Enqueue()
-            // for the whole duration of a reconnect cycle - req->InBuffer/
-            // OutBuffer may already belong to a torn down pool generation.
-            SendQueue.Push(send);
-            RejectStaleGenerationRequest(std::move(req));
-            continue;
         }
 
         StartRequest(std::move(req), send);

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -61,6 +61,12 @@ constexpr TDuration INSTANT_RECONNECT_DELAY = TDuration::MicroSeconds(1);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+const TString StaleGenerationError = SerializeError(
+    E_RDMA_UNAVAILABLE,
+    "buffer generation changed");
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TRequest;
 using TRequestPtr = std::unique_ptr<TRequest>;
 
@@ -716,6 +722,7 @@ private:
     void InvalidateBuffers(TRequest* req) noexcept;
     void CompleteRequest(ui32 reqId) noexcept;
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
+    void RejectStaleGenerationRequest(TRequestPtr req) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     bool PostSend(TRequest* req, TSendWr* send, ibv_send_wr* wr) noexcept;
     void HandleSendError(TSendWr* send) noexcept;
@@ -803,8 +810,6 @@ void TClientEndpoint::ChangeState(
 
 void TClientEndpoint::CreateQP()
 {
-    ++BufferPoolGeneration;
-
     CompletionChannel = Verbs->CreateCompletionChannel(Connection->verbs);
     SetNonBlock(CompletionChannel->fd, true);
 
@@ -858,8 +863,11 @@ void TClientEndpoint::CreateQP()
         recvFlags |= IBV_ACCESS_MW_BIND;
     }
 
-    SendBuffers.Init(Verbs, Connection->pd, sendFlags);
-    RecvBuffers.Init(Verbs, Connection->pd, recvFlags);
+    with_lock (AllocationLock) {
+        ++BufferPoolGeneration;
+        SendBuffers.Init(Verbs, Connection->pd, sendFlags);
+        RecvBuffers.Init(Verbs, Connection->pd, recvFlags);
+    }
 
     SendBuffer = SendBuffers.AcquireBuffer(
         Config.SendQueueSize * sizeof(TRequestMessage), true);
@@ -992,10 +1000,11 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         shared_from_this(),
         std::move(handler),
         std::move(context));
-    req->BufferPoolGeneration = BufferPoolGeneration.load();
 
     try {
         with_lock (AllocationLock) {
+            req->BufferPoolGeneration = BufferPoolGeneration.load();
+
             if (requestBytes) {
                 req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
             }
@@ -1041,23 +1050,8 @@ ui64 TClientEndpoint::SendRequest(
     req->ClientReqId = clientReqId;
 
     if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
-        // Endpoint reconnected between AllocateRequest() and SendRequest():
-        // req->InBuffer/OutBuffer may belong to an already
-        // torn down pool generation/PD, so don't touch them. Point
-        // ResponseBuffer at a statically preallocated, pre-serialized
-        // error instead of OutBuffer - it has static storage duration, so
-        // this is always safe regardless of buffer pool generation
-        static const TString StaleGenerationError = SerializeError(
-            E_REJECTED,
-            "buffer generation changed");
-
-        req->RequestBuffer = {};
-        req->ResponseBuffer = TStringBuf(
-            StaleGenerationError.data(),
-            StaleGenerationError.length());
-
-        auto* handler = req->Handler.get();
-        handler->HandleResponse(std::move(req), RDMA_PROTO_FAIL, StaleGenerationError.length());
+        // Endpoint reconnected between AllocateRequest() and SendRequest()
+        RejectStaleGenerationRequest(std::move(req));
         return clientReqId;
     }
 
@@ -1080,6 +1074,20 @@ ui64 TClientEndpoint::SendRequest(
     }
 
     return clientReqId;
+}
+
+void TClientEndpoint::RejectStaleGenerationRequest(TRequestPtr req) noexcept
+{
+    req->RequestBuffer = {};
+    req->ResponseBuffer = TStringBuf(
+        StaleGenerationError.data(),
+        StaleGenerationError.length());
+
+    auto* handler = req->Handler.get();
+    handler->HandleResponse(
+        std::move(req),
+        RDMA_PROTO_FAIL,
+        StaleGenerationError.length());
 }
 
 bool TClientEndpoint::HandleInputRequests() noexcept
@@ -1139,6 +1147,16 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
             Counters->Error();
             Disconnect();
             return;
+        }
+
+        if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
+            // The caller's thread could have been preempted between the
+            // generation check in SendRequest() and InputRequests.Enqueue()
+            // for the whole duration of a reconnect cycle - req->InBuffer/
+            // OutBuffer may already belong to a torn down pool generation.
+            SendQueue.Push(send);
+            RejectStaleGenerationRequest(std::move(req));
+            continue;
         }
 
         StartRequest(std::move(req), send);

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -1310,6 +1310,11 @@ void TClientEndpoint::AbortRequest(
     ui32 err,
     const TString& msg) noexcept
 {
+    // Bound memory windows prevent MR/PD deallocation.
+    // Destroying a memory window automatically invalidates it.
+    // This ensures that no remote write can succeed after this point.
+    // By destroying all memory windows, we ensure that subsequent
+    // resource deallocation (PD/MR) succeeds.
     if (req->InMemoryWindow) {
         req->InMemoryWindow.reset();
         Counters->ReleaseMemoryWindow();

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -1042,10 +1042,22 @@ ui64 TClientEndpoint::SendRequest(
 
     if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
         // Endpoint reconnected between AllocateRequest() and SendRequest():
-        // req->OutBuffer/OutMemoryWindow may belong to an already torn down
-        // pool generation/PD.
+        // req->InBuffer/OutBuffer may belong to an already
+        // torn down pool generation/PD, so don't touch them. Point
+        // ResponseBuffer at a statically preallocated, pre-serialized
+        // error instead of OutBuffer - it has static storage duration, so
+        // this is always safe regardless of buffer pool generation
+        static const TString StaleGenerationError = SerializeError(
+            E_REJECTED,
+            "buffer generation changed");
+
+        req->RequestBuffer = {};
+        req->ResponseBuffer = TStringBuf(
+            StaleGenerationError.data(),
+            StaleGenerationError.length());
+
         auto* handler = req->Handler.get();
-        handler->HandleResponse(std::move(req), RDMA_PROTO_FAIL, 0);
+        handler->HandleResponse(std::move(req), RDMA_PROTO_FAIL, StaleGenerationError.length());
         return clientReqId;
     }
 
@@ -1280,8 +1292,10 @@ void TClientEndpoint::AbortRequest(
     ui32 err,
     const TString& msg) noexcept
 {
-    // destroying memory window automatically invalidates it. this ensures no
-    // remote write can succeed after this point
+    if (req->InMemoryWindow) {
+        req->InMemoryWindow.reset();
+        Counters->ReleaseMemoryWindow();
+    }
     if (req->OutMemoryWindow) {
         req->OutMemoryWindow.reset();
         Counters->ReleaseMemoryWindow();
@@ -1976,12 +1990,10 @@ void TClientEndpoint::FreeRequest(TRequest* req) noexcept
             req->BufferPoolGeneration == BufferPoolGeneration.load();
 
         if (!sameBufferPoolGeneration) {
-            // Late request destruction after reconnect: buffers/windows
-            // belong to an older pool generation and cannot be safely
-            // released via the current pool/PD, so just drop them without
-            // touching SendBuffers/RecvBuffers or calling ibv_dealloc_mw.
-            req->InMemoryWindow.release();
-            req->OutMemoryWindow.release();
+            // Late request destruction after reconnect: InBuffer/OutBuffer
+            // were acquired eagerly in AllocateRequest() and belong to an
+            // older pool generation, so they cannot be safely released via
+            // the current SendBuffers/RecvBuffers.
             return;
         }
 

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -864,7 +864,7 @@ void TClientEndpoint::CreateQP()
     }
 
     with_lock (AllocationLock) {
-        ++BufferPoolGeneration;
+        BufferPoolGeneration.fetch_add(1);
         SendBuffers.Init(Verbs, Connection->pd, sendFlags);
         RecvBuffers.Init(Verbs, Connection->pd, recvFlags);
 
@@ -2009,10 +2009,7 @@ bool TClientEndpoint::FlushHanging() const
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
 {
     with_lock (AllocationLock) {
-        const bool sameBufferPoolGeneration =
-            req->BufferPoolGeneration == BufferPoolGeneration.load();
-
-        if (!sameBufferPoolGeneration) {
+        if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
             // Late request destruction after reconnect: InBuffer/OutBuffer
             // were acquired eagerly in AllocateRequest() and belong to an
             // older pool generation, so they cannot be safely released via

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -722,7 +722,6 @@ private:
     void InvalidateBuffers(TRequest* req) noexcept;
     void CompleteRequest(ui32 reqId) noexcept;
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
-    void RejectStaleGenerationRequest(TRequestPtr req) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     bool PostSend(TRequest* req, TSendWr* send, ibv_send_wr* wr) noexcept;
     void HandleSendError(TSendWr* send) noexcept;
@@ -1049,12 +1048,6 @@ ui64 TClientEndpoint::SendRequest(
     auto clientReqId = GetNewReqId();
     req->ClientReqId = clientReqId;
 
-    if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
-        // Endpoint reconnected between AllocateRequest() and SendRequest()
-        RejectStaleGenerationRequest(std::move(req));
-        return clientReqId;
-    }
-
     if (!CheckState(EEndpointState::Connected)) {
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
         return clientReqId;
@@ -1074,20 +1067,6 @@ ui64 TClientEndpoint::SendRequest(
     }
 
     return clientReqId;
-}
-
-void TClientEndpoint::RejectStaleGenerationRequest(TRequestPtr req) noexcept
-{
-    req->RequestBuffer = {};
-    req->ResponseBuffer = TStringBuf(
-        StaleGenerationError.data(),
-        StaleGenerationError.length());
-
-    auto* handler = req->Handler.get();
-    handler->HandleResponse(
-        std::move(req),
-        RDMA_PROTO_FAIL,
-        StaleGenerationError.length());
 }
 
 bool TClientEndpoint::HandleInputRequests() noexcept
@@ -1133,17 +1112,21 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
 
         auto req = QueuedRequests.Dequeue();
         Y_ABORT_UNLESS(req);
-        Counters->RequestDequeued();
 
         if (req->BufferPoolGeneration != BufferPoolGeneration.load()) {
             // The caller's thread could have been preempted between the
-            // generation check in SendRequest() and InputRequests.Enqueue()
-            // for the whole duration of a reconnect cycle - req->InBuffer/
+            // state check in SendRequest() and InputRequests.Enqueue() for
+            // the whole duration of a reconnect cycle - req->InBuffer/
             // OutBuffer may already belong to a torn down pool generation.
             SendQueue.Push(send);
-            RejectStaleGenerationRequest(std::move(req));
+            AbortRequest(
+                std::move(req),
+                E_RDMA_UNAVAILABLE,
+                "buffer generation changed");
             continue;
         }
+
+        Counters->RequestDequeued();
 
         if (req->State != ERequestState::Enqueued) {
             RDMA_ERROR(
@@ -1355,10 +1338,21 @@ void TClientEndpoint::AbortRequest(
             break;
     }
 
-    auto len = SerializeError(
-        err,
-        msg,
-        static_cast<TStringBuf>(req->OutBuffer));
+    size_t len = 0;
+
+    if (req->BufferPoolGeneration == BufferPoolGeneration.load()) {
+        len = SerializeError(
+            err,
+            msg,
+            static_cast<TStringBuf>(req->OutBuffer));
+    } else {
+        // stale generation: OutBuffer belongs to a torn down pool, use the
+        // preallocated error instead
+        req->RequestBuffer = {};
+        req->ResponseBuffer = TStringBuf(
+            StaleGenerationError.data(), StaleGenerationError.length());
+        len = StaleGenerationError.length();
+    }
 
     auto* handler = req->Handler.get();
     handler->HandleResponse(std::move(req), RDMA_PROTO_FAIL, len);

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -1684,7 +1684,7 @@ TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
 
         NProto::TError error =
             ParseError(TStringBuf(response.Buffer).Head(response.Bytes));
-        ASSERT_EQ(static_cast<ui32>(E_REJECTED), error.GetCode());
+        ASSERT_EQ(static_cast<ui32>(E_RDMA_UNAVAILABLE), error.GetCode());
     }
 
     TEST(TRdmaClientTest, ShouldEagerlyDestroyBothMemoryWindowsOnAbortRequest)
@@ -1765,7 +1765,7 @@ TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
             SpinLockPause();
         }
 
-\        endpoint->CancelRequest(reqId);
+        endpoint->CancelRequest(reqId);
 
         handler->Received.Wait();
         ASSERT_TRUE(handler->Held);

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -1608,7 +1608,6 @@ TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
         auto verbs = NVerbs::CreateTestVerbs(testContext);
         auto monitoring = CreateMonitoringServiceStub();
         auto clientConfig = std::make_shared<TClientConfig>();
-        clientConfig->UseMemoryWindows = true;
 
         auto logging = CreateLoggingService(
             "console",
@@ -1625,12 +1624,6 @@ TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
             client->Stop();
         };
 
-        std::atomic<int> destroyed = 0;
-        testContext->DestroyMemoryWindow = [&](ibv_mw* mw) {
-            Y_UNUSED(mw);
-            destroyed++;
-        };
-
         auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
         testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
@@ -1645,22 +1638,27 @@ TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
             bool Received = false;
             ui32 Status = 0;
             size_t Bytes = 0;
+            TString Buffer;
         };
 
         TResponse response;
 
         auto ctx = std::make_unique<TRequestContext>();
         ctx->Handler = [&](TStringBuf requestBuffer,
-                            TStringBuf responseBuffer,
-                            ui32 status,
-                            size_t bytes)
+            TStringBuf responseBuffer,
+            ui32 status,
+            size_t bytes)
         {
             Y_UNUSED(requestBuffer);
-            Y_UNUSED(responseBuffer);
-            response = TResponse{true, status, bytes};
+            response =
+                TResponse{
+                    .Received = true,
+                    .Status = status,
+                    .Bytes = bytes,
+                    .Buffer = TString(responseBuffer.Head(bytes))};
         };
 
-        // allocate a request (and its memory windows) against the current
+        // allocate a request (InBuffer/OutBuffer) against the current
         // generation, but do not send it yet
         auto request = endpoint->AllocateRequest(
             std::make_shared<TClientHandler>(),
@@ -1676,23 +1674,20 @@ TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
             recv = AtomicGet(testContext->PostRecvCounter);
         } while (recv != 2 * clientConfig->QueueSize);
 
-        // sending a request allocated before the reconnect must be
-        // rejected instead of using buffers/windows that belong to an
-        // already torn down generation
         endpoint->SendRequest(
             request.ExtractResult(),
             MakeIntrusive<TCallContextBase>(0u));
 
         ASSERT_TRUE(response.Received);
         ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response.Status);
-        ASSERT_EQ(0u, response.Bytes);
+        ASSERT_GT(response.Bytes, 0u);
 
-        // the stale memory window must not be deallocated against an
-        // already destroyed protection domain
-        ASSERT_EQ(0, destroyed.load());
+        NProto::TError error =
+            ParseError(TStringBuf(response.Buffer).Head(response.Bytes));
+        ASSERT_EQ(static_cast<ui32>(E_REJECTED), error.GetCode());
     }
 
-    TEST(TRdmaClientTest, ShouldSafelyFreeRequestFromStaleBufferPoolGeneration)
+    TEST(TRdmaClientTest, ShouldEagerlyDestroyBothMemoryWindowsOnAbortRequest)
     {
         auto testContext = MakeIntrusive<NVerbs::TTestContext>();
         testContext->AllowConnect = true;
@@ -1717,7 +1712,16 @@ TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
             client->Stop();
         };
 
+        std::atomic<int> bound = 0;
         std::atomic<int> destroyed = 0;
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+            Y_UNUSED(qp);
+            if (wr->opcode == IBV_WR_BIND_MW) {
+                bound++;
+            }
+        };
+
         testContext->DestroyMemoryWindow = [&](ibv_mw* mw) {
             Y_UNUSED(mw);
             destroyed++;
@@ -1725,35 +1729,49 @@ TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
 
         auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
-        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
-            PostSend<TRequestMessage>(testContext, qp, wr);
+        struct THoldingHandler: IClientHandler
+        {
+            TClientRequestPtr Held;
+            TManualEvent Received;
+
+            void HandleResponse(
+                TClientRequestPtr req,
+                ui32 status,
+                size_t responseBytes) override
+            {
+                Y_UNUSED(status);
+                Y_UNUSED(responseBytes);
+                Held = std::move(req);
+                Received.Signal();
+            }
         };
 
-        // allocate a request (and its memory windows) against the current
-        // generation, but never send it
+        auto handler = std::make_shared<THoldingHandler>();
+
         auto request = endpoint->AllocateRequest(
-            std::make_shared<TClientHandler>(),
+            handler,
             std::make_unique<TNullContext>(),
             1024,
             1024);
         ASSERT_FALSE(HasError(request.GetError()));
 
-        Disconnect(testContext);
+        auto reqId = endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
 
-        ui64 recv;
-        do {
-            recv = AtomicGet(testContext->PostRecvCounter);
-        } while (recv != 2 * clientConfig->QueueSize);
-
-        const int destroyedBeforeFree = destroyed.load();
-
-        {
-            // the stale memory window must not be deallocated against an
-            // already destroyed protection domain
-            auto req = request.ExtractResult();
+        // wait until the request's memory windows have been acquired and
+        // the first bind work request posted
+        while (bound.load() < 1) {
+            SpinLockPause();
         }
 
-        ASSERT_EQ(destroyedBeforeFree, destroyed.load());
+\        endpoint->CancelRequest(reqId);
+
+        handler->Received.Wait();
+        ASSERT_TRUE(handler->Held);
+        ASSERT_EQ(2, destroyed.load());
+
+        handler->Held.reset();
     }
 
 }   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -1600,4 +1600,160 @@ TEST(TRdmaClientTest, ShouldBindAndInvalidateBuffers)
         }
 }
 
+TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        std::atomic<int> destroyed = 0;
+        testContext->DestroyMemoryWindow = [&](ibv_mw* mw) {
+            Y_UNUSED(mw);
+            destroyed++;
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
+
+        size_t requestBytes = 1024;
+        size_t responseBytes = 1024;
+
+        struct TResponse
+        {
+            bool Received = false;
+            ui32 Status = 0;
+            size_t Bytes = 0;
+        };
+
+        TResponse response;
+
+        auto ctx = std::make_unique<TRequestContext>();
+        ctx->Handler = [&](TStringBuf requestBuffer,
+                            TStringBuf responseBuffer,
+                            ui32 status,
+                            size_t bytes)
+        {
+            Y_UNUSED(requestBuffer);
+            Y_UNUSED(responseBuffer);
+            response = TResponse{true, status, bytes};
+        };
+
+        // allocate a request (and its memory windows) against the current
+        // generation, but do not send it yet
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            std::move(ctx),
+            requestBytes,
+            responseBytes);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        Disconnect(testContext);
+
+        ui64 recv;
+        do {
+            recv = AtomicGet(testContext->PostRecvCounter);
+        } while (recv != 2 * clientConfig->QueueSize);
+
+        // sending a request allocated before the reconnect must be
+        // rejected instead of using buffers/windows that belong to an
+        // already torn down generation
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        ASSERT_TRUE(response.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response.Status);
+        ASSERT_EQ(0u, response.Bytes);
+
+        // the stale memory window must not be deallocated against an
+        // already destroyed protection domain
+        ASSERT_EQ(0, destroyed.load());
+    }
+
+    TEST(TRdmaClientTest, ShouldSafelyFreeRequestFromStaleBufferPoolGeneration)
+    {
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        std::atomic<int> destroyed = 0;
+        testContext->DestroyMemoryWindow = [&](ibv_mw* mw) {
+            Y_UNUSED(mw);
+            destroyed++;
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
+
+        // allocate a request (and its memory windows) against the current
+        // generation, but never send it
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            std::make_unique<TNullContext>(),
+            1024,
+            1024);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        Disconnect(testContext);
+
+        ui64 recv;
+        do {
+            recv = AtomicGet(testContext->PostRecvCounter);
+        } while (recv != 2 * clientConfig->QueueSize);
+
+        const int destroyedBeforeFree = destroyed.load();
+
+        {
+            // the stale memory window must not be deallocated against an
+            // already destroyed protection domain
+            auto req = request.ExtractResult();
+        }
+
+        ASSERT_EQ(destroyedBeforeFree, destroyed.load());
+    }
+
 }   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -1602,176 +1602,236 @@ TEST(TRdmaClientTest, ShouldBindAndInvalidateBuffers)
 
 TEST(TRdmaClientTest, ShouldRejectRequestFromStaleBufferPoolGeneration)
 {
-        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
-        testContext->AllowConnect = true;
+    auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+    testContext->AllowConnect = true;
 
-        auto verbs = NVerbs::CreateTestVerbs(testContext);
-        auto monitoring = CreateMonitoringServiceStub();
-        auto clientConfig = std::make_shared<TClientConfig>();
+    auto verbs = NVerbs::CreateTestVerbs(testContext);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto clientConfig = std::make_shared<TClientConfig>();
 
-        auto logging = CreateLoggingService(
-            "console",
-            TLogSettings{TLOG_RESOURCES});
+    auto logging = CreateLoggingService(
+        "console",
+        TLogSettings{TLOG_RESOURCES});
 
-        auto client = CreateTestClient(
-            verbs,
-            logging,
-            monitoring,
-            clientConfig);
+    auto client = CreateTestClient(
+        verbs,
+        logging,
+        monitoring,
+        clientConfig);
 
-        client->Start();
-        Y_DEFER {
-            client->Stop();
-        };
+    client->Start();
+    Y_DEFER {
+        client->Stop();
+    };
 
-        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+    auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
-        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
-            PostSend<TRequestMessage>(testContext, qp, wr);
-        };
+    testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+        PostSend<TRequestMessage>(testContext, qp, wr);
+    };
 
-        size_t requestBytes = 1024;
-        size_t responseBytes = 1024;
+    size_t requestBytes = 1024;
+    size_t responseBytes = 1024;
 
-        struct TResponse
-        {
-            bool Received = false;
-            ui32 Status = 0;
-            size_t Bytes = 0;
-            TString Buffer;
-        };
-
-        TResponse response;
-
-        auto ctx = std::make_unique<TRequestContext>();
-        ctx->Handler = [&](TStringBuf requestBuffer,
-            TStringBuf responseBuffer,
-            ui32 status,
-            size_t bytes)
-        {
-            Y_UNUSED(requestBuffer);
-            response =
-                TResponse{
-                    .Received = true,
-                    .Status = status,
-                    .Bytes = bytes,
-                    .Buffer = TString(responseBuffer.Head(bytes))};
-        };
-
-        // allocate a request (InBuffer/OutBuffer) against the current
-        // generation, but do not send it yet
-        auto request = endpoint->AllocateRequest(
-            std::make_shared<TClientHandler>(),
-            std::move(ctx),
-            requestBytes,
-            responseBytes);
-        ASSERT_FALSE(HasError(request.GetError()));
-
-        Disconnect(testContext);
-
-        ui64 recv;
-        do {
-            recv = AtomicGet(testContext->PostRecvCounter);
-        } while (recv != 2 * clientConfig->QueueSize);
-
-        endpoint->SendRequest(
-            request.ExtractResult(),
-            MakeIntrusive<TCallContextBase>(0u));
-
-        ASSERT_TRUE(response.Received);
-        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response.Status);
-        ASSERT_GT(response.Bytes, 0u);
-
-        NProto::TError error =
-            ParseError(TStringBuf(response.Buffer).Head(response.Bytes));
-        ASSERT_EQ(static_cast<ui32>(E_RDMA_UNAVAILABLE), error.GetCode());
-    }
-
-    TEST(TRdmaClientTest, ShouldEagerlyDestroyBothMemoryWindowsOnAbortRequest)
+    struct TResponse
     {
-        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
-        testContext->AllowConnect = true;
+        bool Received = false;
+        ui32 Status = 0;
+        size_t Bytes = 0;
+        TString Buffer;
+    };
 
-        auto verbs = NVerbs::CreateTestVerbs(testContext);
-        auto monitoring = CreateMonitoringServiceStub();
-        auto clientConfig = std::make_shared<TClientConfig>();
-        clientConfig->UseMemoryWindows = true;
+    TResponse response;
+    TManualEvent received;
 
-        auto logging = CreateLoggingService(
-            "console",
-            TLogSettings{TLOG_RESOURCES});
+    auto ctx = std::make_unique<TRequestContext>();
+    ctx->Handler = [&](TStringBuf requestBuffer,
+        TStringBuf responseBuffer,
+        ui32 status,
+        size_t bytes)
+    {
+        Y_UNUSED(requestBuffer);
+        response =
+            TResponse{
+                .Received = true,
+                .Status = status,
+                .Bytes = bytes,
+                .Buffer = TString(responseBuffer.Head(bytes))};
+        received.Signal();
+    };
 
-        auto client = CreateTestClient(
-            verbs,
-            logging,
-            monitoring,
-            clientConfig);
+    // allocate a request (InBuffer/OutBuffer) against the current
+    // generation, but do not send it yet
+    auto request = endpoint->AllocateRequest(
+        std::make_shared<TClientHandler>(),
+        std::move(ctx),
+        requestBytes,
+        responseBytes);
+    ASSERT_FALSE(HasError(request.GetError()));
 
-        client->Start();
-        Y_DEFER {
-            client->Stop();
-        };
+    Disconnect(testContext);
 
-        std::atomic<int> bound = 0;
-        std::atomic<int> destroyed = 0;
+    ui64 recv;
+    do {
+        recv = AtomicGet(testContext->PostRecvCounter);
+    } while (recv != 2 * clientConfig->QueueSize);
 
-        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
-            Y_UNUSED(qp);
-            if (wr->opcode == IBV_WR_BIND_MW) {
-                bound++;
-            }
-        };
+    // the endpoint is Connected again, so the request is accepted and
+    // enqueued - the stale generation is detected on the CQ thread, in
+    // HandleQueuedRequests(), before the buffers are touched
+    endpoint->SendRequest(
+        request.ExtractResult(),
+        MakeIntrusive<TCallContextBase>(0u));
 
-        testContext->DestroyMemoryWindow = [&](ibv_mw* mw) {
-            Y_UNUSED(mw);
-            destroyed++;
-        };
+    received.Wait();
 
-        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+    ASSERT_TRUE(response.Received);
+    ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response.Status);
+    ASSERT_GT(response.Bytes, 0u);
 
-        struct THoldingHandler: IClientHandler
-        {
-            TClientRequestPtr Held;
-            TManualEvent Received;
+    NProto::TError error =
+        ParseError(TStringBuf(response.Buffer).Head(response.Bytes));
+    ASSERT_EQ(static_cast<ui32>(E_RDMA_UNAVAILABLE), error.GetCode());
 
-            void HandleResponse(
-                TClientRequestPtr req,
-                ui32 status,
-                size_t responseBytes) override
-            {
-                Y_UNUSED(status);
-                Y_UNUSED(responseBytes);
-                Held = std::move(req);
-                Received.Signal();
-            }
-        };
+    auto counters = GetClientCounters(monitoring);
+    ASSERT_EQ(0, counters->GetCounter("QueuedRequests")->Val());
+    ASSERT_EQ(0, counters->GetCounter("ActiveRequests")->Val());
+}
 
-        auto handler = std::make_shared<THoldingHandler>();
+TEST(TRdmaClientTest, ShouldEagerlyDestroyBothMemoryWindowsOnAbortRequest)
+{
+    auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+    testContext->AllowConnect = true;
 
-        auto request = endpoint->AllocateRequest(
-            handler,
-            std::make_unique<TNullContext>(),
-            1024,
-            1024);
-        ASSERT_FALSE(HasError(request.GetError()));
+    auto verbs = NVerbs::CreateTestVerbs(testContext);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto clientConfig = std::make_shared<TClientConfig>();
+    clientConfig->UseMemoryWindows = true;
 
-        auto reqId = endpoint->SendRequest(
-            request.ExtractResult(),
-            MakeIntrusive<TCallContextBase>(0u));
+    auto logging = CreateLoggingService(
+        "console",
+        TLogSettings{TLOG_RESOURCES});
 
-        // wait until the request's memory windows have been acquired and
-        // the first bind work request posted
-        while (bound.load() < 1) {
-            SpinLockPause();
+    auto client = CreateTestClient(
+        verbs,
+        logging,
+        monitoring,
+        clientConfig);
+
+    client->Start();
+    Y_DEFER {
+        client->Stop();
+    };
+
+    std::atomic<int> bound = 0;
+    std::atomic<int> destroyed = 0;
+
+    testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+        Y_UNUSED(qp);
+        if (wr->opcode == IBV_WR_BIND_MW) {
+            bound++;
         }
+    };
 
-        endpoint->CancelRequest(reqId);
+    testContext->DestroyMemoryWindow = [&](ibv_mw* mw) {
+        Y_UNUSED(mw);
+        destroyed++;
+    };
 
-        handler->Received.Wait();
-        ASSERT_TRUE(handler->Held);
-        ASSERT_EQ(2, destroyed.load());
+    auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
-        handler->Held.reset();
+    struct THoldingHandler: IClientHandler
+    {
+        TClientRequestPtr Held;
+        TManualEvent Received;
+
+        void HandleResponse(
+            TClientRequestPtr req,
+            ui32 status,
+            size_t responseBytes) override
+        {
+            Y_UNUSED(status);
+            Y_UNUSED(responseBytes);
+            Held = std::move(req);
+            Received.Signal();
+        }
+    };
+
+    auto handler = std::make_shared<THoldingHandler>();
+
+    auto request = endpoint->AllocateRequest(
+        handler,
+        std::make_unique<TNullContext>(),
+        1024,
+        1024);
+    ASSERT_FALSE(HasError(request.GetError()));
+
+    auto reqId = endpoint->SendRequest(
+        request.ExtractResult(),
+        MakeIntrusive<TCallContextBase>(0u));
+
+    // wait until the request's memory windows have been acquired and
+    // the first bind work request posted
+    while (bound.load() < 1) {
+        SpinLockPause();
     }
+
+    endpoint->CancelRequest(reqId);
+
+    handler->Received.Wait();
+    ASSERT_TRUE(handler->Held);
+    ASSERT_EQ(2, destroyed.load());
+
+    handler->Held.reset();
+}
+
+TEST(TRdmaClientTest, ShouldNotReleaseBuffersFromStaleBufferPoolGeneration)
+{
+    // NOTE: this test only detects the bug it guards against when built with ASAN.
+    // Without a sanitizer the freed chunk memory is still mapped, so releasing a
+    // buffer into a torn down pool silently corrupts the freelist instead of
+    // crashing, and the test passes either way.
+    auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+    testContext->AllowConnect = true;
+
+    auto verbs = NVerbs::CreateTestVerbs(testContext);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto clientConfig = std::make_shared<TClientConfig>();
+
+    auto logging = CreateLoggingService(
+        "console",
+        TLogSettings{TLOG_RESOURCES});
+
+    auto client = CreateTestClient(
+        verbs,
+        logging,
+        monitoring,
+        clientConfig);
+
+    client->Start();
+    Y_DEFER {
+        client->Stop();
+    };
+
+    auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+    auto request = endpoint->AllocateRequest(
+        std::make_shared<TClientHandler>(),
+        std::make_unique<TNullContext>(),
+        1024,
+        1024);
+    ASSERT_FALSE(HasError(request.GetError()));
+
+    Disconnect(testContext);
+
+    ui64 recv;
+    do {
+        recv = AtomicGet(testContext->PostRecvCounter);
+    } while (recv != 2 * clientConfig->QueueSize);
+
+    // dropping the request must not touch the torn down pool
+    auto req = request.ExtractResult();
+    req.reset();
+}
 
 }   // namespace NCloud::NStorage::NRdma


### PR DESCRIPTION
### Notes

Fix a use-after-free in the RDMA client that can occur when an endpoint
reconnects while a request is still holding buffers from the connection that's
being torn down.

**The problem.** On every reconnect `TClientEndpoint::CreateQP()` reinitializes
`SendBuffers`/`RecvBuffers`. `TBufferPool::Init()` replaces the whole internal
`Impl`, which destroys every `TChunk` of the previous generation — and
`~TChunk()` both deregisters the memory region and `free()`s the chunk memory.
A `TPooledBuffer` handed out earlier keeps a raw `TChunk*` and an address inside
that chunk, so after a reconnect both are dangling. Two places didn't know about
this:

1. `FreeRequest()` (called from `~TRequest()`, whenever the caller drops its
   `TClientRequestPtr`) unconditionally called
   `SendBuffers.ReleaseBuffer()`/`RecvBuffers.ReleaseBuffer()`. Request lifetime
   is controlled by the external caller, not by the endpoint, so a request that
   outlived a reconnect would dereference a freed `TChunk`.
2. Nothing on the send path checked which pool generation a request's buffers
   came from. If the endpoint reconnected between `AllocateRequest()` and the
   moment the request was actually processed — a window invisible to the
   endpoint's own tracking, since the request isn't enqueued anywhere yet — a
   stale request would still be accepted, and its buffers used for
   `IBV_WR_BIND_MW`/`PostSend` (`TBindWr` dereferences the dangling `TChunk*`
   via `GetMemoryRegion()`) or written to by `AbortRequest()`.

**The fix.** Added `BufferPoolGeneration`, an atomic counter bumped in
`CreateQP()`. The bump, both `Init()` calls and the `SendBuffer`/`RecvBuffer`
acquisition now happen under `AllocationLock`, so "generation + pool contents"
is a single atomic unit for every thread; `AllocateRequest()` stamps the request
with the current generation inside the same lock, together with its buffer
acquisition. Three call sites check the stamp:

- `HandleQueuedRequests()` checks it before `StartRequest()`, right after the
  request is dequeued. This is where a stale request is caught on the normal
  send path: the caller's thread can be preempted between the state check in
  `SendRequest()` and `InputRequests.Enqueue()`, so a request can land in the
  queue after `AbortRequests()` has already drained it and before the pools are
  replaced. The work request is returned to `SendQueue` and the request is
  aborted.
- `AbortRequest()` checks it before serializing the error. For a stale request
  `OutBuffer` points into a torn down pool, so instead of writing there it
  points `ResponseBuffer` at a preallocated, pre-serialized
  `E_RDMA_UNAVAILABLE` error with static storage duration. Putting the check
  here covers every abort path at once — the not-connected branch in
  `SendRequest()` and `HandleQueuedRequests()`, the reconnect drain in
  `AbortRequests()`, cancellation, and timeouts — rather than repeating it at
  each call site.
- `FreeRequest()` skips releasing buffers for a stale generation and just drops
  them: the chunk they came from no longer exists, so there is nothing to return
  and nothing to leak in the current pool.

Memory windows are only acquired in `BindBuffers()`, for requests that are
already in `ActiveRequests`, and those are drained through `AbortRequest()`
(which resets both windows) before the endpoint may reach `Disconnected` and
reconnect. A stale-generation request therefore never carries one, so the
memory-window handling in `FreeRequest()` is unreachable on that path and
needed no changes.

Also in this change: `AbortRequest()` now eagerly destroys both memory windows
(destroying a window invalidates it, which guarantees no remote write can
succeed afterwards, and lets the subsequent MR/PD deallocation succeed), and
`SerializeError()` gained a `TString`-returning overload for the preallocated
error above.

### Issue
#5456
