### PR TITLE
issue-6945: add filestore GetNodeAttr service layer probes

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -163,15 +163,15 @@ void TGetNodeAttrActor::HandleGetNodeAttrResponse(
 {
     auto* msg = ev->Get();
 
-    FILESTORE_TRACK(
-        ResponseSent_ServiceWorker,
-        RequestInfo->CallContext,
-        LeaderResponded ? "GetNodeAttrInShard" : "GetNodeAttrInLeader");
-
     if (HasError(msg->GetError())) {
         HandleError(ctx, *msg->Record.MutableError());
         return;
     }
+
+    FILESTORE_TRACK(
+        ResponseSent_ServiceWorker,
+        RequestInfo->CallContext,
+        LeaderResponded ? "GetNodeAttrInShard" : "GetNodeAttrInLeader");
 
     if (LeaderResponded) {
         LOG_DEBUG(
@@ -230,6 +230,11 @@ void TGetNodeAttrActor::HandleError(
     const TActorContext& ctx,
     NProto::TError error)
 {
+    FILESTORE_TRACK(
+        ResponseSent_ServiceWorker,
+        RequestInfo->CallContext,
+        LeaderResponded ? "GetNodeAttrInShard" : "GetNodeAttrInLeader");
+
     auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>(
         std::move(error));
     NCloud::Reply(ctx, *RequestInfo, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -1,7 +1,9 @@
 #include "service_actor.h"
 
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
+#include <cloud/filestore/libs/diagnostics/trace_serializer.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/core/probes.h>
 #include <cloud/filestore/libs/storage/tablet/model/verify.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
@@ -11,6 +13,8 @@ namespace NCloud::NFileStore::NStorage {
 using namespace NActors;
 
 using namespace NKikimr;
+
+LWTRACE_USING(FILESTORE_STORAGE_PROVIDER);
 
 namespace {
 
@@ -33,6 +37,7 @@ private:
     // Stats for reporting
     IRequestStatsPtr RequestStats;
     IProfileLogPtr ProfileLog;
+    ITraceSerializerPtr TraceSerializer;
 
     const bool DisableMultiTabletForwarding;
 
@@ -42,6 +47,7 @@ public:
         NProto::TGetNodeAttrRequest getNodeAttrRequest,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
+        ITraceSerializerPtr traceSerializer,
         bool disableMultiTabletForwarding);
 
     void Bootstrap(const TActorContext& ctx);
@@ -74,12 +80,14 @@ TGetNodeAttrActor::TGetNodeAttrActor(
         NProto::TGetNodeAttrRequest getNodeAttrRequest,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
+        ITraceSerializerPtr traceSerializer,
         bool disableMultiTabletForwarding)
     : RequestInfo(std::move(requestInfo))
     , GetNodeAttrRequest(std::move(getNodeAttrRequest))
     , LogTag(GetNodeAttrRequest.GetFileSystemId())
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
+    , TraceSerializer(std::move(traceSerializer))
     , DisableMultiTabletForwarding(disableMultiTabletForwarding)
 {
 }
@@ -92,6 +100,11 @@ void TGetNodeAttrActor::Bootstrap(const TActorContext& ctx)
 
 void TGetNodeAttrActor::GetNodeAttrInLeader(const TActorContext& ctx)
 {
+    FILESTORE_TRACK(
+        RequestReceived_ServiceWorker,
+        RequestInfo->CallContext,
+        "GetNodeAttrInLeader");
+
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::SERVICE,
@@ -102,6 +115,10 @@ void TGetNodeAttrActor::GetNodeAttrInLeader(const TActorContext& ctx)
 
     auto request = std::make_unique<TEvService::TEvGetNodeAttrRequest>();
     request->Record = GetNodeAttrRequest;
+    request->CallContext = RequestInfo->CallContext;
+    TraceSerializer->BuildTraceRequest(
+        *request->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
+        request->CallContext->LWOrbit);
 
     // forward request through tablet proxy
     ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
@@ -109,6 +126,11 @@ void TGetNodeAttrActor::GetNodeAttrInLeader(const TActorContext& ctx)
 
 void TGetNodeAttrActor::GetNodeAttrInShard(const TActorContext& ctx)
 {
+    FILESTORE_TRACK(
+        RequestReceived_ServiceWorker,
+        RequestInfo->CallContext,
+        "GetNodeAttrInShard");
+
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::SERVICE,
@@ -124,6 +146,10 @@ void TGetNodeAttrActor::GetNodeAttrInShard(const TActorContext& ctx)
         LeaderResponse.GetNode().GetShardFileSystemId());
     request->Record.SetNodeId(RootNodeId);
     request->Record.SetName(LeaderResponse.GetNode().GetShardNodeName());
+    request->CallContext = RequestInfo->CallContext;
+    TraceSerializer->BuildTraceRequest(
+        *request->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
+        request->CallContext->LWOrbit);
 
     // forward request through tablet proxy
     ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
@@ -136,6 +162,11 @@ void TGetNodeAttrActor::HandleGetNodeAttrResponse(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
+
+    FILESTORE_TRACK(
+        ResponseSent_ServiceWorker,
+        RequestInfo->CallContext,
+        LeaderResponded ? "GetNodeAttrInShard" : "GetNodeAttrInLeader");
 
     if (HasError(msg->GetError())) {
         HandleError(ctx, *msg->Record.MutableError());
@@ -301,6 +332,7 @@ void TStorageServiceActor::HandleGetNodeAttr(
         std::move(msg->Record),
         session->RequestStats,
         ProfileLog,
+        TraceSerializer,
         disableMultiTabletForwarding);
 
     NCloud::Register(ctx, std::move(actor));


### PR DESCRIPTION
### Notes
Example:
`2026-08-27T22:11:38.846237Z :NFS_TRACE INFO: [["ExecuteRequest",0,"GetNodeAttr","76","nfs","1","0"],["AuthRequestSent_Proxy",55,"GetNodeAttr","76"],["AuthResponseReceived_Proxy",88,"GetNodeAttr","76"],["RequestReceived_ServiceWorker",152,"GetNodeAttrInLeader","76"],["RequestReceived_TabletProxy",170,"GetNodeAttr","76"],["RequestReceived_Tablet",234,"GetNodeAttr","76","nfs","1"],["TxInit",254,"GetNodeAttr","76"],["Fork",256,"5999"],["TxPrepare",282,"GetNodeAttr","76"],["TxExecute",348,"GetNodeAttr","76"],["TxExecuteDone",349,"GetNodeAttr","76"],["TxComplete",362,"GetNodeAttr","76"],["Join",366,"5999","4"],["TransactionBegin",271,"16","72075186224037896","NCloud::NFileStore::NStorage::TTabletBase<NCloud::NFileStore::NStorage::TIndexTabletActor>::TTransaction<NCloud::NFileStore::NStorage::TIndexTabletActor::TGetNodeAttr>"],["TransactionExecuteBegin",279,"16"],["TransactionExecuteEnd",350,"16","1"],["TransactionCompleteBegin",360,"16"],["ResponseSent_Tablet",372,"GetNodeAttr","76"],["ResponseSent_TabletProxy",420,"GetNodeAttr","76"],["ResponseSent_ServiceWorker",427,"GetNodeAttrInLeader","76"],["RequestReceived_ServiceWorker",429,"GetNodeAttrInShard","76"],["RequestReceived_TabletProxy",453,"GetNodeAttr","76"],["RequestReceived_Tablet",519,"GetNodeAttr","76","nfs","1"],["TxInit",537,"GetNodeAttr","76"],["Fork",539,"5999"],["TxPrepare",565,"GetNodeAttr","76"],["TxExecute",646,"GetNodeAttr","76"],["TxExecuteDone",648,"GetNodeAttr","76"],["TxComplete",662,"GetNodeAttr","76"],["Join",667,"5999","4"],["TransactionBegin",554,"31","72075186224037895","NCloud::NFileStore::NStorage::TTabletBase<NCloud::NFileStore::NStorage::TIndexTabletActor>::TTransaction<NCloud::NFileStore::NStorage::TIndexTabletActor::TGetNodeAttr>"],["TransactionExecuteBegin",562,"31"],["TransactionExecuteEnd",649,"31","1"],["TransactionCompleteBegin",659,"31"],["ResponseSent_Tablet",674,"GetNodeAttr","76"],["ResponseSent_TabletProxy",720,"GetNodeAttr","76"],["ResponseSent_ServiceWorker",727,"GetNodeAttrInShard","76"],["ResponseSent_Service",736,"GetNodeAttr","76"],["SendResponse",811,"GetNodeAttr","76"],["RequestCompleted",978,"GetNodeAttr","76","851","851"],["AllRequests"]]`

<img width="863" height="860" alt="image" src="https://github.com/user-attachments/assets/412781b5-3c06-4e09-83ed-bc30f53f8f04" />


### Issue
#6945
