### PR TITLE
use RecvQueueSize as a basis for MemoryWindowsPoolSize by default

### DIFF
--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -841,10 +841,10 @@ void TClientEndpoint::CreateQP()
 
     if (Config.UseMemoryWindows) {
         if (Config.MemoryWindowsPoolSize == 0) {
-            Config.MemoryWindowsPoolSize = Config.SendQueueSize * 2;
+            Config.MemoryWindowsPoolSize = Config.RecvQueueSize * 2;
             RDMA_INFO(
                 "MemoryWindowsPoolSize is not configured, set to "
-                << "SendQueueSize * 2 = " << Config.MemoryWindowsPoolSize);
+                << "RecvQueueSize * 2 = " << Config.MemoryWindowsPoolSize);
         }
 
         MemoryWindows.Init(Verbs, Connection->pd, Config.MemoryWindowsPoolSize);

--- a/cloud/storage/core/protos/rdma.proto
+++ b/cloud/storage/core/protos/rdma.proto
@@ -126,6 +126,6 @@ message TRdmaClient
     bool UseMemoryWindows = 22;
 
     // Size of the memory windows pool. If not specified or 0, will be set to
-    // SendQueueSize * 2.
+    // RecvQueueSize * 2.
     uint32 MemoryWindowsPoolSize = 23;
 }


### PR DESCRIPTION
Follow-up to #6542. In light of #5790 it seems to be more reasonable to align MemoryWindowsPoolSize with RecvQueueSize/IoDepth
