### PR TITLE
Add LostConnectionDuration to ic.proto in config generator

### DIFF
--- a/cloud/storage/core/tools/common/go/configurator/kikimr-proto/ic.proto
+++ b/cloud/storage/core/tools/common/go/configurator/kikimr-proto/ic.proto
@@ -22,4 +22,5 @@ message TInterconnectConfig {
     optional bool EnableExternalDataChannel = 5;
     optional ESocketSendOptimization SocketSendOptimization = 6;
     optional bool UseRdma = 7;
+    optional TDuration LostConnectionDuration = 8;
 }


### PR DESCRIPTION
### Notes
To be able to set LostConnectionDuration, this field is added to ic.proto in config generator