### PR TITLE
issue-5895: fastshard: rebuild the free page stack under the caller's lsn

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
@@ -243,7 +243,7 @@ NProto::TError TPersistentBitmap::Allocate(
         // on an up to date stack.
         //
 
-        error = UpdateFreeStack();
+        error = UpdateFreeStack(lsn);
         if (HasError(error)) {
             return error;
         }
@@ -315,19 +315,20 @@ NProto::TError TPersistentBitmap::ReadPage(
     return {};
 }
 
-NProto::TError TPersistentBitmap::UpdateFreeStack() const
+NProto::TError TPersistentBitmap::UpdateFreeStack(ui64 lsn) const
 {
     BitmapPagesWithFreeBits = {};
-    TVector<TBuffer> bitmapPages(GetPageCount());
 
-    for (ui64 i = 0; i < bitmapPages.size(); ++i) {
-        auto error = ReadPage(0 /* lsn */, i, &bitmapPages[i]);
+    const ui64 pageCount = GetPageCount();
+    TBuffer page;
+
+    for (ui64 i = 0; i < pageCount; ++i) {
+        auto error = ReadPage(lsn, i, &page);
         if (HasError(error)) {
-            bitmapPages.clear();
             return error;
         }
 
-        if (!IsFull(bitmapPages[i])) {
+        if (!IsFull(page)) {
             BitmapPagesWithFreeBits.push(i);
         }
     }
@@ -341,7 +342,7 @@ NProto::TError TPersistentBitmap::InitIfNeeded() const
         return {};
     }
 
-    auto error = UpdateFreeStack();
+    auto error = UpdateFreeStack(0 /* lsn */);
     if (HasError(error)) {
         return error;
     }

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
@@ -63,7 +63,7 @@ private:
         ui64 lsn,
         ui64 relPageNo,
         TBuffer* page) const;
-    [[nodiscard]] NProto::TError UpdateFreeStack() const;
+    [[nodiscard]] NProto::TError UpdateFreeStack(ui64 lsn) const;
     NProto::TError
     AllocateImpl(ui64 lsn, ui64* bit, TVector<TPageGroup>& pageGroups);
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
@@ -189,6 +189,69 @@ TEST(PersistentBitmapTest, OutOfSpace2Pages)
     DoTestOutOfSpace(60000);
 }
 
+void DoTestOutOfSpaceDuringMultiAllocationTransaction(ui64 maxBits)
+{
+    TFixture fx(maxBits);
+
+    TVector<TPageGroup> pageGroups;
+
+    const ui64 cap = fx.MaxBits;
+
+    //
+    // Filling the whole bitmap.
+    //
+
+    for (ui64 i = 0; i < cap; ++i) {
+        ui64 bit = 0;
+        auto error =
+            fx.Bitmap->Allocate(fx.PageStore->AllocateLsn(), &bit, pageGroups);
+        ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+        Flush(pageGroups, *fx.PageStore);
+    }
+
+    //
+    // Freeing exactly two bits - both belong to the same bitmap page.
+    //
+
+    for (const ui64 freedBit: {ui64(1000), ui64(1001)}) {
+        auto error =
+            fx.Bitmap->Reset(fx.PageStore->AllocateLsn(), freedBit, pageGroups);
+        ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+        Flush(pageGroups, *fx.PageStore);
+    }
+
+    //
+    // Allocating three bits under one lsn - the first two succeed, the third
+    // one must fail with E_FS_OUT_OF_SPACE.
+    //
+
+    const ui64 lsn = fx.PageStore->AllocateLsn();
+
+    ui64 bit = 0;
+    auto error = fx.Bitmap->Allocate(lsn, &bit, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    ASSERT_EQ(1000ULL, bit);
+
+    error = fx.Bitmap->Allocate(lsn, &bit, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    ASSERT_EQ(1001ULL, bit);
+
+    error = fx.Bitmap->Allocate(lsn, &bit, pageGroups);
+    ASSERT_EQ(E_FS_OUT_OF_SPACE, error.GetCode()) << FormatError(error);
+
+    Rollback(pageGroups, *fx.PageStore);
+}
+
+TEST(PersistentBitmapTest, OutOfSpaceDuringMultiAllocationTransaction1Page)
+{
+    DoTestOutOfSpaceDuringMultiAllocationTransaction(30000);
+}
+
+TEST(PersistentBitmapTest, OutOfSpaceDuringMultiAllocationTransaction2Pages)
+{
+    DoTestOutOfSpaceDuringMultiAllocationTransaction(60000);
+}
+
 TEST(PersistentBitmapTest, SetResetAllocateRandomized)
 {
     TFixture fx;


### PR DESCRIPTION
### Notes
Several allocations may share a single lsn - e.g. one WriteData request
needing several clusters. If such a request runs out of space midway,
Allocate() rebuilds BitmapPagesWithFreeBits, but the rebuild used to read
the bitmap pages at lsn 0, and the page store rejects reads of the pages
that the current transaction has already dirtied.
    
As a result a full filesystem returned E_REJECTED - a retryable error -
instead of E_FS_OUT_OF_SPACE, so the request retried forever instead of
reporting ENOSPC to the client.

### Issue
https://github.com/ydb-platform/nbs/issues/5895
