### PR TITLE
fix: ya make pattern matching?

### DIFF
--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -29,7 +29,7 @@ CHECK_DEPENDENT_DIRS(ALLOW_ONLY PEERDIRS
     cloud/contrib
     cloud/storage
     contrib/libs
-    contrib/proto/opentelemetry/
+    contrib/proto/opentelemetry
     contrib/restricted
     library/cpp
     contrib/ydb/core


### PR DESCRIPTION
Theoretically it should fix
```
 Error[-WBadDep]: in $B/cloud/blockstore/apps/server_lightweight/nbsd-lightweight: forbids direct or indirect PEERDIR dependency to module $B/contrib/proto/opentelemetry/libcontrib-proto-opentelemetry.a via CHECK_DEPENDENT_DIRS
        $B/cloud/blockstore/apps/server_lightweight/nbsd-lightweight -> $B/cloud/blockstore/libs/daemon/local/liblibs-daemon-local.a
        $B/cloud/blockstore/libs/daemon/local/liblibs-daemon-local.a -> $B/cloud/blockstore/libs/daemon/common/liblibs-daemon-common.a
        $B/cloud/blockstore/libs/daemon/common/liblibs-daemon-common.a -> $B/cloud/storage/core/libs/opentelemetry/iface/liblibs-opentelemetry-iface.a
        $B/cloud/storage/core/libs/opentelemetry/iface/liblibs-opentelemetry-iface.a -> $B/contrib/proto/opentelemetry/libcontrib-proto-opentelemetry.a
```
