### PR TITLE
Fix flapping test cloud/storage/core/tools/testing/unstable-process/tests

### DIFF
--- a/cloud/storage/core/tools/testing/unstable-process/tests/test.py
+++ b/cloud/storage/core/tools/testing/unstable-process/tests/test.py
@@ -131,17 +131,18 @@ class Env:
             stealer.stop()
 
 
-def port_bound(port):
-    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-    try:
-        sock.bind(("::", port))
-    except OSError as e:
-        if e.errno == errno.EADDRINUSE:
-            return True
-        raise
-    finally:
-        sock.close()
-    return False
+def port_listening(port):
+    # A bind-based probe can briefly capture the port and make the daemon's
+    # concurrent bind fail with EADDRINUSE. Connecting verifies readiness
+    # without competing with the daemon for ownership of the port.
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
+        error = sock.connect_ex(("::1", port))
+
+    if error == 0:
+        return True
+    if error == errno.ECONNREFUSED:
+        return False
+    raise OSError(error, os.strerror(error))
 
 
 def wait_for(predicate, timeout=60, step=0.1):
@@ -168,7 +169,7 @@ def test_cannot_steal_reserved_port():
             "port stealer captured the port before launcer is started"
 
         launcher = env.start_launcher(port, reserve=True)
-        assert wait_for(lambda: port_bound(port))
+        assert wait_for(lambda: port_listening(port))
         assert launcher.is_alive(), \
             "launcher died shortly after start"
 
@@ -202,7 +203,7 @@ def test_steals_port_without_reservation():
         env.start_stealers(port)
 
         launcher = env.start_launcher(port, reserve=False)
-        assert wait_for(lambda: port_bound(port))
+        assert wait_for(lambda: port_listening(port))
         pm.release_port(port)
 
         assert wait_for(env.stolen), \

--- a/cloud/storage/core/tools/testing/unstable-process/tests/test.py
+++ b/cloud/storage/core/tools/testing/unstable-process/tests/test.py
@@ -136,13 +136,8 @@ def port_listening(port):
     # concurrent bind fail with EADDRINUSE. Connecting verifies readiness
     # without competing with the daemon for ownership of the port.
     with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
-        error = sock.connect_ex(("::1", port))
-
-    if error == 0:
-        return True
-    if error == errno.ECONNREFUSED:
-        return False
-    raise OSError(error, os.strerror(error))
+        sock.settimeout(0.1)
+        return sock.connect_ex(("::1", port)) == 0
 
 
 def wait_for(predicate, timeout=60, step=0.1):


### PR DESCRIPTION
```
cloud/storage/core/tools/testing/unstable-process/tests/test.py:171: in test_cannot_steal_reserved_port
    assert wait_for(lambda: port_bound(port))
E   assert False
E    +  where False = wait_for(&lt;function test_cannot_steal_reserved_port.&lt;locals&gt;.&lt;lambda&gt; at 0x72596063be90&gt;)

logsdir:
/var/www/build/logs/run_26_08_27__20_45_01/cloud/storage/core/tools/testing/unstable-process/tests/test-results/py3test/testing_out_stuff
log:
/var/www/build/logs/run_26_08_27__20_45_01/cloud/storage/core/tools/testing/unstable-process/tests/test-results/py3test/testing_out_stuff/test.py.test_cannot_steal_reserved_port.log
```

The problem is a race in the test’s readiness check, not in port reservation.

[`port_bound()`](https://github.com/ydb-platform/nbs/tree/main/cloud/storage/core/tools/testing/unstable-process/tests/test.py#L134) checks the port by binding it itself:

```python
sock.bind(("::", port))
```

Immediately after asynchronously starting the launcher, line 171 repeatedly calls this function. It can temporarily acquire the port just as the dummy daemon performs the identical bind at [`dummy-daemon/__main__.py:15`](https://github.com/ydb-platform/nbs/tree/main/cloud/storage/core/tools/testing/unstable-process/tests/dummy-daemon/__main__.py#L15).

The remote `launcher_stderr_ovxw96pu` confirms this sequence:

- Launcher starts dummy on port `23615`.
- Dummy fails immediately with `OSError: [Errno 98] Address already in use`.
- Launcher reports `subprocess unexpectedly exited with code 255`.
- The probe releases its temporary socket, leaving the port free.
- Subsequent probes return `False` for 60 seconds, producing the reported assertion.

A `PortStealer` did not capture the port—if it had, `port_bound()` would see `EADDRINUSE` and return `True`.

The minimal fix is a non-binding readiness probe:

```python
def port_listening(port):
    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
        sock.settimeout(0.1)
        return sock.connect_ex(("::1", port)) == 0
```

Use it at both lines 171 and 205. An explicit ready signal from the dummy daemon would be even more deterministic. 