### PR TITLE
Fix flapping test cloud/blockstore/tests/rdma/rdma-test

### DIFF
--- a/cloud/blockstore/tests/rdma/rdma-test/test.py
+++ b/cloud/blockstore/tests/rdma/rdma-test/test.py
@@ -21,6 +21,14 @@ def check_rdma_connectivity(h1, h2, rdma_port=9999, timeout=10):
         "checking rdma connectivity %s->%s", h1.get_local_ip(), h2.get_local_ip()
     )
 
+    # RDMA server logging resolves the peer address synchronously on the
+    # connection-manager thread.  Keep that lookup local so a DNS timeout does
+    # not delay the handshake past the initiator's reconnect timeout.
+    h2.execute(
+        f"printf '%s\\n' '{h1.get_local_ip()} rdma-initiator' "
+        "| sudo tee -a /etc/hosts >/dev/null"
+    )
+
     target_cmd = [
         h2.get_rdma_test_util_path(),
         "--test", "Target",


### PR DESCRIPTION
```
cloud/blockstore/tests/rdma/rdma-test/test.py:63: in test_rdma
    check_rdma_connectivity(h1, h2, timeout=test_duration_sec)
cloud/blockstore/tests/rdma/rdma-test/test.py:47: in check_rdma_connectivity
    h1.execute(initiator_cmd)
cloud/blockstore/tests/python/lib/rdma.py:54: in execute
    return yatest.common.execute(cmd, *args, **kwargs)
library/python/testing/yatest_common/yatest/common/process.py:656: in execute
    res.wait(check_exit_code, timeout, on_timeout)
library/python/testing/yatest_common/yatest/common/process.py:411: in wait
    self._finalise(check_exit_code)
library/python/testing/yatest_common/yatest/common/process.py:422: in _finalise
    raise ExecutionError(self)
E   yatest.common.process.ExecutionError: Command 'ssh -n -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o IdentitiesOnly=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=10 -i /var/www/build/logs/run_26_08_27__12_00_01/cloud/blockstore/tests/rdma/rdma-test/test-results/py3test/id_rsa -l qemu -p 33709 127.0.0.1 /var/www/build/logs/run_26_08_27__12_00_01/cloud/blockstore/tools/testing/rdma-test/rdma-test --test Initiator --host 192.168.1.2 --port 9999 --wait Poll --storage Rdma --verbose debug --test-duration 10 --connect-timeout 120' has failed with code 255.
E   Errors:
E   b'...DEBUG: [18315379586644462265] new generation 3\n2026-08-27T14:14:23.590311Z :BLOCKSTORE_RDMA DEBUG: [18315379586644462265] reconnect timer hit in Connecting state\n2026-08-27T14:14:23.590402Z :BLOCKSTORE_RDMA DEBUG: [18315379586644462265] Connecting -&gt; Disconnected\n2026-08-27T14:14:23.590981Z :BLOCKSTORE_RDMA WARN: [18315379586644462265] reconnect\n2026-08-27T14:14:23.591143Z :BLOCKSTORE_RDMA DEBUG: [18315379586644462265] Disconnected -&gt; ResolvingAddress\n2026-08-27T14:14:23.591183Z :BLOCKSTORE_RDMA DEBUG: [18315379586644462265] resolve address\n2026-08-27T14:14:23.591481Z :BLOCKSTORE_RDMA INFO: [18315379586644462265] RDMA_CM_EVENT_ADDR_RESOLVED received\n2026-08-27T14:14:23.591516Z :BLOCKSTORE_RDMA DEBUG: [18315379586644462265] resolve route\n2026-08-27T14:14:23.591520Z :BLOCKSTORE_RDMA DEBUG: [18315379586644462265] ResolvingAddress -&gt; ResolvingRoute\n2026-08-27T14:14:23.591743Z :BLOCKSTORE_RDMA INFO: [18315379586644462265] RDMA_CM_EVENT_ROUTE_RESOLVED received\n2026-08-27T14:14:23.591769Z :BLOCKSTORE_RDMA INFO: [18315379586644462265] connect to 192.168.1.2\n2026-08-27T14:14:23.591772Z :BLOCKSTORE_RDMA DEBUG: [18315379586644462265] ResolvingRoute -&gt; Connecting\n2026-08-27T14:14:23.591986Z :BLOCKSTORE_RDMA DEBUG: [18315379586644462265] new generation 4\n2026-08-27T14:14:39.592288Z :BLOCKSTORE_RDMA ERROR: [18315379586644462265] connection timeout\nuncaught exception:\n    address -&gt; 0x450b7f7c0910\n    what() -&gt; "E_RDMA_UNAVAILABLE connection timeout | "\n    type -&gt; NCloud::TServiceError\n'
```

The problem is server-side blocking reverse DNS, not basic network connectivity.

In target log `ssh.err.12`:

```text
14:14:08.586 CONNECT_REQUEST received
14:14:18.597 validate 192.168.1.1          # +10s
14:14:28.612 start session [...]           # +10s
14:14:28.625 rdma_create_qp: EINVAL
14:14:38.636 reject ...                    # +10s
```

Each delay comes from [`GetPeer()`](https://github.com/ydb-platform/nbs/tree/main/cloud/storage/core/libs/rdma/impl/verbs.cpp#L321), which calls `getnameinfo(..., flags=0)` and performs a synchronous PTR lookup. It runs on the single RDMA connection thread from [`server.cpp`](https://github.com/ydb-platform/nbs/tree/main/cloud/storage/core/libs/rdma/impl/server.cpp#L1894).

Meanwhile, the initiator abandons its first connection after one second at [`client.cpp`](https://github.com/ydb-platform/nbs/tree/main/cloud/storage/core/libs/rdma/impl/client.cpp#L2857). By the time the target creates the QP 20 seconds later, the request is stale, producing the secondary `rdma_create_qp EINVAL`.

The proper fix is to avoid DNS resolution in this path:

```cpp
TString GetPeer(rdma_cm_id* id) override
{
    return PrintAddress(rdma_get_peer_addr(id));
}
```

Using `NI_NUMERICHOST` is another option. Adding both addresses to `/etc/hosts` is only a workaround. Increasing `--connect-timeout` or adding a target-start sleep will not properly fix it—the target was already listening and received the request immediately.