### PR TITLE
[NBS] Complete cleanup on device error

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_device_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_device_state.cpp
@@ -90,6 +90,12 @@ void TDiskRegistryActor::CompleteUpdateDeviceState(
         SendEnableDevice(ctx, args.DeviceId);
     }
 
+    if (!args.AffectedDisk.empty() &&
+        !State->HasPendingCleanup(args.AffectedDisk))
+    {
+        ReplyToPendingDeallocations(ctx, args.AffectedDisk);
+    }
+
     ReallocateDisks(ctx);
     NotifyUsers(ctx);
     PublishDiskStates(ctx);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -6181,7 +6181,12 @@ NProto::TError TDiskRegistryState::UpdateDeviceState(
     ApplyDeviceStateChange(db, *agentPtr, *devicePtr, now, affectedDisk);
 
     if (newState == NProto::DEVICE_STATE_ERROR) {
-        RemoveDeviceFromPendingCleanup(db, deviceId);
+        auto cleanupDiskId = RemoveDeviceFromPendingCleanup(db, deviceId);
+        if (!cleanupDiskId.empty()) {
+            Y_DEBUG_ABORT_UNLESS(
+                affectedDisk.empty() || affectedDisk == cleanupDiskId);
+            affectedDisk = std::move(cleanupDiskId);
+        }
     }
 
     return error;
@@ -7658,17 +7663,17 @@ NProto::TError TDiskRegistryState::AddDevicesToPendingCleanup(
     return PendingCleanup.Insert(diskId, std::move(devicesAllowedToBeCleaned));
 }
 
-void TDiskRegistryState::RemoveDeviceFromPendingCleanup(
+TDiskRegistryState::TDiskId TDiskRegistryState::RemoveDeviceFromPendingCleanup(
     TDiskRegistryDatabase& db,
     const TDeviceId& deviceId)
 {
-    if (!IsDirtyDevice(deviceId) || PendingCleanup.FindDiskId(deviceId).empty())
-    {
-        return;
+    TDiskId diskId = PendingCleanup.EraseDevice(deviceId);
+
+    if (IsDirtyDevice(deviceId)) {
+        db.UpdateDirtyDevice(deviceId, {});
     }
 
-    PendingCleanup.EraseDevice(deviceId);
-    db.UpdateDirtyDevice(deviceId, {});
+    return diskId;
 }
 
 NProto::TError TDiskRegistryState::DeallocateDiskReplicas(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -1279,7 +1279,7 @@ private:
         const TString& diskId,
         TVector<TDeviceId> uuids);
 
-    void RemoveDeviceFromPendingCleanup(
+    TDiskId RemoveDeviceFromPendingCleanup(
         TDiskRegistryDatabase& db,
         const TDeviceId& deviceId);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -3508,8 +3508,21 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         runtime->DispatchEvents({}, 100ms);
 
-        diskRegistry.DeallocateDisk("vol", true);
-        diskRegistry.RecvDeallocateDiskResponse();
+        const auto deallocateResponse =
+            diskRegistry.RecvDeallocateDiskResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, deallocateResponse->GetStatus());
+
+        const auto backup = diskRegistry.BackupDiskRegistryState(
+            NProto::BDRSS_LOCAL_DB);
+        const auto& dirtyDevices =
+            backup->Record.GetLocalDBBackup().GetDirtyDevices();
+        const auto* dirtyDevice = FindIfPtr(
+            dirtyDevices,
+            [&] (const auto& x) {
+                return x.GetId() == deviceUuid;
+            });
+        UNIT_ASSERT(dirtyDevice);
+        UNIT_ASSERT_VALUES_EQUAL("", dirtyDevice->GetDiskId());
     }
 }
 


### PR DESCRIPTION
### Notes
Devices in the error state cannot be securely erased and therefore should no longer block pending cleanup. When such a device is removed from `PendingCleanup`, the Disk Registry now detects when it was the last pending device and replies to postponed synchronous deallocation requests.

### Issue
https://github.com/ydb-platform/nbs/issues/5441
