### PR TITLE
issue-5895: fastshard - storage group retry policy

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -2575,7 +2575,20 @@ struct TNaiveMirroredStorageGroupFactory: IStorageGroupFactory
             });
         }
 
-        return CreateNaiveMirroredStorageGroup(std::move(devices));
+        TStorageGroupRetryPolicy retryPolicy;
+        if (config.GetRetryTotalTimeoutMs()) {
+            retryPolicy.TotalTimeout =
+                TDuration::MilliSeconds(config.GetRetryTotalTimeoutMs());
+        }
+        if (config.GetRetryBackoffIncrementMs()) {
+            retryPolicy.BackoffIncrement =
+                TDuration::MilliSeconds(config.GetRetryBackoffIncrementMs());
+        }
+
+        return CreateNaiveMirroredStorageGroup(
+            std::move(devices),
+            retryPolicy,
+            CreateFiberTimer());
     }
 };
 

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
@@ -14,18 +14,84 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TFiberTimer final: public ITimer
+{
+public:
+    TInstant Now() override
+    {
+        return TInstant::Now();
+    }
+
+    void Sleep(TDuration duration) override
+    {
+        silk::FiberScheduler::sleep(duration.NanoSeconds());
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Repeats the call until it succeeds, fails with a non-retriable error or the
+// total timeout is reached. All time arithmetic goes through the provided
+// timer. See TStorageGroupRetryPolicy.
+//
+
+template <typename TCall>
+auto CallWithRetries(
+    const TStorageGroupRetryPolicy& policy,
+    ITimer& timer,
+    TCall call)
+{
+    const TInstant start = timer.Now();
+    ui32 errorCount = 0;
+
+    for (;;) {
+        auto response = call();
+        const auto& error = response.GetError();
+        if (GetErrorKind(error) != EErrorKind::ErrorRetriable) {
+            return response;
+        }
+
+        if (timer.Now() - start >= policy.TotalTimeout) {
+            SILK_ERROR(
+                "sg retries timed out after %u errors: %s",
+                errorCount + 1,
+                FormatError(error).c_str());
+
+            return response;
+        }
+
+        ++errorCount;
+        const TDuration backoff = policy.BackoffIncrement * errorCount;
+        SILK_DEBUG(
+            "sg retry #%u, backoff: %luus, error: %s",
+            errorCount,
+            backoff.MicroSeconds(),
+            FormatError(error).c_str());
+
+        timer.Sleep(backoff);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TAcquireDevicesParams
 {
     TStorageDevice Device;
     NProto::TAcquireDevicesRequest* Request;
     NProto::TAcquireDevicesResponse* Response;
+    const TStorageGroupRetryPolicy* RetryPolicy;
+    ITimer* Timer;
 };
 
 int AcquireDevicesFiberMain(TAcquireDevicesParams* params) noexcept
 {
     NProto::TAcquireDevicesRequest request = *params->Request;
     request.AddDeviceUUIDs(std::move(params->Device.DeviceUUID));
-    *params->Response = params->Device.Node->AcquireDevices(std::move(request));
+    *params->Response = CallWithRetries(
+        *params->RetryPolicy,
+        *params->Timer,
+        [&] { return params->Device.Node->AcquireDevices(request); });
     return 0;
 }
 
@@ -34,13 +100,18 @@ struct TReleaseDevicesParams
     TStorageDevice Device;
     NProto::TReleaseDevicesRequest* Request;
     NProto::TReleaseDevicesResponse* Response;
+    const TStorageGroupRetryPolicy* RetryPolicy;
+    ITimer* Timer;
 };
 
 int ReleaseDevicesFiberMain(TReleaseDevicesParams* params) noexcept
 {
     NProto::TReleaseDevicesRequest request = *params->Request;
     request.AddDeviceUUIDs(std::move(params->Device.DeviceUUID));
-    *params->Response = params->Device.Node->ReleaseDevices(std::move(request));
+    *params->Response = CallWithRetries(
+        *params->RetryPolicy,
+        *params->Timer,
+        [&] { return params->Device.Node->ReleaseDevices(request); });
     return 0;
 }
 
@@ -49,13 +120,18 @@ struct TWriteLogRecordParams
     TStorageDevice Device;
     NProto::TWriteLogRecordRequest* Request;
     NProto::TWriteLogRecordResponse* Response;
+    const TStorageGroupRetryPolicy* RetryPolicy;
+    ITimer* Timer;
 };
 
 int WriteLogRecordFiberMain(TWriteLogRecordParams* params) noexcept
 {
     NProto::TWriteLogRecordRequest request = *params->Request;
     request.SetDeviceUUID(std::move(params->Device.DeviceUUID));
-    *params->Response = params->Device.Node->WriteLogRecord(std::move(request));
+    *params->Response = CallWithRetries(
+        *params->RetryPolicy,
+        *params->Timer,
+        [&] { return params->Device.Node->WriteLogRecord(request); });
     return 0;
 }
 
@@ -65,11 +141,18 @@ class TStorageGroupImpl: public IStorageGroup
 {
 private:
     TVector<TStorageDevice> Devices;
+    const TStorageGroupRetryPolicy RetryPolicy;
+    ITimerPtr Timer;
     std::atomic<ui32> Selector{0};
 
 public:
-    explicit TStorageGroupImpl(TVector<TStorageDevice> devices)
+    TStorageGroupImpl(
+            TVector<TStorageDevice> devices,
+            TStorageGroupRetryPolicy retryPolicy,
+            ITimerPtr timer)
         : Devices(std::move(devices))
+        , RetryPolicy(retryPolicy)
+        , Timer(std::move(timer))
     {}
 
 public:
@@ -132,9 +215,6 @@ public:
         const TString clientId = "fastshard-prototype-client";
         headers.SetClientId(clientId);
 
-        const ui32 i =
-            Selector.fetch_add(1, std::memory_order_relaxed) % Devices.size();
-        request.SetDeviceUUID(Devices[i].DeviceUUID);
         *request.MutableHeaders() = std::move(headers);
         for (const auto& pg: pageGroupRefs) {
             auto* pgr = request.AddPageGroupRefs();
@@ -142,8 +222,27 @@ public:
             pgr->SetFirstPageNo(pg.FirstPageNo);
             pgr->SetPageCount(pg.PageCount);
         }
-        SILK_DEBUG("sg read: %s", request.ShortUtf8DebugString().c_str());
-        auto response = Devices[i].Node->ReadPages(request);
+
+        //
+        // Each attempt advances the round-robin selector, so retries after
+        // retriable errors go to the other replicas and a single broken
+        // device does not fail the read.
+        //
+
+        auto response = CallWithRetries(
+            RetryPolicy,
+            *Timer,
+            [&]
+            {
+                const ui32 i =
+                    Selector.fetch_add(1, std::memory_order_relaxed) %
+                    Devices.size();
+                request.SetDeviceUUID(Devices[i].DeviceUUID);
+                SILK_DEBUG(
+                    "sg read: %s",
+                    request.ShortUtf8DebugString().c_str());
+                return Devices[i].Node->ReadPages(request);
+            });
         if (!HasError(response.GetError())) {
             pageGroups->reserve(response.PageGroupsSize());
             for (auto& pg: *response.MutablePageGroups()) {
@@ -193,7 +292,9 @@ private:
                 TParams{
                     .Device = Devices[i],
                     .Request = &request,
-                    .Response = &responses[i]},
+                    .Response = &responses[i],
+                    .RetryPolicy = &RetryPolicy,
+                    .Timer = Timer.get()},
                 &futures[i]);
             Y_ABORT_UNLESS(r == 0, "failed to spawn fiber: %s", ::strerror(r));
         }
@@ -230,9 +331,19 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 IStorageGroupPtr CreateNaiveMirroredStorageGroup(
-    TVector<TStorageDevice> devices)
+    TVector<TStorageDevice> devices,
+    TStorageGroupRetryPolicy retryPolicy,
+    ITimerPtr timer)
 {
-    return std::make_shared<TStorageGroupImpl>(std::move(devices));
+    return std::make_shared<TStorageGroupImpl>(
+        std::move(devices),
+        retryPolicy,
+        std::move(timer));
+}
+
+ITimerPtr CreateFiberTimer()
+{
+    return std::make_shared<TFiberTimer>();
 }
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
@@ -2,6 +2,9 @@
 
 #include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
 
+#include <cloud/storage/core/libs/common/timer.h>
+
+#include <util/datetime/base.h>
 #include <util/generic/buffer.h>
 #include <util/generic/vector.h>
 
@@ -58,6 +61,21 @@ struct TStorageDevice
 };
 
 /**
+ * Retry policy for the requests which a storage group sends to its storage
+ * nodes. Retriable errors (see GetErrorKind) are retried with a backoff which
+ * grows by BackoffIncrement after each failed attempt of the same request:
+ * BackoffIncrement after the first error, 2 * BackoffIncrement after the
+ * second one, etc. When the time passed since the start of the first attempt
+ * till the last error reaches TotalTimeout, the last error is propagated to
+ * the caller.
+ */
+struct TStorageGroupRetryPolicy
+{
+    TDuration TotalTimeout = TDuration::Minutes(5);
+    TDuration BackoffIncrement = TDuration::MilliSeconds(500);
+};
+
+/**
  * Returns an IStorageGroup which mirrors each write into all storage nodes and
  * reads from one of the nodes selecting it in a round-robin manner. The
  * implementation is naive in the sense that it does no crash recovery and is
@@ -65,9 +83,25 @@ struct TStorageDevice
  * there's also no real m/n write / k/n read quorum here - it's just always
  * n/n for writes, 1/n for reads.
  *
+ * @param devices - Storage devices to mirror the data across.
+ * @param retryPolicy - Retry policy for storage node requests.
+ * @param timer - Time source for the retry deadline checks and backoff
+ *                sleeps. Production callers should pass the timer returned
+ *                by CreateFiberTimer(). Tests can pass TTestTimer to make
+ *                retries deterministic.
  * @return - The constructed group.
  */
 IStorageGroupPtr CreateNaiveMirroredStorageGroup(
-    TVector<TStorageDevice> devices);
+    TVector<TStorageDevice> devices,
+    TStorageGroupRetryPolicy retryPolicy,
+    ITimerPtr timer);
+
+/**
+ * Returns an ITimer which sleeps by suspending the calling silk fiber, so
+ * backoffs do not block the fiber scheduler threads.
+ *
+ * @return - The constructed timer.
+ */
+ITimerPtr CreateFiberTimer();
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_stub.cpp
@@ -47,11 +47,18 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 IStorageGroupPtr CreateNaiveMirroredStorageGroup(
-    TVector<TStorageDevice> devices)
+    TVector<TStorageDevice> devices,
+    TStorageGroupRetryPolicy retryPolicy,
+    ITimerPtr timer)
 {
-    Y_UNUSED(devices);
+    Y_UNUSED(devices, retryPolicy, timer);
 
     return std::make_shared<TStorageGroupStub>();
+}
+
+ITimerPtr CreateFiberTimer()
+{
+    return CreateWallClockTimer();
 }
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
@@ -4,6 +4,7 @@
 #include <cloud/filestore/libs/storage/fastshard/testlib/silk_env.h>
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/timer_test.h>
 #include <cloud/storage/core/protos/device.pb.h>
 
 #include <silk/fibers/fiber.h>
@@ -39,6 +40,7 @@ struct TStorageFixture
         "dev-b",
         "dev-c",
     };
+    std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
     IStorageGroupPtr Group;
 
     TStorageFixture()
@@ -53,9 +55,79 @@ struct TStorageFixture
             };
         }
 
-        Group = CreateNaiveMirroredStorageGroup(std::move(devices));
+        Group = CreateNaiveMirroredStorageGroup(
+            std::move(devices),
+            TStorageGroupRetryPolicy{},
+            Timer);
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// The tests below use the default retry policy (300s total timeout, 0.5s
+// backoff increment) against the fake TTestTimer, which advances its clock
+// by the requested duration upon each Sleep() call. For a permanently
+// failing request the k-th error therefore happens at
+// t = 0.25 * k * (k + 1) seconds and the first k with t >= 300s is 35. So
+// such a request makes 36 attempts and sleeps 35 times: 0.5s, 1.0s, ...,
+// 17.5s.
+//
+
+constexpr ui32 ExpectedTimeoutAttempts = 36;
+constexpr ui32 ExpectedTimeoutBackoffs = 35;
+
+const TDuration DefaultBackoffIncrement = TDuration::MilliSeconds(500);
+
+void CheckBackoffDurations(
+    const TVector<TDuration>& sleeps,
+    ui32 expectedCount)
+{
+    ASSERT_EQ(expectedCount, sleeps.size());
+    for (ui32 i = 0; i < sleeps.size(); ++i) {
+        EXPECT_EQ(DefaultBackoffIncrement * (i + 1), sleeps[i]);
+    }
+}
+
+NProto::TWriteLogRecordResponse WriteErrorResponse(ui32 code)
+{
+    NProto::TWriteLogRecordResponse resp;
+    *resp.MutableError() = MakeError(code, "scripted error");
+    return resp;
+}
+
+NProto::TReadPagesResponse ReadErrorResponse(ui32 code)
+{
+    NProto::TReadPagesResponse resp;
+    *resp.MutableError() = MakeError(code, "scripted error");
+    return resp;
+}
+
+NProto::TError WriteSomething(IStorageGroup& group)
+{
+    TPageGroup pageGroup{.FirstPageNo = 111};
+    pageGroup.Content.emplace_back("page1", 5U /* len */);
+    TVector<TPageGroup> pageGroups;
+    pageGroups.push_back(std::move(pageGroup));
+
+    return group.WriteLogRecord(
+        defaultHeaders,
+        std::move(pageGroups),
+        1234 /* lsn */);
+}
+
+NProto::TError ReadSomething(
+    IStorageGroup& group,
+    TVector<TPageGroup>* pageGroups)
+{
+    TVector<TPageGroupRef> pageGroupRefs = {{
+        .FirstPageNo = 111,
+        .PageCount = 1,
+        .PageSize = 4_KB,
+    }};
+
+    return group.ReadPages(defaultHeaders, pageGroupRefs, pageGroups);
+}
 
 }   // namespace
 
@@ -219,6 +291,200 @@ TEST(NaiveGroupTest, RoundRobinsRead)
                 EXPECT_EQ(100U, pg.GetPageCount());
                 EXPECT_EQ(111U, pg.GetFirstPageNo());
             }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(NaiveGroupTest, RetriesRetriableWriteErrors)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TStorageFixture fx;
+
+            auto& flaky = *fx.StorageNodes[1];
+            flaky.WriteRespQueue.push_back(WriteErrorResponse(E_REJECTED));
+            flaky.WriteRespQueue.push_back(WriteErrorResponse(E_TIMEOUT));
+
+            auto error = WriteSomething(*fx.Group);
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+
+            //
+            // The healthy nodes should see exactly one attempt, the flaky one
+            // should see two failed attempts and the successful third one. All
+            // attempts should carry the same request. Two backoffs should
+            // have been applied: 0.5s after the first error and 1s after the
+            // second one.
+            //
+
+            EXPECT_EQ(1U, fx.StorageNodes[0]->WriteCalls.size());
+            EXPECT_EQ(3U, flaky.WriteCalls.size());
+            EXPECT_EQ(1U, fx.StorageNodes[2]->WriteCalls.size());
+
+            for (const auto& call: flaky.WriteCalls) {
+                EXPECT_EQ(fx.DeviceUUIDs[1], call.GetDeviceUUID());
+                EXPECT_EQ(1234U, call.GetLogSequenceNumber());
+                EXPECT_EQ(1U, call.PageGroupsSize());
+                EXPECT_EQ("page1", call.GetPageGroups(0).GetContent(0));
+            }
+
+            CheckBackoffDurations(
+                fx.Timer->GetSleepDurations(),
+                2 /* expectedCount */);
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(NaiveGroupTest, DoesNotRetryNonRetriableWriteErrors)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TStorageFixture fx;
+
+            auto& broken = *fx.StorageNodes[1];
+            broken.WriteRespQueue.push_back(WriteErrorResponse(E_ARGUMENT));
+
+            auto error = WriteSomething(*fx.Group);
+            EXPECT_EQ(E_ARGUMENT, error.GetCode()) << error.GetMessage();
+
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                EXPECT_EQ(1U, fx.StorageNodes[i]->WriteCalls.size());
+            }
+
+            EXPECT_TRUE(fx.Timer->GetSleepDurations().empty());
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(NaiveGroupTest, PropagatesWriteErrorUponRetryTimeout)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TStorageFixture fx;
+
+            //
+            // The canned response makes the node fail every attempt, so the
+            // request should burn through the whole retry budget with the
+            // exact default backoff schedule and propagate the last error.
+            //
+
+            auto& broken = *fx.StorageNodes[1];
+            broken.WriteResp = WriteErrorResponse(E_REJECTED);
+
+            auto error = WriteSomething(*fx.Group);
+            EXPECT_EQ(E_REJECTED, error.GetCode()) << error.GetMessage();
+
+            EXPECT_EQ(1U, fx.StorageNodes[0]->WriteCalls.size());
+            EXPECT_EQ(
+                ExpectedTimeoutAttempts,
+                broken.WriteCalls.size());
+            EXPECT_EQ(1U, fx.StorageNodes[2]->WriteCalls.size());
+
+            CheckBackoffDurations(
+                fx.Timer->GetSleepDurations(),
+                ExpectedTimeoutBackoffs);
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(NaiveGroupTest, RetriesReadsOnAnotherDevice)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TStorageFixture fx;
+
+            auto& flaky = *fx.StorageNodes[0];
+            flaky.ReadRespQueue.push_back(ReadErrorResponse(E_REJECTED));
+
+            NProto::TReadPagesResponse goodResp;
+            auto* rpg = goodResp.AddPageGroups();
+            rpg->SetFirstPageNo(111);
+            rpg->AddContent("bbb");
+            fx.StorageNodes[1]->ReadResp = goodResp;
+
+            TVector<TPageGroup> pageGroups;
+            auto error = ReadSomething(*fx.Group, &pageGroups);
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+
+            //
+            // The first attempt should hit node 0 and fail, the retry should
+            // advance the round-robin selector and read from node 1.
+            //
+
+            EXPECT_EQ(1U, fx.StorageNodes[0]->ReadCalls.size());
+            EXPECT_EQ(1U, fx.StorageNodes[1]->ReadCalls.size());
+            EXPECT_EQ(0U, fx.StorageNodes[2]->ReadCalls.size());
+
+            EXPECT_EQ(
+                fx.DeviceUUIDs[0],
+                fx.StorageNodes[0]->ReadCalls[0].GetDeviceUUID());
+            EXPECT_EQ(
+                fx.DeviceUUIDs[1],
+                fx.StorageNodes[1]->ReadCalls[0].GetDeviceUUID());
+
+            EXPECT_EQ(1U, pageGroups.size());
+            EXPECT_EQ(111U, pageGroups[0].FirstPageNo);
+            EXPECT_EQ(1U, pageGroups[0].Content.size());
+            const auto& c = pageGroups[0].Content[0];
+            EXPECT_EQ("bbb", TString(c.Data(), c.Size()));
+
+            CheckBackoffDurations(
+                fx.Timer->GetSleepDurations(),
+                1 /* expectedCount */);
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(NaiveGroupTest, PropagatesReadErrorUponRetryTimeout)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TStorageFixture fx;
+
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                fx.StorageNodes[i]->ReadResp =
+                    ReadErrorResponse(E_UNAVAILABLE);
+            }
+
+            TVector<TPageGroup> pageGroups;
+            auto error = ReadSomething(*fx.Group, &pageGroups);
+
+            EXPECT_EQ(E_UNAVAILABLE, error.GetCode()) << error.GetMessage();
+            EXPECT_TRUE(pageGroups.empty());
+
+            //
+            // Each attempt advances the round-robin selector, so the retry
+            // budget should be spread across the replicas evenly.
+            //
+
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                EXPECT_EQ(
+                    ExpectedTimeoutAttempts / TStorageFixture::NodeCount,
+                    fx.StorageNodes[i]->ReadCalls.size());
+            }
+
+            CheckBackoffDurations(
+                fx.Timer->GetSleepDurations(),
+                ExpectedTimeoutBackoffs);
 
             return 0;
         },

--- a/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.cpp
+++ b/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.cpp
@@ -2,6 +2,24 @@
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TResponse>
+TResponse PopResponse(TDeque<TResponse>& queue, const TResponse& canned)
+{
+    if (queue.empty()) {
+        return canned;
+    }
+
+    TResponse response = std::move(queue.front());
+    queue.pop_front();
+    return response;
+}
+
+}   // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 
 NCloud::NProto::TAcquireDevicesResponse TFakeStorageNode::AcquireDevices(
@@ -9,8 +27,8 @@ NCloud::NProto::TAcquireDevicesResponse TFakeStorageNode::AcquireDevices(
 {
     with_lock (Lock) {
         AcquireCalls.push_back(std::move(request));
+        return PopResponse(AcquireRespQueue, AcquireResp);
     }
-    return AcquireResp;
 }
 
 NCloud::NProto::TReleaseDevicesResponse TFakeStorageNode::ReleaseDevices(
@@ -18,8 +36,8 @@ NCloud::NProto::TReleaseDevicesResponse TFakeStorageNode::ReleaseDevices(
 {
     with_lock (Lock) {
         ReleaseCalls.push_back(std::move(request));
+        return PopResponse(ReleaseRespQueue, ReleaseResp);
     }
-    return ReleaseResp;
 }
 
 NCloud::NProto::TReadPagesResponse TFakeStorageNode::ReadPages(
@@ -27,8 +45,8 @@ NCloud::NProto::TReadPagesResponse TFakeStorageNode::ReadPages(
 {
     with_lock (Lock) {
         ReadCalls.push_back(std::move(request));
+        return PopResponse(ReadRespQueue, ReadResp);
     }
-    return ReadResp;
 }
 
 NCloud::NProto::TWriteLogRecordResponse TFakeStorageNode::WriteLogRecord(
@@ -36,8 +54,8 @@ NCloud::NProto::TWriteLogRecordResponse TFakeStorageNode::WriteLogRecord(
 {
     with_lock (Lock) {
         WriteCalls.push_back(std::move(request));
+        return PopResponse(WriteRespQueue, WriteResp);
     }
-    return WriteResp;
 }
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h
@@ -4,6 +4,7 @@
 
 #include <cloud/storage/core/protos/device.pb.h>
 
+#include <util/generic/deque.h>
 #include <util/generic/vector.h>
 #include <util/system/spinlock.h>
 
@@ -20,6 +21,11 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
  * output, register the fake with an sn server, drive it through the
  * client, then inspect the *Calls vectors to check what the server
  * dispatched.
+ *
+ * The *RespQueue members hold one-shot responses: while a queue is not
+ * empty, each call pops and returns its front element; after the queue
+ * drains, the corresponding canned *Resp member is returned. Useful for
+ * scripting transient errors in retry tests.
  */
 struct TFakeStorageNode: public IStorageNode
 {
@@ -34,6 +40,11 @@ struct TFakeStorageNode: public IStorageNode
     NCloud::NProto::TReleaseDevicesResponse ReleaseResp;
     NCloud::NProto::TReadPagesResponse ReadResp;
     NCloud::NProto::TWriteLogRecordResponse WriteResp;
+
+    TDeque<NCloud::NProto::TAcquireDevicesResponse> AcquireRespQueue;
+    TDeque<NCloud::NProto::TReleaseDevicesResponse> ReleaseRespQueue;
+    TDeque<NCloud::NProto::TReadPagesResponse> ReadRespQueue;
+    TDeque<NCloud::NProto::TWriteLogRecordResponse> WriteRespQueue;
 
     NCloud::NProto::TAcquireDevicesResponse AcquireDevices(
         NCloud::NProto::TAcquireDevicesRequest request) override;

--- a/cloud/filestore/private/api/unsafe_protos/unsafe.proto
+++ b/cloud/filestore/private/api/unsafe_protos/unsafe.proto
@@ -165,6 +165,11 @@ message TPersistentFastShardConfig
     repeated TStorageGroup StorageGroups = 1;
     uint64 NodesPerGroup = 2;
     uint64 ExpectedGroupCapacity = 3;
+
+    // Retry policy for storage node requests. Zero values mean defaults:
+    // 5min total timeout, 500ms backoff increment.
+    uint64 RetryTotalTimeoutMs = 4;
+    uint64 RetryBackoffIncrementMs = 5;
 }
 
 message TMemFastShardConfig


### PR DESCRIPTION
### Notes
Storage group should retry storage device requests by itself. Even for the naive storage group implementation it's required because a temporary storage node outage will lead to data inconsistency among the devices in the group. In the real implementation it will be needed as well because even though it won't lead to data inconsistency, still, error propagation to the layer above will lead to the cancellation of the whole operation and then error propagation up to the client which will introduce too much overhead and extra latency.

### Issue
https://github.com/ydb-platform/nbs/issues/5895
