### PR TITLE
[NBS] Allow secondary disk fallback for volume alterations

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
@@ -223,7 +223,7 @@ void TAlterVolumeActor::DescribeVolume(const TActorContext& ctx)
         MakeSSProxyServiceId(),
         std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
             DiskId,
-            /*exactDiskIdMatch=*/true));
+            /*exactDiskIdMatch=*/false));
 }
 
 void TAlterVolumeActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_ut_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_alter.cpp
@@ -7,6 +7,7 @@
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/model/volume_label.h>
 #include <cloud/blockstore/libs/storage/testlib/test_runtime.h>
 
 #include <util/generic/size_literals.h>
@@ -975,7 +976,7 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldUseExactDiskIdMatchOnAlterVolume)
+    Y_UNIT_TEST(ShouldDisableExactDiskIdMatchOnAlterVolume)
     {
         TTestEnv env;
         NProto::TStorageServiceConfig config;
@@ -991,7 +992,8 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
             "test_folder",
             "test_cloud");
 
-        bool exactDiskIdMatch = false;
+        bool describeRequestObserved = false;
+        bool describeExactDiskIdMatch = true;
 
         runtime.SetEventFilter(
             [&](auto& runtime, TAutoPtr<IEventHandle>& event)
@@ -1001,7 +1003,8 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
                     case TEvSSProxy::EvDescribeVolumeRequest: {
                         auto& msg =
                             *event->Get<TEvSSProxy::TEvDescribeVolumeRequest>();
-                        exactDiskIdMatch = msg.ExactDiskIdMatch;
+                        describeRequestObserved = true;
+                        describeExactDiskIdMatch = msg.ExactDiskIdMatch;
                         break;
                     }
                 }
@@ -1011,7 +1014,36 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
 
         service.AlterVolume(DefaultDiskId, "project", "folder", "cloud");
 
-        UNIT_ASSERT_VALUES_EQUAL(true, exactDiskIdMatch);
+        UNIT_ASSERT_VALUES_EQUAL(true, describeRequestObserved);
+        UNIT_ASSERT_VALUES_EQUAL(false, describeExactDiskIdMatch);
+    }
+
+    Y_UNIT_TEST(ShouldAlterAndResizeSecondaryDiskUsingPrimaryDiskId)
+    {
+        TTestEnv env;
+        ui32 nodeIdx = SetupTestEnvWithAllowVersionInModifyScheme(env);
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        const auto secondaryDiskId = GetSecondaryDiskId(DefaultDiskId);
+        service.CreateVolume(
+            secondaryDiskId,
+            DefaultBlocksCount,
+            DefaultBlockSize,
+            "test_folder",
+            "test_cloud");
+
+        service.AlterVolume(DefaultDiskId, "project", "folder", "cloud");
+        service.ResizeVolume(DefaultDiskId, DefaultBlocksCount * 2);
+
+        auto response = service.DescribeVolume(secondaryDiskId, true);
+        const auto& volume = response->Record.GetVolume();
+        UNIT_ASSERT_VALUES_EQUAL(secondaryDiskId, volume.GetDiskId());
+        UNIT_ASSERT_VALUES_EQUAL("project", volume.GetProjectId());
+        UNIT_ASSERT_VALUES_EQUAL("folder", volume.GetFolderId());
+        UNIT_ASSERT_VALUES_EQUAL("cloud", volume.GetCloudId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            DefaultBlocksCount * 2,
+            volume.GetBlocksCount());
     }
 }
 


### PR DESCRIPTION
## Problem

After a disk is copied and the original disk is deleted, clients may continue using the original disk ID for control-plane operations.
AlterVolume and ResizeVolume use TAlterVolumeActor, which describes the volume with ExactDiskIdMatch enabled. As a result, SSProxy cannot fall back from the original disk ID to the existing `<disk-id>-copy` volume, and the operation fails even though the copied disk is available.

## Solution

Disable ExactDiskIdMatch for DescribeVolume requests sent by TAlterVolumeActor.
This allows SSProxy to resolve the original disk ID to the secondary copied volume, so AlterVolume, ResizeVolume, and SetupChannels can modify the currently available disk.
