### PR TITLE
issue-1751: [Filestore] Resolve data race in WriteBackCache when a handle may be released during flush

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
@@ -36,11 +36,12 @@ struct TReleaseHandleRequest: public TIntrusiveListItem<TReleaseHandleRequest>
 
 struct THandleState
 {
-    // Pending requests from TNodeState::Cache filtered by Handle
-    TIntrusiveList<TPendingWriteDataRequest, THandleStateTag> PendingRequests;
-
     // Unflushed requests from TNodeState::Cache filtered by Handle
     TIntrusiveList<TCachedWriteDataRequest, THandleStateTag> UnflushedRequests;
+
+    // The total amount of pending requests and flush operations holding the
+    // handle
+    size_t ReferenceCount = 0;
 
     // The field is initialized when ReleaseHandle request is made.
     // Only one ReleaseHandle request may be active at a time for a handle.
@@ -48,7 +49,7 @@ struct THandleState
 
     bool HasRequests() const
     {
-        return !PendingRequests.Empty() || !UnflushedRequests.Empty();
+        return !UnflushedRequests.Empty() || ReferenceCount > 0;
     }
 };
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 
 #include <util/string/builder.h>
+#include <util/string/printf.h>
 
 namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
@@ -561,7 +562,7 @@ TFuture<TWriteDataResponse> TWriteBackCacheState::AddRequest(
         Nodes.GetOrCreateNodeState(request->GetRequest().GetNodeId());
 
     auto& handleState = nodeState.Handles[request->GetRequest().GetHandle()];
-    handleState.PendingRequests.PushBack(request.get());
+    handleState.ReferenceCount++;
 
     nodeState.Cache.EnqueuePendingRequest(std::move(request));
 
@@ -819,8 +820,15 @@ void TWriteBackCacheState::ProcessPendingRequests()
             std::move(pendingRequest->AccessPromise()));
 
         auto& handleState = nodeState.Handles[request->GetHandle()];
-        handleState.PendingRequests.Remove(pendingRequest.get());
         handleState.UnflushedRequests.PushBack(request.get());
+
+        if (handleState.ReferenceCount > 0) {
+            handleState.ReferenceCount--;
+        } else {
+            ReportWriteBackCacheImpossibleState(Sprintf(
+                "Reference count for handle %lu, cannot go below zero",
+                request->GetHandle()));
+        }
 
         EnqueueUnflushedRequest(nodeId, nodeState, std::move(request));
 
@@ -849,7 +857,14 @@ void TWriteBackCacheState::RemoveActiveRequestFromHandleState(
     auto handle = request->GetRequest().GetHandle();
     auto& handleState = nodeState.Handles[handle];
 
-    handleState.PendingRequests.Remove(request);
+    if (handleState.ReferenceCount > 0) {
+        handleState.ReferenceCount--;
+    } else {
+        ReportWriteBackCacheImpossibleState(Sprintf(
+            "Reference count for handle %lu, cannot go below zero",
+            handle));
+    }
+
     if (!handleState.HasRequests()) {
         TriggerReleaseHandleCompletion(nodeState, handle, handleState);
         nodeState.Handles.erase(handle);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -1397,6 +1397,48 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         b.State->ReleaseBarrier(3, barrier.GetResult());
         UNIT_ASSERT_VALUES_EQUAL("3", b.DumpEvents());
     }
+
+    Y_UNIT_TEST(ShouldNotReleaseHandleBeingUsedForFlush)
+    {
+        TBootstrap b;
+        b.Storage->SetCapacity(2);
+
+        UNIT_ASSERT(b.Add(1, 101, 0, "abc").GetValue());
+        UNIT_ASSERT(b.Add(1, 102, 3, "def").GetValue());
+
+        auto release = b.State->AddReleaseHandleRequest(1, 102);
+        UNIT_ASSERT(!release.HasValue());
+
+        UNIT_ASSERT(
+            b.State->FlushFailed(1, MakeError(E_IO)) ==
+            EFlushRetryStatus::ShouldRetry);
+
+        UNIT_ASSERT(release.HasValue());
+
+        auto pending2 = b.Add(2, 201, 0, "ghi");
+        auto pending1 = b.Add(1, 103, 10, "jkl");
+
+        b.State->FlushSucceeded(1, 1);
+
+        UNIT_ASSERT(pending2.HasValue());
+        UNIT_ASSERT(!pending1.HasValue());
+
+        // Current state:
+        // Node 1:
+        // - 1 unflushed request with released handle
+        // - 1 pending request with live handle
+        // Node 2:
+        // - 1 unflushed request with live handle
+
+        UNIT_ASSERT_VALUES_EQUAL(103, b.State->GetLiveHandle(1));
+
+        UNIT_ASSERT(
+            b.State->FlushFailed(2, MakeError(E_FS_NOSPC)) ==
+            EFlushRetryStatus::ShouldRetry);
+
+        UNIT_ASSERT(!pending1.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(103, b.State->GetLiveHandle(2));
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache


### PR DESCRIPTION
### Notes
Describe your PR - what it does and why this needs to be done.

### Issue
Put links to the related issues here
