### PR TITLE
Filestore: fix memory overflow in compression

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
@@ -316,14 +316,17 @@ void TIndexTabletActor::HandleWriteBlob(
 
             const auto chunkSize = Config->GetBlobCompressionChunkSize();
             TString chunk;
-            chunk.ReserveAndResize(chunkSize);
 
             const auto& data = blob.BlobContent;
             for (auto begin = data.begin(); begin < data.end(); begin += chunkSize) {
                 const auto end = Min(begin + chunkSize, data.end());
-                compressedSize += BlobCodec->Compress(
-                    TStringBuf(begin, end),
-                    chunk.begin());
+                const TStringBuf src(begin, end);
+                const auto maxCompressedLength =
+                    BlobCodec->MaxCompressedLength(src);
+                if (chunk.size() < maxCompressedLength) {
+                    chunk.ReserveAndResize(maxCompressedLength);
+                }
+                compressedSize += BlobCodec->Compress(src, chunk.begin());
             }
 
             Metrics->UncompressedBytesWritten.fetch_add(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
@@ -321,7 +321,7 @@ void TIndexTabletActor::HandleWriteBlob(
             for (auto begin = data.begin(); begin < data.end(); begin += chunkSize) {
                 const auto end = Min(begin + chunkSize, data.end());
                 const TStringBuf src(begin, end);
-                const auto maxCompressedLength =
+                const size_t maxCompressedLength =
                     BlobCodec->MaxCompressedLength(src);
                 if (chunk.size() < maxCompressedLength) {
                     chunk.ReserveAndResize(maxCompressedLength);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -5,6 +5,7 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/random/fast.h>
 #include <util/stream/file.h>
 
 #include <memory>
@@ -824,6 +825,52 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
                     {"filesystem", "test"},
                 },
                 [](i64 val) { return val > 0 && val < 370; } // expected
+            },
+        });
+    }
+
+    Y_UNIT_TEST(ShouldReportCompressionMetricsForIncompressibleData)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetBlobCompressionRate(1);
+        storageConfig.SetWriteBlobThreshold(1);
+
+        TTestEnv env({}, std::move(storageConfig));
+        auto registry = env.GetRegistry();
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+        const auto nodeId =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        const auto handle = CreateHandle(tablet, nodeId);
+
+        TString data(100_KB, 0);
+        TReallyFastRng32 rng(42);
+        for (auto& c: data) {
+            c = rng.Uniform(256);
+        }
+
+        tablet.WriteData(handle, 0, data.size(), data.data());
+
+        TTestRegistryVisitor visitor;
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCountersWithPredicate({
+            {
+                {
+                    {"sensor", "UncompressedBytesWritten"},
+                    {"filesystem", "test"}
+                },
+                [](i64 val) { return val == static_cast<i64>(100_KB); }
+            },
+            {
+                {
+                    {"sensor", "CompressedBytesWritten"},
+                    {"filesystem", "test"},
+                },
+                [](i64 val) { return val >= static_cast<i64>(100_KB); }
             },
         });
     }


### PR DESCRIPTION
### Notes
We used wrong size for compressed data. It should be bigger. It triggers only if data is incompressible 
```
[crashed] TIndexTabletTest_Counters::ShouldReportCompressionMetricsForIncompressibleData [default-linux-x86_64-relwithdebinfo-FORCE_STATIC_LINKING=yes-asan] (0.00s)
Test crashed (return code: 100)
==2395790==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x53200077c808 at pc 0x000013f3d604 bp 0x7ffecb182630 sp 0x7ffecb181df0
WRITE of size 81920 at 0x53200077c808 thread T0
```


