### PR TITLE
Revert "[Blockstore] Advertise read-only feature for vhost devices (#6698)

### DIFF
--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -3,7 +3,6 @@
 #include <cloud/blockstore/libs/client/session.h>
 #include <cloud/blockstore/libs/common/constants.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_listener.h>
-#include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/vhost/server.h>
 #include <cloud/storage/core/libs/common/media.h>
 
@@ -75,7 +74,6 @@ public:
             ShouldDropDiscardRequestsForVolume(DropDiscardRequests, volume);
         options.MaxZeroBlocksSubRequestSize = MaxZeroBlocksSubRequestSize;
         options.OptimalIoSize = OptimalIoSize;
-        options.ReadOnly = !IsReadWriteMode(request.GetVolumeAccessMode());
 
         return Server->StartEndpoint(
             request.GetUnixSocketPath(),

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -269,8 +269,7 @@ TFuture<NProto::TError> TServer::StartEndpoint(
         options.OptimalIoSize,
         std::move(queues),
         endpoint->GetCookie(),
-        Callbacks,
-        options.ReadOnly);
+        Callbacks);
     endpoint->SetVhostDevice(std::move(vhostDevice));
 
     auto error = SafeExecute<NProto::TError>([&] { return endpoint->Start(); });

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -39,7 +39,6 @@ struct TStorageOptions
     bool DropDiscardRequests = false;
     ui32 MaxZeroBlocksSubRequestSize = 0;
     ui32 OptimalIoSize = 0;
-    bool ReadOnly = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -151,8 +151,7 @@ public:
             bool writeZeroesEnabled,
             ui32 optimalIoSize,
             void* cookie,
-            const TVhostCallbacks& callbacks,
-            bool readOnly)
+            const TVhostCallbacks& callbacks)
         : VhdQueues(std::move(vhdQueues))
         , SocketPath(std::move(socketPath))
         , DeviceName(std::move(deviceName))
@@ -178,9 +177,6 @@ public:
         }
         if (writeZeroesEnabled) {
             VhdBdevInfo.features |= VHD_BDEV_F_WRITE_ZEROES;
-        }
-        if (readOnly) {
-            VhdBdevInfo.features |= VHD_BDEV_F_READONLY;
         }
     }
 
@@ -377,8 +373,7 @@ public:
         ui32 optimalIoSize,
         TVector<IVhostQueuePtr> queues,
         void* cookie,
-        const TVhostCallbacks& callbacks,
-        bool readOnly) override
+        const TVhostCallbacks& callbacks) override
     {
         Y_ABORT_UNLESS(!queues.empty());
 
@@ -400,8 +395,7 @@ public:
             writeZeroesEnabled,
             optimalIoSize,
             cookie,
-            callbacks,
-            readOnly);
+            callbacks);
     }
 };
 

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -93,8 +93,7 @@ struct IVhostQueueFactory
         ui32 optimalIoSize,
         TVector<IVhostQueuePtr> queues,
         void* cookie,
-        const TVhostCallbacks& callbacks,
-        bool readOnly) = 0;
+        const TVhostCallbacks& callbacks) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/vhost/vhost_test.cpp
+++ b/cloud/blockstore/libs/vhost/vhost_test.cpp
@@ -295,8 +295,7 @@ IVhostDevicePtr TTestVhostQueueFactory::CreateDevice(
     ui32 optimalIoSize,
     TVector<IVhostQueuePtr> queues,
     void* cookie,
-    const TVhostCallbacks& callbacks,
-    bool readOnly)
+    const TVhostCallbacks& callbacks)
 {
     Y_UNUSED(deviceName);
     Y_UNUSED(blockSize);
@@ -304,7 +303,6 @@ IVhostDevicePtr TTestVhostQueueFactory::CreateDevice(
     Y_UNUSED(discardEnabled);
     Y_UNUSED(writeZeroesEnabled);
     Y_UNUSED(callbacks);
-    Y_UNUSED(readOnly);
 
     Y_ABORT_UNLESS(!queues.empty());
     Y_ABORT_UNLESS(queues.size() <= queuesCount);

--- a/cloud/blockstore/libs/vhost/vhost_test.h
+++ b/cloud/blockstore/libs/vhost/vhost_test.h
@@ -65,8 +65,7 @@ struct TTestVhostQueueFactory final
         ui32 optimalIoSize,
         TVector<IVhostQueuePtr> queues,
         void* cookie,
-        const TVhostCallbacks& callbacks,
-        bool readOnly) override;
+        const TVhostCallbacks& callbacks) override;
 };
 
 }   // namespace NCloud::NBlockStore::NVhost


### PR DESCRIPTION
revert https://github.com/ydb-platform/nbs/pull/6698 due to vm migration failures