### PR TITLE
issue-5895: ProfileLog support in TCPSideChannel

### DIFF
--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -170,6 +170,7 @@ private:
     ITimerPtr Timer;
     ISchedulerPtr Scheduler;
     ILoggingServicePtr Logging;
+    IProfileLogPtr ProfileLog;
     IFileStoreServicePtr LocalService;
     IActorSystemPtr ActorSystem;
 
@@ -182,12 +183,14 @@ public:
             ITimerPtr timer,
             ISchedulerPtr scheduler,
             ILoggingServicePtr logging,
+            IProfileLogPtr profileLog,
             IFileStoreServicePtr localService,
             IActorSystemPtr actorSystem)
         : CertificateProviderFactory(std::move(certificateProviderFactory))
         , Timer(std::move(timer))
         , Scheduler(std::move(scheduler))
         , Logging(std::move(logging))
+        , ProfileLog(std::move(profileLog))
         , LocalService(std::move(localService))
         , ActorSystem(std::move(actorSystem))
     {}
@@ -306,6 +309,8 @@ private:
             case NProto::SCT_TCP: {
                 return CreateTCPSideChannel(
                     *Logging,
+                    ProfileLog,
+                    Timer,
                     std::make_shared<NStorage::NFastShard::TAsyncClient>());
             }
         }
@@ -571,6 +576,7 @@ void TBootstrapVhost::InitEndpoints()
         Timer,
         Scheduler,
         Logging,
+        ProfileLog,
         LocalService,
         ActorSystem);
 

--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -1,7 +1,12 @@
 #include "side_channel.h"
 
+#include <cloud/filestore/libs/diagnostics/profile_log.h>
+#include <cloud/filestore/libs/diagnostics/profile_log_events.h>
+#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
+
+#include <cloud/storage/core/libs/common/timer.h>
 
 #include <cloud/filestore/public/api/protos/data.pb.h>
 #include <cloud/filestore/public/api/protos/headers.pb.h>
@@ -407,13 +412,19 @@ private:
     THashMap<TString, TFileSystemTCPSideChannelPtr> Id2Channel;
 
     TLog Log;
+    const IProfileLogPtr ProfileLog;
+    const ITimerPtr Timer;
     std::shared_ptr<IAsyncClient> Client;
 
 public:
     TTCPSideChannel(
             ILoggingService& logging,
+            IProfileLogPtr profileLog,
+            ITimerPtr timer,
             std::shared_ptr<IAsyncClient> client)
         : Log(logging.CreateLog("TCP_SIDE_CHANNEL"))
+        , ProfileLog(std::move(profileLog))
+        , Timer(std::move(timer))
         , Client(std::move(client))
     {}
 
@@ -425,6 +436,13 @@ public:
     {
         Y_UNUSED(callContext);
 
+        NProto::TProfileLogRequestInfo profileLogRequest;
+        NFuse::InitProfileLogRequestInfo(
+            profileLogRequest,
+            EFileStoreRequest::ReadData,
+            Timer->Now());
+        InitProfileLogRequestInfo(profileLogRequest, *request);
+
         // Iovec base addresses are pointers in this process and cannot be
         // sent over the wire. Strip them from the request and copy data
         // from the response Buffer back into the original iovecs.
@@ -435,7 +453,8 @@ public:
 
         auto channel = AccessFileSystemChannel(*request);
 
-        return channel->Dispatch(
+        auto future = response.GetFuture();
+        const bool dispatched = channel->Dispatch(
             *request,
             std::move(response),
             [](TRequest& req, const NProto::TReadDataRequest& body) {
@@ -448,6 +467,15 @@ public:
                 resp = std::move(*r.MutableReadData());
                 MoveBufferToIovecs(resp, iovecs);
             });
+
+        if (dispatched) {
+            SubscribeProfileLogging(
+                std::move(profileLogRequest),
+                request->GetFileSystemId(),
+                std::move(future));
+        }
+
+        return dispatched;
     }
 
     bool ExecuteRequest(
@@ -457,6 +485,13 @@ public:
     {
         Y_UNUSED(callContext);
 
+        NProto::TProfileLogRequestInfo profileLogRequest;
+        NFuse::InitProfileLogRequestInfo(
+            profileLogRequest,
+            EFileStoreRequest::WriteData,
+            Timer->Now());
+        InitProfileLogRequestInfo(profileLogRequest, *request);
+
         const ui64 iovecsSize = request->IovecsSize();
         const ui64 bufferOffset = request->GetBufferOffset();
         if (iovecsSize > 0 && bufferOffset > 0) {
@@ -465,13 +500,22 @@ public:
                 E_ARGUMENT,
                 TStringBuilder() << "BufferOffset=" << bufferOffset
                     << ", iovecsSize=" << iovecsSize << " are both nonzero");
+
+            NFuse::FinalizeProfileLogRequestInfo(
+                std::move(profileLogRequest),
+                Timer->Now(),
+                request->GetFileSystemId(),
+                errorResponse.GetError(),
+                ProfileLog);
+
             response.SetValue(std::move(errorResponse));
             return true;
         }
 
         auto channel = AccessFileSystemChannel(*request);
 
-        return channel->Dispatch(
+        auto future = response.GetFuture();
+        const bool dispatched = channel->Dispatch(
             *request,
             std::move(response),
             [](TRequest& req, const NProto::TWriteDataRequest& body) {
@@ -488,6 +532,15 @@ public:
             [](NProto::TWriteDataResponse& resp, TResponse& r) {
                 resp = std::move(*r.MutableWriteData());
             });
+
+        if (dispatched) {
+            SubscribeProfileLogging(
+                std::move(profileLogRequest),
+                request->GetFileSystemId(),
+                std::move(future));
+        }
+
+        return dispatched;
     }
 
     void Update(const NProto::TBackendInfo& backendInfo) override
@@ -499,6 +552,35 @@ public:
     }
 
 private:
+    //
+    // Requests dispatched via the side channel bypass TStorageServiceActor,
+    // so their profile log records are written here upon response arrival.
+    //
+
+    template <typename TResponse>
+    void SubscribeProfileLogging(
+        NProto::TProfileLogRequestInfo profileLogRequest,
+        TString fileSystemId,
+        TFuture<TResponse> future)
+    {
+        future.Subscribe(
+            [profileLog = ProfileLog,
+             timer = Timer,
+             fileSystemId = std::move(fileSystemId),
+             profileLogRequest = std::move(profileLogRequest)] (
+                const TFuture<TResponse>& f) mutable
+            {
+                const auto& response = f.GetValue();
+                FinalizeProfileLogRequestInfo(profileLogRequest, response);
+                NFuse::FinalizeProfileLogRequestInfo(
+                    std::move(profileLogRequest),
+                    timer->Now(),
+                    fileSystemId,
+                    response.GetError(),
+                    profileLog);
+            });
+    }
+
     TString MakeFileSystemId(const TString& mainFileSystemId, ui32 shardNo)
         const
     {
@@ -548,10 +630,14 @@ private:
 
 ISideChannelPtr CreateTCPSideChannel(
     ILoggingService& logging,
+    IProfileLogPtr profileLog,
+    ITimerPtr timer,
     std::shared_ptr<IAsyncClient> client)
 {
     return std::make_shared<TTCPSideChannel>(
         logging,
+        std::move(profileLog),
+        std::move(timer),
         std::move(client));
 }
 

--- a/cloud/filestore/libs/service_kikimr/side_channel.h
+++ b/cloud/filestore/libs/service_kikimr/side_channel.h
@@ -5,8 +5,11 @@
 #include <cloud/filestore/libs/service/context.h>
 #include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
 
+#include <cloud/filestore/libs/diagnostics/public.h>
+
 #include <cloud/filestore/public/api/protos/headers.pb.h>
 
+#include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 namespace NCloud::NFileStore {
@@ -36,6 +39,8 @@ public:
 
 ISideChannelPtr CreateTCPSideChannel(
     ILoggingService& logging,
+    IProfileLogPtr profileLog,
+    ITimerPtr timer,
     std::shared_ptr<NStorage::NFastShard::IAsyncClient> client);
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
@@ -1,8 +1,11 @@
 #include "side_channel.h"
 
+#include <cloud/filestore/libs/diagnostics/profile_log.h>
+#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
 
+#include <cloud/storage/core/libs/common/timer_test.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -47,6 +50,29 @@ struct TTestAsyncEndpoint: public IAsyncEndpoint
         UNIT_ASSERT(Response.Initialized());
         Response.SetValue(std::move(r));
         return true;
+    }
+};
+
+struct TTestProfileLog: public IProfileLog
+{
+    TAdaptiveLock Lock;
+    TVector<TRecord> Records;
+
+    void Start() override
+    {}
+
+    void Stop() override
+    {}
+
+    void Write(TRecord record) override
+    {
+        auto g = Guard(Lock);
+        Records.push_back(std::move(record));
+    }
+
+    void RegisterCounters(NMonitoring::TDynamicCounters& root) override
+    {
+        Y_UNUSED(root);
     }
 };
 
@@ -165,7 +191,10 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
     {
         auto logging = CreateLoggingService("console", { TLOG_DEBUG });
         auto client = std::make_shared<TTestAsyncClient>();
-        auto sideChannel = CreateTCPSideChannel(*logging, client);
+        auto profileLog = std::make_shared<TTestProfileLog>();
+        auto timer = std::make_shared<TTestTimer>();
+        auto sideChannel =
+            CreateTCPSideChannel(*logging, profileLog, timer, client);
 
         auto writeResponse = NewPromise<NProto::TWriteDataResponse>();
         bool success = sideChannel->ExecuteRequest(
@@ -228,11 +257,106 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
             readResponse.GetValue().GetBuffer());
     }
 
+    Y_UNIT_TEST(ShouldWriteProfileLogRecords)
+    {
+        auto logging = CreateLoggingService("console", { TLOG_DEBUG });
+        auto client = std::make_shared<TTestAsyncClient>();
+        auto profileLog = std::make_shared<TTestProfileLog>();
+        auto timer = std::make_shared<TTestTimer>();
+        auto sideChannel =
+            CreateTCPSideChannel(*logging, profileLog, timer, client);
+
+        //
+        // A request which the side channel refuses to dispatch is served and
+        // profile-logged by the main channel - no record should appear here.
+        //
+
+        auto writeResponse = NewPromise<NProto::TWriteDataResponse>();
+        bool success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(1, 100, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(!success);
+        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Records.size());
+
+        sideChannel->Update(BackendInfo());
+
+        TConnInfo connInfo;
+        auto e = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e);
+
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(1, 100, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(success);
+        UNIT_ASSERT_VALUES_EQUAL(0, profileLog->Records.size());
+
+        timer->AdvanceTime(TDuration::Seconds(1));
+        UNIT_ASSERT(e->Reply(WriteResp(MakeError(S_ALREADY))));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, profileLog->Records.size());
+        {
+            const auto& record = profileLog->Records[0];
+            UNIT_ASSERT_VALUES_EQUAL(FileSystemId, record.FileSystemId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<ui32>(EFileStoreRequest::WriteData),
+                record.Request.GetRequestType());
+            UNIT_ASSERT_VALUES_EQUAL(0, record.Request.GetTimestampMcs());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1'000'000,
+                record.Request.GetDurationMcs());
+            UNIT_ASSERT_VALUES_EQUAL(
+                S_ALREADY,
+                record.Request.GetErrorCode());
+            UNIT_ASSERT_VALUES_EQUAL(1, record.Request.RangesSize());
+            const auto& range = record.Request.GetRanges(0);
+            UNIT_ASSERT_VALUES_EQUAL(1, range.GetHandle());
+            UNIT_ASSERT_VALUES_EQUAL(100, range.GetOffset());
+            UNIT_ASSERT_VALUES_EQUAL(1_KB, range.GetBytes());
+        }
+
+        auto readResponse = NewPromise<NProto::TReadDataResponse>();
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            ReadReq(1, 200, 1_KB),
+            readResponse);
+        UNIT_ASSERT(success);
+
+        timer->AdvanceTime(TDuration::Seconds(3));
+        UNIT_ASSERT(e->Reply(ReadResp(MakeError(S_OK), TString(1_KB, 'b'))));
+
+        UNIT_ASSERT_VALUES_EQUAL(2, profileLog->Records.size());
+        {
+            const auto& record = profileLog->Records[1];
+            UNIT_ASSERT_VALUES_EQUAL(FileSystemId, record.FileSystemId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<ui32>(EFileStoreRequest::ReadData),
+                record.Request.GetRequestType());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1'000'000,
+                record.Request.GetTimestampMcs());
+            UNIT_ASSERT_VALUES_EQUAL(
+                3'000'000,
+                record.Request.GetDurationMcs());
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, record.Request.GetErrorCode());
+            UNIT_ASSERT_VALUES_EQUAL(1, record.Request.RangesSize());
+            const auto& range = record.Request.GetRanges(0);
+            UNIT_ASSERT_VALUES_EQUAL(1, range.GetHandle());
+            UNIT_ASSERT_VALUES_EQUAL(200, range.GetOffset());
+            UNIT_ASSERT_VALUES_EQUAL(1_KB, range.GetBytes());
+            UNIT_ASSERT_VALUES_EQUAL(1_KB, range.GetActualBytes());
+        }
+    }
+
     Y_UNIT_TEST(ShouldProcessRequestsBeforeConnectionCompletes)
     {
         auto logging = CreateLoggingService("console", { TLOG_DEBUG });
         auto client = std::make_shared<TTestAsyncClient>();
-        auto sideChannel = CreateTCPSideChannel(*logging, client);
+        auto profileLog = std::make_shared<TTestProfileLog>();
+        auto timer = std::make_shared<TTestTimer>();
+        auto sideChannel =
+            CreateTCPSideChannel(*logging, profileLog, timer, client);
 
         sideChannel->Update(BackendInfo());
 
@@ -272,7 +396,10 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
     {
         auto logging = CreateLoggingService("console", { TLOG_DEBUG });
         auto client = std::make_shared<TTestAsyncClient>();
-        auto sideChannel = CreateTCPSideChannel(*logging, client);
+        auto profileLog = std::make_shared<TTestProfileLog>();
+        auto timer = std::make_shared<TTestTimer>();
+        auto sideChannel =
+            CreateTCPSideChannel(*logging, profileLog, timer, client);
 
         sideChannel->Update(BackendInfo());
 
@@ -329,7 +456,10 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
     {
         auto logging = CreateLoggingService("console", { TLOG_DEBUG });
         auto client = std::make_shared<TTestAsyncClient>();
-        auto sideChannel = CreateTCPSideChannel(*logging, client);
+        auto profileLog = std::make_shared<TTestProfileLog>();
+        auto timer = std::make_shared<TTestTimer>();
+        auto sideChannel =
+            CreateTCPSideChannel(*logging, profileLog, timer, client);
 
         sideChannel->Update(BackendInfo());
 
@@ -400,7 +530,10 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
     {
         auto logging = CreateLoggingService("console", { TLOG_RESOURCES });
         auto client = std::make_shared<TTestAsyncClient>();
-        auto sideChannel = CreateTCPSideChannel(*logging, client);
+        auto profileLog = std::make_shared<TTestProfileLog>();
+        auto timer = std::make_shared<TTestTimer>();
+        auto sideChannel =
+            CreateTCPSideChannel(*logging, profileLog, timer, client);
 
         sideChannel->Update(BackendInfo());
 
@@ -495,7 +628,10 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
     {
         auto logging = CreateLoggingService("console", { TLOG_DEBUG });
         auto client = std::make_shared<TTestAsyncClient>();
-        auto sideChannel = CreateTCPSideChannel(*logging, client);
+        auto profileLog = std::make_shared<TTestProfileLog>();
+        auto timer = std::make_shared<TTestTimer>();
+        auto sideChannel =
+            CreateTCPSideChannel(*logging, profileLog, timer, client);
 
         sideChannel->Update(BackendInfo());
 

--- a/cloud/filestore/libs/service_kikimr/ya.make
+++ b/cloud/filestore/libs/service_kikimr/ya.make
@@ -11,6 +11,7 @@ SRCS(
 )
 
 PEERDIR(
+    cloud/filestore/libs/diagnostics
     cloud/filestore/libs/service
     cloud/filestore/libs/storage/api
     cloud/filestore/libs/storage/core


### PR DESCRIPTION
### Notes
ProfileLog-ging is done by StorageServiceActor which is bypassed for the requests successfully processed by TCPSideChannel. This PR adds successful request ProfileLog-ging in TCPSideChannel.

### Issue
https://github.com/ydb-platform/nbs/issues/5895
