### PR TITLE
Add PrevLogSequenceNumber to TWriteLogRecordRequest

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_journalled_device_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_journalled_device_ut.cpp
@@ -261,12 +261,14 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
             {[&](auto& proto)
              {
                  proto.SetDeviceUUID(uuid);
+                 proto.SetLogSequenceNumber(1);
                  proto.MutablePageGroups()->Add();
              },
              MakeError(E_ARGUMENT, "empty page group")},
             {[&](auto& proto)
              {
                  proto.SetDeviceUUID(uuid);
+                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -281,6 +283,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
             {[&](auto& proto)
              {
                  proto.SetDeviceUUID(uuid);
+                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -303,6 +306,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
             {[&](auto& proto)
              {
                  proto.SetDeviceUUID(uuid);
+                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -315,7 +319,9 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
              MakeError(E_ARGUMENT, "invalid page data: block size mismatch")},
             {[&](auto& proto)
              {
-                 proto.SetDeviceUUID(uuid);
+                 // the client id is checked after the device is found
+                 proto.SetDeviceUUID(FileDevices[0].GetDeviceId());
+                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -334,6 +340,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
              {
                  proto.MutableHeaders()->SetClientId(clientId);
                  proto.SetDeviceUUID(uuid);
+                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -352,6 +359,7 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
              {
                  proto.MutableHeaders()->SetClientId(clientId);
                  proto.SetDeviceUUID(FileDevices[0].GetDeviceId());
+                 proto.SetLogSequenceNumber(1);
 
                  auto& groups = *proto.MutablePageGroups();
 
@@ -367,6 +375,43 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
                  }
              },
              MakeError(E_BS_INVALID_SESSION, "not acquired by client")},
+            {[&](auto& proto)
+             {
+                 proto.MutableHeaders()->SetClientId(clientId);
+                 proto.SetDeviceUUID(uuid);
+                 // LogSequenceNumber is not set
+
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add()->resize(
+                         DefaultBlockSize,
+                         'A');
+                 }
+             },
+             MakeError(E_ARGUMENT, "invalid lsn: 0")},
+            {[&](auto& proto)
+             {
+                 proto.MutableHeaders()->SetClientId(clientId);
+                 proto.SetDeviceUUID(uuid);
+                 proto.SetLogSequenceNumber(10);
+                 proto.SetPrevLogSequenceNumber(10);
+
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add()->resize(
+                         DefaultBlockSize,
+                         'A');
+                 }
+             },
+             MakeError(
+                 E_ARGUMENT,
+                 "invalid lsn: 10, must be greater than the prev one: 10")},
         };
 
         for (ui64 i = 0; i != std::size(testCases); ++i) {
@@ -697,6 +742,129 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
 
             const auto& error = response.GetWriteLogRecord().GetError();
 
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldValidateLogSequenceNumber, TFixture)
+    {
+        const TString clientId = "client-id";
+        const TString uuid = FileDevices[0].GetDeviceId();
+
+        auto env =
+            TTestEnvBuilder(*Runtime).With(CreateDiskAgentConfig()).Build();
+
+        TDiskAgentClient diskAgent(*Runtime);
+        diskAgent.WaitReady();
+
+        TTestClient client{Port};
+
+        // Acquire device
+
+        {
+            NCloud::NProto::TDeviceProtocolRequest request;
+            auto& proto = *request.MutableAcquireDevices();
+            proto.MutableHeaders()->SetClientId(clientId);
+            *proto.MutableDeviceUUIDs()->Add() = uuid;
+            client.Send(request);
+        }
+
+        Runtime->DispatchEvents(TDispatchOptions(), 10ms);
+
+        {
+            auto response = client.Receive();
+            UNIT_ASSERT_EQUAL(
+                NProto::TDeviceProtocolResponse::ResponseCase::kAcquireDevices,
+                response.GetResponseCase());
+
+            const auto& error = response.GetAcquireDevices().GetError();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        ui64 requestId = 0;
+
+        const auto writeLogRecord = [&](ui64 lsn, ui64 prevLsn)
+        {
+            NCloud::NProto::TDeviceProtocolRequest request;
+            request.SetRequestId(++requestId);
+
+            auto& proto = *request.MutableWriteLogRecord();
+            proto.MutableHeaders()->SetClientId(clientId);
+            proto.SetDeviceUUID(uuid);
+            proto.SetLogSequenceNumber(lsn);
+            proto.SetPrevLogSequenceNumber(prevLsn);
+
+            auto& group = *proto.MutablePageGroups()->Add();
+            group.SetFirstPageNo(0x10);
+            group.MutableContent()->Add()->resize(DefaultBlockSize, 'A');
+
+            client.Send(request);
+
+            Runtime->DispatchEvents(TDispatchOptions(), 10ms);
+
+            auto response = client.Receive();
+            UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
+            UNIT_ASSERT_EQUAL(
+                NProto::TDeviceProtocolResponse::ResponseCase::kWriteLogRecord,
+                response.GetResponseCase());
+
+            return response.GetWriteLogRecord().GetError();
+        };
+
+        // the very first record is accepted with any prev lsn
+
+        {
+            const auto error = writeLogRecord(10, 5);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            const auto error = writeLogRecord(11, 10);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        // a gap in the log
+
+        {
+            const auto error = writeLogRecord(20, 15);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "Wrong lsn: 15, expected 11");
+        }
+
+        // an outdated record
+
+        {
+            const auto error = writeLogRecord(13, 5);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_INVALID_STATE,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "Wrong lsn: 5, expected 11");
+        }
+
+        // the rejected records have not changed the state
+
+        {
+            const auto error = writeLogRecord(12, 11);
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
@@ -10,6 +10,8 @@
 #include <contrib/ydb/library/actors/core/hfunc.h>
 #include <contrib/ydb/library/actors/core/log.h>
 
+#include <atomic>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -77,6 +79,13 @@ auto ValidateWriteLogRecordRequest(
         return MakeError(E_ARGUMENT, "nothing to write");
     }
 
+    if (request.GetLogSequenceNumber() <= request.GetPrevLogSequenceNumber()) {
+        return MakeError(E_ARGUMENT, TStringBuilder()
+                << "invalid lsn: " << request.GetLogSequenceNumber()
+                << ", must be greater than the prev one: "
+                << request.GetPrevLogSequenceNumber());
+    }
+
     for (const auto& group: request.GetPageGroups()) {
         if (group.ContentSize() == 0) {
             return MakeError(E_ARGUMENT, "empty page group");
@@ -95,11 +104,9 @@ auto ValidateWriteLogRecordRequest(
             }
 
             if (blockSize != block.size()) {
-                return MakeError(
-                    E_ARGUMENT,
-                    TStringBuilder() << "invalid page data: block size "
-                                        "mismatch: expected "
-                                     << blockSize << ", got " << block.size());
+                return MakeError(E_ARGUMENT, TStringBuilder()
+                    << "invalid page data: block size mismatch: expected "
+                    << blockSize << ", got " << block.size());
             }
         }
     }
@@ -135,6 +142,13 @@ auto ValidateReadPagesRequest(const NCloud::NProto::TReadPagesRequest& request)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TJournalledState
+{
+    std::atomic<ui64> LastLsn = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TJournalledDeviceHandler final: public IServerBackend
 {
 private:
@@ -142,15 +156,22 @@ private:
     const TActorId DiskAgentActorId;
     const TDeviceClientPtr DeviceClient;
 
+    THashMap<TString, TJournalledState> JournalledStateByDevice;
+
 public:
     TJournalledDeviceHandler(
         TActorSystem* actorSystem,
         const TActorId& diskAgentActorId,
-        TDeviceClientPtr deviceClient)
+        TDeviceClientPtr deviceClient,
+        const TVector<TString>& deviceUUIDs)
         : ActorSystem(actorSystem)
         , DiskAgentActorId(diskAgentActorId)
         , DeviceClient(std::move(deviceClient))
-    {}
+    {
+        for (const auto& uuid: deviceUUIDs) {
+            JournalledStateByDevice[uuid];
+        }
+    }
 
     // IServerBackend
 
@@ -292,8 +313,6 @@ public:
         NCloud::NProto::TWriteLogRecordRequest request)
         -> TFuture<NCloud::NProto::TWriteLogRecordResponse> final
     {
-        // TODO(sharpeye): check LogSequenceNumber
-
         ui32 requestBlockSize = 0;
         if (auto [bs, error] = ValidateWriteLogRecordRequest(request);
             HasError(error))
@@ -304,8 +323,30 @@ public:
             requestBlockSize = bs;
         }
 
+        const auto& deviceUUID = request.GetDeviceUUID();
+        auto* state = JournalledStateByDevice.FindPtr(deviceUUID);
+
+        if (!state) {
+            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(E_NOT_FOUND, TStringBuilder()
+                    << "Device " << deviceUUID.Quote() << " not found"));
+        }
+
+        const ui64 lastLsn = state->LastLsn.load(std::memory_order_relaxed);
+        const ui64 lsn = request.GetLogSequenceNumber();
+        const ui64 prevLsn = request.GetPrevLogSequenceNumber();
+
+        // TODO(#6956): allow to handle request with wrong lsn order
+        if (lastLsn != 0 && prevLsn != lastLsn) {
+            const auto code = prevLsn > lastLsn ? E_REJECTED : E_INVALID_STATE;
+
+            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(code, TStringBuilder()
+                    << "Wrong lsn: " << prevLsn << ", expected " << lastLsn));
+        }
+
         auto [storageAdapter, error] = DeviceClient->AccessDevice(
-            request.GetDeviceUUID(),
+            deviceUUID,
             request.GetHeaders().GetClientId(),
             DefaultAccessMode);
 
@@ -330,7 +371,7 @@ public:
         auto all = WaitAll(futures);
 
         return all.Apply(
-            [futures](const TFuture<void>& future) mutable
+            [futures, state, lsn](const TFuture<void>& future) mutable
                 -> NCloud::NProto::TWriteLogRecordResponse
             {
                 if (future.HasException()) {
@@ -343,6 +384,8 @@ public:
                         return TErrorResponse(sub.GetError());
                     }
                 }
+
+                state->LastLsn.store(lsn, std::memory_order_relaxed);
 
                 return {};
             });
@@ -422,7 +465,8 @@ void TDiskAgentActor::StartJournalledDeviceTcpServer(
             std::make_shared<TJournalledDeviceHandler>(
                 TActivationContext::ActorSystem(),
                 ctx.SelfID,
-                State->GetDeviceClient()));
+                State->GetDeviceClient(),
+                State->GetDeviceIds()));
 
         JournalledDeviceTcpServer->Start();
 

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
@@ -144,6 +144,7 @@ private:
     const TStorageGroupRetryPolicy RetryPolicy;
     ITimerPtr Timer;
     std::atomic<ui32> Selector{0};
+    std::atomic<ui64> LastLsn{0};
 
 public:
     TStorageGroupImpl(
@@ -195,6 +196,7 @@ public:
             }
         }
         request.SetLogSequenceNumber(lsn);
+        request.SetPrevLogSequenceNumber(LastLsn.exchange(lsn));
         SILK_DEBUG("sg write: %s", DebugMessage(request).c_str());
 
         return MirrorRequest<

--- a/cloud/storage/core/protos/device.proto
+++ b/cloud/storage/core/protos/device.proto
@@ -134,6 +134,9 @@ message TWriteLogRecordRequest
 
     // Log sequence number used to order the writes.
     uint64 LogSequenceNumber = 4;
+
+    // Prev log sequence number used to validate order.
+    uint64 PrevLogSequenceNumber = 5;
 }
 
 message TWriteLogRecordResponse
@@ -155,6 +158,9 @@ message TJournalRecord
 
     // Log sequence number this record was written with.
     uint64 LogSequenceNumber = 2;
+
+    // Prev log sequence number used to validate order.
+    uint64 PrevLogSequenceNumber = 3;
 }
 
 message TReadJournalTailRequest


### PR DESCRIPTION
### Notes
Add `PrevLogSequenceNumber` to the request and makes the disk agent enforce the chain.
The stored lsn is advanced only after the writes have actually succeeded, so a request rejected for an invalid order.

### Issue
https://github.com/ydb-platform/nbs/issues/6956
