### PR TITLE
chore: Move to updated kernel and add proper udev rules for nvme-loop devices

### DIFF
--- a/.github/packer/nvme-loop/nvme-loop-setup.sh
+++ b/.github/packer/nvme-loop/nvme-loop-setup.sh
@@ -6,6 +6,8 @@ LOG_FILE="${NVME_LOOP_LOG_FILE:-/var/log/nvme-loop.log}"
 CONFIG_DIR="${NVME_LOOP_CONFIG_DIR:-/etc/nvme-loop}"
 DEVICES_DIR="${NVME_LOOP_DEVICES_DIR:-/opt/nvme-loop/devices}"
 IMAGES_DIR="${NVME_LOOP_IMAGES_DIR:-/opt/nvme-loop/images}"
+UDEV_RULES_FILE="/etc/udev/rules.d/70-nvme-loop-access.rules"
+NVME_ACCESS_GROUP="disk"
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
@@ -30,6 +32,21 @@ log "Configuration loaded: target=$TARGET_NAME, namespaces=$NUM_NAMESPACES, size
 
 log ""
 log "=== Setting up single NVMe-loop target with $NUM_NAMESPACES namespaces ==="
+
+if [[ "$USER_NAME" != "" ]]; then
+    log "Configuring persistent NVMe access for '$USER_NAME'..."
+
+    usermod -a -G "$NVME_ACCESS_GROUP" "$USER_NAME"
+
+    cat > "$UDEV_RULES_FILE" << EOF
+# Make this NVMe-loop controller and its namespace nodes accessible to the disk group.
+# The kernel still enforces privilege checks for restricted NVMe commands.
+SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", ATTR{subsysnqn}=="${TARGET_NAME}", GROUP:="${NVME_ACCESS_GROUP}", MODE:="0660"
+SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{subsysnqn}=="${TARGET_NAME}", GROUP:="${NVME_ACCESS_GROUP}", MODE:="0660"
+EOF
+    chmod 0644 "$UDEV_RULES_FILE"
+    udevadm control --reload-rules
+fi
 
 mkdir -p $DEVICES_DIR
 chmod a+rw $DEVICES_DIR
@@ -180,22 +197,18 @@ fi
 log "Symbolic links stored in: $DEVICES_DIR"
 
 if [[ "$USER_NAME" != "" ]]; then
-    log "Configuring access for '$USER_NAME'..."
+    log "Applying NVMe access for '$USER_NAME'..."
 
-    GROUP=disk
+    chown "$USER_NAME:$NVME_ACCESS_GROUP" "/dev/$NVME_NAME"
 
-    usermod -a -G $GROUP "$USER_NAME"
-
-    chown $USER_NAME:$GROUP "/dev/$NVME_NAME"
-
-    chown $USER_NAME:$GROUP "$DEVICES_DIR"
+    chown "$USER_NAME:$NVME_ACCESS_GROUP" "$DEVICES_DIR"
     chmod 755 "$DEVICES_DIR"
 
     for link in "$DEVICES_DIR"/*; do
-        chown $USER_NAME:$GROUP "$link"
+        chown "$USER_NAME:$NVME_ACCESS_GROUP" "$link"
 
         DEV=$(realpath $link)
-        chown $USER_NAME:$GROUP "$DEV"
+        chown "$USER_NAME:$NVME_ACCESS_GROUP" "$DEV"
     done
 fi
 

--- a/.github/packer/scripts/github-runner.sh
+++ b/.github/packer/scripts/github-runner.sh
@@ -101,18 +101,15 @@ nebius version || nebius --version
 apt-get update
 apt-get -y upgrade
 
-# linux-image-6.2.0-39-generic is important because default kernel doesn't allow
+# linux-image-generic-hwe-22.04 is important because default (5.15) kernel doesn't allow
 # `nvme --id-ctrl` without CAP_SYS_ADMIN or root privilege
-LINUX_VER=6.2.0-39-generic
-
-LINUX_PKGS="linux-image-${LINUX_VER} \
-    linux-modules-${LINUX_VER} \
-    linux-modules-extra-${LINUX_VER} \
-    linux-tools-${LINUX_VER} \
-    linux-tools-common"
+LINUX_PKGS=(
+    linux-image-generic-hwe-22.04
+    linux-tools-generic-hwe-22.04
+)
 
 apt-get install -y --no-install-recommends \
-    ${LINUX_PKGS} \
+    "${LINUX_PKGS[@]}" \
     git wget gnupg lsb-release curl tzdata \
     libidn11-dev libaio1 libaio-dev \
     file qemu-kvm qemu-utils \
@@ -155,8 +152,10 @@ create_password_user "${DEBUG_USER}"
 sed -i -e 's/\\\$/$/g' /etc/shadow
 usermod -a -G kvm "${USER_TO_CREATE}"
 usermod -a -G docker "${USER_TO_CREATE}"
+usermod -a -G disk "${USER_TO_CREATE}"
 usermod -a -G kvm "${DEBUG_USER}"
 usermod -a -G docker "${DEBUG_USER}"
+usermod -a -G disk "${DEBUG_USER}"
 cat > "/etc/sudoers.d/99-${USER_TO_CREATE}" << EOF
 Cmnd_Alias GITHUB_RUNNER_LOGS = /usr/local/bin/actions-runner-collect-system-logs.sh
 ${USER_TO_CREATE} ALL=(root) NOPASSWD: GITHUB_RUNNER_LOGS

--- a/.github/workflows/on_demand_build_and_test.yaml
+++ b/.github/workflows/on_demand_build_and_test.yaml
@@ -76,6 +76,10 @@ on:
         type: string
         default: ""
         description: "Per ya make test attempt timeout in minutes"
+      image_id:
+        type: string
+        default: ""
+        description: "Nebius image id to use for VM"
   workflow_call:
     inputs:
       actions_checkout_ref:
@@ -163,6 +167,10 @@ on:
         type: string
         default: ""
         description: "Per ya make test attempt timeout in minutes"
+      image_id:
+        type: string
+        default: ""
+        description: "Nebius image id to use for VM"
 
 env:
   allow_downgrade: ${{ vars.GLOBAL_ALLOW_DOWNGRADE == 'yes' || ((github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'allow-downgrade')) || inputs.allow_downgrade == 'yes') }}
@@ -210,7 +218,7 @@ jobs:
           vm_disk_type: ${{ inputs.disk_type || 'network-ssd-nonreplicated' }}
           vm_disk_size: ${{ vars.POOLED_HEAVY_DISK_SIZE_GB || '1023' }}
           vm_subnet: ${{ vars.POOLED_HEAVY_SUBNET_ID }}
-          vm_image: ${{ vars.POOLED_HEAVY_IMAGE_ID_2204 }}
+          vm_image: ${{ inputs.image_id != '' && inputs.image_id || vars.POOLED_HEAVY_IMAGE_ID_2204 }}
           vm_labels: ${{ github.event.pull_request.number && format('pr={0},run={1}-{2},repo={3},owner={4}', github.event.pull_request.number, github.run_id, github.run_attempt, github.event.repository.name, github.repository_owner) || format('run={0}-{1},repo={2},owner={3}', github.run_id, github.run_attempt, github.event.repository.name, github.repository_owner) }}
           vm_user_passwd: ${{ secrets.VM_USER_PASSWD }}
           vm_allow_downgrade: ${{ env.allow_downgrade == 'true' && 'yes' || 'no' }}


### PR DESCRIPTION
We were using 6.2 kernel because it was earliest that had `nvme --id-ctrl`, but this kernel doesn't receive security fixes, apparently.
So next best thing is 6.8 in hwe package.

Also created udev rule to label devices correctly (not entirely necessary, but good thing to do)

Large test run with vm image containing this change
https://github.com/ydb-platform/nbs/actions/runs/33387263122
https://github.com/ydb-platform/nbs/actions/runs/33416737191
