### PR TITLE
journalled device: ReadJournalTail and AdvanceLsnLowWatermark stubs

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
@@ -347,6 +347,30 @@ public:
                 return {};
             });
     }
+
+    [[nodiscard]] auto ReadJournalTail(
+        TInstant now,
+        NCloud::NProto::TReadJournalTailRequest request)
+        -> TFuture<NCloud::NProto::TReadJournalTailResponse> final
+    {
+        // TODO(#6956): implement journal tail reading
+        Y_UNUSED(now, request);
+
+        return MakeFuture<NCloud::NProto::TReadJournalTailResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "ReadJournalTail"));
+    }
+
+    [[nodiscard]] auto AdvanceLsnLowWatermark(
+        TInstant now,
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> final
+    {
+        // TODO(#6956): implement lsn low watermark advancing
+        Y_UNUSED(now, request);
+
+        return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "AdvanceLsnLowWatermark"));
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h
@@ -12,7 +12,9 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
     xxx(AcquireDevices, __VA_ARGS__)                                           \
     xxx(ReleaseDevices, __VA_ARGS__)                                           \
     xxx(ReadPages, __VA_ARGS__)                                                \
-    xxx(WriteLogRecord, __VA_ARGS__)
+    xxx(WriteLogRecord, __VA_ARGS__)                                           \
+    xxx(ReadJournalTail, __VA_ARGS__)                                          \
+    xxx(AdvanceLsnLowWatermark, __VA_ARGS__)
 
 // SN_METHODS
 

--- a/cloud/filestore/libs/storage/fastshard/sn/impl/storage_node.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/impl/storage_node.cpp
@@ -430,6 +430,24 @@ public:
         return resp;
     }
 
+    NCloud::NProto::TReadJournalTailResponse ReadJournalTail(
+        NCloud::NProto::TReadJournalTailRequest request) override
+    {
+        // WriteLogRecord writes in place, so the journal is always empty and
+        // there is never anything to replay.
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NCloud::NProto::TAdvanceLsnLowWatermarkResponse AdvanceLsnLowWatermark(
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request) override
+    {
+        // Every page is already at its final location, so the watermark can be
+        // advanced to any value without doing anything.
+        Y_UNUSED(request);
+        return {};
+    }
+
 private:
     const TString Path;
     TFileHandle File;

--- a/cloud/filestore/libs/storage/fastshard/sn/impl/storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/impl/storage_node.h
@@ -13,6 +13,8 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
  *
  * Semantics:
  *   - AcquireDevices and ReleaseDevices are stubbed and return S_OK.
+ *   - There is no journal, so ReadJournalTail returns an empty record
+ *     list and AdvanceLsnLowWatermark is a no-op; both return S_OK.
  *   - WriteLogRecord writes every page in every TDevicePageGroup
  *     straight to `path` at offset (FirstPageNo + i) * pageSize, where
  *     pageSize is the size of the first Content entry of that group.

--- a/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.cpp
+++ b/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.cpp
@@ -40,4 +40,23 @@ NCloud::NProto::TWriteLogRecordResponse TFakeStorageNode::WriteLogRecord(
     return WriteResp;
 }
 
+NCloud::NProto::TReadJournalTailResponse TFakeStorageNode::ReadJournalTail(
+    NCloud::NProto::TReadJournalTailRequest request)
+{
+    with_lock (Lock) {
+        ReadJournalTailCalls.push_back(std::move(request));
+    }
+    return ReadJournalTailResp;
+}
+
+NCloud::NProto::TAdvanceLsnLowWatermarkResponse
+TFakeStorageNode::AdvanceLsnLowWatermark(
+    NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+{
+    with_lock (Lock) {
+        AdvanceLsnLowWatermarkCalls.push_back(std::move(request));
+    }
+    return AdvanceLsnLowWatermarkResp;
+}
+
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h
@@ -29,11 +29,17 @@ struct TFakeStorageNode: public IStorageNode
     TVector<NCloud::NProto::TReleaseDevicesRequest> ReleaseCalls;
     TVector<NCloud::NProto::TReadPagesRequest> ReadCalls;
     TVector<NCloud::NProto::TWriteLogRecordRequest> WriteCalls;
+    TVector<NCloud::NProto::TReadJournalTailRequest> ReadJournalTailCalls;
+    TVector<NCloud::NProto::TAdvanceLsnLowWatermarkRequest>
+        AdvanceLsnLowWatermarkCalls;
 
     NCloud::NProto::TAcquireDevicesResponse AcquireResp;
     NCloud::NProto::TReleaseDevicesResponse ReleaseResp;
     NCloud::NProto::TReadPagesResponse ReadResp;
     NCloud::NProto::TWriteLogRecordResponse WriteResp;
+    NCloud::NProto::TReadJournalTailResponse ReadJournalTailResp;
+    NCloud::NProto::TAdvanceLsnLowWatermarkResponse
+        AdvanceLsnLowWatermarkResp;
 
     NCloud::NProto::TAcquireDevicesResponse AcquireDevices(
         NCloud::NProto::TAcquireDevicesRequest request) override;
@@ -46,6 +52,12 @@ struct TFakeStorageNode: public IStorageNode
 
     NCloud::NProto::TWriteLogRecordResponse WriteLogRecord(
         NCloud::NProto::TWriteLogRecordRequest request) override;
+
+    NCloud::NProto::TReadJournalTailResponse ReadJournalTail(
+        NCloud::NProto::TReadJournalTailRequest request) override;
+
+    NCloud::NProto::TAdvanceLsnLowWatermarkResponse AdvanceLsnLowWatermark(
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request) override;
 };
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server.cpp
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server.cpp
@@ -25,7 +25,9 @@ namespace {
     xxx(AcquireDevices, __VA_ARGS__)               \
     xxx(ReleaseDevices, __VA_ARGS__)               \
     xxx(ReadPages, __VA_ARGS__)                    \
-    xxx(WriteLogRecord, __VA_ARGS__)
+    xxx(WriteLogRecord, __VA_ARGS__)               \
+    xxx(ReadJournalTail, __VA_ARGS__)              \
+    xxx(AdvanceLsnLowWatermark, __VA_ARGS__)
 
 // STORAGE_JOURNALLED_DEVICE_SERVER
 
@@ -418,6 +420,16 @@ void TServer::HandleRequest(
         }
         case ERequestCase::kWriteLogRecord: {
             ProcessRequest<TWriteLogRecordMethod>(conn, std::move(request));
+            break;
+        }
+        case ERequestCase::kReadJournalTail: {
+            ProcessRequest<TReadJournalTailMethod>(conn, std::move(request));
+            break;
+        }
+        case ERequestCase::kAdvanceLsnLowWatermark: {
+            ProcessRequest<TAdvanceLsnLowWatermarkMethod>(
+                conn,
+                std::move(request));
             break;
         }
         default: {

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server.h
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server.h
@@ -39,6 +39,16 @@ struct IServerBackend
         TInstant now,
         NProto::TWriteLogRecordRequest request)
         -> NThreading::TFuture<NProto::TWriteLogRecordResponse> = 0;
+
+    [[nodiscard]] virtual auto ReadJournalTail(
+        TInstant now,
+        NProto::TReadJournalTailRequest request)
+        -> NThreading::TFuture<NProto::TReadJournalTailResponse> = 0;
+
+    [[nodiscard]] virtual auto AdvanceLsnLowWatermark(
+        TInstant now,
+        NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> NThreading::TFuture<NProto::TAdvanceLsnLowWatermarkResponse> = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server_ut.cpp
@@ -38,10 +38,20 @@ struct TTestBackend: public IServerBackend
         std::function<TFuture<NProto::TWriteLogRecordResponse>(
             NProto::TWriteLogRecordRequest)>;
 
+    using TReadJournalTailFunc =
+        std::function<TFuture<NProto::TReadJournalTailResponse>(
+            NProto::TReadJournalTailRequest)>;
+
+    using TAdvanceLsnLowWatermarkFunc =
+        std::function<TFuture<NProto::TAdvanceLsnLowWatermarkResponse>(
+            NProto::TAdvanceLsnLowWatermarkRequest)>;
+
     TAcquireDevicesFunc AcquireDevicesImpl;
     TReleaseDevicesFunc ReleaseDevicesImpl;
     TReadPagesFunc ReadPagesImpl;
     TWriteLogRecordFunc WriteLogRecordImpl;
+    TReadJournalTailFunc ReadJournalTailImpl;
+    TAdvanceLsnLowWatermarkFunc AdvanceLsnLowWatermarkImpl;
 
     [[nodiscard]] auto AcquireDevices(
         TInstant now,
@@ -81,6 +91,26 @@ struct TTestBackend: public IServerBackend
         Y_UNUSED(now);
 
         return WriteLogRecordImpl(std::move(request));
+    }
+
+    [[nodiscard]] auto ReadJournalTail(
+        TInstant now,
+        NProto::TReadJournalTailRequest request)
+        -> TFuture<NProto::TReadJournalTailResponse> final
+    {
+        Y_UNUSED(now);
+
+        return ReadJournalTailImpl(std::move(request));
+    }
+
+    [[nodiscard]] auto AdvanceLsnLowWatermark(
+        TInstant now,
+        NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> TFuture<NProto::TAdvanceLsnLowWatermarkResponse> final
+    {
+        Y_UNUSED(now);
+
+        return AdvanceLsnLowWatermarkImpl(std::move(request));
     }
 };
 

--- a/cloud/storage/core/protos/device.proto
+++ b/cloud/storage/core/protos/device.proto
@@ -146,6 +146,71 @@ message TWriteLogRecordResponse
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Journal tail read request/response.
+
+message TJournalRecord
+{
+    // Pages written by this record.
+    repeated TDevicePageGroup PageGroups = 1;
+
+    // Log sequence number this record was written with.
+    uint64 LogSequenceNumber = 2;
+}
+
+message TReadJournalTailRequest
+{
+    // Headers.
+    TDeviceRequestHeaders Headers = 1;
+
+    // UUID of the device to read the journal from.
+    string DeviceUUID = 2;
+
+    // Only the records whose LogSequenceNumber is strictly greater than this
+    // value are returned.
+    uint64 AfterLogSequenceNumber = 3;
+
+    // Maximum number of records to return. Zero means "no limit".
+    uint32 MaxRecordCount = 4;
+}
+
+message TReadJournalTailResponse
+{
+    // Headers.
+    TDeviceResponseHeaders Headers = 1;
+
+    // Optional error, set only if error happened.
+    TError Error = 2;
+
+    // The records still kept in the journal, ordered by LogSequenceNumber.
+    repeated TJournalRecord Records = 3;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Lsn low watermark advance request/response.
+
+message TAdvanceLsnLowWatermarkRequest
+{
+    // Headers.
+    TDeviceRequestHeaders Headers = 1;
+
+    // UUID of the device whose watermark is being advanced.
+    string DeviceUUID = 2;
+
+    // The records with LogSequenceNumber below this value may be applied to
+    // their final locations and dropped from the journal.
+    uint64 LsnLowWatermark = 3;
+}
+
+message TAdvanceLsnLowWatermarkResponse
+{
+    // Headers.
+    TDeviceResponseHeaders Headers = 1;
+
+    // Optional error, set only if error happened.
+    TError Error = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Device protocol request/response wrappers.
 
 message TDeviceProtocolRequest
@@ -158,6 +223,8 @@ message TDeviceProtocolRequest
         TReleaseDevicesRequest ReleaseDevices = 3;
         TReadPagesRequest ReadPages = 4;
         TWriteLogRecordRequest WriteLogRecord = 5;
+        TReadJournalTailRequest ReadJournalTail = 6;
+        TAdvanceLsnLowWatermarkRequest AdvanceLsnLowWatermark = 7;
     }
 }
 
@@ -173,5 +240,7 @@ message TDeviceProtocolResponse
         TReleaseDevicesResponse ReleaseDevices = 4;
         TReadPagesResponse ReadPages = 5;
         TWriteLogRecordResponse WriteLogRecord = 6;
+        TReadJournalTailResponse ReadJournalTail = 7;
+        TAdvanceLsnLowWatermarkResponse AdvanceLsnLowWatermark = 8;
     }
 }

--- a/doc/filestore/design/storage/fastshard/storage-node.md
+++ b/doc/filestore/design/storage/fastshard/storage-node.md
@@ -9,7 +9,7 @@ page-oriented protocol with a write-ahead journal.
 The protocol is defined in `cloud/storage/core/protos/device.proto` and
 served over TCP by `cloud/storage/core/libs/journalled_device_tcp_server`.
 Each message is a `TDeviceProtocolRequest` / `TDeviceProtocolResponse` pair
-matched by `RequestId`. Four methods:
+matched by `RequestId`. Six methods:
 
 | Method | Purpose |
 |--------|---------|
@@ -17,8 +17,10 @@ matched by `RequestId`. Four methods:
 | `ReleaseDevices` | Release the writer's lock. |
 | `ReadPages` | Read page groups (`FirstPageNo`, `PageCount`, `PageSize`). |
 | `WriteLogRecord` | Write one log record: several page groups plus a `LogSequenceNumber`. |
+| `ReadJournalTail` | Read the log records still kept in the journal - needed for storage group recovery. *Not implemented yet.* |
+| `AdvanceLsnLowWatermark` | Move the LSN low watermark so that the storage node can apply and drop the journal records below it. *Not implemented yet.* |
 
-On the shard side the same four methods form the `IStorageNode` interface
+On the shard side the same six methods form the `IStorageNode` interface
 (`sn/iface/storage_node.h`); `sn/client` speaks the TCP protocol from silk
 fibers, `sn/server` and `sn/impl` provide an in-process implementation for
 tests.


### PR DESCRIPTION
### Notes
Adds two methods to the journalled device protocol. Both are stubs for now.

### Issue
https://github.com/ydb-platform/nbs/issues/6956
