### PR TITLE
[NBS] Fix service volume counter re-registration

### DIFF
--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -114,15 +114,17 @@ void TStatsServiceActor::RegisterServiceVolumeCounters(
     Y_ABORT_UNLESS(!chain.empty());
 
     if (!volume.ServiceVolumeCounters) {
+        // Initial registration: create a new counter subgroup.
         volume.ServiceVolumeCounters = RegisterChain(head, chain);
         volume.PerfCounters.Register(volume.ServiceVolumeCounters);
     } else {
-        auto parent = head;
-        for (size_t i = 0; i + 1 < chain.size(); ++i) {
-            parent = parent->GetSubgroup(chain[i].first, chain[i].second);
-        }
-
+        // Re-registration: reattach the existing subgroup to preserve accumulated counter values.
         const auto& [name, value] = chain.back();
+
+        auto parentChain = chain;
+        parentChain.pop_back();
+
+        const auto parent = RegisterChain(head, parentChain);
         parent->RegisterSubgroup(name, value, volume.ServiceVolumeCounters);
     }
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -101,7 +101,7 @@ void TStatsServiceActor::RegisterServiceVolumeCounters(
     if (!counters) {
         return;
     }
-    if (volume.ServiceVolumeCounters) {
+    if (volume.ServiceVolumeCountersRegistered) {
         return;
     }
 
@@ -110,10 +110,21 @@ void TStatsServiceActor::RegisterServiceVolumeCounters(
             ->GetSubgroup("component", "service_volume")
             ->GetSubgroup("host", "cluster");
 
-    volume.ServiceVolumeCounters =
-        RegisterChain(head, BuildVolumeChain(volume.VolumeInfo));
+    const auto chain = BuildVolumeChain(volume.VolumeInfo);
+    Y_ABORT_UNLESS(!chain.empty());
 
-    volume.PerfCounters.Register(volume.ServiceVolumeCounters);
+    if (!volume.ServiceVolumeCounters) {
+        volume.ServiceVolumeCounters = RegisterChain(head, chain);
+        volume.PerfCounters.Register(volume.ServiceVolumeCounters);
+    } else {
+        auto parent = head;
+        for (size_t i = 0; i + 1 < chain.size(); ++i) {
+            parent = parent->GetSubgroup(chain[i].first, chain[i].second);
+        }
+
+        const auto& [name, value] = chain.back();
+        parent->RegisterSubgroup(name, value, volume.ServiceVolumeCounters);
+    }
 
     NUserCounter::RegisterServiceVolume(
         *UserCounters,
@@ -122,6 +133,8 @@ void TStatsServiceActor::RegisterServiceVolumeCounters(
         volume.VolumeInfo.GetDiskId(),
         DiagnosticsConfig->GetHistogramCounterOptions(),
         volume.ServiceVolumeCounters);
+
+    volume.ServiceVolumeCountersRegistered = true;
 }
 
 void TStatsServiceActor::UnregisterServiceVolumeCounters(
@@ -132,6 +145,9 @@ void TStatsServiceActor::UnregisterServiceVolumeCounters(
         return;
     }
     if (!volume.ServiceVolumeCounters) {
+        return;
+    }
+    if (!volume.ServiceVolumeCountersRegistered) {
         return;
     }
 
@@ -148,7 +164,7 @@ void TStatsServiceActor::UnregisterServiceVolumeCounters(
         volume.VolumeInfo.GetFolderId(),
         volume.VolumeInfo.GetDiskId());
 
-    volume.ServiceVolumeCounters = nullptr;
+    volume.ServiceVolumeCountersRegistered = false;
 }
 
 void TStatsServiceActor::UpdateVolumeSelfCounters(const TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -111,26 +111,37 @@ void TStatsServiceActor::RegisterServiceVolumeCounters(
             ->GetSubgroup("component", "service_volume")
             ->GetSubgroup("host", "cluster");
 
-    const auto chain = BuildVolumeChain(volume.VolumeInfo);
+    auto chain = BuildVolumeChain(volume.VolumeInfo);
     STORAGE_VERIFY_C(
         !chain.empty(),
         TWellKnownEntityTypes::DISK,
         volume.VolumeInfo.GetDiskId(),
         "BuildVolumeChain returned an empty chain");
 
+    const auto leaf = chain.back();
+    chain.pop_back();
+
+    const auto parent = RegisterChain(head, chain);
+
     if (!volume.ServiceVolumeCounters) {
         // Initial registration: create a new counter subgroup.
-        volume.ServiceVolumeCounters = RegisterChain(head, chain);
+        volume.ServiceVolumeCounters =
+            parent->GetSubgroup(leaf.first, leaf.second);
         volume.PerfCounters.Register(volume.ServiceVolumeCounters);
     } else {
-        // Re-registration: reattach the existing subgroup to preserve accumulated counter values.
-        const auto& [name, value] = chain.back();
+        // Re-registration: reattach the existing subgroup to preserve
+        // accumulated counter values
+        const auto existing = parent->FindSubgroup(leaf.first, leaf.second);
 
-        auto parentChain = chain;
-        parentChain.pop_back();
-
-        const auto parent = RegisterChain(head, parentChain);
-        parent->RegisterSubgroup(name, value, volume.ServiceVolumeCounters);
+        if (!existing) {
+            parent->RegisterSubgroup(leaf.first, leaf.second,
+                                     volume.ServiceVolumeCounters);
+        } else if (existing != volume.ServiceVolumeCounters) {
+            // The path is occupied by an unexpected subgroup.
+            // Restore the subgroup owned by this volume.
+            parent->ReplaceSubgroup(leaf.first, leaf.second,
+                                    volume.ServiceVolumeCounters);
+        }
     }
 
     NUserCounter::RegisterServiceVolume(
@@ -151,12 +162,14 @@ void TStatsServiceActor::UnregisterServiceVolumeCounters(
     if (!counters) {
         return;
     }
-    if (!volume.ServiceVolumeCounters) {
-        return;
-    }
     if (!volume.ServiceVolumeCountersRegistered) {
         return;
     }
+
+    STORAGE_VERIFY_C(
+        volume.ServiceVolumeCounters, TWellKnownEntityTypes::DISK,
+        volume.VolumeInfo.GetDiskId(),
+        "Registered service volume counters have no retained subgroup");
 
     auto head =
         counters->GetSubgroup("counters", "blockstore")
@@ -325,8 +338,8 @@ void TStatsServiceActor::HandleVolumeConfigUpdated(
     auto *volume = State.GetVolume(msg->DiskId);
     if (!volume) {
         LOG_WARN(ctx, TBlockStoreComponents::STATS_SERVICE,
-            "Volume %s not found",
-            msg->DiskId.Quote().data());
+                 "Volume %s not found", msg->DiskId.Quote().data());
+
         return;
     }
 
@@ -335,6 +348,9 @@ void TStatsServiceActor::HandleVolumeConfigUpdated(
          volume->VolumeInfo.GetFolderId() != msg->Config.GetFolderId() ||
          volume->VolumeInfo.GetStorageMediaKind() !=
              msg->Config.GetStorageMediaKind());
+
+    const bool wasServiceVolumeCountersRegistered =
+        volume->ServiceVolumeCountersRegistered;
 
     if (updateCounters) {
         UnregisterIsLocalMountCounter(AppData(ctx)->Counters, *volume);
@@ -345,7 +361,10 @@ void TStatsServiceActor::HandleVolumeConfigUpdated(
 
     if (updateCounters) {
         RegisterIsLocalMountCounter(AppData(ctx)->Counters, *volume);
-        RegisterServiceVolumeCounters(AppData(ctx)->Counters, *volume);
+
+        if (wasServiceVolumeCountersRegistered) {
+            RegisterServiceVolumeCounters(AppData(ctx)->Counters, *volume);
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_solomon.cpp
@@ -4,6 +4,7 @@
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 
+#include <cloud/storage/core/libs/common/verify.h>
 #include <cloud/storage/core/libs/diagnostics/histogram.h>
 #include <cloud/storage/core/libs/diagnostics/weighted_percentile.h>
 
@@ -111,7 +112,11 @@ void TStatsServiceActor::RegisterServiceVolumeCounters(
             ->GetSubgroup("host", "cluster");
 
     const auto chain = BuildVolumeChain(volume.VolumeInfo);
-    Y_ABORT_UNLESS(!chain.empty());
+    STORAGE_VERIFY_C(
+        !chain.empty(),
+        TWellKnownEntityTypes::DISK,
+        volume.VolumeInfo.GetDiskId(),
+        "BuildVolumeChain returned an empty chain");
 
     if (!volume.ServiceVolumeCounters) {
         // Initial registration: create a new counter subgroup.

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -145,6 +145,8 @@ struct TVolumeStatsInfo
 
     bool IsLocalMount = false;
     NMonitoring::TDynamicCounters::TCounterPtr IsLocalMountCounter;
+
+    bool ServiceVolumeCountersRegistered = false;
     TIntrusivePtr<NMonitoring::TDynamicCounters> ServiceVolumeCounters;
 
     TDiskPerfData PerfCounters;

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_state.h
@@ -146,6 +146,14 @@ struct TVolumeStatsInfo
     bool IsLocalMount = false;
     NMonitoring::TDynamicCounters::TCounterPtr IsLocalMountCounter;
 
+    // ServiceVolumeCounters is retained across detach/reattach cycles to
+    // preserve accumulated values and references held by expiring counters.
+    // Valid states:
+    // null,     false - the subgroup has never been registered.
+    // non-null, true  - the subgroup is attached and user counters are
+    //                   registered.
+    // non-null, false - the subgroup is detached but retained for reattachment.
+    // The null, true state is invalid.
     bool ServiceVolumeCountersRegistered = false;
     TIntrusivePtr<NMonitoring::TDynamicCounters> ServiceVolumeCounters;
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -2107,7 +2107,8 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-    namespace {
+namespace
+{
 
     using TCounterGroupPtr = TIntrusivePtr<NMonitoring::TDynamicCounters>;
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -4,7 +4,6 @@
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/stats_service.h>
-#include <cloud/storage/core/libs/api/user_stats.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
 #include <cloud/blockstore/libs/storage/service/service_events_private.h>
@@ -15,6 +14,7 @@
 #include <cloud/blockstore/libs/ydbstats/ydbstats.h>
 
 #include <cloud/storage/core/config/features.pb.h>
+#include <cloud/storage/core/libs/api/user_stats.h>
 #include <cloud/storage/core/libs/common/media.h>
 
 #include <library/cpp/monlib/metrics/metric_registry.h>
@@ -2107,413 +2107,412 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace
+namespace {
+
+using TCounterGroupPtr = TIntrusivePtr<NMonitoring::TDynamicCounters>;
+
+using TCounterPath = std::initializer_list<std::pair<TString, TString>>;
+
+struct TServiceVolumeLabels {
+    TString CloudId = DefaultCloudId;
+    TString FolderId = DefaultFolderId;
+    TString type = "ssd";
+};
+
+// never creates missing groups.
+TCounterGroupPtr FindCounterGroup(
+    TCounterGroupPtr group,
+    TCounterPath path)
 {
+    for (const auto& [name, value]: path) {
+        if (!group) {
+            return {};
+        }
 
-    using TCounterGroupPtr = TIntrusivePtr<NMonitoring::TDynamicCounters>;
+        group = group->FindSubgroup(name, value);
+    }
 
-    using TCounterPath = std::initializer_list<std::pair<TString, TString>>;
+    return group;
+}
 
-    struct TServiceVolumeLabels {
-        TString CloudId = DefaultCloudId;
-        TString FolderId = DefaultFolderId;
-        TString type = "ssd";
-    };
+void AssertScalarCounter(
+    const TCounterGroupPtr& group,
+    const TString name,
+    ui64 expectedValue,
+    bool derivative = false)
+{
+    UNIT_ASSERT(group);
 
-    // never creates missing groups.
-    TCounterGroupPtr FindCounterGroup(
-        TCounterGroupPtr group,
-        TCounterPath path)
+    auto counter = group->FindCounter(name);
+    UNIT_ASSERT_C(counter, name);
+
+    UNIT_ASSERT_VALUES_EQUAL(counter->Val(), expectedValue);
+    UNIT_ASSERT_VALUES_EQUAL(counter->ForDerivative(), derivative);
+}
+
+// Check both scalar counters and nested request/histogram counters.
+void AssertPublishedVolumeCounters(
+    const TCounterGroupPtr& group,
+    ui64 latestValue,
+    ui64 accumulatedValue)
+{
+    // Expiring partition counter.
+    AssertScalarCounter(group, "IORequestsQueued", latestValue);
+
+    // Permanent partition counter.
+    AssertScalarCounter(group, "MixedBytesCount", latestValue * 100);
+
+    // Expired and permanent volume-self counters.
+    AssertScalarCounter(group, "LongRunningReadBlob", latestValue);
+    AssertScalarCounter(group, "MaxUsedQuota", latestValue);
+
+    // Cumulative scalar counter.
+    AssertScalarCounter(group, "UsedQuota", accumulatedValue, true);
+
+    auto readCounters = FindCounterGroup(group, {{"request", "ReadBlocks"}});
+    AssertScalarCounter(readCounters, "Count", accumulatedValue, true);
+
+    auto histogramGroup = FindCounterGroup(
+        readCounters,
+        {{"histogram", "ThrottlerDelay"}});
+
+    UNIT_ASSERT(histogramGroup);
+
+    auto histogram = histogramGroup->FindHistogram("ThrottlerDelay");
+    UNIT_ASSERT(histogram);
+
+    auto snapshot = histogram->Snapshot();
+    ui64 samples = 0;
+    for (ui64 i = 0; i < snapshot->Count(); ++i) {
+        samples += snapshot->Value(i);
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(samples, accumulatedValue);
+}
+
+// Reads the actor's actual user-metric supplier without JSON encoders.
+class TServiceVolumeUserMetricsProbe final
+    : public NMonitoring::IMetricConsumer
+{
+private:
+    TServiceVolumeLabels ExpectedLabels;
+    THashMap<TString, TString> CurrentLabels;
+    TString CurrentMetricName;
+
+public:
+    THashSet<TString> Names;
+    bool HasMaxUsedQuota = false;
+    i64 MaxUsedQuota = 0;
+
+    explicit TServiceVolumeUserMetricsProbe(TServiceVolumeLabels expectedLabels)
+        : ExpectedLabels(std::move(expectedLabels))
+    {}
+
+    void OnStreamBegin() override {}
+    void OnStreamEnd() override {}
+    void OnCommonTime(TInstant) override {}
+
+    void OnMetricBegin(NMonitoring::EMetricType) override
     {
+        CurrentLabels.clear();
+        CurrentMetricName.clear();
+    }
+
+    void OnMetricEnd() override {}
+    void OnLabelsBegin() override {}
+
+    void OnLabel(TStringBuf name, TStringBuf value) override
+    {
+        CurrentLabels.emplace(TString(name), TString(value));
+    }
+
+    void AssertLabel(TStringBuf name, const TString& expected)
+    {
+        const auto it = CurrentLabels.find(TString(name));
+        UNIT_ASSERT_C(
+            it != CurrentLabels.end(),
+            TStringBuilder() << "Missing user metric label: " << name);
+        UNIT_ASSERT_VALUES_EQUAL(it->second, expected);
+    }
+
+    void OnLabelsEnd() override
+    {
+        AssertLabel("service", "compute");
+        AssertLabel("project", ExpectedLabels.CloudId);
+        AssertLabel("cluster", ExpectedLabels.FolderId);
+        AssertLabel("disk", DefaultDiskId);
+
+        CurrentMetricName = CurrentLabels.at("name");
+
+        // A second registration must not produce duplicate metrics
+        UNIT_ASSERT_C(
+            Names.insert(CurrentMetricName).second,
+            CurrentMetricName);
+    }
+
+    void OnInt64(TInstant, i64 value) override
+    {
+        if (CurrentMetricName ==
+            "disk.io_quota_utilization_percentage_burst")
+        {
+            HasMaxUsedQuota = true;
+            MaxUsedQuota = value;
+        }
+    }
+
+    void OnDouble(TInstant, double) override {}
+    void OnUint64(TInstant, ui64) override {}
+
+    void OnHistogram(
+        TInstant,
+        NMonitoring::IHistogramSnapshotPtr) override
+    {}
+
+    void OnLogHistogram(
+        TInstant,
+        NMonitoring::TLogHistogramSnapshotPtr) override
+    {}
+
+    void OnSummaryDouble(
+        TInstant,
+        NMonitoring::ISummaryDoubleSnapshotPtr) override
+    {}
+};
+
+NProto::TStorageServiceConfig MakeRegistrationTestConfig()
+{
+    NProto::TStorageServiceConfig config;
+    config.SetUsePullSchemeForVolumeStatistics(false);
+    return config;
+}
+
+struct TServiceVolumeCountersTestEnv
+{
+    TTestBasicRuntime Runtime;
+    TTestEnv Env;
+    TActorId Edge;
+    NCloud::NStorage::IUserMetricsSupplierPtr UserCounters;
+    ui64 LastCookie = 0;
+
+    TServiceVolumeCountersTestEnv()
+        : Env(
+            Runtime,
+            MakeRegistrationTestConfig(),
+            NYdbStats::CreateVolumesStatsUploaderStub()),
+        Edge(Runtime.AllocateEdgeActor())
+    {
+        // Register the receiver before dispatching the stats actor's bootstrap event
+        Runtime.RegisterService(
+            NCloud::NStorage::MakeStorageUserStatsId(),
+            Edge);
+
+        auto event = Runtime.GrabEdgeEventRethrow<
+            NCloud::NStorage::TEvUserStats::TEvUserStatsProviderCreate>(
+                Edge,
+                TDuration::Seconds(5));
+
+        UNIT_ASSERT(event);
+        UserCounters = event->Get()->Provider;
+        UNIT_ASSERT(UserCounters);
+
+        RegisterVolume(Runtime, DefaultDiskId);
+    }
+
+    template <typename TEvent>
+    void SendAndDispatch(std::unique_ptr<TEvent> event)
+    {
+        const ui64 cookie = ++LastCookie;
+        const auto sender = Edge;
+        bool delivered = false;
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            [cookie, sender, &delivered](IEventHandle& ev) {
+                if (ev.GetTypeRewrite() == TEvent::EventType &&
+                    ev.Sender == sender &&
+                    ev.Cookie == cookie)
+                {
+                    delivered = true;
+                    return true;
+                }
+                return false;
+            });
+
+        Runtime.Send(
+            new IEventHandle(
+                MakeStorageStatsServiceId(),
+                sender,
+                event.release(),
+                0,
+                cookie),
+            0);
+
+        Runtime.DispatchEvents(options, TDuration::Seconds(5));
+        UNIT_ASSERT(delivered);
+    }
+
+    void Flush()
+    {
+        SendAndDispatch(std::make_unique<TEvents::TEvWakeup>());
+    }
+
+    // "value" is the latest gauge value and an increment for cumulative counters.
+    // Pass zero when disabling publication.
+    void Publish(EVolumeTestOptions options, ui64 value)
+    {
+        auto diskCounters = CreatePartitionDiskCounters(
+            EPublishingPolicy::Repl,
+            EHistogramCounterOption::ReportMultipleCounters);
+
+        auto volumeCounters = CreateVolumeSelfCounters(
+            EPublishingPolicy::Repl,
+            EHistogramCounterOption::ReportMultipleCounters);
+
+        diskCounters->Simple.IORequestsQueued.Set(value);
+        diskCounters->Simple.MixedBytesCount.Set(value * 100);
+        diskCounters->RequestCounters.ReadBlocks.Count = value;
+        diskCounters->RequestCounters.ReadBlocks.Total.Increment(
+            100,
+            value);
+
+        volumeCounters->Simple.LongRunningReadBlob.Set(value);
+        volumeCounters->Simple.MaxUsedQuota.Set(value);
+        volumeCounters->Cumulative.UsedQuota.Increment(value);
+        volumeCounters->ThrottlerDelayRequestCounters.ReadBlocks.Increment(
+            100,
+            value);
+
+        SendDiskStats(
+            Runtime,
+            DefaultDiskId,
+            false,
+            std::move(diskCounters),
+            std::move(volumeCounters),
+            options,
+            0);
+
+        Flush();
+    }
+
+    TCounterGroupPtr FindVolume(
+        const TServiceVolumeLabels& labels = {})
+    {
+        return FindCounterGroup(
+            Runtime.GetAppData(0).Counters,
+            {
+                {"counters", "blockstore"},
+                {"component", "service_volume"},
+                {"host", "cluster"},
+                {"volume", DefaultDiskId},
+                {"cloud", labels.CloudId},
+                {"folder", labels.FolderId},
+                {"type", labels.type},
+            });
+    }
+
+    void AssertDetached()
+    {
+        // The IsLocalMount branch without host=cluster is intentionally outside the scope of this check
+        auto volume = FindCounterGroup(
+            Runtime.GetAppData(0).Counters,
+            {
+                {"counters", "blockstore"},
+                {"component", "service_volume"},
+                {"host", "cluster"},
+                {"volume", DefaultDiskId},
+            });
+
+        UNIT_ASSERT(!volume);
+    }
+
+    // This fixture has one volume. Verify that no obsolete label branches
+    // or duplicate paths remain at any level below host=cluster.
+    TCounterGroupPtr AssertOnlyVolume(
+        const TServiceVolumeLabels& labels = {})
+    {
+        auto group = FindCounterGroup(
+            Runtime.GetAppData(0).Counters,
+            {
+                {"counters", "blockstore"},
+                {"component", "service_volume"},
+                {"host", "cluster"},
+            });
+
+        UNIT_ASSERT(group);
+
+        const TCounterPath path = {
+            {"volume", DefaultDiskId},
+            {"cloud", labels.CloudId},
+            {"folder", labels.FolderId},
+            {"type", labels.type},
+        };
+
         for (const auto& [name, value]: path) {
-            if (!group) {
-                return {};
-            }
+            size_t count = 0;
+
+            group->EnumerateSubgroups(
+                [&](const TString& childName, const TString& childValue) {
+                    ++count;
+                    UNIT_ASSERT_VALUES_EQUAL(name, childName);
+                    UNIT_ASSERT_VALUES_EQUAL(value, childValue);
+                });
+
+            UNIT_ASSERT_VALUES_EQUAL(1, count);
 
             group = group->FindSubgroup(name, value);
+            UNIT_ASSERT(group);
         }
 
         return group;
     }
 
-    void AssertScalarCounter(
-        const TCounterGroupPtr& group,
-        const TString name,
-        ui64 expectedValue,
-        bool derivative = false)
+    void UpdateConfig(
+        const TServiceVolumeLabels& labels,
+        NProto::EStorageMediaKind mediaKind = NProto::STORAGE_MEDIA_SSD)
     {
-        UNIT_ASSERT(group);
+        NProto::TVolume config;
+        config.SetDiskId(DefaultDiskId);
+        config.SetCloudId(labels.CloudId);
+        config.SetFolderId(labels.FolderId);
+        config.SetStorageMediaKind(mediaKind);
+        config.SetPartitionsCount(1);
 
-        auto counter = group->FindCounter(name);
-        UNIT_ASSERT_C(counter, name);
-
-        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), expectedValue);
-        UNIT_ASSERT_VALUES_EQUAL(counter->ForDerivative(), derivative);
-    }
-
-    // Check both scalar counters and nested request/histogram counters.
-    void AssertPublishedVolumeCounters(
-        const TCounterGroupPtr& group,
-        ui64 latestValue,
-        ui64 accumulatedValue)
-    {
-        // Expiring partition counter.
-        AssertScalarCounter(group, "IORequestsQueued", latestValue);
-
-        // Permanent partition counter.
-        AssertScalarCounter(group, "MixedBytesCount", latestValue * 100);
-
-        // Expired and permanent volume-self counters.
-        AssertScalarCounter(group, "LongRunningReadBlob", latestValue);
-        AssertScalarCounter(group, "MaxUsedQuota", latestValue);
-
-        // Cumulative scalar counter.
-        AssertScalarCounter(group, "UsedQuota", accumulatedValue, true);
-
-        auto readCounters = FindCounterGroup(group, {{"request", "ReadBlocks"}});
-        AssertScalarCounter(readCounters, "Count", accumulatedValue, true);
-
-        auto histogramGroup = FindCounterGroup(
-            readCounters,
-            {{"histogram", "ThrottlerDelay"}});
-
-        UNIT_ASSERT(histogramGroup);
-
-        auto histogram = histogramGroup->FindHistogram("ThrottlerDelay");
-        UNIT_ASSERT(histogram);
-
-        auto snapshot = histogram->Snapshot();
-        ui64 samples = 0;
-        for (ui64 i = 0; i < snapshot->Count(); ++i) {
-            samples += snapshot->Value(i);
-        }
-
-        UNIT_ASSERT_VALUES_EQUAL(samples, accumulatedValue);
-    }
-
-    // Reads the actor's actual user-metric supplier without JSON encoders.
-    class TServiceVolumeUserMetricsProbe final
-        : public NMonitoring::IMetricConsumer
-    {
-    private:
-        TServiceVolumeLabels ExpectedLabels;
-        THashMap<TString, TString> CurrentLabels;
-        TString CurrentMetricName;
-
-    public:
-        THashSet<TString> Names;
-        bool HasMaxUsedQuota = false;
-        i64 MaxUsedQuota = 0;
-
-        explicit TServiceVolumeUserMetricsProbe(TServiceVolumeLabels expectedLabels)
-            : ExpectedLabels(std::move(expectedLabels))
-        {}
-
-        void OnStreamBegin() override {}
-        void OnStreamEnd() override {}
-        void OnCommonTime(TInstant) override {}
-
-        void OnMetricBegin(NMonitoring::EMetricType) override
-        {
-            CurrentLabels.clear();
-            CurrentMetricName.clear();
-        }
-
-        void OnMetricEnd() override {}
-        void OnLabelsBegin() override {}
-
-        void OnLabel(TStringBuf name, TStringBuf value) override
-        {
-            CurrentLabels.emplace(TString(name), TString(value));
-        }
-
-        void AssertLabel(TStringBuf name, const TString& expected)
-        {
-            const auto it = CurrentLabels.find(TString(name));
-            UNIT_ASSERT_C(
-                it != CurrentLabels.end(),
-                TStringBuilder() << "Missing user metric label: " << name);
-            UNIT_ASSERT_VALUES_EQUAL(it->second, expected);
-        }
-
-        void OnLabelsEnd() override
-        {
-            AssertLabel("service", "compute");
-            AssertLabel("project", ExpectedLabels.CloudId);
-            AssertLabel("cluster", ExpectedLabels.FolderId);
-            AssertLabel("disk", DefaultDiskId);
-
-            CurrentMetricName = CurrentLabels.at("name");
-
-            // A second registration must not produce duplicate metrics
-            UNIT_ASSERT_C(
-                Names.insert(CurrentMetricName).second,
-                CurrentMetricName);
-        }
-
-        void OnInt64(TInstant, i64 value) override
-        {
-            if (CurrentMetricName ==
-                "disk.io_quota_utilization_percentage_burst")
-            {
-                HasMaxUsedQuota = true;
-                MaxUsedQuota = value;
-            }
-        }
-
-        void OnDouble(TInstant, double) override {}
-        void OnUint64(TInstant, ui64) override {}
-
-        void OnHistogram(
-            TInstant,
-            NMonitoring::IHistogramSnapshotPtr) override
-        {}
-
-        void OnLogHistogram(
-            TInstant,
-            NMonitoring::TLogHistogramSnapshotPtr) override
-        {}
-
-        void OnSummaryDouble(
-            TInstant,
-            NMonitoring::ISummaryDoubleSnapshotPtr) override
-        {}
-    };
-
-    NProto::TStorageServiceConfig MakeRegistrationTestConfig()
-    {
-        NProto::TStorageServiceConfig config;
-        config.SetUsePullSchemeForVolumeStatistics(false);
-        return config;
-    }
-
-    struct TServiceVolumeCountersTestEnv
-    {
-        TTestBasicRuntime Runtime;
-        TTestEnv Env;
-        TActorId Edge;
-        NCloud::NStorage::IUserMetricsSupplierPtr UserCounters;
-        ui64 LastCookie = 0;
-
-        TServiceVolumeCountersTestEnv()
-            : Env(
-                Runtime,
-                MakeRegistrationTestConfig(),
-                NYdbStats::CreateVolumesStatsUploaderStub()),
-            Edge(Runtime.AllocateEdgeActor())
-        {
-            // Register the receiver before dispatching the stats actor's bootstrap event
-            Runtime.RegisterService(
-                NCloud::NStorage::MakeStorageUserStatsId(),
-                Edge);
-
-            auto event = Runtime.GrabEdgeEventRethrow<
-                NCloud::NStorage::TEvUserStats::TEvUserStatsProviderCreate>(
-                    Edge,
-                    TDuration::Seconds(5));
-
-            UNIT_ASSERT(event);
-            UserCounters = event->Get()->Provider;
-            UNIT_ASSERT(UserCounters);
-
-            RegisterVolume(Runtime, DefaultDiskId);
-        }
-
-        template <typename TEvent>
-        void SendAndDispatch(std::unique_ptr<TEvent> event)
-        {
-            const ui64 cookie = ++LastCookie;
-            const auto sender = Edge;
-            bool delivered = false;
-
-            TDispatchOptions options;
-            options.FinalEvents.emplace_back(
-                [cookie, sender, &delivered](IEventHandle& ev) {
-                    if (ev.GetTypeRewrite() == TEvent::EventType &&
-                        ev.Sender == sender &&
-                        ev.Cookie == cookie)
-                    {
-                        delivered = true;
-                        return true;
-                    }
-                    return false;
-                });
-
-            Runtime.Send(
-                new IEventHandle(
-                    MakeStorageStatsServiceId(),
-                    sender,
-                    event.release(),
-                    0,
-                    cookie),
-                0);
-
-            Runtime.DispatchEvents(options, TDuration::Seconds(5));
-            UNIT_ASSERT(delivered);
-        }
-
-        void Flush()
-        {
-            SendAndDispatch(std::make_unique<TEvents::TEvWakeup>());
-        }
-
-        // "value" is the latest gauge value and an increment for cumulative counters.
-        // Pass zero when disabling publication.
-        void Publish(EVolumeTestOptions options, ui64 value)
-        {
-            auto diskCounters = CreatePartitionDiskCounters(
-                EPublishingPolicy::Repl,
-                EHistogramCounterOption::ReportMultipleCounters);
-
-            auto volumeCounters = CreateVolumeSelfCounters(
-                EPublishingPolicy::Repl,
-                EHistogramCounterOption::ReportMultipleCounters);
-
-            diskCounters->Simple.IORequestsQueued.Set(value);
-            diskCounters->Simple.MixedBytesCount.Set(value * 100);
-            diskCounters->RequestCounters.ReadBlocks.Count = value;
-            diskCounters->RequestCounters.ReadBlocks.Total.Increment(
-                100,
-                value);
-
-            volumeCounters->Simple.LongRunningReadBlob.Set(value);
-            volumeCounters->Simple.MaxUsedQuota.Set(value);
-            volumeCounters->Cumulative.UsedQuota.Increment(value);
-            volumeCounters->ThrottlerDelayRequestCounters.ReadBlocks.Increment(
-                100,
-                value);
-
-            SendDiskStats(
-                Runtime,
+        SendAndDispatch(
+            std::make_unique<TEvStatsService::TEvVolumeConfigUpdated>(
                 DefaultDiskId,
-                false,
-                std::move(diskCounters),
-                std::move(volumeCounters),
-                options,
-                0);
+                std::move(config)));
+    }
 
-            Flush();
+    void AssertUserCounters(
+        bool registered,
+        ui64 expectedMaxUsedQuota = 0,
+        const TServiceVolumeLabels& labels = {})
+    {
+        TServiceVolumeUserMetricsProbe probe(labels);
+        UserCounters->Accept(Runtime.GetCurrentTime(), &probe);
+
+        if (!registered) {
+            UNIT_ASSERT(probe.Names.empty());
+            UNIT_ASSERT(!probe.HasMaxUsedQuota);
+            return;
         }
 
-        TCounterGroupPtr FindVolume(
-            const TServiceVolumeLabels& labels = {})
+        UNIT_ASSERT_VALUES_EQUAL(probe.Names.size(), 4);
+
+        for (const auto* name: {
+                "disk.io_quota_utilization_percentage",
+                "disk.io_quota_utilization_percentage_burst",
+                "disk.read_throttler_delay",
+                "disk.write_throttler_delay"})
+
         {
-            return FindCounterGroup(
-                Runtime.GetAppData(0).Counters,
-                {
-                    {"counters", "blockstore"},
-                    {"component", "service_volume"},
-                    {"host", "cluster"},
-                    {"volume", DefaultDiskId},
-                    {"cloud", labels.CloudId},
-                    {"folder", labels.FolderId},
-                    {"type", labels.type},
-                });
+            UNIT_ASSERT_C(probe.Names.contains(name), name);
         }
 
-        void AssertDetached()
-        {
-            // The IsLocalMount branch without host=cluster is intentionally outside the scope of this check
-            auto volume = FindCounterGroup(
-                Runtime.GetAppData(0).Counters,
-                {
-                    {"counters", "blockstore"},
-                    {"component", "service_volume"},
-                    {"host", "cluster"},
-                    {"volume", DefaultDiskId},
-                });
-
-            UNIT_ASSERT(!volume);
-        }
-
-        // This fixture has one volume. Verify that no obsolete label branches
-        // or duplicate paths remain at any level below host=cluster.
-        TCounterGroupPtr AssertOnlyVolume(
-            const TServiceVolumeLabels& labels = {})
-        {
-            auto group = FindCounterGroup(
-                Runtime.GetAppData(0).Counters,
-                {
-                    {"counters", "blockstore"},
-                    {"component", "service_volume"},
-                    {"host", "cluster"},
-                });
-
-            UNIT_ASSERT(group);
-
-            const TCounterPath path = {
-                {"volume", DefaultDiskId},
-                {"cloud", labels.CloudId},
-                {"folder", labels.FolderId},
-                {"type", labels.type},
-            };
-
-            for (const auto& [name, value]: path) {
-                size_t count = 0;
-
-                group->EnumerateSubgroups(
-                    [&](const TString& childName, const TString& childValue) {
-                        ++count;
-                        UNIT_ASSERT_VALUES_EQUAL(name, childName);
-                        UNIT_ASSERT_VALUES_EQUAL(value, childValue);
-                    });
-
-                UNIT_ASSERT_VALUES_EQUAL(1, count);
-
-                group = group->FindSubgroup(name, value);
-                UNIT_ASSERT(group);
-            }
-
-            return group;
-        }
-
-        void UpdateConfig(
-            const TServiceVolumeLabels& labels,
-            NProto::EStorageMediaKind mediaKind = NProto::STORAGE_MEDIA_SSD)
-        {
-            NProto::TVolume config;
-            config.SetDiskId(DefaultDiskId);
-            config.SetCloudId(labels.CloudId);
-            config.SetFolderId(labels.FolderId);
-            config.SetStorageMediaKind(mediaKind);
-            config.SetPartitionsCount(1);
-
-            SendAndDispatch(
-                std::make_unique<TEvStatsService::TEvVolumeConfigUpdated>(
-                    DefaultDiskId,
-                    std::move(config)));
-        }
-
-        void AssertUserCounters(
-            bool registered,
-            ui64 expectedMaxUsedQuota = 0,
-            const TServiceVolumeLabels& labels = {})
-        {
-            TServiceVolumeUserMetricsProbe probe(labels);
-            UserCounters->Accept(Runtime.GetCurrentTime(), &probe);
-
-            if (!registered) {
-                UNIT_ASSERT(probe.Names.empty());
-                UNIT_ASSERT(!probe.HasMaxUsedQuota);
-                return;
-            }
-
-            UNIT_ASSERT_VALUES_EQUAL(probe.Names.size(), 4);
-
-            for (const auto* name: {
-                    "disk.io_quota_utilization_percentage",
-                    "disk.io_quota_utilization_percentage_burst",
-                    "disk.read_throttler_delay",
-                    "disk.write_throttler_delay"})
-
-            {
-                UNIT_ASSERT_C(probe.Names.contains(name), name);
-            }
-
-            UNIT_ASSERT(probe.HasMaxUsedQuota);
-            UNIT_ASSERT_VALUES_EQUAL(probe.MaxUsedQuota, expectedMaxUsedQuota);
-        }
-    };
+        UNIT_ASSERT(probe.HasMaxUsedQuota);
+        UNIT_ASSERT_VALUES_EQUAL(probe.MaxUsedQuota, expectedMaxUsedQuota);
+    }
+};
 
 }  // namespace
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -4,7 +4,9 @@
 #include <cloud/blockstore/libs/diagnostics/stats_aggregator.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/stats_service.h>
+#include <cloud/storage/core/libs/api/user_stats.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/core/disk_counters.h>
 #include <cloud/blockstore/libs/storage/service/service_events_private.h>
 #include <cloud/blockstore/libs/storage/stats_service/stats_service.h>
 #include <cloud/blockstore/libs/storage/stats_service/stats_service_events_private.h>
@@ -15,12 +17,18 @@
 #include <cloud/storage/core/config/features.pb.h>
 #include <cloud/storage/core/libs/common/media.h>
 
+#include <library/cpp/monlib/metrics/metric_registry.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/datetime/base.h>
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
 #include <util/generic/size_literals.h>
 #include <util/generic/string.h>
 #include <util/string/printf.h>
+
+#include <initializer_list>
+#include <utility>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -2094,6 +2102,643 @@ Y_UNIT_TEST_SUITE(TServiceVolumeStatsTest)
             {0},
             EVolumeTestOptions::VOLUME_HASCLIENTS);
         UNIT_ASSERT(counters[0] == 1);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+    namespace {
+
+    using TCounterGroupPtr = TIntrusivePtr<NMonitoring::TDynamicCounters>;
+
+    using TCounterPath = std::initializer_list<std::pair<TString, TString>>;
+
+    struct TServiceVolumeLabels {
+        TString CloudId = DefaultCloudId;
+        TString FolderId = DefaultFolderId;
+        TString type = "ssd";
+    };
+
+    // never creates missing groups.
+    TCounterGroupPtr FindCounterGroup(
+        TCounterGroupPtr group,
+        TCounterPath path)
+    {
+        for (const auto& [name, value]: path) {
+            if (!group) {
+                return {};
+            }
+
+            group = group->FindSubgroup(name, value);
+        }
+
+        return group;
+    }
+
+    void AssertScalarCounter(
+        const TCounterGroupPtr& group,
+        const TString name,
+        ui64 expectedValue,
+        bool derivative = false)
+    {
+        UNIT_ASSERT(group);
+
+        auto counter = group->FindCounter(name);
+        UNIT_ASSERT_C(counter, name);
+
+        UNIT_ASSERT_VALUES_EQUAL(counter->Val(), expectedValue);
+        UNIT_ASSERT_VALUES_EQUAL(counter->ForDerivative(), derivative);
+    }
+
+    // Check both scalar counters and nested request/histogram counters.
+    void AssertPublishedVolumeCounters(
+        const TCounterGroupPtr& group,
+        ui64 latestValue,
+        ui64 accumulatedValue)
+    {
+        // Expiring partition counter.
+        AssertScalarCounter(group, "IORequestsQueued", latestValue);
+
+        // Permanent partition counter.
+        AssertScalarCounter(group, "MixedBytesCount", latestValue * 100);
+
+        // Expired and permanent volume-self counters.
+        AssertScalarCounter(group, "LongRunningReadBlob", latestValue);
+        AssertScalarCounter(group, "MaxUsedQuota", latestValue);
+
+        // Cumulative scalar counter.
+        AssertScalarCounter(group, "UsedQuota", accumulatedValue, true);
+
+        auto readCounters = FindCounterGroup(group, {{"request", "ReadBlocks"}});
+        AssertScalarCounter(readCounters, "Count", accumulatedValue, true);
+
+        auto histogramGroup = FindCounterGroup(
+            readCounters,
+            {{"histogram", "ThrottlerDelay"}});
+
+        UNIT_ASSERT(histogramGroup);
+
+        auto histogram = histogramGroup->FindHistogram("ThrottlerDelay");
+        UNIT_ASSERT(histogram);
+
+        auto snapshot = histogram->Snapshot();
+        ui64 samples = 0;
+        for (ui64 i = 0; i < snapshot->Count(); ++i) {
+            samples += snapshot->Value(i);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(samples, accumulatedValue);
+    }
+
+    // Reads the actor's actual user-metric supplier without JSON encoders.
+    class TServiceVolumeUserMetricsProbe final
+        : public NMonitoring::IMetricConsumer
+    {
+    private:
+        TServiceVolumeLabels ExpectedLabels;
+        THashMap<TString, TString> CurrentLabels;
+        TString CurrentMetricName;
+
+    public:
+        THashSet<TString> Names;
+        bool HasMaxUsedQuota = false;
+        i64 MaxUsedQuota = 0;
+
+        explicit TServiceVolumeUserMetricsProbe(TServiceVolumeLabels expectedLabels)
+            : ExpectedLabels(std::move(expectedLabels))
+        {}
+
+        void OnStreamBegin() override {}
+        void OnStreamEnd() override {}
+        void OnCommonTime(TInstant) override {}
+
+        void OnMetricBegin(NMonitoring::EMetricType) override
+        {
+            CurrentLabels.clear();
+            CurrentMetricName.clear();
+        }
+
+        void OnMetricEnd() override {}
+        void OnLabelsBegin() override {}
+
+        void OnLabel(TStringBuf name, TStringBuf value) override
+        {
+            CurrentLabels.emplace(TString(name), TString(value));
+        }
+
+        void AssertLabel(TStringBuf name, const TString& expected)
+        {
+            const auto it = CurrentLabels.find(TString(name));
+            UNIT_ASSERT_C(
+                it != CurrentLabels.end(),
+                TStringBuilder() << "Missing user metric label: " << name);
+            UNIT_ASSERT_VALUES_EQUAL(it->second, expected);
+        }
+
+        void OnLabelsEnd() override
+        {
+            AssertLabel("service", "compute");
+            AssertLabel("project", ExpectedLabels.CloudId);
+            AssertLabel("cluster", ExpectedLabels.FolderId);
+            AssertLabel("disk", DefaultDiskId);
+
+            CurrentMetricName = CurrentLabels.at("name");
+
+            // A second registration must not produce duplicate metrics
+            UNIT_ASSERT_C(
+                Names.insert(CurrentMetricName).second,
+                CurrentMetricName);
+        }
+
+        void OnInt64(TInstant, i64 value) override
+        {
+            if (CurrentMetricName ==
+                "disk.io_quota_utilization_percentage_burst")
+            {
+                HasMaxUsedQuota = true;
+                MaxUsedQuota = value;
+            }
+        }
+
+        void OnDouble(TInstant, double) override {}
+        void OnUint64(TInstant, ui64) override {}
+
+        void OnHistogram(
+            TInstant,
+            NMonitoring::IHistogramSnapshotPtr) override
+        {}
+
+        void OnLogHistogram(
+            TInstant,
+            NMonitoring::TLogHistogramSnapshotPtr) override
+        {}
+
+        void OnSummaryDouble(
+            TInstant,
+            NMonitoring::ISummaryDoubleSnapshotPtr) override
+        {}
+    };
+
+    NProto::TStorageServiceConfig MakeRegistrationTestConfig()
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetUsePullSchemeForVolumeStatistics(false);
+        return config;
+    }
+
+    struct TServiceVolumeCountersTestEnv
+    {
+        TTestBasicRuntime Runtime;
+        TTestEnv Env;
+        TActorId Edge;
+        NCloud::NStorage::IUserMetricsSupplierPtr UserCounters;
+        ui64 LastCookie = 0;
+
+        TServiceVolumeCountersTestEnv()
+            : Env(
+                Runtime,
+                MakeRegistrationTestConfig(),
+                NYdbStats::CreateVolumesStatsUploaderStub()),
+            Edge(Runtime.AllocateEdgeActor())
+        {
+            // Register the receiver before dispatching the stats actor's bootstrap event
+            Runtime.RegisterService(
+                NCloud::NStorage::MakeStorageUserStatsId(),
+                Edge);
+
+            auto event = Runtime.GrabEdgeEventRethrow<
+                NCloud::NStorage::TEvUserStats::TEvUserStatsProviderCreate>(
+                    Edge,
+                    TDuration::Seconds(5));
+
+            UNIT_ASSERT(event);
+            UserCounters = event->Get()->Provider;
+            UNIT_ASSERT(UserCounters);
+
+            RegisterVolume(Runtime, DefaultDiskId);
+        }
+
+        template <typename TEvent>
+        void SendAndDispatch(std::unique_ptr<TEvent> event)
+        {
+            const ui64 cookie = ++LastCookie;
+            const auto sender = Edge;
+            bool delivered = false;
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                [cookie, sender, &delivered](IEventHandle& ev) {
+                    if (ev.GetTypeRewrite() == TEvent::EventType &&
+                        ev.Sender == sender &&
+                        ev.Cookie == cookie)
+                    {
+                        delivered = true;
+                        return true;
+                    }
+                    return false;
+                });
+
+            Runtime.Send(
+                new IEventHandle(
+                    MakeStorageStatsServiceId(),
+                    sender,
+                    event.release(),
+                    0,
+                    cookie),
+                0);
+
+            Runtime.DispatchEvents(options, TDuration::Seconds(5));
+            UNIT_ASSERT(delivered);
+        }
+
+        void Flush()
+        {
+            SendAndDispatch(std::make_unique<TEvents::TEvWakeup>());
+        }
+
+        // "value" is the latest gauge value and an increment for cumulative counters.
+        // Pass zero when disabling publication.
+        void Publish(EVolumeTestOptions options, ui64 value)
+        {
+            auto diskCounters = CreatePartitionDiskCounters(
+                EPublishingPolicy::Repl,
+                EHistogramCounterOption::ReportMultipleCounters);
+
+            auto volumeCounters = CreateVolumeSelfCounters(
+                EPublishingPolicy::Repl,
+                EHistogramCounterOption::ReportMultipleCounters);
+
+            diskCounters->Simple.IORequestsQueued.Set(value);
+            diskCounters->Simple.MixedBytesCount.Set(value * 100);
+            diskCounters->RequestCounters.ReadBlocks.Count = value;
+            diskCounters->RequestCounters.ReadBlocks.Total.Increment(
+                100,
+                value);
+
+            volumeCounters->Simple.LongRunningReadBlob.Set(value);
+            volumeCounters->Simple.MaxUsedQuota.Set(value);
+            volumeCounters->Cumulative.UsedQuota.Increment(value);
+            volumeCounters->ThrottlerDelayRequestCounters.ReadBlocks.Increment(
+                100,
+                value);
+
+            SendDiskStats(
+                Runtime,
+                DefaultDiskId,
+                false,
+                std::move(diskCounters),
+                std::move(volumeCounters),
+                options,
+                0);
+
+            Flush();
+        }
+
+        TCounterGroupPtr FindVolume(
+            const TServiceVolumeLabels& labels = {})
+        {
+            return FindCounterGroup(
+                Runtime.GetAppData(0).Counters,
+                {
+                    {"counters", "blockstore"},
+                    {"component", "service_volume"},
+                    {"host", "cluster"},
+                    {"volume", DefaultDiskId},
+                    {"cloud", labels.CloudId},
+                    {"folder", labels.FolderId},
+                    {"type", labels.type},
+                });
+        }
+
+        void AssertDetached()
+        {
+            // The IsLocalMount branch without host=cluster is intentionally outside the scope of this check
+            auto volume = FindCounterGroup(
+                Runtime.GetAppData(0).Counters,
+                {
+                    {"counters", "blockstore"},
+                    {"component", "service_volume"},
+                    {"host", "cluster"},
+                    {"volume", DefaultDiskId},
+                });
+
+            UNIT_ASSERT(!volume);
+        }
+
+        // This fixture has one volume. Verify that no obsolete label branches
+        // or duplicate paths remain at any level below host=cluster.
+        TCounterGroupPtr AssertOnlyVolume(
+            const TServiceVolumeLabels& labels = {})
+        {
+            auto group = FindCounterGroup(
+                Runtime.GetAppData(0).Counters,
+                {
+                    {"counters", "blockstore"},
+                    {"component", "service_volume"},
+                    {"host", "cluster"},
+                });
+
+            UNIT_ASSERT(group);
+
+            const TCounterPath path = {
+                {"volume", DefaultDiskId},
+                {"cloud", labels.CloudId},
+                {"folder", labels.FolderId},
+                {"type", labels.type},
+            };
+
+            for (const auto& [name, value]: path) {
+                size_t count = 0;
+
+                group->EnumerateSubgroups(
+                    [&](const TString& childName, const TString& childValue) {
+                        ++count;
+                        UNIT_ASSERT_VALUES_EQUAL(name, childName);
+                        UNIT_ASSERT_VALUES_EQUAL(value, childValue);
+                    });
+
+                UNIT_ASSERT_VALUES_EQUAL(1, count);
+
+                group = group->FindSubgroup(name, value);
+                UNIT_ASSERT(group);
+            }
+
+            return group;
+        }
+
+        void UpdateConfig(
+            const TServiceVolumeLabels& labels,
+            NProto::EStorageMediaKind mediaKind = NProto::STORAGE_MEDIA_SSD)
+        {
+            NProto::TVolume config;
+            config.SetDiskId(DefaultDiskId);
+            config.SetCloudId(labels.CloudId);
+            config.SetFolderId(labels.FolderId);
+            config.SetStorageMediaKind(mediaKind);
+            config.SetPartitionsCount(1);
+
+            SendAndDispatch(
+                std::make_unique<TEvStatsService::TEvVolumeConfigUpdated>(
+                    DefaultDiskId,
+                    std::move(config)));
+        }
+
+        void AssertUserCounters(
+            bool registered,
+            ui64 expectedMaxUsedQuota = 0,
+            const TServiceVolumeLabels& labels = {})
+        {
+            TServiceVolumeUserMetricsProbe probe(labels);
+            UserCounters->Accept(Runtime.GetCurrentTime(), &probe);
+
+            if (!registered) {
+                UNIT_ASSERT(probe.Names.empty());
+                UNIT_ASSERT(!probe.HasMaxUsedQuota);
+                return;
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(probe.Names.size(), 4);
+
+            for (const auto* name: {
+                    "disk.io_quota_utilization_percentage",
+                    "disk.io_quota_utilization_percentage_burst",
+                    "disk.read_throttler_delay",
+                    "disk.write_throttler_delay"})
+
+            {
+                UNIT_ASSERT_C(probe.Names.contains(name), name);
+            }
+
+            UNIT_ASSERT(probe.HasMaxUsedQuota);
+            UNIT_ASSERT_VALUES_EQUAL(probe.MaxUsedQuota, expectedMaxUsedQuota);
+        }
+    };
+
+}  // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TServiceVolumeCountersReregistrationTest)
+{
+    Y_UNIT_TEST(ShouldRegisterServiceVolumeCountersAfterClientsReturn)
+    {
+        TServiceVolumeCountersTestEnv env;
+
+        env.Publish(VOLUME_HASCLIENTS, 7);
+
+        auto original = env.AssertOnlyVolume();
+        AssertPublishedVolumeCounters(original, 7, 7);
+
+        // Materialize the expiring counter before detaching the group.
+        auto originalQueued = original->FindCounter("IORequestsQueued");
+        UNIT_ASSERT(originalQueued);
+
+        env.Publish({}, 0);
+        env.AssertDetached();
+
+        env.Publish(VOLUME_HASCLIENTS, 11);
+
+        auto restored = env.AssertOnlyVolume();
+        AssertPublishedVolumeCounters(restored, 11, 18);
+
+        UNIT_ASSERT(original.Get() == restored.Get());
+
+        auto restoredQueued = restored->FindCounter("IORequestsQueued");
+        UNIT_ASSERT(restoredQueued);
+        UNIT_ASSERT(originalQueued.Get() == restoredQueued.Get());
+    }
+
+    Y_UNIT_TEST(ShouldRegisterServiceVolumeCountersAfterCheckpointAppears)
+    {
+        TServiceVolumeCountersTestEnv env;
+
+        // No clients and no checkpoint.
+        env.Publish({}, 0);
+        env.AssertDetached();
+
+        // Publication starts because of a checkpoint alone.
+        env.Publish(VOLUME_HASCHECKPOINT, 3);
+
+        auto original = env.AssertOnlyVolume();
+        AssertPublishedVolumeCounters(original, 3, 3);
+
+        env.Publish({}, 0);
+        env.AssertDetached();
+
+        // Still no clients: the checkpoint restores publication.
+        env.Publish(VOLUME_HASCHECKPOINT, 5);
+
+        auto restored = env.AssertOnlyVolume();
+        AssertPublishedVolumeCounters(restored, 5, 8);
+        UNIT_ASSERT(original.Get() == restored.Get());
+    }
+
+    Y_UNIT_TEST(ShouldMoveServiceVolumeCountersAfterVolumeConfigUpdate)
+    {
+        struct TCase
+        {
+            TServiceVolumeLabels Labels;
+            NProto::EStorageMediaKind MediaKind;
+        };
+
+        const TCase cases[] = {
+            {
+                {"new_cloud", DefaultFolderId, "ssd"},
+                NProto::STORAGE_MEDIA_SSD,
+            },
+            {
+                {DefaultCloudId, "new_folder", "ssd"},
+                NProto::STORAGE_MEDIA_SSD,
+            },
+            {
+                {"new_cloud", "new_folder", "ssd"},
+                NProto::STORAGE_MEDIA_SSD,
+            },
+            {
+                {DefaultCloudId, DefaultFolderId, "hdd"},
+                NProto::STORAGE_MEDIA_HDD,
+            },
+        };
+
+        for (const auto& testCase: cases) {
+            TServiceVolumeCountersTestEnv env;
+
+            env.Publish(VOLUME_HASCLIENTS, 7);
+            auto original = env.AssertOnlyVolume();
+            AssertPublishedVolumeCounters(original, 7, 7);
+
+            env.UpdateConfig(testCase.Labels, testCase.MediaKind);
+
+            UNIT_ASSERT(!env.FindVolume());
+
+            auto moved = env.AssertOnlyVolume(testCase.Labels);
+            UNIT_ASSERT(original.Get() == moved.Get());
+
+            // Reattachment preserves already published counters.
+            AssertPublishedVolumeCounters(moved, 7, 7);
+            env.AssertUserCounters(true, 7, testCase.Labels);
+
+            env.Publish(VOLUME_HASCLIENTS, 11);
+
+            AssertPublishedVolumeCounters(
+                env.AssertOnlyVolume(testCase.Labels),
+                11,
+                18);
+            UNIT_ASSERT(!env.FindVolume());
+
+            // Subsequent detach/reattach must use the NEW labels too.
+            env.Publish({}, 0);
+            env.AssertDetached();
+            env.AssertUserCounters(false);
+
+            env.Publish(VOLUME_HASCLIENTS, 13);
+
+            auto restored = env.AssertOnlyVolume(testCase.Labels);
+            UNIT_ASSERT(original.Get() == restored.Get());
+            AssertPublishedVolumeCounters(restored, 13, 31);
+
+            UNIT_ASSERT(!env.FindVolume());
+            env.AssertUserCounters(true, 13, testCase.Labels);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRegisterServiceVolumeCountersAcrossMultipleCycles)
+    {
+        TServiceVolumeCountersTestEnv env;
+
+        TCounterGroupPtr original;
+        ui64 accumulated = 0;
+
+        for (const ui64 value: {7, 11, 13}) {
+            env.Publish(VOLUME_HASCLIENTS, value);
+            accumulated += value;
+
+            auto current = env.AssertOnlyVolume();
+            if (!original) {
+                original = current;
+            }
+
+            UNIT_ASSERT(original.Get() == current.Get());
+            AssertPublishedVolumeCounters(current, value, accumulated);
+
+            // true -> true: repeated registration must be harmless
+            env.Publish(VOLUME_HASCLIENTS, value);
+            accumulated += value;
+
+            auto repeated = env.AssertOnlyVolume();
+            UNIT_ASSERT(original.Get() == repeated.Get());
+            AssertPublishedVolumeCounters(repeated, value, accumulated);
+            env.AssertUserCounters(true, value);
+
+            if (value != 13) {
+                env.Publish({}, 0);
+                env.AssertDetached();
+                env.AssertUserCounters(false);
+
+                // false -> false: repeated unregister must be harmless
+                env.Publish({}, 0);
+                env.AssertDetached();
+                env.AssertUserCounters(false);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ShouldPreserveCumulativeCountersAfterRegistration)
+    {
+        TServiceVolumeCountersTestEnv env;
+
+        env.Publish(VOLUME_HASCLIENTS, 10);
+        AssertPublishedVolumeCounters(env.AssertOnlyVolume(), 10, 10);
+
+        env.Publish({}, 0);
+        env.AssertDetached();
+
+        env.Publish(VOLUME_HASCLIENTS, 3);
+        AssertPublishedVolumeCounters(env.AssertOnlyVolume(), 3, 13);
+
+        env.Flush();
+
+        AssertPublishedVolumeCounters(env.AssertOnlyVolume(), 0, 13);
+    }
+
+    Y_UNIT_TEST(ShouldRegisterServiceVolumeUserCounters)
+    {
+        TServiceVolumeCountersTestEnv env;
+
+        env.AssertUserCounters(false);
+
+        env.Publish(VOLUME_HASCLIENTS, 7);
+        env.AssertUserCounters(true, 7);
+
+        env.Publish({}, 0);
+        env.AssertDetached();
+        env.AssertUserCounters(false);
+
+        env.Publish(VOLUME_HASCLIENTS, 11);
+        env.AssertUserCounters(true, 11);
+
+        // Repeated publication must neither duplicate user metrics nor leave them bound to stale values.
+        env.Publish(VOLUME_HASCLIENTS, 13);
+        env.AssertUserCounters(true, 13);
+
+        const TServiceVolumeLabels labels = {
+            "new_cloud",
+            "new_folder",
+            "ssd",
+        };
+
+        env.UpdateConfig(labels);
+
+        env.AssertUserCounters(true, 13, labels);
+
+        env.Publish(VOLUME_HASCLIENTS, 17);
+        env.AssertUserCounters(true, 17, labels);
+
+        env.Publish({}, 0);
+        env.AssertUserCounters(false);
+
+        env.Publish(VOLUME_HASCHECKPOINT, 19);
+        env.AssertUserCounters(true, 19, labels);
     }
 }
 

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_ut.cpp
@@ -2116,7 +2116,7 @@ using TCounterPath = std::initializer_list<std::pair<TString, TString>>;
 struct TServiceVolumeLabels {
     TString CloudId = DefaultCloudId;
     TString FolderId = DefaultFolderId;
-    TString type = "ssd";
+    TString Type = "ssd";
 };
 
 // never creates missing groups.
@@ -2135,11 +2135,8 @@ TCounterGroupPtr FindCounterGroup(
     return group;
 }
 
-void AssertScalarCounter(
-    const TCounterGroupPtr& group,
-    const TString name,
-    ui64 expectedValue,
-    bool derivative = false)
+void AssertScalarCounter(const TCounterGroupPtr& group, const TString& name,
+                         ui64 expectedValue, bool derivative = false)
 {
     UNIT_ASSERT(group);
 
@@ -2242,7 +2239,11 @@ public:
         AssertLabel("cluster", ExpectedLabels.FolderId);
         AssertLabel("disk", DefaultDiskId);
 
-        CurrentMetricName = CurrentLabels.at("name");
+        const auto it = CurrentLabels.find("name");
+        UNIT_ASSERT_C(it != CurrentLabels.end(),
+                      "Missing user metric label: name");
+
+        CurrentMetricName = it->second;
 
         // A second registration must not produce duplicate metrics
         UNIT_ASSERT_C(
@@ -2406,8 +2407,21 @@ struct TServiceVolumeCountersTestEnv
                 {"volume", DefaultDiskId},
                 {"cloud", labels.CloudId},
                 {"folder", labels.FolderId},
-                {"type", labels.type},
+                {"type", labels.Type},
             });
+    }
+
+    TCounterGroupPtr CreateUnexpectedServiceVolumeSubgroup(
+        const TServiceVolumeLabels& labels = {})
+    {
+        return Runtime.GetAppData(0)
+            .Counters->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "service_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", DefaultDiskId)
+            ->GetSubgroup("cloud", labels.CloudId)
+            ->GetSubgroup("folder", labels.FolderId)
+            ->GetSubgroup("type", labels.Type);
     }
 
     void AssertDetached()
@@ -2444,7 +2458,7 @@ struct TServiceVolumeCountersTestEnv
             {"volume", DefaultDiskId},
             {"cloud", labels.CloudId},
             {"folder", labels.FolderId},
-            {"type", labels.type},
+            {"type", labels.Type},
         };
 
         for (const auto& [name, value]: path) {
@@ -2496,8 +2510,6 @@ struct TServiceVolumeCountersTestEnv
             UNIT_ASSERT(!probe.HasMaxUsedQuota);
             return;
         }
-
-        UNIT_ASSERT_VALUES_EQUAL(probe.Names.size(), 4);
 
         for (const auto* name: {
                 "disk.io_quota_utilization_percentage",
@@ -2739,6 +2751,82 @@ Y_UNIT_TEST_SUITE(TServiceVolumeCountersReregistrationTest)
 
         env.Publish(VOLUME_HASCHECKPOINT, 19);
         env.AssertUserCounters(true, 19, labels);
+    }
+
+    Y_UNIT_TEST(ShouldKeepServiceVolumeCountersDetachedAfterIdleConfigUpdate)
+    {
+        TServiceVolumeCountersTestEnv env;
+
+        env.Publish(VOLUME_HASCLIENTS, 7);
+
+        auto original = env.AssertOnlyVolume();
+        AssertPublishedVolumeCounters(original, 7, 7);
+        env.AssertUserCounters(true, 7);
+
+        // The volume becomes idle: no clients and no checkpoint.
+        env.Publish({}, 0);
+        env.AssertDetached();
+        env.AssertUserCounters(false);
+
+        const TServiceVolumeLabels labels = {
+            "new_cloud",
+            "new_folder",
+            "ssd",
+        };
+
+        env.UpdateConfig(labels);
+
+        // Updating labels must not reattach counters for an idle volume.
+        env.AssertDetached();
+        env.AssertUserCounters(false, 0, labels);
+
+        // Publication resumes under new labels when a client returns.
+        env.Publish(VOLUME_HASCLIENTS, 11);
+
+        auto restored = env.AssertOnlyVolume(labels);
+        UNIT_ASSERT(original.Get() == restored.Get());
+
+        AssertPublishedVolumeCounters(restored, 11, 18);
+
+        // The old label path must not be recreated.
+        UNIT_ASSERT(!env.FindVolume());
+
+        env.AssertUserCounters(true, 11, labels);
+    }
+
+    Y_UNIT_TEST(ShouldReplaceUnexpectedSubgroupOnReattach)
+    {
+        TServiceVolumeCountersTestEnv env;
+
+        env.Publish(VOLUME_HASCLIENTS, 7);
+
+        auto original = env.AssertOnlyVolume();
+        AssertPublishedVolumeCounters(original, 7, 7);
+
+        env.Publish({}, 0);
+        env.AssertDetached();
+        env.AssertUserCounters(false);
+
+        // Simulate unrelated code materializing the same path while the real
+        // service-volume subgroup is detached.
+        auto unexpected = env.CreateUnexpectedServiceVolumeSubgroup();
+
+        UNIT_ASSERT(unexpected.Get() != original.Get());
+
+        auto occupied = env.FindVolume();
+        UNIT_ASSERT(occupied.Get() == unexpected.Get());
+
+        // Reattachment must replace the unexpected subgroup instead of
+        // aborting.
+        env.Publish(VOLUME_HASCLIENTS, 11);
+
+        auto restored = env.AssertOnlyVolume();
+
+        UNIT_ASSERT(restored.Get() == original.Get());
+        UNIT_ASSERT(unexpected.Get() != restored.Get());
+
+        AssertPublishedVolumeCounters(restored, 11, 18);
+        env.AssertUserCounters(true, 11);
     }
 }
 


### PR DESCRIPTION
## Summary

- Track service-volume counter attachment state separately from subgroup ownership.
- Reattach the retained subgroup after clients or checkpoints return.
- Re-register service-volume user counters together with the subgroup.
- Add regression tests for re-registration, label updates and repeated cycles.

Fixes #6734

## Tests

`./ya make -t -j8 cloud/blockstore/libs/storage/stats_service/ut --fail-fast`