### PR TITLE
Avoid per-request actor registration in NBS Kikimr service

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -333,6 +333,9 @@ message TLocalServiceConfig
 
 message TKikimrServiceConfig
 {
+    // If nonzero, permanent handler actors are used instead of creating one
+    // request actor for every request.
+    optional uint32 PermanentActorCount = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -106,6 +106,7 @@ using TCritEventParams =
     xxx(RdmaMessageTypeMismatch)                                               \
     xxx(BlockChecksumAbsent)                                                   \
     xxx(CleanupBlobMetaBlocksMismatch)                                         \
+    xxx(ServiceProxyReceivedUnknownCookie)                                     \
     xxx(Bug) /* General software bug event.                                    \
                 Used for non-specialized or unclassified errors. */            \
     // BLOCKSTORE_IMPOSSIBLE_EVENTS

--- a/cloud/blockstore/libs/rdma/fake/client_ut.cpp
+++ b/cloud/blockstore/libs/rdma/fake/client_ut.cpp
@@ -17,6 +17,7 @@
 #include <contrib/ydb/core/testlib/basics/runtime.h>
 #include <contrib/ydb/core/testlib/tablet_helpers.h>
 #include <contrib/ydb/library/actors/core/actorsystem.h>
+#include <contrib/ydb/library/actors/core/scheduler_cookie.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -109,6 +110,17 @@ struct TTestActorSystem
         Runtime.SendAsync(event.release());
 
         return true;
+    }
+
+    void Schedule(
+        TDuration delta,
+        IEventHandlePtr event,
+        ISchedulerCookie* cookie) override
+    {
+        if (cookie) {
+            cookie->Detach();
+        }
+        Runtime.Schedule(event.release(), delta);
     }
 
     TProgramShouldContinue& GetProgramShouldContinue() override

--- a/cloud/blockstore/libs/service_kikimr/method_handler.cpp
+++ b/cloud/blockstore/libs/service_kikimr/method_handler.cpp
@@ -1,0 +1,1 @@
+#include "method_handler.h"

--- a/cloud/blockstore/libs/service_kikimr/method_handler.h
+++ b/cloud/blockstore/libs/service_kikimr/method_handler.h
@@ -158,11 +158,9 @@ public:
     {
         auto state = ExtractRequest(ev->Cookie);
         if (!state) {
-            LOG_TRACE_S(
-                ctx,
-                TBlockStoreComponents::SERVICE_PROXY,
-                GetBlockStoreRequestName(T::Request)
-                    << " response received for unknown cookie: " << ev->Cookie);
+            ReportServiceProxyReceivedUnknownCookie(
+                {{"request", GetBlockStoreRequestName(T::Request)},
+                 {"cookie", ev->Cookie}});
             return;
         }
 

--- a/cloud/blockstore/libs/service_kikimr/method_handler.h
+++ b/cloud/blockstore/libs/service_kikimr/method_handler.h
@@ -1,0 +1,313 @@
+#pragma once
+
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/service/request_helpers.h>
+#include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/blockstore/libs/storage/core/probes.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/kikimr/actorsystem.h>
+
+#include <contrib/ydb/library/actors/core/event.h>
+#include <contrib/ydb/library/actors/core/events.h>
+#include <contrib/ydb/library/actors/core/log.h>
+#include <contrib/ydb/library/actors/core/scheduler_cookie.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/hash.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/generic/yexception.h>
+#include <util/system/spinlock.h>
+
+#include <memory>
+#include <utility>
+
+namespace NCloud::NBlockStore::NServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+class TMethodHandler final
+{
+    using TRequest = typename T::TRequest;
+    using TRequestProto = typename T::TRequestProto;
+
+    using TResponse = typename T::TResponse;
+    using TResponseProto = typename T::TResponseProto;
+
+    struct TRequestState
+    {
+        NThreading::TPromise<TResponseProto> Response;
+        TCallContextPtr CallContext;
+        TString DiskId;
+        NActors::TSchedulerCookieHolder TimeoutCookie;
+        bool Dispatching = true;
+
+        TRequestState(
+            NThreading::TPromise<TResponseProto> response,
+            TCallContextPtr callContext,
+            TString diskId)
+            : Response(std::move(response))
+            , CallContext(std::move(callContext))
+            , DiskId(std::move(diskId))
+        {}
+    };
+
+    using TRequestStatePtr = std::shared_ptr<TRequestState>;
+
+private:
+    THashMap<ui64, TRequestStatePtr> Requests;
+    TAdaptiveLock Lock;
+    bool Closed = false;
+
+public:
+    // TEvWakeup reserves zero as its default, untagged value.
+    static constexpr ui64 TimeoutTag = static_cast<ui64>(T::Request) + 1;
+
+    void SendRequest(
+        NCloud::IActorSystem& actorSystem,
+        TLog& Log,
+        TCallContextPtr callContext,
+        std::shared_ptr<TRequestProto> request,
+        NThreading::TPromise<TResponseProto> response,
+        TDuration requestTimeout,
+        NActors::TActorId actorId,
+        ui64 cookie)
+    {
+        auto state = std::make_shared<TRequestState>(
+            std::move(response),
+            std::move(callContext),
+            GetDiskId(*request));
+
+        auto event = std::make_unique<NActors::IEventHandle>(
+            NStorage::MakeStorageServiceId(),
+            actorId,
+            std::make_unique<TRequest>(state->CallContext, std::move(*request))
+                .release(),
+            /*flags=*/0,
+            cookie,
+            /*forwardOnNondelivery=*/nullptr);
+
+        NActors::IEventHandlePtr timeoutEvent;
+        if (requestTimeout && requestTimeout != TDuration::Max()) {
+            timeoutEvent = std::make_unique<NActors::IEventHandle>(
+                actorId,
+                actorId,
+                new NActors::TEvents::TEvWakeup(TimeoutTag),
+                /*flags=*/0,
+                cookie);
+        }
+
+        bool accepted = false;
+        with_lock (Lock) {
+            if (!Closed) {
+                accepted = true;
+                Requests.emplace(cookie, state);
+            }
+        }
+
+        if (!accepted) {
+            RejectRequest(Log, *state);
+            return;
+        }
+
+        STORAGE_TRACE(
+            TRequestInfo(
+                T::Request,
+                state->CallContext->RequestId,
+                state->DiskId)
+            << " sending request");
+
+        GLOBAL_LWTRACK(
+            BLOCKSTORE_STORAGE_PROVIDER,
+            RequestSent_Proxy,
+            state->CallContext->LWOrbit,
+            GetBlockStoreRequestName(T::Request),
+            state->CallContext->RequestId);
+
+        actorSystem.Send(std::move(event));
+
+        if (timeoutEvent) {
+            state->TimeoutCookie.Reset(NActors::ISchedulerCookie::Make2Way());
+            actorSystem.Schedule(
+                requestTimeout,
+                std::move(timeoutEvent),
+                state->TimeoutCookie.Get());
+        }
+
+        FinishDispatch(Log, cookie, state);
+    }
+
+    void HandleResponse(
+        const typename TResponse::TPtr& ev,
+        const NActors::TActorContext& ctx)
+    {
+        auto state = ExtractRequest(ev->Cookie);
+        if (!state) {
+            LOG_TRACE_S(
+                ctx,
+                TBlockStoreComponents::SERVICE_PROXY,
+                GetBlockStoreRequestName(T::Request)
+                    << " response received for unknown cookie: " << ev->Cookie);
+            return;
+        }
+
+        GLOBAL_LWTRACK(
+            BLOCKSTORE_STORAGE_PROVIDER,
+            ResponseReceived_Proxy,
+            state->CallContext->LWOrbit,
+            GetBlockStoreRequestName(T::Request),
+            state->CallContext->RequestId);
+
+        LOG_TRACE_S(
+            ctx,
+            TBlockStoreComponents::SERVICE_PROXY,
+            TRequestInfo(
+                T::Request,
+                state->CallContext->RequestId,
+                state->DiskId)
+                << " response received");
+
+        CompleteRequest(ctx, *state, std::move(ev->Get()->Record));
+    }
+
+    void HandleTimeout(ui64 cookie, const NActors::TActorContext& ctx)
+    {
+        TRequestStatePtr state;
+        if constexpr (IsWriteRequest(T::Request)) {
+            state = FindRequest(cookie);
+        } else {
+            state = ExtractRequest(cookie);
+        }
+
+        if (!state) {
+            return;
+        }
+
+        LOG_WARN_S(
+            ctx,
+            TBlockStoreComponents::SERVICE_PROXY,
+            TRequestInfo(
+                T::Request,
+                state->CallContext->RequestId,
+                state->DiskId)
+                << " request wakeup timer hit");
+
+        if constexpr (IsWriteRequest(T::Request)) {
+            ReportServiceProxyWakeupTimerHit(
+                {{"disk", state->DiskId},
+                 {"RequestId", state->CallContext->RequestId}});
+            return;
+        }
+
+        TResponseProto response;
+        auto& error = *response.MutableError();
+        error.SetCode(E_TIMEOUT);
+        error.SetMessage("Timeout");
+
+        CompleteRequest(ctx, *state, std::move(response));
+    }
+
+    void RejectRequests(TLog& Log)
+    {
+        TVector<TRequestStatePtr> requests;
+        with_lock (Lock) {
+            Closed = true;
+            requests.reserve(Requests.size());
+            for (auto it = Requests.begin(); it != Requests.end();) {
+                if (!it->second->Dispatching) {
+                    requests.push_back(std::move(it->second));
+                    Requests.erase(it++);
+                } else {
+                    ++it;
+                }
+            }
+        }
+
+        for (const auto& request: requests) {
+            RejectRequest(Log, *request);
+        }
+    }
+
+private:
+    void FinishDispatch(TLog& Log, ui64 cookie, const TRequestStatePtr& state)
+    {
+        bool reject = false;
+        with_lock (Lock) {
+            state->Dispatching = false;
+            if (Closed) {
+                auto it = Requests.find(cookie);
+                if (it != Requests.end() && it->second == state) {
+                    Requests.erase(it);
+                    reject = true;
+                }
+            }
+        }
+
+        if (reject) {
+            RejectRequest(Log, *state);
+        }
+    }
+
+    TRequestStatePtr FindRequest(ui64 cookie)
+    {
+        with_lock (Lock) {
+            auto it = Requests.find(cookie);
+            return it != Requests.end() ? it->second : nullptr;
+        }
+    }
+
+    TRequestStatePtr ExtractRequest(ui64 cookie)
+    {
+        TRequestStatePtr request;
+        with_lock (Lock) {
+            auto it = Requests.find(cookie);
+            if (it != Requests.end()) {
+                request = std::move(it->second);
+                Requests.erase(it);
+            }
+        }
+        return request;
+    }
+
+    void CompleteRequest(
+        const NActors::TActorContext& ctx,
+        TRequestState& state,
+        TResponseProto&& response)
+    {
+        try {
+            state.Response.SetValue(std::move(response));
+        } catch (...) {
+            LOG_ERROR_S(
+                ctx,
+                TBlockStoreComponents::SERVICE_PROXY,
+                TRequestInfo(
+                    T::Request,
+                    state.CallContext->RequestId,
+                    state.DiskId)
+                    << " failed to complete request: "
+                    << CurrentExceptionMessage());
+        }
+    }
+
+    static void RejectRequest(TLog& Log, TRequestState& state)
+    {
+        TResponseProto response;
+        response.MutableError()->SetCode(E_REJECTED);
+
+        try {
+            state.Response.SetValue(std::move(response));
+        } catch (...) {
+            STORAGE_ERROR(
+                TRequestInfo(
+                    T::Request,
+                    state.CallContext->RequestId,
+                    state.DiskId)
+                << " failed to reject request: " << CurrentExceptionMessage());
+        }
+    }
+};
+
+}   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/service_kikimr/method_handler.h
+++ b/cloud/blockstore/libs/service_kikimr/method_handler.h
@@ -28,6 +28,10 @@ namespace NCloud::NBlockStore::NServer {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Tracks in-flight requests of one method type for a permanent handler actor.
+// SendRequest may be called concurrently from arbitrary service threads, while
+// responses and timeouts arrive on actor-system threads. Lock protects the
+// request map and coordinates dispatch with actor shutdown.
 template <typename T>
 class TMethodHandler final
 {
@@ -43,6 +47,11 @@ class TMethodHandler final
         TCallContextPtr CallContext;
         TString DiskId;
         NActors::TSchedulerCookieHolder TimeoutCookie;
+
+        // Set until SendRequest has finished sending the request and scheduling
+        // its timeout. RejectRequests leaves such a request in the map so the
+        // dispatching thread can safely finish and reject it in FinishDispatch.
+        // Access after publication is protected by Lock.
         bool Dispatching = true;
 
         TRequestState(
@@ -58,13 +67,16 @@ class TMethodHandler final
     using TRequestStatePtr = std::shared_ptr<TRequestState>;
 
 private:
-    THashMap<ui64, TRequestStatePtr> Requests;
     TAdaptiveLock Lock;
+    THashMap<ui64, TRequestStatePtr> Requests;
     bool Closed = false;
 
 public:
     // TEvWakeup reserves zero as its default, untagged value.
     static constexpr ui64 TimeoutTag = static_cast<ui64>(T::Request) + 1;
+
+    TMethodHandler() = default;
+    ~TMethodHandler() = default;
 
     void SendRequest(
         NCloud::IActorSystem& actorSystem,
@@ -196,6 +208,8 @@ public:
                 << " request wakeup timer hit");
 
         if constexpr (IsWriteRequest(T::Request)) {
+            // Write requests are a special case: do not time them out because
+            // TVolumeActor already protects against overlapping requests.
             ReportServiceProxyWakeupTimerHit(
                 {{"disk", state->DiskId},
                  {"RequestId", state->CallContext->RequestId}});
@@ -251,7 +265,7 @@ private:
         }
     }
 
-    TRequestStatePtr FindRequest(ui64 cookie)
+    TRequestStatePtr FindRequest(ui64 cookie) const
     {
         with_lock (Lock) {
             auto it = Requests.find(cookie);
@@ -272,7 +286,7 @@ private:
         return request;
     }
 
-    void CompleteRequest(
+    static void CompleteRequest(
         const NActors::TActorContext& ctx,
         TRequestState& state,
         TResponseProto&& response)

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
@@ -246,7 +246,10 @@ struct THandler
 {
     TActorId SelfId;
     TLog Log;
-    std::atomic<ui64> Cookie{0};
+    // A zero cookie usually means that a responder did not copy the request
+    // cookie. Should not issue it, so such a response cannot complete an
+    // unrelated request by accident.
+    std::atomic<ui64> Cookie{1};
 
     explicit THandler(TLog log)
         : Log(std::move(log))
@@ -399,12 +402,12 @@ public:
         : ActorSystem(std::move(actorSystem))
         , Config(config)
         , Log(ActorSystem->CreateLog("KIKIMR_SERVICE"))
-    {
-        Handlers.resize(Config.GetPermanentActorCount());
-    }
+    {}
 
     void Start() override
     {
+        Y_ABORT_UNLESS(Handlers.empty(), "KikimrService already started");
+        Handlers.resize(Config.GetPermanentActorCount());
         for (auto& handler: Handlers) {
             handler = std::make_shared<THandler>(Log);
             auto actorId =

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
@@ -36,6 +36,12 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Requests are handled in one of two ways. Without permanent actors, every
+// request gets its own TRequestActor. Otherwise, requests are distributed among
+// a fixed pool of THandlerActor instances. In the latter case request state is
+// registered and the request is sent on the calling thread, while responses and
+// timeouts are processed by the permanent actors on actor-system threads.
+
 #define BLOCKSTORE_DECLARE_METHOD(name, ...)                                   \
     struct T##name##Method                                                     \
     {                                                                          \
@@ -212,6 +218,8 @@ private:
                 << " request wakeup timer hit");
 
         if constexpr (IsWriteRequest(T::Request)) {
+            // Write requests are a special case: do not time them out because
+            // TVolumeActor already protects against overlapping requests.
             ReportServiceProxyWakeupTimerHit(
                 {{"disk", DiskId}, {"RequestId", CallContext->RequestId}});
             return;
@@ -229,18 +237,19 @@ private:
     }
 };
 
-////////////////////////////////////////////////////////////////////////////////
-
+// Bridges calls arriving on service threads with replies handled by an actor.
+// It is separate from THandlerActor because the actor system owns and may
+// destroy the actor independently, while TKikimrService may still be entered by
+// a request thread. Shared ownership keeps the request-tracking state alive for
+// both sides.
 struct THandler
 {
     TActorId SelfId;
     TLog Log;
-    const std::shared_ptr<std::atomic<bool>> PoolClosed;
     std::atomic<ui64> Cookie{0};
 
-    THandler(TLog log, std::shared_ptr<std::atomic<bool>> poolClosed)
+    explicit THandler(TLog log)
         : Log(std::move(log))
-        , PoolClosed(std::move(poolClosed))
     {}
 
 #define BLOCKSTORE_SEND_REQUEST(name, ...)                                     \
@@ -252,18 +261,6 @@ struct THandler
         TPromise<NProto::T##name##Response> response,                          \
         TDuration requestTimeout)                                              \
     {                                                                          \
-        if (PoolClosed->load(std::memory_order_acquire)) {                     \
-            NProto::T##name##Response rejected;                                \
-            rejected.MutableError()->SetCode(E_REJECTED);                      \
-            try {                                                              \
-                response.SetValue(std::move(rejected));                        \
-            } catch (...) {                                                    \
-                STORAGE_ERROR(                                                 \
-                    "Couldn't set E_REJECTED to response: "                    \
-                    << CurrentExceptionMessage());                             \
-            }                                                                  \
-            return;                                                            \
-        }                                                                      \
         const ui64 cookie = Cookie.fetch_add(1, std::memory_order_relaxed);    \
         name##Handler.SendRequest(                                             \
             actorSystem,                                                       \
@@ -301,8 +298,6 @@ struct THandler
 
     void RejectRequests()
     {
-        PoolClosed->store(true, std::memory_order_release);
-
 #define BLOCKSTORE_REJECT_REQUESTS(name, ...)                                  \
     name##Handler.RejectRequests(Log);                                         \
 // BLOCKSTORE_REJECT_REQUESTS
@@ -320,6 +315,8 @@ class THandlerActor final: public TActor<THandlerActor>
     using TThis = THandlerActor;
 
 private:
+    // Shared with TKikimrService because the actor and service have independent
+    // lifetimes and are owned by different subsystems.
     std::shared_ptr<THandler> Impl;
 
 public:
@@ -388,6 +385,9 @@ private:
     TLog Log;
 
     using THandlerPtr = std::shared_ptr<THandler>;
+
+    // The actors are independent and each can handle every storage request
+    // type. Concurrent callers are assigned to them round-robin.
     TVector<THandlerPtr> Handlers;
 
     std::atomic<ui32> HandlerSelector{0};
@@ -405,9 +405,8 @@ public:
 
     void Start() override
     {
-        auto poolClosed = std::make_shared<std::atomic<bool>>(false);
         for (auto& handler: Handlers) {
-            handler = std::make_shared<THandler>(Log, poolClosed);
+            handler = std::make_shared<THandler>(Log);
             auto actorId =
                 ActorSystem->Register(std::make_unique<THandlerActor>(handler));
             handler->SelfId = actorId;
@@ -415,7 +414,13 @@ public:
     }
 
     void Stop() override
-    {}
+    {
+        for (const auto& handler: Handlers) {
+            if (handler) {
+                handler->RejectRequests();
+            }
+        }
+    }
 
     TStorageBuffer AllocateBuffer(size_t bytesCount) override
     {
@@ -473,6 +478,11 @@ private:
             const ui32 handlerIdx =
                 HandlerSelector.fetch_add(1, std::memory_order_relaxed);
             auto& handler = Handlers[handlerIdx % Handlers.size()];
+
+            // The request is not sent to THandlerActor in the usual actor
+            // fashion. Instead, the current service thread calls the shared
+            // handler directly; it records the request and sends it to the
+            // storage service using THandlerActor as the reply recipient.
             handler->SendRequest(
                 *ActorSystem,
                 std::move(ctx),

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr.cpp
@@ -1,7 +1,8 @@
 #include "service_kikimr.h"
 
-#include <cloud/blockstore/config/server.pb.h>
+#include "method_handler.h"
 
+#include <cloud/blockstore/config/server.pb.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/service/context.h>
@@ -9,6 +10,7 @@
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/kikimr/actorsystem.h>
 
@@ -17,6 +19,9 @@
 #include <contrib/ydb/library/actors/core/log.h>
 
 #include <util/datetime/base.h>
+#include <util/generic/vector.h>
+
+#include <atomic>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -34,7 +39,8 @@ namespace {
 #define BLOCKSTORE_DECLARE_METHOD(name, ...)                                   \
     struct T##name##Method                                                     \
     {                                                                          \
-        static constexpr EBlockStoreRequest Request = EBlockStoreRequest::name;\
+        static constexpr EBlockStoreRequest Request =                          \
+            EBlockStoreRequest::name;                                          \
                                                                                \
         using TRequest = TEvService::TEv##name##Request;                       \
         using TRequestProto = NProto::T##name##Request;                        \
@@ -51,8 +57,7 @@ BLOCKSTORE_STORAGE_SERVICE(BLOCKSTORE_DECLARE_METHOD)
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-class TRequestActor final
-    : public TActorBootstrapped<TRequestActor<T>>
+class TRequestActor final: public TActorBootstrapped<TRequestActor<T>>
 {
     using TThis = TRequestActor<T>;
     using TBase = TActorBootstrapped<TThis>;
@@ -118,13 +123,14 @@ public:
 private:
     void SendRequest(const TActorContext& ctx)
     {
-        LOG_TRACE_S(ctx, TBlockStoreComponents::SERVICE_PROXY,
+        LOG_TRACE_S(
+            ctx,
+            TBlockStoreComponents::SERVICE_PROXY,
             TRequestInfo(T::Request, CallContext->RequestId, DiskId)
-            << " sending request");
+                << " sending request");
 
-        auto request = std::make_unique<TRequest>(
-            CallContext,
-            std::move(*Request));
+        auto request =
+            std::make_unique<TRequest>(CallContext, std::move(*Request));
 
         LWTRACK(
             RequestSent_Proxy,
@@ -132,10 +138,7 @@ private:
             GetBlockStoreRequestName(T::Request),
             CallContext->RequestId);
 
-        NCloud::Send(
-            ctx,
-            MakeStorageServiceId(),
-            std::move(request));
+        NCloud::Send(ctx, MakeStorageServiceId(), std::move(request));
 
         if (RequestTimeout && RequestTimeout != TDuration::Max()) {
             ctx.Schedule(RequestTimeout, new TEvents::TEvWakeup());
@@ -147,9 +150,11 @@ private:
         try {
             Response.SetValue(std::move(response));
         } catch (...) {
-            LOG_ERROR_S(ctx, TBlockStoreComponents::SERVICE_PROXY,
+            LOG_ERROR_S(
+                ctx,
+                TBlockStoreComponents::SERVICE_PROXY,
                 TRequestInfo(T::Request, CallContext->RequestId, DiskId)
-                << " exception in callback: " << CurrentExceptionMessage());
+                    << " exception in callback: " << CurrentExceptionMessage());
         }
 
         RequestCompleted = true;
@@ -183,9 +188,11 @@ private:
             GetBlockStoreRequestName(T::Request),
             CallContext->RequestId);
 
-        LOG_TRACE_S(ctx, TBlockStoreComponents::SERVICE_PROXY,
+        LOG_TRACE_S(
+            ctx,
+            TBlockStoreComponents::SERVICE_PROXY,
             TRequestInfo(T::Request, CallContext->RequestId, DiskId)
-            << " response received");
+                << " response received");
 
         CompleteRequest(ctx, std::move(msg->Record));
 
@@ -198,9 +205,11 @@ private:
     {
         Y_UNUSED(ev);
 
-        LOG_WARN_S(ctx, TBlockStoreComponents::SERVICE_PROXY,
+        LOG_WARN_S(
+            ctx,
+            TBlockStoreComponents::SERVICE_PROXY,
             TRequestInfo(T::Request, CallContext->RequestId, DiskId)
-            << " request wakeup timer hit");
+                << " request wakeup timer hit");
 
         if constexpr (IsWriteRequest(T::Request)) {
             ReportServiceProxyWakeupTimerHit(
@@ -222,23 +231,191 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TKikimrService final
-    : public IBlockStore
+struct THandler
+{
+    TActorId SelfId;
+    TLog Log;
+    const std::shared_ptr<std::atomic<bool>> PoolClosed;
+    std::atomic<ui64> Cookie{0};
+
+    THandler(TLog log, std::shared_ptr<std::atomic<bool>> poolClosed)
+        : Log(std::move(log))
+        , PoolClosed(std::move(poolClosed))
+    {}
+
+#define BLOCKSTORE_SEND_REQUEST(name, ...)                                     \
+    TMethodHandler<T##name##Method> name##Handler;                             \
+    void SendRequest(                                                          \
+        IActorSystem& actorSystem,                                             \
+        TCallContextPtr callContext,                                           \
+        std::shared_ptr<NProto::T##name##Request> request,                     \
+        TPromise<NProto::T##name##Response> response,                          \
+        TDuration requestTimeout)                                              \
+    {                                                                          \
+        if (PoolClosed->load(std::memory_order_acquire)) {                     \
+            NProto::T##name##Response rejected;                                \
+            rejected.MutableError()->SetCode(E_REJECTED);                      \
+            try {                                                              \
+                response.SetValue(std::move(rejected));                        \
+            } catch (...) {                                                    \
+                STORAGE_ERROR(                                                 \
+                    "Couldn't set E_REJECTED to response: "                    \
+                    << CurrentExceptionMessage());                             \
+            }                                                                  \
+            return;                                                            \
+        }                                                                      \
+        const ui64 cookie = Cookie.fetch_add(1, std::memory_order_relaxed);    \
+        name##Handler.SendRequest(                                             \
+            actorSystem,                                                       \
+            Log,                                                               \
+            std::move(callContext),                                            \
+            std::move(request),                                                \
+            std::move(response),                                               \
+            requestTimeout,                                                    \
+            SelfId,                                                            \
+            cookie);                                                           \
+    }                                                                          \
+// BLOCKSTORE_SEND_REQUEST
+
+    BLOCKSTORE_STORAGE_SERVICE(BLOCKSTORE_SEND_REQUEST)
+
+#undef BLOCKSTORE_SEND_REQUEST
+
+    void HandleTimeout(ui64 tag, ui64 cookie, const TActorContext& ctx)
+    {
+#define BLOCKSTORE_HANDLE_TIMEOUT(name, ...)                                   \
+    case TMethodHandler<T##name##Method>::TimeoutTag:                          \
+        name##Handler.HandleTimeout(cookie, ctx);                              \
+        return;                                                                \
+// BLOCKSTORE_HANDLE_TIMEOUT
+
+        switch (tag) {
+            BLOCKSTORE_STORAGE_SERVICE(BLOCKSTORE_HANDLE_TIMEOUT)
+
+            default:
+                return;
+        }
+
+#undef BLOCKSTORE_HANDLE_TIMEOUT
+    }
+
+    void RejectRequests()
+    {
+        PoolClosed->store(true, std::memory_order_release);
+
+#define BLOCKSTORE_REJECT_REQUESTS(name, ...)                                  \
+    name##Handler.RejectRequests(Log);                                         \
+// BLOCKSTORE_REJECT_REQUESTS
+
+        BLOCKSTORE_STORAGE_SERVICE(BLOCKSTORE_REJECT_REQUESTS)
+
+#undef BLOCKSTORE_REJECT_REQUESTS
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class THandlerActor final: public TActor<THandlerActor>
+{
+    using TThis = THandlerActor;
+
+private:
+    std::shared_ptr<THandler> Impl;
+
+public:
+    explicit THandlerActor(std::shared_ptr<THandler> impl)
+        : TActor<THandlerActor>(&THandlerActor::StateWork)
+        , Impl(std::move(impl))
+    {}
+
+    ~THandlerActor() override
+    {
+        Impl->RejectRequests();
+    }
+
+    static constexpr const char ActorName[] =
+        "NCloud::NBlockStore::NServer::THandlerActor";
+
+private:
+#define BLOCKSTORE_HANDLE_RESPONSE_IMPL(name, ...)                             \
+    HFunc(T##name##Method::TResponse, Impl->name##Handler.HandleResponse);
+
+// BLOCKSTORE_HANDLE_RESPONSE_IMPL
+
+    STFUNC(StateWork)
+    {
+        switch (ev->GetTypeRewrite()) {
+            BLOCKSTORE_STORAGE_SERVICE(BLOCKSTORE_HANDLE_RESPONSE_IMPL)
+            HFunc(TEvents::TEvWakeup, HandleTimeout);
+            HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+            default:
+                HandleUnexpectedEvent(
+                    ev,
+                    TBlockStoreComponents::SERVICE_PROXY,
+                    __PRETTY_FUNCTION__);
+                break;
+        }
+    }
+
+#undef BLOCKSTORE_HANDLE_RESPONSE_IMPL
+
+    void HandleTimeout(
+        const TEvents::TEvWakeup::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        Impl->HandleTimeout(ev->Get()->Tag, ev->Cookie, ctx);
+    }
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx)
+    {
+        Y_UNUSED(ev);
+
+        Impl->RejectRequests();
+        TThis::Die(ctx);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TKikimrService final: public IBlockStore
 {
 private:
     const IActorSystemPtr ActorSystem;
     const NProto::TKikimrServiceConfig Config;
+    TLog Log;
+
+    using THandlerPtr = std::shared_ptr<THandler>;
+    TVector<THandlerPtr> Handlers;
+
+    std::atomic<ui32> HandlerSelector{0};
 
 public:
     TKikimrService(
-            IActorSystemPtr actorSystem,
-            const NProto::TKikimrServiceConfig& config)
+        IActorSystemPtr actorSystem,
+        const NProto::TKikimrServiceConfig& config)
         : ActorSystem(std::move(actorSystem))
         , Config(config)
-    {}
+        , Log(ActorSystem->CreateLog("KIKIMR_SERVICE"))
+    {
+        Handlers.resize(Config.GetPermanentActorCount());
+    }
 
-    void Start() override {}
-    void Stop() override {}
+    void Start() override
+    {
+        auto poolClosed = std::make_shared<std::atomic<bool>>(false);
+        for (auto& handler: Handlers) {
+            handler = std::make_shared<THandler>(Log, poolClosed);
+            auto actorId =
+                ActorSystem->Register(std::make_unique<THandlerActor>(handler));
+            handler->SelfId = actorId;
+        }
+    }
+
+    void Stop() override
+    {}
 
     TStorageBuffer AllocateBuffer(size_t bytesCount) override
     {
@@ -253,7 +430,9 @@ public:
     {                                                                          \
         auto response = NewPromise<NProto::T##name##Response>();               \
         ExecuteRequest<T##name##Method>(                                       \
-            std::move(ctx), std::move(request), response);                     \
+            std::move(ctx),                                                    \
+            std::move(request),                                                \
+            response);                                                         \
         return response.GetFuture();                                           \
     }                                                                          \
 // BLOCKSTORE_IMPLEMENT_METHOD
@@ -290,6 +469,19 @@ private:
         const auto& headers = request->GetHeaders();
         auto timeout = TDuration::MilliSeconds(headers.GetRequestTimeout());
 
+        if (!Handlers.empty()) {
+            const ui32 handlerIdx =
+                HandlerSelector.fetch_add(1, std::memory_order_relaxed);
+            auto& handler = Handlers[handlerIdx % Handlers.size()];
+            handler->SendRequest(
+                *ActorSystem,
+                std::move(ctx),
+                std::move(request),
+                std::move(response),
+                timeout);
+            return;
+        }
+
         ActorSystem->Register(std::make_unique<TRequestActor<T>>(
             std::move(request),
             std::move(response),
@@ -306,9 +498,7 @@ IBlockStorePtr CreateKikimrService(
     IActorSystemPtr actorSystem,
     const NProto::TKikimrServiceConfig& config)
 {
-    return std::make_shared<TKikimrService>(
-        std::move(actorSystem),
-        config);
+    return std::make_shared<TKikimrService>(std::move(actorSystem), config);
 }
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
@@ -14,6 +14,9 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/set.h>
+#include <util/generic/vector.h>
+
 namespace NCloud::NBlockStore::NServer {
 
 using namespace NActors;
@@ -25,16 +28,16 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NProto::TKikimrServiceConfig DefaultConfig()
+NProto::TKikimrServiceConfig MakeConfig(ui32 permanentActorCount)
 {
-    // TODO
-    return {};
+    NProto::TKikimrServiceConfig config;
+    config.SetPermanentActorCount(permanentActorCount);
+    return config;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TTestServiceActor final
-    : public TActor<TTestServiceActor>
+struct TTestServiceActor final: public TActor<TTestServiceActor>
 {
     TTestServiceActor()
         : TActor(&TThis::StateWork)
@@ -42,8 +45,8 @@ struct TTestServiceActor final
 
 #define BLOCKSTORE_IMPLEMENT_METHOD(name, ns)                                  \
     using T##name##ResponsePtr = std::unique_ptr<ns::TEv##name##Response>;     \
-    using T##name##Handler = std::function<                                    \
-        T##name##ResponsePtr(const ns::TEv##name##Request::TPtr& ev)>;         \
+    using T##name##Handler = std::function<T##name##ResponsePtr(               \
+        const ns::TEv##name##Request::TPtr& ev)>;                              \
     T##name##Handler name##Handler;                                            \
                                                                                \
     void Handle##name(                                                         \
@@ -54,7 +57,7 @@ struct TTestServiceActor final
             NCloud::Reply(ctx, *ev, std::move(response));                      \
         }                                                                      \
     }                                                                          \
-// BLOCKSTORE_IMPLEMENT_METHOD
+    // BLOCKSTORE_IMPLEMENT_METHOD
 
     BLOCKSTORE_STORAGE_SERVICE(BLOCKSTORE_IMPLEMENT_METHOD, TEvService)
     BLOCKSTORE_SERVICE_REQUESTS(BLOCKSTORE_IMPLEMENT_METHOD, TEvService)
@@ -91,70 +94,176 @@ struct TTestServiceActor final
 
 Y_UNIT_TEST_SUITE(TKikimrServiceTest)
 {
-    Y_UNIT_TEST(ShouldHandleRequests)
+    void DoTestShouldHandleRequests(ui32 permanentActorCount)
     {
         auto serviceActor = std::make_unique<TTestServiceActor>();
         serviceActor->PingHandler =
-            [] (const TEvService::TEvPingRequest::TPtr& ev) {
-                Y_UNUSED(ev);
-                return std::make_unique<TEvService::TEvPingResponse>();
-            };
+            [](const TEvService::TEvPingRequest::TPtr& ev)
+        {
+            Y_UNUSED(ev);
+            return std::make_unique<TEvService::TEvPingResponse>();
+        };
 
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service = CreateKikimrService(
-            actorSystem,
-            DefaultConfig());
+        auto service =
+            CreateKikimrService(actorSystem, MakeConfig(permanentActorCount));
+        service->Start();
 
         auto request = std::make_shared<NProto::TPingRequest>();
+        request->MutableHeaders()->SetRequestTimeout(100);   // ms
 
-        auto future = service->Ping(
-            MakeIntrusive<TCallContext>(),
-            std::move(request));
+        auto future =
+            service->Ping(MakeIntrusive<TCallContext>(), std::move(request));
 
         actorSystem->DispatchEvents(TDuration::Seconds(5));
 
         const auto& response = future.GetValue(TDuration::Seconds(5));
         UNIT_ASSERT(!HasError(response));
+
+        service->Stop();
+        actorSystem->Stop();
     }
 
-    Y_UNIT_TEST(ShouldHandleWriteAndZeroRequestTimeout)
+    Y_UNIT_TEST(ShouldHandleRequests)
     {
+        DoTestShouldHandleRequests(/*permanentActorCount=*/ 0);
+    }
+
+    Y_UNIT_TEST(ShouldHandleRequestsWithPermanentActors)
+    {
+        DoTestShouldHandleRequests(/*permanentActorCount=*/ 4);
+    }
+
+    Y_UNIT_TEST(ShouldReusePermanentActors)
+    {
+        constexpr ui32 PermanentActorCount = 4;
+        constexpr ui32 RequestCount = 16;
+
+        TSet<TActorId> requestActorIds;
+        TVector<IEventHandlePtr> requests;
+        auto serviceActor = std::make_unique<TTestServiceActor>();
+        serviceActor->PingHandler =
+            [&requestActorIds, &requests](
+                const TEvService::TEvPingRequest::TPtr& ev)
+        {
+            requestActorIds.insert(ev->Sender);
+            requests.emplace_back(ev.Release());
+            return nullptr;
+        };
+
+        auto actorSystem = MakeIntrusive<TTestActorSystem>();
+        actorSystem->RegisterTestService(std::move(serviceActor));
+        const ui64 registrationsBeforeStart =
+            actorSystem->GetRegistrationCount();
+
+        auto service =
+            CreateKikimrService(actorSystem, MakeConfig(PermanentActorCount));
+        service->Start();
+
+        const ui64 registrationsAfterStart =
+            actorSystem->GetRegistrationCount();
+        UNIT_ASSERT_VALUES_EQUAL(
+            registrationsBeforeStart + PermanentActorCount,
+            registrationsAfterStart);
+
+        TVector<TFuture<NProto::TPingResponse>> futures;
+        for (ui32 i = 0; i < RequestCount; ++i) {
+            auto request = std::make_shared<NProto::TPingRequest>();
+            request->MutableHeaders()->SetRequestId(i + 1);
+            futures.push_back(service->Ping(
+                MakeIntrusive<TCallContext>(),
+                std::move(request)));
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            registrationsAfterStart,
+            actorSystem->GetRegistrationCount());
+
+        actorSystem->DispatchEvents(TDuration::Seconds(5));
+
+        UNIT_ASSERT_VALUES_EQUAL(RequestCount, requests.size());
+        for (const auto& future: futures) {
+            UNIT_ASSERT(!future.HasValue());
+        }
+
+        for (auto it = requests.rbegin(); it != requests.rend(); ++it) {
+            auto* request = (*it)->Get<TEvService::TEvPingRequest>();
+            auto response = std::make_unique<TEvService::TEvPingResponse>();
+            response->Record.SetLastRequestCount(
+                request->Record.GetHeaders().GetRequestId());
+            actorSystem->Send(std::make_unique<IEventHandle>(
+                (*it)->Sender,
+                TActorId(),
+                response.release(),
+                /*flags=*/ 0,
+                (*it)->Cookie));
+        }
+
+        actorSystem->DispatchEvents(TDuration::Seconds(5));
+
+        for (ui32 i = 0; i < RequestCount; ++i) {
+            const auto& response =
+                futures[i].GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT(!HasError(response));
+            UNIT_ASSERT_VALUES_EQUAL(i + 1, response.GetLastRequestCount());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(PermanentActorCount, requestActorIds.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            registrationsAfterStart,
+            actorSystem->GetRegistrationCount());
+
+        service->Stop();
+        actorSystem->Stop();
+    }
+
+    void DoTestShouldHandleWriteAndZeroRequestTimeout(ui32 permanentActorCount)
+    {
+        IEventHandlePtr writeBlocksEvent;
+        IEventHandlePtr writeBlocksLocalEvent;
+        IEventHandlePtr zeroBlocksEvent;
+
         auto serviceActor = std::make_unique<TTestServiceActor>();
         serviceActor->WriteBlocksHandler =
-            [] (const TEvService::TEvWriteBlocksRequest::TPtr& ev) {
-                Y_UNUSED(ev);
-                return nullptr;
-            };
+            [&writeBlocksEvent](
+                const TEvService::TEvWriteBlocksRequest::TPtr& ev)
+        {
+            writeBlocksEvent.reset(ev.Release());
+            return nullptr;
+        };
         serviceActor->WriteBlocksLocalHandler =
-            [] (const TEvService::TEvWriteBlocksLocalRequest::TPtr& ev) {
-                Y_UNUSED(ev);
-                return nullptr;
-            };
+            [&writeBlocksLocalEvent](
+                const TEvService::TEvWriteBlocksLocalRequest::TPtr& ev)
+        {
+            writeBlocksLocalEvent.reset(ev.Release());
+            return nullptr;
+        };
         serviceActor->ZeroBlocksHandler =
-            [] (const TEvService::TEvZeroBlocksRequest::TPtr& ev) {
-                Y_UNUSED(ev);
-                return nullptr;
-            };
+            [&zeroBlocksEvent](const TEvService::TEvZeroBlocksRequest::TPtr& ev)
+        {
+            zeroBlocksEvent.reset(ev.Release());
+            return nullptr;
+        };
 
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        NMonitoring::TDynamicCountersPtr counters
-            = new NMonitoring::TDynamicCounters();
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
         InitCriticalEventsCounter(counters);
         auto counter = counters->GetCounter(
-            "AppCriticalEvents/ServiceProxyWakeupTimerHit", true);
+            "AppCriticalEvents/ServiceProxyWakeupTimerHit",
+            true);
 
-        auto service = CreateKikimrService(
-            actorSystem,
-            DefaultConfig());
+        auto service =
+            CreateKikimrService(actorSystem, MakeConfig(permanentActorCount));
+        service->Start();
 
         {
             auto request = std::make_shared<NProto::TWriteBlocksRequest>();
             auto& headers = *request->MutableHeaders();
-            headers.SetRequestTimeout(100); // ms
+            headers.SetRequestTimeout(100);   // ms
 
             auto future = service->WriteBlocks(
                 MakeIntrusive<TCallContext>(),
@@ -164,12 +273,22 @@ Y_UNIT_TEST_SUITE(TKikimrServiceTest)
 
             UNIT_ASSERT(!future.HasValue());
             UNIT_ASSERT_VALUES_EQUAL(1, counter->Val());
+
+            actorSystem->Send(std::make_unique<IEventHandle>(
+                writeBlocksEvent->Sender,
+                TActorId(),
+                new TEvService::TEvWriteBlocksResponse(),
+                /*flags=*/ 0,
+                writeBlocksEvent->Cookie));
+            actorSystem->DispatchEvents(TDuration::Seconds(5));
+
+            UNIT_ASSERT(!HasError(future.GetValue(TDuration::Seconds(5))));
         }
 
         {
             auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
             auto& headers = *request->MutableHeaders();
-            headers.SetRequestTimeout(100); // ms
+            headers.SetRequestTimeout(100);   // ms
 
             auto future = service->WriteBlocksLocal(
                 MakeIntrusive<TCallContext>(),
@@ -179,12 +298,22 @@ Y_UNIT_TEST_SUITE(TKikimrServiceTest)
 
             UNIT_ASSERT(!future.HasValue());
             UNIT_ASSERT_VALUES_EQUAL(2, counter->Val());
+
+            actorSystem->Send(std::make_unique<IEventHandle>(
+                writeBlocksLocalEvent->Sender,
+                TActorId(),
+                new TEvService::TEvWriteBlocksLocalResponse(),
+                /*flags=*/ 0,
+                writeBlocksLocalEvent->Cookie));
+            actorSystem->DispatchEvents(TDuration::Seconds(5));
+
+            UNIT_ASSERT(!HasError(future.GetValue(TDuration::Seconds(5))));
         }
 
         {
             auto request = std::make_shared<NProto::TZeroBlocksRequest>();
             auto& headers = *request->MutableHeaders();
-            headers.SetRequestTimeout(100); // ms
+            headers.SetRequestTimeout(100);   // ms
 
             auto future = service->ZeroBlocks(
                 MakeIntrusive<TCallContext>(),
@@ -194,66 +323,132 @@ Y_UNIT_TEST_SUITE(TKikimrServiceTest)
 
             UNIT_ASSERT(!future.HasValue());
             UNIT_ASSERT_VALUES_EQUAL(3, counter->Val());
+
+            actorSystem->Send(std::make_unique<IEventHandle>(
+                zeroBlocksEvent->Sender,
+                TActorId(),
+                new TEvService::TEvZeroBlocksResponse(),
+                /*flags=*/ 0,
+                zeroBlocksEvent->Cookie));
+            actorSystem->DispatchEvents(TDuration::Seconds(5));
+
+            UNIT_ASSERT(!HasError(future.GetValue(TDuration::Seconds(5))));
         }
+
+        service->Stop();
+        actorSystem->Stop();
     }
 
-    Y_UNIT_TEST(ShouldHandleOtherRequestTimeout)
+    Y_UNIT_TEST(ShouldHandleWriteAndZeroRequestTimeout)
+    {
+        DoTestShouldHandleWriteAndZeroRequestTimeout(
+            /*permanentActorCount=*/ 0);
+    }
+
+    Y_UNIT_TEST(ShouldHandleWriteAndZeroRequestTimeoutWithPermanentActors)
+    {
+        DoTestShouldHandleWriteAndZeroRequestTimeout(
+            /*permanentActorCount=*/ 4);
+    }
+
+    void DoTestShouldHandleOtherRequestTimeout(ui32 permanentActorCount)
     {
         auto serviceActor = std::make_unique<TTestServiceActor>();
         serviceActor->PingHandler =
-            [] (const TEvService::TEvPingRequest::TPtr& ev) {
-                Y_UNUSED(ev);
-                return nullptr;
-            };
+            [](const TEvService::TEvPingRequest::TPtr& ev)
+        {
+            Y_UNUSED(ev);
+            return nullptr;
+        };
 
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service = CreateKikimrService(
-            actorSystem,
-            DefaultConfig());
+        auto service =
+            CreateKikimrService(actorSystem, MakeConfig(permanentActorCount));
+        service->Start();
 
         auto request = std::make_shared<NProto::TPingRequest>();
         auto& headers = *request->MutableHeaders();
-        headers.SetRequestTimeout(100); // ms
+        headers.SetRequestTimeout(100);   // ms
 
-        auto future = service->Ping(
-            MakeIntrusive<TCallContext>(),
-            std::move(request));
+        auto future =
+            service->Ping(MakeIntrusive<TCallContext>(), std::move(request));
 
         actorSystem->DispatchEvents(TDuration::Seconds(5));
 
         const auto& response = future.GetValue(TDuration::Seconds(5));
         UNIT_ASSERT_EQUAL(response.GetError().GetCode(), E_TIMEOUT);
+
+        service->Stop();
+        actorSystem->Stop();
     }
 
-    Y_UNIT_TEST(ShouldCompleteRequestWhenShuttingDown)
+    Y_UNIT_TEST(ShouldHandleOtherRequestTimeout)
+    {
+        DoTestShouldHandleOtherRequestTimeout(/*permanentActorCount=*/ 0);
+    }
+
+    Y_UNIT_TEST(ShouldHandleOtherRequestTimeoutWithPermanentActors)
+    {
+        DoTestShouldHandleOtherRequestTimeout(/*permanentActorCount=*/ 4);
+    }
+
+    void DoTestShouldCompleteRequestWhenShuttingDown(ui32 permanentActorCount)
     {
         auto serviceActor = std::make_unique<TTestServiceActor>();
         serviceActor->PingHandler =
-            [] (const TEvService::TEvPingRequest::TPtr& ev) {
-                Y_UNUSED(ev);
-                return nullptr;
-            };
-
-
+            [](const TEvService::TEvPingRequest::TPtr& ev)
+        {
+            Y_UNUSED(ev);
+            return nullptr;
+        };
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service = CreateKikimrService(
-            actorSystem,
-            DefaultConfig());
+        auto service =
+            CreateKikimrService(actorSystem, MakeConfig(permanentActorCount));
+        service->Start();
 
         auto request = std::make_shared<NProto::TPingRequest>();
 
-        auto future = service->Ping(
-            MakeIntrusive<TCallContext>(),
-            std::move(request));
+        auto future =
+            service->Ping(MakeIntrusive<TCallContext>(), std::move(request));
+
+        TFuture<NProto::TPingResponse> reentrantFuture;
+        if (permanentActorCount) {
+            future.Subscribe([&](const auto&) {
+                reentrantFuture = service->Ping(
+                    MakeIntrusive<TCallContext>(),
+                    std::make_shared<NProto::TPingRequest>());
+            });
+        }
 
         actorSystem->Stop();
 
         const auto& response = future.GetValue(TDuration::Seconds(5));
         UNIT_ASSERT_EQUAL(response.GetError().GetCode(), E_REJECTED);
+
+        if (permanentActorCount) {
+            UNIT_ASSERT(reentrantFuture.Initialized());
+            const auto& reentrantResponse =
+                reentrantFuture.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_EQUAL(
+                reentrantResponse.GetError().GetCode(),
+                E_REJECTED);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCompleteRequestWhenShuttingDown)
+    {
+        DoTestShouldCompleteRequestWhenShuttingDown(
+            /*permanentActorCount=*/ 0);
+    }
+
+    Y_UNIT_TEST(ShouldCompleteRequestWhenShuttingDownWithPermanentActors)
+    {
+        DoTestShouldCompleteRequestWhenShuttingDown(
+            /*permanentActorCount=*/ 4);
     }
 }
 

--- a/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
+++ b/cloud/blockstore/libs/service_kikimr/service_kikimr_ut.cpp
@@ -424,6 +424,7 @@ Y_UNIT_TEST_SUITE(TKikimrServiceTest)
             });
         }
 
+        service->Stop();
         actorSystem->Stop();
 
         const auto& response = future.GetValue(TDuration::Seconds(5));

--- a/cloud/blockstore/libs/service_kikimr/ut/kikimr_test_env.cpp
+++ b/cloud/blockstore/libs/service_kikimr/ut/kikimr_test_env.cpp
@@ -6,6 +6,7 @@
 #include <cloud/storage/core/libs/auth/authorizer.h>
 
 #include <contrib/ydb/core/testlib/tablet_helpers.h>
+#include <contrib/ydb/library/actors/core/scheduler_cookie.h>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -79,6 +80,8 @@ TActorId TTestActorSystem::Register(
 {
     Y_UNUSED(executorName);
 
+    RegistrationCount.fetch_add(1, std::memory_order_relaxed);
+
     auto actorId = Runtime->Register(actor.release());
     Runtime->EnableScheduleForActor(actorId);
 
@@ -95,6 +98,17 @@ bool TTestActorSystem::Send(IEventHandlePtr event)
 {
     Runtime->Send(event.release());
     return true;
+}
+
+void TTestActorSystem::Schedule(
+    TDuration delta,
+    IEventHandlePtr event,
+    ISchedulerCookie* cookie)
+{
+    if (cookie) {
+        cookie->Detach();
+    }
+    Runtime->Schedule(event.release(), delta);
 }
 
 TProgramShouldContinue& TTestActorSystem::GetProgramShouldContinue()
@@ -119,6 +133,11 @@ void TTestActorSystem::RegisterTestAuthorizer(IActorPtr authorizer)
     Runtime->RegisterService(
         MakeAuthorizerServiceId(),
         Register(std::move(authorizer)));
+}
+
+ui64 TTestActorSystem::GetRegistrationCount() const
+{
+    return RegistrationCount.load(std::memory_order_relaxed);
 }
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/service_kikimr/ut/kikimr_test_env.h
+++ b/cloud/blockstore/libs/service_kikimr/ut/kikimr_test_env.h
@@ -6,6 +6,8 @@
 
 #include <contrib/ydb/core/testlib/basics/runtime.h>
 
+#include <atomic>
+
 namespace NCloud::NBlockStore::NServer {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -18,6 +20,7 @@ private:
     NActors::TActorId Sender;
 
     TProgramShouldContinue ProgramShouldContinue;
+    std::atomic<ui64> RegistrationCount{0};
 
 public:
     TTestActorSystem();
@@ -62,6 +65,11 @@ public:
 
     bool Send(NActors::IEventHandlePtr event) override;
 
+    void Schedule(
+        TDuration delta,
+        NActors::IEventHandlePtr event,
+        NActors::ISchedulerCookie* cookie) override;
+
     TProgramShouldContinue& GetProgramShouldContinue() override;
 
     //
@@ -72,6 +80,8 @@ public:
 
     void RegisterTestService(NActors::IActorPtr serviceActor);
     void RegisterTestAuthorizer(NActors::IActorPtr authorizer);
+
+    ui64 GetRegistrationCount() const;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/service_kikimr/ya.make
+++ b/cloud/blockstore/libs/service_kikimr/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     auth_provider_kikimr.cpp
+    method_handler.cpp
     service_kikimr.cpp
 )
 

--- a/cloud/blockstore/libs/storage/init/common/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/common/actorsystem.cpp
@@ -104,6 +104,14 @@ bool TActorSystem::Send(IEventHandlePtr ev)
     return ActorSystem->Send(ev.release());
 }
 
+void TActorSystem::Schedule(
+    TDuration delta,
+    IEventHandlePtr ev,
+    ISchedulerCookie* cookie)
+{
+    ActorSystem->Schedule(delta, ev.release(), cookie);
+}
+
 TLog TActorSystem::CreateLog(const TString& componentName)
 {
     if (LogBackend) {

--- a/cloud/blockstore/libs/storage/init/common/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/common/actorsystem.h
@@ -67,6 +67,10 @@ public:
         const NActors::TActorId& recipient,
         NActors::IEventBasePtr event) override;
     bool Send(NActors::IEventHandlePtr ev) override;
+    void Schedule(
+        TDuration delta,
+        NActors::IEventHandlePtr ev,
+        NActors::ISchedulerCookie* cookie) override;
 
     TLog CreateLog(const TString& component) override;
 

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -595,7 +595,7 @@ def __run_test(test_case):
     server.ServerConfig.NbdSocketSuffix = nbd_socket_suffix
     server.ServerConfig.EndpointStorageType = EEndpointStorageType.ENDPOINT_STORAGE_FILE
     server.ServerConfig.EndpointStorageDir = endpoint_storage_dir
-    server.KikimrServiceConfig.CopyFrom(TKikimrServiceConfig())
+    server.KikimrServiceConfig.CopyFrom(TKikimrServiceConfig(PermanentActorCount=10))
 
     env = LocalLoadTest(
         "",

--- a/cloud/filestore/libs/service_kikimr/ut/kikimr_test_env.cpp
+++ b/cloud/filestore/libs/service_kikimr/ut/kikimr_test_env.cpp
@@ -6,6 +6,7 @@
 
 #include <contrib/ydb/core/testlib/basics/appdata.h>
 #include <contrib/ydb/core/testlib/tablet_helpers.h>
+#include <contrib/ydb/library/actors/core/scheduler_cookie.h>
 
 namespace NCloud::NFileStore {
 
@@ -94,6 +95,17 @@ bool TTestActorSystem::Send(NActors::IEventHandlePtr event)
 {
     Runtime->Send(event.release());
     return true;
+}
+
+void TTestActorSystem::Schedule(
+    TDuration delta,
+    IEventHandlePtr event,
+    ISchedulerCookie* cookie)
+{
+    if (cookie) {
+        cookie->Detach();
+    }
+    Runtime->Schedule(event.release(), delta);
 }
 
 TProgramShouldContinue& TTestActorSystem::GetProgramShouldContinue()

--- a/cloud/filestore/libs/service_kikimr/ut/kikimr_test_env.h
+++ b/cloud/filestore/libs/service_kikimr/ut/kikimr_test_env.h
@@ -60,6 +60,11 @@ public:
 
     bool Send(NActors::IEventHandlePtr event) override;
 
+    void Schedule(
+        TDuration delta,
+        NActors::IEventHandlePtr event,
+        NActors::ISchedulerCookie* cookie) override;
+
     TProgramShouldContinue& GetProgramShouldContinue() override;
 
     //

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -344,6 +344,10 @@ public:
     TActorId Register(IActorPtr actor, TStringBuf executorName) override;
     bool Send(const TActorId& recipient, IEventBasePtr event) override;
     bool Send(IEventHandlePtr ev) override;
+    void Schedule(
+        TDuration delta,
+        IEventHandlePtr ev,
+        ISchedulerCookie* cookie) override;
 
     TLog CreateLog(const TString& component) override;
 
@@ -486,6 +490,14 @@ bool TActorSystem::Send(const TActorId& recipient, IEventBasePtr event)
 bool TActorSystem::Send(IEventHandlePtr ev)
 {
     return ActorSystem->Send(ev.release());
+}
+
+void TActorSystem::Schedule(
+    TDuration delta,
+    IEventHandlePtr ev,
+    ISchedulerCookie* cookie)
+{
+    ActorSystem->Schedule(delta, ev.release(), cookie);
 }
 
 TLog TActorSystem::CreateLog(const TString& componentName)

--- a/cloud/storage/core/libs/kikimr/actorsystem.h
+++ b/cloud/storage/core/libs/kikimr/actorsystem.h
@@ -10,8 +10,15 @@
 #include <contrib/ydb/library/actors/core/actorid.h>
 #include <contrib/ydb/library/actors/util/should_continue.h>
 
+#include <util/datetime/base.h>
 #include <util/generic/ptr.h>
 #include <util/generic/strbuf.h>
+
+namespace NActors {
+
+class ISchedulerCookie;
+
+}   // namespace NActors
 
 namespace NCloud {
 
@@ -32,6 +39,11 @@ struct IActorSystem
         NActors::IEventBasePtr event) = 0;
 
     virtual bool Send(NActors::IEventHandlePtr ev) = 0;
+
+    virtual void Schedule(
+        TDuration delta,
+        NActors::IEventHandlePtr ev,
+        NActors::ISchedulerCookie* cookie) = 0;
 
     virtual TProgramShouldContinue& GetProgramShouldContinue() = 0;
 };


### PR DESCRIPTION
### Notes
Pre-register configurable request handler actors when the service starts and reuse them for subsequent requests. 
Preserve the legacy TRequestActor behavior when the permanent actor count is zero.
The implementation is very similar to the one in filestore.

Note: After enabling the `PermanentActorCount`there will be a slight behavior change: the `TKikimrService::Stop()` function will stop all handlers, which will reject any in-flight requests.
