### PR TITLE
issue-1751: [Filestore] Support multiple incomplete allocations by TFileRingBuffer

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -121,9 +121,25 @@ public:
         return allocResult.AllocationPtr;
     }
 
-    NProto::TError Commit() override
+    NProto::TError Commit(const void* ptr) override
     {
-        auto commitResult = Storage.Commit();
+        auto commitResult = Storage.Commit(ptr);
+
+        SetCounters();
+
+        if (HasError(commitResult)) {
+            ReportWriteBackCacheCorruptionError(Sprintf(
+                "%s Storage::Commit failed with an error: %s",
+                LogTag.c_str(),
+                FormatError(commitResult).c_str()));
+        }
+
+        return commitResult;
+    }
+
+    NProto::TError Commit(const void* ptr, ui32 crc32c) override
+    {
+        auto commitResult = Storage.Commit(ptr, crc32c);
 
         SetCounters();
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -110,6 +110,8 @@ public:
     {
         auto allocResult = Storage.Alloc(size);
 
+        SetCounters();
+
         if (HasError(allocResult.Error)) {
             ReportWriteBackCacheCorruptionError(Sprintf(
                 "%s Storage::Alloc failed with an error: %s",

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -50,9 +50,6 @@ struct IPersistentStorage
      *
      * On failure, returns nullptr if the buffer is full or an error if
      * allocation is not possible due to corruption or invalid argument.
-     *
-     * Note: only one allocation is possible at a time. Repeated Alloc will
-     * return an error.
      */
     [[nodiscard]] virtual TResultOrError<char*> Alloc(size_t size) = 0;
 
@@ -72,22 +69,8 @@ struct IPersistentStorage
     [[nodiscard]] virtual NProto::TError Commit(const void* ptr) = 0;
 
     /**
-     * Completes the previously made allocation using checksum provided by
-     * caller and making the allocation visible.
-     *
-     * Since IPersistentStorage is non-thread safe, it requires external
-     * synchronization and executing its methods under a lock. Calculating
-     * checksums inside Commit() consumes some time and it will prevent other
-     * threads from using IPersistentStorage. The purpose of this method is to
-     * make multi-threaded work with IPersistentStorage more efficient by
-     * reducing the time spent inside the lock.
-     *
-     * Once committed, it is not allowed to modify the contents of the allocated
-     * entry. If there is a need to augment the allocation with additional data,
-     * GetTag/SetTag can be used.
-     *
-     * An error is returned if there is no incomplete allocation correponding to
-     * the provided pointer or the buffer is corrupted.
+     * Commits previously allocated memory buffer but takes a checksum provided
+     * by the caller instead of calculating it.
      *
      * Note: the checksum is not validated, the calling code has responsibility
      * to provide the correct Crc32c checksum. Passing an incorrect checksum may

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -64,8 +64,8 @@ struct IPersistentStorage
      * Memory that was allocated but not committed will be lost at buffer
      * recreation.
      *
-     * An error is returned if there is no incomplete allocation correponding to
-     * the provided pointer or the buffer is corrupted.
+     * An error is returned if there is no incomplete allocation corresponding
+     * to the provided pointer or the buffer is corrupted.
      */
     [[nodiscard]] virtual NProto::TError Commit(const void* ptr) = 0;
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -69,7 +69,33 @@ struct IPersistentStorage
      * An error is returned if there is no incomplete allocation or the buffer
      * is corrupted.
      */
-    [[nodiscard]] virtual NProto::TError Commit() = 0;
+    [[nodiscard]] virtual NProto::TError Commit(const void* ptr) = 0;
+
+    /**
+     * Completes the previously made allocation using checksum provided by
+     * caller and making the allocation visible.
+     *
+     * Since IPersistentStorage is non-thread safe, it requires external
+     * synchronization and executing its methods under a lock. Calculating
+     * checksums inside Commit() consumes some time and it will prevent other
+     * threads from using IPersistentStorage. The purpose of this method is to
+     * make multi-threaded work with IPersistentStorage more efficient by
+     * reducing the time spent inside the lock.
+     *
+     * Once committed, it is not allowed to modify the contents of the allocated
+     * entry. If there is a need to augment the allocation with additional data,
+     * GetTag/SetTag can be used.
+     *
+     * An error is returned if there is no incomplete allocation correponding to
+     * the provided pointer or the buffer is corrupted.
+     *
+     * Note: the checksum is not validated, the calling code has responsibility
+     * to provide the correct Crc32c checksum. Passing an incorrect checksum may
+     * lead to a corruption error.
+     */
+    [[nodiscard]] virtual NProto::TError Commit(
+        const void* ptr,
+        ui32 crc32c) = 0;
 
     /**
      * Frees a previously allocated and committed buffer.

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -54,7 +54,8 @@ struct IPersistentStorage
     [[nodiscard]] virtual TResultOrError<char*> Alloc(size_t size) = 0;
 
     /**
-     * Commits previously allocated memory buffer.
+     * Completes the previously made allocation by calculating checksum and
+     * making the allocation visible.
      *
      * Once committed, it is not allowed to modify the contents of the allocated
      * entry. If there is a need to augment the allocation with additional data,
@@ -63,14 +64,14 @@ struct IPersistentStorage
      * Memory that was allocated but not committed will be lost at buffer
      * recreation.
      *
-     * An error is returned if there is no incomplete allocation or the buffer
-     * is corrupted.
+     * An error is returned if there is no incomplete allocation correponding to
+     * the provided pointer or the buffer is corrupted.
      */
     [[nodiscard]] virtual NProto::TError Commit(const void* ptr) = 0;
 
     /**
-     * Commits previously allocated memory buffer but takes a checksum provided
-     * by the caller instead of calculating it.
+     * Commits the previously allocated memory buffer but takes a checksum
+     * provided by the caller instead of calculating it.
      *
      * Note: the checksum is not validated, the calling code has responsibility
      * to provide the correct Crc32c checksum. Passing an incorrect checksum may

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -84,6 +84,26 @@ struct TBootstrap
         return HasError(allocationResult);
     }
 
+    const char* BeginAlloc(const TString& data) const
+    {
+        auto allocationResult = Storage->Alloc(data.size());
+        if (HasError(allocationResult)) {
+            return nullptr;
+        }
+
+        char* ptr = allocationResult.GetResult();
+        if (ptr != nullptr) {
+            data.copy(ptr, data.size());
+        }
+        return ptr;
+    }
+
+    void EndAlloc(const char* ptr)
+    {
+        UNIT_ASSERT(ptr != nullptr);
+        UNIT_ASSERT(!HasError(Storage->Commit(ptr)));
+    }
+
     NProto::TError Free(const void* ptr) const
     {
         return Storage->Free(ptr);
@@ -240,8 +260,15 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         UNIT_ASSERT(!HasError(b.Initialize()));
         UNIT_ASSERT(b.Storage->Empty());
 
-        const auto* ptr1 = b.Alloc("1234");
+        const auto* ptr1 = b.BeginAlloc("1234");
         UNIT_ASSERT(ptr1);
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.EntryCount->Get());
+        auto rawUsed = stats.RawUsedByteCount->Get();
+        UNIT_ASSERT_LT(0, rawUsed);
+
+        b.EndAlloc(ptr1);
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.EntryCount->Get());
+        UNIT_ASSERT_VALUES_EQUAL(rawUsed, stats.RawUsedByteCount->Get());
 
         const auto* ptr2 = b.Alloc("567890");
         UNIT_ASSERT(ptr2);
@@ -250,7 +277,7 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
 
         UNIT_ASSERT_VALUES_EQUAL(2, stats.EntryCount->Get());
         UNIT_ASSERT_VALUES_EQUAL(2, stats.EntryMaxCount->Get());
-        UNIT_ASSERT_LT(0, stats.RawUsedByteCount->Get());
+        UNIT_ASSERT_LT(rawUsed, stats.RawUsedByteCount->Get());
         UNIT_ASSERT_VALUES_EQUAL(maxByteCount, stats.RawUsedByteCount->Get());
         UNIT_ASSERT_VALUES_EQUAL(
             DefaultCapacity,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -262,7 +262,7 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
 
         const auto* ptr1 = b.BeginAlloc("1234");
         UNIT_ASSERT(ptr1);
-        UNIT_ASSERT_VALUES_EQUAL(0, stats.EntryCount->Get());
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.EntryCount->Get());
         auto rawUsed = stats.RawUsedByteCount->Get();
         UNIT_ASSERT_LT(0, rawUsed);
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -73,7 +73,7 @@ struct TBootstrap
         char* ptr = allocationResult.GetResult();
         if (ptr != nullptr) {
             data.copy(ptr, data.size());
-            UNIT_ASSERT(!HasError(Storage->Commit()));
+            UNIT_ASSERT(!HasError(Storage->Commit(ptr)));
         }
         return ptr;
     }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
@@ -49,8 +49,16 @@ TResultOrError<char*> TTestStorage::Alloc(size_t size)
     return res;
 }
 
-NProto::TError TTestStorage::Commit()
+NProto::TError TTestStorage::Commit(const void* ptr)
 {
+    Y_UNUSED(ptr);
+    return {};
+}
+
+NProto::TError TTestStorage::Commit(const void* ptr, ui32 crc32)
+{
+    Y_UNUSED(ptr);
+    Y_UNUSED(crc32);
     return {};
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
@@ -33,7 +33,8 @@ public:
     NProto::TError Visit(const TVisitor& visitor) override;
     ui64 GetMaxSupportedAllocationByteCount() const override;
     TResultOrError<char*> Alloc(size_t size) override;
-    NProto::TError Commit() override;
+    NProto::TError Commit(const void* ptr) override;
+    NProto::TError Commit(const void* ptr, ui32 crc32) override;
     NProto::TError Free(const void* ptr) override;
     NProto::TError SetTag(const void* ptr, ui32 tag) override;
     void UpdateStats() const override;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -432,7 +432,7 @@ auto TWriteDataRequestManager::TryStoreRequestInPersistentStorage(
         memoryOutput.Exhausted(),
         "Buffer is expected to be written completely");
 
-    auto commitResult = PersistentStorage->Commit();
+    auto commitResult = PersistentStorage->Commit(allocationPtr);
     if (HasError(commitResult)) {
         return {.Failed = true};
     }

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -678,25 +678,11 @@ public:
             crc32c = Crc32c(ptr, eh.DataSize);
         }
 
-        if (Capabilities().EntryHeaderIsProcessedAtomically) {
-            eh.DataChecksum = *crc32c;
-            eh.FreeFlag = false;
+        eh.DataChecksum = *crc32c;
+        eh.FreeFlag = false;
 
-            if (!WriteEntryHeader(pos, eh)) {
-                return MakeBufferIsCorruptError();
-            }
-        } else {
-            eh.DataChecksum = *crc32c;
-
-            if (!WriteEntryHeader(pos, eh)) {
-                return MakeBufferIsCorruptError();
-            }
-
-            eh.FreeFlag = false;
-
-            if (!WriteEntryHeader(pos, eh)) {
-                return MakeBufferIsCorruptError();
-            }
+        if (!WriteEntryHeader(pos, eh)) {
+            return MakeBufferIsCorruptError();
         }
 
         return {};
@@ -728,25 +714,11 @@ public:
             return MakeBufferIsCorruptError();
         }
 
-        if (Capabilities().EntryHeaderIsProcessedAtomically) {
-            eh.DataChecksum = 0;
-            eh.FreeFlag = true;
+        eh.DataChecksum = 0;
+        eh.FreeFlag = true;
 
-            if (!WriteEntryHeader(pos, eh)) {
-                return MakeBufferIsCorruptError();
-            }
-        } else {
-            eh.FreeFlag = true;
-
-            if (!WriteEntryHeader(pos, eh)) {
-                return MakeBufferIsCorruptError();
-            }
-
-            eh.DataChecksum = 0;
-
-            if (!WriteEntryHeader(pos, eh)) {
-                return MakeBufferIsCorruptError();
-            }
+        if (!WriteEntryHeader(pos, eh)) {
+            return MakeBufferIsCorruptError();
         }
 
         EntryMap.erase(it);

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -18,6 +18,7 @@
 #include <util/system/filemap.h>
 
 #include <atomic>
+#include <optional>
 
 namespace NCloud {
 
@@ -147,9 +148,6 @@ private:
 
     // Map of allocated entries: data ptr -> pos
     THashMap<const void*, ui64> EntryMap;
-
-    // Allocated entries that have not been committed yet
-    THashSet<ui64> IncompleteEntries;
 
 private:
     THeader* Header()
@@ -392,7 +390,7 @@ private:
     {
         auto front = GetFrontEntry();
         while (front.HasValue() && front.GetFreeFlag() &&
-               !IncompleteEntries.contains(front.ActualPos))
+               !EntryMap.contains(front.Data))
         {
             front = GetNextEntry(front);
         }
@@ -527,7 +525,8 @@ public:
 
         data.copy(allocationResult.AllocationPtr, data.size());
 
-        auto commitResult = Commit(allocationResult.AllocationPtr, 0, false);
+        auto commitResult =
+            Commit(allocationResult.AllocationPtr, std::nullopt);
 
         if (HasError(commitResult)) {
             return TPushBackResult(commitResult);
@@ -617,16 +616,8 @@ public:
             return TAllocResult(MakeBufferIsCorruptError());
         }
 
-        auto [it1, inserted1] = IncompleteEntries.insert(writePos);
-        if (!inserted1) {
-            SetCorrupted(
-                TStringBuilder()
-                << "Duplicate incomplete allocation at " << writePos);
-            return TAllocResult(MakeBufferIsCorruptError());
-        }
-
-        auto [it2, inserted2] = EntryMap.insert({ptr, writePos});
-        if (!inserted2) {
+        auto [_, inserted] = EntryMap.insert({ptr, writePos});
+        if (!inserted) {
             SetCorrupted(
                 TStringBuilder() << "Duplicate allocation at " << writePos);
             return TAllocResult(MakeBufferIsCorruptError());
@@ -653,7 +644,7 @@ public:
         return TAllocResult(ptr);
     }
 
-    NProto::TError Commit(const void* ptr, ui32 crc32c, bool hasCrc)
+    NProto::TError Commit(const void* ptr, std::optional<ui32> crc32c)
     {
         if (!ValidateAccess("Commit")) {
             return MakeBufferIsCorruptError();
@@ -663,12 +654,8 @@ public:
         if (it == EntryMap.end()) {
             return MakeInvalidPointerError();
         }
-        ui64 pos = it->second;
 
-        auto removed = IncompleteEntries.erase(pos);
-        if (!removed) {
-            return MakeInvalidPointerError();
-        }
+        ui64 pos = it->second;
 
         auto eh = Data()->ReadEntryHeader(pos);
         if (!eh.FreeFlag || eh.DataSize == 0 || eh.DataChecksum != 0 ||
@@ -680,7 +667,7 @@ public:
             return MakeBufferIsCorruptError();
         }
 
-        if (!hasCrc) {
+        if (!crc32c) {
             if (ptr != Data()->GetEntryDataPtr(pos, eh.DataSize)) {
                 SetCorrupted(
                     TStringBuilder()
@@ -692,14 +679,14 @@ public:
         }
 
         if (Capabilities().EntryHeaderIsProcessedAtomically) {
-            eh.DataChecksum = crc32c;
+            eh.DataChecksum = *crc32c;
             eh.FreeFlag = false;
 
             if (!WriteEntryHeader(pos, eh)) {
                 return MakeBufferIsCorruptError();
             }
         } else {
-            eh.DataChecksum = crc32c;
+            eh.DataChecksum = *crc32c;
 
             if (!WriteEntryHeader(pos, eh)) {
                 return MakeBufferIsCorruptError();
@@ -728,12 +715,14 @@ public:
 
         auto pos = it->second;
 
-        if (IncompleteEntries.contains(pos)) {
+        auto eh = Data()->ReadEntryHeader(pos);
+
+        if (eh.FreeFlag) {
+            // Releasing incomplete entries is not allowed
             return MakeInvalidPointerError();
         }
 
-        auto eh = Data()->ReadEntryHeader(pos);
-        if (eh.FreeFlag || eh.DataSize == 0) {
+        if (eh.DataSize == 0) {
             SetCorrupted(
                 TStringBuilder() << "Invalid header for allocation at " << pos);
             return MakeBufferIsCorruptError();
@@ -790,11 +779,11 @@ public:
 
         auto pos = it->second;
 
-        if (IncompleteEntries.contains(pos)) {
+        auto eh = Data()->ReadEntryHeader(pos);
+        if (eh.FreeFlag) {
             return TGetTagResult(MakeInvalidPointerError());
         }
 
-        auto eh = Data()->ReadEntryHeader(pos);
         return TGetTagResult(eh.Tag);
     }
 
@@ -811,10 +800,6 @@ public:
 
         auto pos = it->second;
 
-        if (IncompleteEntries.contains(pos)) {
-            return MakeInvalidPointerError();
-        }
-
         if (tag > Capabilities().MaxTag) {
             return MakeError(
                 E_ARGUMENT,
@@ -824,6 +809,10 @@ public:
         }
 
         auto eh = Data()->ReadEntryHeader(pos);
+        if (eh.FreeFlag) {
+            return MakeInvalidPointerError();
+        }
+
         eh.Tag = tag;
 
         bool written = WriteEntryHeader(pos, eh);
@@ -867,7 +856,7 @@ public:
             return TPopFrontResult(MakeBufferIsCorruptError());
         }
 
-        if (!e.HasValue() || e.GetFreeFlag()) {
+        if (!e.HasValue()) {
             return TPopFrontResult(false);
         }
 
@@ -882,7 +871,7 @@ public:
 
     ui64 Size() const
     {
-        return EntryMap.size() - IncompleteEntries.size();
+        return EntryMap.size();
     }
 
     bool Empty() const
@@ -1067,14 +1056,13 @@ TFileRingBuffer::TAllocResult TFileRingBuffer::Alloc(size_t size)
 
 NProto::TError TFileRingBuffer::Commit(const void* ptr)
 {
-    return Impl->Commit(ptr, 0, false);
+    return Impl->Commit(ptr, std::nullopt);
 }
 
 NProto::TError TFileRingBuffer::Commit(const void* ptr, ui32 crc32c)
 {
-    return Impl->Commit(ptr, crc32c, true);
+    return Impl->Commit(ptr, crc32c);
 }
-
 
 NProto::TError TFileRingBuffer::Free(const void* ptr)
 {

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -681,6 +681,13 @@ public:
         }
 
         if (!hasCrc) {
+            if (ptr != Data()->GetEntryDataPtr(pos, eh.DataSize)) {
+                SetCorrupted(
+                    TStringBuilder()
+                    << "Invalid data pointer for incomplete allocation at "
+                    << pos);
+                return MakeBufferIsCorruptError();
+            }
             crc32c = Crc32c(ptr, eh.DataSize);
         }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -8,6 +8,7 @@
 #include <library/cpp/digest/crc32c/crc32c.h>
 
 #include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
 #include <util/generic/size_literals.h>
 #include <util/stream/mem.h>
 #include <util/string/builder.h>
@@ -142,11 +143,13 @@ private:
     TFileMapFileRingBufferAccessor Accessor;
     std::atomic<bool> Corrupted = false;
 
-    TEntryInfo CurrentAllocation = TEntryInfo::CreateInvalid();
     ui64 MaxObservedEntryByteCount = 0;
 
-    // Map of non-free entries: data ptr -> pos
+    // Map of allocated entries: data ptr -> pos
     THashMap<const void*, ui64> EntryMap;
+
+    // Allocated entries that have not been committed yet
+    THashSet<ui64> IncompleteEntries;
 
 private:
     THeader* Header()
@@ -253,6 +256,22 @@ private:
         return e.HasValue()
             ? GetEntry(e.ActualPos + Data()->GetEntrySize(e.Header.DataSize))
             : TEntryInfo::CreateInvalid();
+    }
+
+    // Sets corrupted state if Data()->WriteEntryHeader is failed
+    bool WriteEntryHeader(ui64 pos, const TFileRingBufferEntryHeader& header)
+    {
+        // A compiler-only fence is sufficient here because there is no
+        // concurrent access to the memory and we just need to ensure
+        // that a compiler does not reorder writes.
+        std::atomic_signal_fence(std::memory_order_seq_cst);
+
+        auto success = Data()->WriteEntryHeader(pos, header);
+        if (!success) {
+            SetCorrupted(
+                TStringBuilder() << "Cannot write entry header at " << pos);
+        }
+        return success;
     }
 
     void CopyMappedData(ui64 destPos, ui64 srcPos, ui64 size)
@@ -372,7 +391,9 @@ private:
     void EraseFreeEntriesFromFront()
     {
         auto front = GetFrontEntry();
-        while (front.HasValue() && front.GetFreeFlag()) {
+        while (front.HasValue() && front.GetFreeFlag() &&
+               !IncompleteEntries.contains(front.ActualPos))
+        {
             front = GetNextEntry(front);
         }
 
@@ -506,7 +527,7 @@ public:
 
         data.copy(allocationResult.AllocationPtr, data.size());
 
-        auto commitResult = Commit();
+        auto commitResult = Commit(allocationResult.AllocationPtr, 0, false);
 
         if (HasError(commitResult)) {
             return TPushBackResult(commitResult);
@@ -519,12 +540,6 @@ public:
     {
         if (!ValidateAccess("Alloc")) {
             return TAllocResult(MakeBufferIsCorruptError());
-        }
-
-        if (CurrentAllocation.HasValue()) {
-            return TAllocResult(MakeError(
-                E_INVALID_STATE,
-                "Previous allocation is not committed"));
         }
 
         if (size == 0) {
@@ -595,38 +610,37 @@ public:
             Max(MaxObservedEntryByteCount, size);
 
         char* ptr = Data()->GetEntryDataPtr(writePos, size);
-        Y_ABORT_UNLESS(ptr != nullptr);
-
-        CurrentAllocation = TEntryInfo::Create(
-            writePos,
-            {.DataSize = static_cast<ui32>(size)},
-            ptr);
-
-        return TAllocResult(ptr);
-    }
-
-    NProto::TError Commit()
-    {
-        if (!ValidateAccess("Commit")) {
-            return MakeBufferIsCorruptError();
-        }
-
-        if (!CurrentAllocation.HasValue()) {
-            return MakeError(E_ARGUMENT, "No allocation to commit");
-        }
-
-        CurrentAllocation.Header.DataChecksum =
-            Crc32c(CurrentAllocation.Data, CurrentAllocation.Header.DataSize);
-
-        bool written = Data()->WriteEntryHeader(
-            CurrentAllocation.ActualPos,
-            CurrentAllocation.Header);
-
-        if (!written) {
+        if (ptr == nullptr) {
             SetCorrupted(
-                TStringBuilder() << "Cannot write entry header at "
-                                 << CurrentAllocation.ActualPos);
-            return MakeBufferIsCorruptError();
+                TStringBuilder() << "Cannot access data buffer at " << writePos
+                                 << ", size = " << size);
+            return TAllocResult(MakeBufferIsCorruptError());
+        }
+
+        auto [it1, inserted1] = IncompleteEntries.insert(writePos);
+        if (!inserted1) {
+            SetCorrupted(
+                TStringBuilder()
+                << "Duplicate incomplete allocation at " << writePos);
+            return TAllocResult(MakeBufferIsCorruptError());
+        }
+
+        auto [it2, inserted2] = EntryMap.insert({ptr, writePos});
+        if (!inserted2) {
+            SetCorrupted(
+                TStringBuilder() << "Duplicate allocation at " << writePos);
+            return TAllocResult(MakeBufferIsCorruptError());
+        }
+
+        auto headerWritten = WriteEntryHeader(
+            writePos,
+            {.DataSize = static_cast<ui32>(size),
+             .DataChecksum = 0,
+             .Tag = 0,
+             .FreeFlag = true});
+
+        if (!headerWritten) {
+            return TAllocResult(MakeBufferIsCorruptError());
         }
 
         // A compiler-only fence is sufficient here because there is no
@@ -634,13 +648,63 @@ public:
         // that a compiler does not reorder writes.
         std::atomic_signal_fence(std::memory_order_seq_cst);
 
-        Header()->WritePos =
-            CurrentAllocation.ActualPos +
-            Data()->GetEntrySize(CurrentAllocation.Header.DataSize);
+        Header()->WritePos = writePos + sz;
 
-        EntryMap[CurrentAllocation.Data] = CurrentAllocation.ActualPos;
+        return TAllocResult(ptr);
+    }
 
-        CurrentAllocation = TEntryInfo::CreateInvalid();
+    NProto::TError Commit(const void* ptr, ui32 crc32c, bool hasCrc)
+    {
+        if (!ValidateAccess("Commit")) {
+            return MakeBufferIsCorruptError();
+        }
+
+        const auto it = EntryMap.find(ptr);
+        if (it == EntryMap.end()) {
+            return MakeInvalidPointerError();
+        }
+        ui64 pos = it->second;
+
+        auto removed = IncompleteEntries.erase(pos);
+        if (!removed) {
+            return MakeInvalidPointerError();
+        }
+
+        auto eh = Data()->ReadEntryHeader(pos);
+        if (!eh.FreeFlag || eh.DataSize == 0 || eh.DataChecksum != 0 ||
+            eh.Tag != 0)
+        {
+            SetCorrupted(
+                TStringBuilder()
+                << "Invalid header for incomplete allocation at " << pos);
+            return MakeBufferIsCorruptError();
+        }
+
+        if (!hasCrc) {
+            crc32c = Crc32c(ptr, eh.DataSize);
+        }
+
+        if (Capabilities().EntryHeaderIsProcessedAtomically) {
+            eh.DataChecksum = crc32c;
+            eh.FreeFlag = false;
+
+            if (!WriteEntryHeader(pos, eh)) {
+                return MakeBufferIsCorruptError();
+            }
+        } else {
+            eh.DataChecksum = crc32c;
+
+            if (!WriteEntryHeader(pos, eh)) {
+                return MakeBufferIsCorruptError();
+            }
+
+            eh.FreeFlag = false;
+
+            if (!WriteEntryHeader(pos, eh)) {
+                return MakeBufferIsCorruptError();
+            }
+        }
+
         return {};
     }
 
@@ -655,17 +719,38 @@ public:
             return MakeInvalidPointerError();
         }
 
-        auto eh = Data()->ReadEntryHeader(it->second);
-        eh.DataChecksum = 0;
-        eh.FreeFlag = true;
+        auto pos = it->second;
 
-        bool written = Data()->WriteEntryHeader(it->second, eh);
+        if (IncompleteEntries.contains(pos)) {
+            return MakeInvalidPointerError();
+        }
 
-        if (!written) {
+        auto eh = Data()->ReadEntryHeader(pos);
+        if (eh.FreeFlag || eh.DataSize == 0) {
             SetCorrupted(
-                TStringBuilder()
-                << "Cannot write entry header at " << it->second);
+                TStringBuilder() << "Invalid header for allocation at " << pos);
             return MakeBufferIsCorruptError();
+        }
+
+        if (Capabilities().EntryHeaderIsProcessedAtomically) {
+            eh.DataChecksum = 0;
+            eh.FreeFlag = true;
+
+            if (!WriteEntryHeader(pos, eh)) {
+                return MakeBufferIsCorruptError();
+            }
+        } else {
+            eh.FreeFlag = true;
+
+            if (!WriteEntryHeader(pos, eh)) {
+                return MakeBufferIsCorruptError();
+            }
+
+            eh.DataChecksum = 0;
+
+            if (!WriteEntryHeader(pos, eh)) {
+                return MakeBufferIsCorruptError();
+            }
         }
 
         EntryMap.erase(it);
@@ -696,7 +781,13 @@ public:
             return TGetTagResult(MakeInvalidPointerError());
         }
 
-        auto eh = Data()->ReadEntryHeader(it->second);
+        auto pos = it->second;
+
+        if (IncompleteEntries.contains(pos)) {
+            return TGetTagResult(MakeInvalidPointerError());
+        }
+
+        auto eh = Data()->ReadEntryHeader(pos);
         return TGetTagResult(eh.Tag);
     }
 
@@ -711,6 +802,12 @@ public:
             return MakeInvalidPointerError();
         }
 
+        auto pos = it->second;
+
+        if (IncompleteEntries.contains(pos)) {
+            return MakeInvalidPointerError();
+        }
+
         if (tag > Capabilities().MaxTag) {
             return MakeError(
                 E_ARGUMENT,
@@ -719,15 +816,11 @@ public:
                                  << Capabilities().MaxTag << ")");
         }
 
-        auto eh = Data()->ReadEntryHeader(it->second);
+        auto eh = Data()->ReadEntryHeader(pos);
         eh.Tag = tag;
 
-        bool written = Data()->WriteEntryHeader(it->second, eh);
-
+        bool written = WriteEntryHeader(pos, eh);
         if (!written) {
-            SetCorrupted(
-                TStringBuilder()
-                << "Cannot write entry header at " << it->second);
             return MakeBufferIsCorruptError();
         }
 
@@ -747,6 +840,10 @@ public:
             return TFrontResult(MakeBufferIsCorruptError());
         }
 
+        if (!e.HasValue() || e.GetFreeFlag()) {
+            return TFrontResult(TStringBuf());
+        }
+
         return TFrontResult(e.GetData());
     }
 
@@ -763,7 +860,7 @@ public:
             return TPopFrontResult(MakeBufferIsCorruptError());
         }
 
-        if (!e.HasValue()) {
+        if (!e.HasValue() || e.GetFreeFlag()) {
             return TPopFrontResult(false);
         }
 
@@ -778,7 +875,7 @@ public:
 
     ui64 Size() const
     {
-        return EntryMap.size();
+        return EntryMap.size() - IncompleteEntries.size();
     }
 
     bool Empty() const
@@ -961,10 +1058,16 @@ TFileRingBuffer::TAllocResult TFileRingBuffer::Alloc(size_t size)
     return Impl->Alloc(size);
 }
 
-NProto::TError TFileRingBuffer::Commit()
+NProto::TError TFileRingBuffer::Commit(const void* ptr)
 {
-    return Impl->Commit();
+    return Impl->Commit(ptr, 0, false);
 }
+
+NProto::TError TFileRingBuffer::Commit(const void* ptr, ui32 crc32c)
+{
+    return Impl->Commit(ptr, crc32c, true);
+}
+
 
 NProto::TError TFileRingBuffer::Free(const void* ptr)
 {

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -128,6 +128,11 @@ NProto::TError MakeBufferIsCorruptError()
     return MakeError(E_INVALID_STATE, "Buffer is corrupted");
 }
 
+NProto::TError MakeBufferIsCorruptError(const TString& message)
+{
+    return MakeError(E_INVALID_STATE, "Buffer is corrupted: " + message);
+}
+
 NProto::TError MakeInvalidPointerError()
 {
     return MakeError(E_ARGUMENT, "Invalid pointer");
@@ -254,22 +259,6 @@ private:
         return e.HasValue()
             ? GetEntry(e.ActualPos + Data()->GetEntrySize(e.Header.DataSize))
             : TEntryInfo::CreateInvalid();
-    }
-
-    // Sets corrupted state if Data()->WriteEntryHeader is failed
-    bool WriteEntryHeader(ui64 pos, const TFileRingBufferEntryHeader& header)
-    {
-        // A compiler-only fence is sufficient here because there is no
-        // concurrent access to the memory and we just need to ensure
-        // that a compiler does not reorder writes.
-        std::atomic_signal_fence(std::memory_order_seq_cst);
-
-        auto success = Data()->WriteEntryHeader(pos, header);
-        if (!success) {
-            SetCorrupted(
-                TStringBuilder() << "Cannot write entry header at " << pos);
-        }
-        return success;
     }
 
     void CopyMappedData(ui64 destPos, ui64 srcPos, ui64 size)
@@ -610,20 +599,18 @@ public:
 
         char* ptr = Data()->GetEntryDataPtr(writePos, size);
         if (ptr == nullptr) {
-            SetCorrupted(
+            return TAllocResult(SetCorruptedAndReturnError(
                 TStringBuilder() << "Cannot access data buffer at " << writePos
-                                 << ", size = " << size);
-            return TAllocResult(MakeBufferIsCorruptError());
+                                 << ", size = " << size));
         }
 
         auto [_, inserted] = EntryMap.insert({ptr, writePos});
         if (!inserted) {
-            SetCorrupted(
-                TStringBuilder() << "Duplicate allocation at " << writePos);
-            return TAllocResult(MakeBufferIsCorruptError());
+            return TAllocResult(SetCorruptedAndReturnError(
+                TStringBuilder() << "Duplicate allocation at " << writePos));
         }
 
-        auto headerWritten = WriteEntryHeader(
+        auto headerWritten = Data()->WriteEntryHeader(
             writePos,
             {.DataSize = static_cast<ui32>(size),
              .DataChecksum = 0,
@@ -631,9 +618,13 @@ public:
              .FreeFlag = true});
 
         if (!headerWritten) {
-            return TAllocResult(MakeBufferIsCorruptError());
+            return TAllocResult(SetCorruptedAndReturnError(
+                TStringBuilder()
+                << "Cannot write entry header for a new allocation at "
+                << writePos));
         }
 
+        // Ensure that the entry header is written before WritePos is updated
         // A compiler-only fence is sufficient here because there is no
         // concurrent access to the memory and we just need to ensure
         // that a compiler does not reorder writes.
@@ -658,22 +649,23 @@ public:
         ui64 pos = it->second;
 
         auto eh = Data()->ReadEntryHeader(pos);
-        if (!eh.FreeFlag || eh.DataSize == 0 || eh.DataChecksum != 0 ||
-            eh.Tag != 0)
-        {
-            SetCorrupted(
+
+        if (!eh.FreeFlag) {
+            return MakeInvalidPointerError();
+        }
+
+        if (eh.DataSize == 0 || eh.DataChecksum != 0 || eh.Tag != 0) {
+            return SetCorruptedAndReturnError(
                 TStringBuilder()
                 << "Invalid header for incomplete allocation at " << pos);
-            return MakeBufferIsCorruptError();
         }
 
         if (!crc32c) {
             if (ptr != Data()->GetEntryDataPtr(pos, eh.DataSize)) {
-                SetCorrupted(
+                return SetCorruptedAndReturnError(
                     TStringBuilder()
                     << "Invalid data pointer for incomplete allocation at "
                     << pos);
-                return MakeBufferIsCorruptError();
             }
             crc32c = Crc32c(ptr, eh.DataSize);
         }
@@ -681,8 +673,11 @@ public:
         eh.DataChecksum = *crc32c;
         eh.FreeFlag = false;
 
-        if (!WriteEntryHeader(pos, eh)) {
-            return MakeBufferIsCorruptError();
+        if (!Data()->WriteEntryHeader(pos, eh)) {
+            return SetCorruptedAndReturnError(
+                TStringBuilder()
+                << "Cannot write entry header for a committed allocation at "
+                << pos);
         }
 
         return {};
@@ -709,16 +704,18 @@ public:
         }
 
         if (eh.DataSize == 0) {
-            SetCorrupted(
+            return SetCorruptedAndReturnError(
                 TStringBuilder() << "Invalid header for allocation at " << pos);
-            return MakeBufferIsCorruptError();
         }
 
         eh.DataChecksum = 0;
         eh.FreeFlag = true;
 
-        if (!WriteEntryHeader(pos, eh)) {
-            return MakeBufferIsCorruptError();
+        if (!Data()->WriteEntryHeader(pos, eh)) {
+            return SetCorruptedAndReturnError(
+                TStringBuilder()
+                << "Cannot write entry header for a freed allocation at "
+                << pos);
         }
 
         EntryMap.erase(it);
@@ -787,9 +784,11 @@ public:
 
         eh.Tag = tag;
 
-        bool written = WriteEntryHeader(pos, eh);
+        bool written = Data()->WriteEntryHeader(pos, eh);
         if (!written) {
-            return MakeBufferIsCorruptError();
+            return SetCorruptedAndReturnError(
+                TStringBuilder()
+                << "Cannot write entry header with updated tag at " << pos);
         }
 
         return {};
@@ -902,6 +901,12 @@ public:
                 "Corruption detected in FileRingBuffer, path: " +
                 Args.FilePath + ", message: " + message);
         }
+    }
+
+    NProto::TError SetCorruptedAndReturnError(const TString& message)
+    {
+        SetCorrupted(message);
+        return MakeBufferIsCorruptError(message);
     }
 
     ui64 GetRawCapacity() const

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -134,8 +134,8 @@ public:
      * entry. If there is a need to augment the allocation with additional data,
      * GetTag/SetTag can be used.
      *
-     * An error is returned if there is no incomplete allocation correponding to
-     * the provided pointer or the buffer is corrupted.
+     * An error is returned if there is no incomplete allocation corresponding
+     * to the provided pointer or the buffer is corrupted.
      *
      * Note: the checksum is not validated, the calling code has responsibility
      * to provide the correct Crc32c checksum. Passing an incorrect checksum may

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -114,8 +114,8 @@ public:
      * entry. If there is a need to augment the allocation with additional data,
      * GetTag/SetTag can be used.
      *
-     * An error is returned if there is no incomplete allocation correponding to
-     * the provided pointer or the buffer is corrupted.
+     * An error is returned if there is no incomplete allocation corresponding
+     * to the provided pointer or the buffer is corrupted.
      */
     [[nodiscard]] NProto::TError Commit(const void* ptr);
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -85,9 +85,6 @@ public:
      * Additionally, TPushBackResult::Error is set if allocation has failed for
      * any reason other than insufficient capacity, for example, buffer
      * corruption or invalid argument.
-     *
-     * Note: only one allocation is possible at a time. Calling PushBack while
-     * an allocation made by Alloc is not committed will return an error.
      */
     [[nodiscard]] TPushBackResult PushBack(TStringBuf data);
 
@@ -103,9 +100,6 @@ public:
      * Additionally, TAllocResult::Error is set if allocation has failed for any
      * reason other than insufficient capacity, for example, buffer corruption
      * or invalid argument.
-     *
-     * Note: only one allocation is possible at a time. Repeated Alloc will
-     * return an error.
      */
     [[nodiscard]] TAllocResult Alloc(size_t size);
 
@@ -117,10 +111,34 @@ public:
      * entry. If there is a need to augment the allocation with additional data,
      * GetTag/SetTag can be used.
      *
-     * An error is returned if there is no incomplete allocation or the buffer
-     * is corrupted.
+     * An error is returned if there is no incomplete allocation correponding to
+     * the provided pointer or the buffer is corrupted.
      */
-    [[nodiscard]] NProto::TError Commit();
+    [[nodiscard]] NProto::TError Commit(const void* ptr);
+
+    /**
+     * Completes the previously made allocation using checksum provided by
+     * caller and making the allocation visible.
+     *
+     * Since TFileRingBuffer is non-thread safe, it requires external
+     * synchronization and executing its methods under a lock. Calculating
+     * checksums inside Commit() consumes some time and it will prevent other
+     * threads from using TFileRingBuffer. The purpose of this method is to make
+     * multi-threaded work with TFileRingBuffer more efficient by reducing the
+     * time spent inside the lock.
+     *
+     * Once committed, it is not allowed to modify the contents of the allocated
+     * entry. If there is a need to augment the allocation with additional data,
+     * GetTag/SetTag can be used.
+     *
+     * An error is returned if there is no incomplete allocation correponding to
+     * the provided pointer or the buffer is corrupted.
+     *
+     * Note: the checksum is not validated, the calling code has responsibility
+     * to provide the correct Crc32c checksum. Passing an incorrect checksum may
+     * lead to a corruption error.
+     */
+    [[nodiscard]] NProto::TError Commit(const void* ptr, ui32 crc32c);
 
     /**
      * Frees a memory block that was previously allocated and committed.
@@ -162,7 +180,8 @@ public:
      * Gets the front allocation of the buffer.
      *
      * TFrontResult::Data contains the contents of the front allocation or
-     * empty value if the buffer is empty or corrupted.
+     * empty value if the buffer is empty, the front allocation is not committed
+     * or the buffer is corrupted.
      *
      * Additionally, TFrontResult::Error is set on corruption.
      */
@@ -172,7 +191,8 @@ public:
      * Frees the front allocation.
      *
      * TPopFrontResult::Removed is true if the front allocation has been
-     * successfully freed or false if the buffer is empty or corrupted.
+     * successfully freed or false if the buffer is empty, the front allocation
+     * is not committed or the buffer is corrupted.
      *
      * Additionally, TFrontResult::Error is set on corruption.
      */
@@ -185,7 +205,7 @@ public:
     [[nodiscard]] ui64 Size() const;
 
     /**
-     * Checks if the buffer is empty.
+     * Checks if the buffer has no visible and incomplete allocations.
      * The behavior is unspecified if the buffer is corrupted.
      */
     [[nodiscard]] bool Empty() const;

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -100,6 +100,9 @@ public:
      * Additionally, TAllocResult::Error is set if allocation has failed for any
      * reason other than insufficient capacity, for example, buffer corruption
      * or invalid argument.
+     *
+     * Note: methods Front() and PopFront() should not be called while an
+     * allocation is in progress.
      */
     [[nodiscard]] TAllocResult Alloc(size_t size);
 
@@ -191,15 +194,16 @@ public:
      * Frees the front allocation.
      *
      * TPopFrontResult::Removed is true if the front allocation has been
-     * successfully freed or false if the buffer is empty, the front allocation
-     * is not committed or the buffer is corrupted.
+     * successfully freed or false otherwise.
      *
-     * Additionally, TFrontResult::Error is set on corruption.
+     * TFrontResult::Error is set if the front allocation is incomplete or the
+     * buffer is corrupted.
      */
     [[nodiscard]] TPopFrontResult PopFront();
 
     /**
-     * Returns the number of visible allocations in the buffer.
+     * Returns the number of all allocations in the buffer (including
+     * incomplete ones).
      * The behavior is unspecified if the buffer is corrupted.
      */
     [[nodiscard]] ui64 Size() const;

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -179,7 +179,7 @@ public:
 
         // In V5 format it is allowed for a entry with FreeFlag set to have an
         // invalid checksum - we need to ensure that fields are visible in the
-        // correct order
+        // correct order.
         //
         // A compiler-only fence is sufficient here because there is no
         // concurrent access to the memory and we just need to ensure

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -174,9 +174,26 @@ public:
             return false;
         }
 
-        eh->DataSize = header.DataSize | (header.Tag << TagShift) |
-                       (header.FreeFlag ? FreeFlagMask : 0);
-        eh->Checksum = header.DataChecksum;
+        const ui32 dataSize = header.DataSize | (header.Tag << TagShift) |
+                              (header.FreeFlag ? FreeFlagMask : 0);
+
+        // In V5 format it is allowed for a entry with FreeFlag set to have an
+        // invalid checksum - we need to ensure that fields are visible in the
+        // correct order
+        //
+        // A compiler-only fence is sufficient here because there is no
+        // concurrent access to the memory and we just need to ensure
+        // that a compiler does not reorder writes.
+        //
+        if (header.FreeFlag) {
+            eh->DataSize = dataSize;
+            std::atomic_signal_fence(std::memory_order_seq_cst);
+            eh->Checksum = header.DataChecksum;
+        } else {
+            eh->Checksum = header.DataChecksum;
+            std::atomic_signal_fence(std::memory_order_seq_cst);
+            eh->DataSize = dataSize;
+        }
         return true;
     }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -1306,6 +1306,185 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         }
     }
 
+    struct TRandomizedTestWithIncompleteAllocationsBootstrap
+    {
+        static constexpr ui64 BufferSize = 1024;
+        static constexpr ui64 MaxAllocSize = 256;
+
+        const EFileRingBufferVersion Version;
+
+        TTempFileHandle FileHandle;
+        std::unique_ptr<TFileRingBuffer> RingBuffer;
+
+        struct TAllocation
+        {
+            TString Data;
+            const char* Ptr = nullptr;
+            bool Committed = false;
+        };
+
+        TVector<TAllocation> Allocations;
+        size_t IncompleteAllocationCount = 0;
+
+        TRandomizedTestWithIncompleteAllocationsBootstrap(
+            EFileRingBufferVersion version)
+            : Version(version)
+        {
+            Recreate();
+        }
+
+        void Recreate()
+        {
+            RingBuffer = std::make_unique<TFileRingBuffer>(
+                FileHandle.GetName(),
+                BufferSize,
+                0,
+                Version);
+
+            UNIT_ASSERT(RingBuffer->Validate());
+            UNIT_ASSERT(!RingBuffer->IsCorrupted());
+
+            IncompleteAllocationCount = 0;
+
+            EraseIf(
+                Allocations,
+                [](const TAllocation& alloc) { return !alloc.Committed; });
+
+            size_t index = 0;
+
+            auto visitResult = RingBuffer->Visit(
+                [&](ui32 checksum, ui32 tag, TStringBuf entry)
+                {
+                    Y_UNUSED(checksum);
+                    Y_UNUSED(tag);
+                    UNIT_ASSERT(index < Allocations.size());
+                    Allocations[index].Ptr = entry.data();
+                    index++;
+                });
+
+            UNIT_ASSERT(!HasError(visitResult));
+            UNIT_ASSERT_VALUES_EQUAL(Allocations.size(), index);
+
+            Check();
+        }
+
+        void Alloc()
+        {
+            const auto size = RandomNumber(MaxAllocSize) + 1;
+            auto data = GenerateData(static_cast<ui32>(size));
+            auto allocation = RingBuffer->Alloc(size);
+            UNIT_ASSERT(!HasError(allocation.Error));
+            if (allocation.AllocationPtr) {
+                data.copy(allocation.AllocationPtr, data.size());
+                Allocations.push_back(
+                    {std::move(data), allocation.AllocationPtr, false});
+                ++IncompleteAllocationCount;
+            }
+
+            Check();
+        }
+
+        void Commit()
+        {
+            if (IncompleteAllocationCount == 0) {
+                return;
+            }
+
+            const size_t index = GetRandomAllocation(false);
+            UNIT_ASSERT(!HasError(RingBuffer->Commit(Allocations[index].Ptr)));
+            Allocations[index].Committed = true;
+            --IncompleteAllocationCount;
+
+            Check();
+        }
+
+        void Free()
+        {
+            if (Allocations.size() == IncompleteAllocationCount) {
+                return;
+            }
+
+            const size_t index = GetRandomAllocation(true);
+            if (index != Allocations.size()) {
+                UNIT_ASSERT(
+                    !HasError(RingBuffer->Free(Allocations[index].Ptr)));
+                Allocations.erase(Allocations.begin() + index);
+            }
+
+            Check();
+        }
+
+        size_t GetRandomAllocation(bool committed)
+        {
+            if (committed) {
+                Y_ABORT_UNLESS(Allocations.size() > IncompleteAllocationCount);
+            } else {
+                Y_ABORT_UNLESS(IncompleteAllocationCount > 0);
+            }
+
+            size_t index = RandomNumber(Allocations.size());
+            for (size_t i = 0; i < Allocations.size(); ++i) {
+                if (Allocations[index].Committed == committed) {
+                    return index;
+                }
+                index = (index + 1) % Allocations.size();
+            }
+
+            return index;
+        }
+
+        TString DumpReference()
+        {
+            TStringBuilder res;
+            for (const auto& allocation: Allocations) {
+                if (allocation.Committed) {
+                    if (!res.empty()) {
+                        res += ", ";
+                    }
+                    res += allocation.Data;
+                }
+            }
+            return res;
+        }
+
+        void Check()
+        {
+            UNIT_ASSERT_VALUES_EQUAL(DumpReference(), Dump(*RingBuffer));
+            UNIT_ASSERT_VALUES_EQUAL(Allocations.size(), RingBuffer->Size());
+            UNIT_ASSERT_VALUES_EQUAL(Allocations.empty(), RingBuffer->Empty());
+        }
+    };
+
+    FILE_RING_BUFFER_TEST(RandomizedTestWithIncompleteAllocations)
+    {
+        constexpr size_t numIterations = 10000;
+        constexpr ui32 recreateProbability = 10;
+        constexpr ui32 allocProbability = 30;
+        constexpr ui32 commitProbability = 40;
+        constexpr ui32 freeProbability = 20;
+
+        TRandomizedTestWithIncompleteAllocationsBootstrap b(ver);
+
+        for (size_t i = 0; i < numIterations; ++i) {
+            const ui32 action = static_cast<ui32>(RandomNumber(
+                recreateProbability + allocProbability + commitProbability +
+                freeProbability));
+
+            if (action < recreateProbability) {
+                b.Recreate();
+            } else if (action < recreateProbability + allocProbability) {
+                b.Alloc();
+            } else if (
+                action <
+                recreateProbability + allocProbability + commitProbability)
+            {
+                b.Commit();
+            } else {
+                b.Free();
+            }
+        }
+    }
+
     FILE_RING_BUFFER_TEST(AllocShouldReturnExtendedStatus)
     {
         const auto f = TTempFileHandle();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -1391,8 +1391,17 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             }
 
             const size_t index = GetRandomAllocation(false);
-            UNIT_ASSERT(!HasError(RingBuffer->Commit(Allocations[index].Ptr)));
-            Allocations[index].Committed = true;
+            const auto& allocation = Allocations[index];
+
+            if (RandomNumber(2u) == 0) {
+                const ui32 crc =
+                    Crc32c(allocation.Data.data(), allocation.Data.size());
+                UNIT_ASSERT(!HasError(RingBuffer->Commit(allocation.Ptr, crc)));
+            } else {
+                UNIT_ASSERT(!HasError(RingBuffer->Commit(allocation.Ptr)));
+            }
+
+            allocation.Committed = true;
             --IncompleteAllocationCount;
 
             Check();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -3,6 +3,7 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 
+#include <library/cpp/digest/crc32c/crc32c.h>
 #include <library/cpp/string_utils/base64/base64.h>
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -634,7 +635,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         ptr[0] = 'a';
         ptr[1] = 'b';
         ptr[2] = 'c';
-        UNIT_ASSERT(!HasError(rb.Commit()));
+        UNIT_ASSERT(!HasError(rb.Commit(ptr)));
         UNIT_ASSERT(rb.SetMetadata("123").Updated);
 
         rb.SetCorrupted();
@@ -664,7 +665,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(HasError(rb.Free(ptr)));
         UNIT_ASSERT_STRINGS_EQUAL(dump, Dump(f));
 
-        UNIT_ASSERT(HasError(rb.Commit()));
+        UNIT_ASSERT(HasError(rb.Commit(ptr)));
         UNIT_ASSERT_STRINGS_EQUAL(dump, Dump(f));
 
         UNIT_ASSERT(HasError(rb.GetTag(ptr).Error));
@@ -695,14 +696,14 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             frontAllocationPtr[0] = 'a';
             frontAllocationPtr[1] = 'b';
             frontAllocationPtr[2] = 'c';
-            UNIT_ASSERT(!HasError(RingBuffer.Commit()));
+            UNIT_ASSERT(!HasError(RingBuffer.Commit(frontAllocationPtr)));
 
             secondAllocationPtr = RingBuffer.Alloc(3).AllocationPtr;
             UNIT_ASSERT(secondAllocationPtr != nullptr);
             secondAllocationPtr[0] = 'd';
             secondAllocationPtr[1] = 'e';
             secondAllocationPtr[2] = 'f';
-            UNIT_ASSERT(!HasError(RingBuffer.Commit()));
+            UNIT_ASSERT(!HasError(RingBuffer.Commit(secondAllocationPtr)));
         }
 
         void Corrupt(ui64 ofs)
@@ -1069,13 +1070,13 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(!HasError(alloc1.Error));
         UNIT_ASSERT(alloc1.AllocationPtr != nullptr);
         data1.copy(alloc1.AllocationPtr, data1.size());
-        UNIT_ASSERT(!HasError(rb.Commit()));
+        UNIT_ASSERT(!HasError(rb.Commit(alloc1.AllocationPtr)));
 
         auto alloc2 = rb.Alloc(data2.size());
         UNIT_ASSERT(!HasError(alloc2.Error));
         UNIT_ASSERT(alloc2.AllocationPtr != nullptr);
         data2.copy(alloc2.AllocationPtr, data2.size());
-        UNIT_ASSERT(!HasError(rb.Commit()));
+        UNIT_ASSERT(!HasError(rb.Commit(alloc2.AllocationPtr)));
 
         UNIT_ASSERT_VALUES_EQUAL(data1, rb.Front().Data);
         UNIT_ASSERT(rb.PopFront().Removed);
@@ -1084,39 +1085,196 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT_VALUES_EQUAL("", rb.Front().Data);
     }
 
-    FILE_RING_BUFFER_TEST(ShouldDropNotCommittedEntry)
+    FILE_RING_BUFFER_TEST(ShouldNotAccessIncompleteAllocations)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 64;
+        TFileRingBuffer rb(f.GetName(), len, 0, ver);
+
+        TString data = "vasya";
+
+        auto ptr = rb.Alloc(data.size()).AllocationPtr;
+        UNIT_ASSERT(ptr != nullptr);
+        data.copy(ptr, data.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, rb.Free(ptr).GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, rb.GetTag(ptr).Error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, rb.SetTag(ptr, 0).GetCode());
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldSupportMultipleIncompleteAllocations)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 128;
+        TFileRingBuffer rb(f.GetName(), len, 0, ver);
+
+        const TString data1 = "one";
+        const TString data2 = "two";
+        const TString data3 = "three";
+
+        auto* ptr1 = rb.Alloc(data1.size()).AllocationPtr;
+        auto* ptr2 = rb.Alloc(data2.size()).AllocationPtr;
+        auto* ptr3 = rb.Alloc(data3.size()).AllocationPtr;
+
+        UNIT_ASSERT(ptr1 != nullptr);
+        UNIT_ASSERT(ptr2 != nullptr);
+        UNIT_ASSERT(ptr3 != nullptr);
+
+        data1.copy(ptr1, data1.size());
+        data2.copy(ptr2, data2.size());
+        data3.copy(ptr3, data3.size());
+
+        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb));
+
+        // Allocations may be committed in a different order from allocation.
+        UNIT_ASSERT(!HasError(rb.Commit(ptr2)));
+        UNIT_ASSERT_VALUES_EQUAL("two", Dump(rb));
+
+        UNIT_ASSERT(!HasError(rb.Commit(ptr1)));
+        UNIT_ASSERT_VALUES_EQUAL("one, two", Dump(rb));
+
+        // Removing committed entries must not discard an incomplete entry at
+        // the front of the remaining allocation range.
+        UNIT_ASSERT(!HasError(rb.Free(ptr1)));
+        UNIT_ASSERT(!HasError(rb.Free(ptr2)));
+        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb));
+
+        UNIT_ASSERT(!HasError(rb.Commit(ptr3)));
+        UNIT_ASSERT_VALUES_EQUAL("three", Dump(rb));
+        UNIT_ASSERT_VALUES_EQUAL(data3, rb.Front().Data);
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotPopFrontIncompleteAllocation)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 128;
+        TFileRingBuffer rb(f.GetName(), len, 0, ver);
+
+        const TString data1 = "one";
+        const TString data2 = "two";
+
+        auto* ptr1 = rb.Alloc(data1.size()).AllocationPtr;
+        auto* ptr2 = rb.Alloc(data2.size()).AllocationPtr;
+
+        UNIT_ASSERT(ptr1 != nullptr);
+        UNIT_ASSERT(ptr2 != nullptr);
+
+        data1.copy(ptr1, data1.size());
+        data2.copy(ptr2, data2.size());
+
+        UNIT_ASSERT(!HasError(rb.Commit(ptr2)));
+
+        UNIT_ASSERT_VALUES_EQUAL("two", Dump(rb));
+
+        auto frontResult = rb.Front();
+        UNIT_ASSERT(!HasError(frontResult.Error));
+        UNIT_ASSERT(frontResult.Data.empty());
+
+        auto popFrontResult = rb.PopFront();
+        UNIT_ASSERT(!popFrontResult.Removed);
+        UNIT_ASSERT(!HasError(popFrontResult.Error));
+
+        UNIT_ASSERT_VALUES_EQUAL("two", Dump(rb));
+
+        UNIT_ASSERT(!HasError(rb.Commit(ptr1)));
+
+        UNIT_ASSERT_VALUES_EQUAL("one, two", Dump(rb));
+        UNIT_ASSERT_VALUES_EQUAL("one", rb.Front().Data);
+
+        UNIT_ASSERT(rb.PopFront().Removed);
+
+        UNIT_ASSERT_VALUES_EQUAL("two", Dump(rb));
+        UNIT_ASSERT_VALUES_EQUAL("two", rb.Front().Data);
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldCommitWithPrecomputedChecksum)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 64;
+        const TString data = "precomputed checksum";
+        const ui32 checksum = Crc32c(data.data(), data.size());
+
+        {
+            TFileRingBuffer rb(f.GetName(), len, 0, ver);
+            auto alloc = rb.Alloc(data.size());
+
+            UNIT_ASSERT(!HasError(alloc.Error));
+            UNIT_ASSERT(alloc.AllocationPtr != nullptr);
+            data.copy(alloc.AllocationPtr, data.size());
+            UNIT_ASSERT(!HasError(rb.Commit(alloc.AllocationPtr, checksum)));
+
+            ui32 visitedChecksum = 0;
+            UNIT_ASSERT(!HasError(rb.Visit(
+                [&](ui32 crc32, ui32, TStringBuf entry)
+                {
+                    visitedChecksum = crc32;
+                    UNIT_ASSERT_VALUES_EQUAL(data, entry);
+                })));
+            UNIT_ASSERT_VALUES_EQUAL(checksum, visitedChecksum);
+        }
+
+        // A caller-provided checksum must produce an entry that survives
+        // validation when the ring buffer is reopened.
+        TFileRingBuffer rb(f.GetName(), len, 0, ver);
+        UNIT_ASSERT(!rb.IsCorrupted());
+        UNIT_ASSERT_VALUES_EQUAL(data, rb.Front().Data);
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldDropNotCommittedEntries)
     {
         const auto f = TTempFileHandle();
         const ui32 len = 64;
 
         TString data1 = "vasya";
         TString data2 = "ivan";
+        TString data3 = "peter";
 
         {
             TFileRingBuffer rb(f.GetName(), len, 0, ver);
+            UNIT_ASSERT(rb.Empty());
 
             auto alloc1 = rb.Alloc(data1.size());
             UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
+            UNIT_ASSERT(!rb.Empty());
             UNIT_ASSERT(!HasError(alloc1.Error));
             UNIT_ASSERT(alloc1.AllocationPtr != nullptr);
             data1.copy(alloc1.AllocationPtr, data1.size());
-            UNIT_ASSERT(!HasError(rb.Commit()));
-            UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
 
             auto alloc2 = rb.Alloc(data2.size());
-            UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
+            UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
+            UNIT_ASSERT(!rb.Empty());
             UNIT_ASSERT(!HasError(alloc2.Error));
             UNIT_ASSERT(alloc2.AllocationPtr != nullptr);
             data2.copy(alloc2.AllocationPtr, data2.size());
+            UNIT_ASSERT(!HasError(rb.Commit(alloc2.AllocationPtr)));
+            UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
+
+            auto alloc3 = rb.Alloc(data3.size());
+            UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
+            UNIT_ASSERT(!rb.Empty());
+            UNIT_ASSERT(!HasError(alloc3.Error));
+            UNIT_ASSERT(alloc3.AllocationPtr != nullptr);
+            data3.copy(alloc3.AllocationPtr, data3.size());
         }
 
         {
             TFileRingBuffer rb(f.GetName(), len, 0, ver);
             UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
-            UNIT_ASSERT_VALUES_EQUAL(data1, rb.Front().Data);
+            UNIT_ASSERT(!rb.Empty());
+            UNIT_ASSERT_VALUES_EQUAL(data2, rb.Front().Data);
             UNIT_ASSERT(rb.PopFront().Removed);
 
             UNIT_ASSERT_VALUES_EQUAL("", rb.Front().Data);
+
+            UNIT_ASSERT(rb.Empty());
+            auto alloc4 = rb.Alloc(data1.size());
+            UNIT_ASSERT(!rb.Empty());
+            UNIT_ASSERT(!HasError(alloc4.Error));
+        }
+
+        {
+            TFileRingBuffer rb(f.GetName(), len, 0, ver);
+            UNIT_ASSERT(rb.Empty());
         }
     }
 
@@ -1134,24 +1292,19 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(alloc2.AllocationPtr == nullptr);
         UNIT_ASSERT(HasError(alloc2.Error));
 
-        // Alloc without commit
         auto alloc3 = rb.Alloc(1);
         UNIT_ASSERT(alloc3.AllocationPtr != nullptr);
         UNIT_ASSERT(!HasError(alloc3.Error));
+        UNIT_ASSERT(!HasError(rb.Commit(alloc3.AllocationPtr)));
 
-        auto alloc4 = rb.Alloc(1);
-        UNIT_ASSERT(alloc4.AllocationPtr == nullptr);
-        UNIT_ASSERT(HasError(alloc4.Error));
-        UNIT_ASSERT(!HasError(rb.Commit()));
-
-        // Commit without alloc
-        UNIT_ASSERT(HasError(rb.Commit()));
+        // Already allocated
+        UNIT_ASSERT(HasError(rb.Commit(alloc3.AllocationPtr)));
 
         rb.SetCorrupted();
 
-        auto alloc5 = rb.Alloc(2);
-        UNIT_ASSERT(alloc5.AllocationPtr == nullptr);
-        UNIT_ASSERT(HasError(alloc5.Error));
+        auto alloc4 = rb.Alloc(2);
+        UNIT_ASSERT(alloc4.AllocationPtr == nullptr);
+        UNIT_ASSERT(HasError(alloc4.Error));
     }
 
     FILE_RING_BUFFER_TEST(ShouldSupportRandomDeletion)
@@ -1170,7 +1323,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             auto res = rb->Alloc(data.size());
             UNIT_ASSERT(res.AllocationPtr != nullptr);
             data.copy(res.AllocationPtr, data.size());
-            UNIT_ASSERT(!HasError(rb->Commit()));
+            UNIT_ASSERT(!HasError(rb->Commit(res.AllocationPtr)));
             return res.AllocationPtr;
         };
 
@@ -1234,7 +1387,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         UNIT_ASSERT(rb->PopFront().Removed);
 
-        UNIT_ASSERT(!HasError(rb->Commit()));
+        UNIT_ASSERT(!HasError(rb->Commit(alloc.AllocationPtr)));
 
         UNIT_ASSERT_VALUES_EQUAL(data, rb->Front().Data);
 
@@ -1262,12 +1415,12 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             auto* ptr1 = rb->Alloc(data1.size()).AllocationPtr;
             UNIT_ASSERT(ptr1 != nullptr);
             data1.copy(ptr1, data1.size());
-            UNIT_ASSERT(!HasError(rb->Commit()));
+            UNIT_ASSERT(!HasError(rb->Commit(ptr1)));
 
             auto* ptr2 = rb->Alloc(data2.size()).AllocationPtr;
             UNIT_ASSERT(ptr2 != nullptr);
             data2.copy(ptr2, data2.size());
-            UNIT_ASSERT(!HasError(rb->Commit()));
+            UNIT_ASSERT(!HasError(rb->Commit(ptr2)));
 
             UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr1).Tag);
             UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr2).Tag);
@@ -1310,7 +1463,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             auto* ptr5 = rb->Alloc(data1.size()).AllocationPtr;
             UNIT_ASSERT(ptr5 != nullptr);
             data1.copy(ptr5, data1.size());
-            UNIT_ASSERT(!HasError(rb->Commit()));
+            UNIT_ASSERT(!HasError(rb->Commit(ptr5)));
 
             UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr5).Tag);
         };
@@ -1330,12 +1483,12 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(ptr1 != nullptr);
         ptr1[0] = 'a';
         ptr1[1] = 'b';
-        UNIT_ASSERT(!HasError(rb.Commit()));
+        UNIT_ASSERT(!HasError(rb.Commit(ptr1)));
 
         auto ptr2 = rb.Alloc(1).AllocationPtr;
         UNIT_ASSERT(ptr2 != nullptr);
         ptr2[0] = 'c';
-        UNIT_ASSERT(!HasError(rb.Commit()));
+        UNIT_ASSERT(!HasError(rb.Commit(ptr2)));
 
         UNIT_ASSERT(AlignDown(ptr1, sizeof(ui64)) == ptr1);
         UNIT_ASSERT(AlignDown(ptr2, sizeof(ui64)) == ptr2);

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -1325,7 +1325,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(!HasError(alloc3.Error));
         UNIT_ASSERT(!HasError(rb.Commit(alloc3.AllocationPtr)));
 
-        // Already allocated
+        // Already committed
         UNIT_ASSERT(HasError(rb.Commit(alloc3.AllocationPtr)));
 
         rb.SetCorrupted();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -1391,7 +1391,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             }
 
             const size_t index = GetRandomAllocation(false);
-            const auto& allocation = Allocations[index];
+            auto& allocation = Allocations[index];
 
             if (RandomNumber(2u) == 0) {
                 const ui32 crc =

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -1172,7 +1172,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         auto popFrontResult = rb.PopFront();
         UNIT_ASSERT(!popFrontResult.Removed);
-        UNIT_ASSERT(!HasError(popFrontResult.Error));
+        UNIT_ASSERT(HasError(popFrontResult.Error));
 
         UNIT_ASSERT_VALUES_EQUAL("two", Dump(rb));
 
@@ -1193,6 +1193,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 len = 64;
         const TString data = "precomputed checksum";
         const ui32 checksum = Crc32c(data.data(), data.size());
+        const ui32 badChecksum = checksum ^ 1;
 
         {
             TFileRingBuffer rb(f.GetName(), len, 0, ver);
@@ -1213,11 +1214,38 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             UNIT_ASSERT_VALUES_EQUAL(checksum, visitedChecksum);
         }
 
-        // A caller-provided checksum must produce an entry that survives
-        // validation when the ring buffer is reopened.
-        TFileRingBuffer rb(f.GetName(), len, 0, ver);
-        UNIT_ASSERT(!rb.IsCorrupted());
-        UNIT_ASSERT_VALUES_EQUAL(data, rb.Front().Data);
+        {
+            // A caller-provided checksum must produce an entry that survives
+            // validation when the ring buffer is reopened.
+            TFileRingBuffer rb(f.GetName(), len, 0, ver);
+            UNIT_ASSERT(!rb.IsCorrupted());
+            UNIT_ASSERT_VALUES_EQUAL(data, rb.Front().Data);
+        }
+
+        // Bad checksum
+        {
+            TFileRingBuffer rb(f.GetName(), len, 0, ver);
+            auto alloc = rb.Alloc(data.size());
+
+            UNIT_ASSERT(!HasError(alloc.Error));
+            UNIT_ASSERT(alloc.AllocationPtr != nullptr);
+            data.copy(alloc.AllocationPtr, data.size());
+            UNIT_ASSERT(!HasError(rb.Commit(alloc.AllocationPtr, badChecksum)));
+
+            ui32 visitedChecksum = 0;
+            UNIT_ASSERT(!HasError(rb.Visit(
+                [&](ui32 crc32, ui32, TStringBuf entry)
+                {
+                    visitedChecksum = crc32;
+                    UNIT_ASSERT_VALUES_EQUAL(data, entry);
+                })));
+            UNIT_ASSERT_VALUES_EQUAL(badChecksum, visitedChecksum);
+        }
+
+        {
+            TFileRingBuffer rb(f.GetName(), len, 0, ver);
+            UNIT_ASSERT(rb.IsCorrupted());
+        }
     }
 
     FILE_RING_BUFFER_TEST(ShouldDropNotCommittedEntries)
@@ -1234,23 +1262,23 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             UNIT_ASSERT(rb.Empty());
 
             auto alloc1 = rb.Alloc(data1.size());
-            UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
+            UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
             UNIT_ASSERT(!rb.Empty());
             UNIT_ASSERT(!HasError(alloc1.Error));
             UNIT_ASSERT(alloc1.AllocationPtr != nullptr);
             data1.copy(alloc1.AllocationPtr, data1.size());
 
             auto alloc2 = rb.Alloc(data2.size());
-            UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
+            UNIT_ASSERT_VALUES_EQUAL(2, rb.Size());
             UNIT_ASSERT(!rb.Empty());
             UNIT_ASSERT(!HasError(alloc2.Error));
             UNIT_ASSERT(alloc2.AllocationPtr != nullptr);
             data2.copy(alloc2.AllocationPtr, data2.size());
             UNIT_ASSERT(!HasError(rb.Commit(alloc2.AllocationPtr)));
-            UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
+            UNIT_ASSERT_VALUES_EQUAL(2, rb.Size());
 
             auto alloc3 = rb.Alloc(data3.size());
-            UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
+            UNIT_ASSERT_VALUES_EQUAL(3, rb.Size());
             UNIT_ASSERT(!rb.Empty());
             UNIT_ASSERT(!HasError(alloc3.Error));
             UNIT_ASSERT(alloc3.AllocationPtr != nullptr);


### PR DESCRIPTION
### Notes
The PR adds support for multiple incomplete allocations by `TFileRingBuffer`.
This enables its clients not to block on each other when adding data from multiple threads.

Implementation details:
- `Alloc` adds an entry with `FreeFlag` set in the entry header;
- `Commit` makes the entry visible by resetting `FreeFlag`.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
