### PR TITLE
issue-5895: implemented monpage with json fastshard layout + dumping this layout in fastshard tests after test completion

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/monpage_helpers.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/monpage_helpers.cpp
@@ -1,0 +1,20 @@
+#include "monpage_helpers.h"
+
+#include <library/cpp/json/writer/json.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString JsonError(const NProto::TError& e)
+{
+    TStringStream ss;
+    NJsonWriter::TBuf writer(NJsonWriter::HEM_DONT_ESCAPE_HTML, &ss);
+    writer.BeginObject();
+    writer.WriteKey("error");
+    writer.WriteString(FormatError(e));
+    writer.EndObject();
+    return ss.Str();
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/monpage_helpers.h
+++ b/cloud/filestore/libs/storage/tablet/model/monpage_helpers.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/generic/string.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString JsonError(const NProto::TError& e);
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ya.make
@@ -28,6 +28,7 @@ SRCS(
     layer.cpp
     metadata_cache.cpp
     mixed_blocks.cpp
+    monpage_helpers.cpp
     node_access_stats.cpp
     node_latency_stats.cpp
     node_ref.cpp

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -708,6 +708,10 @@ private:
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
+    void HandleHttpInfo_FastShardLayoutJson(
+        const NActors::TActorContext& ctx,
+        const TCgiParameters& params,
+        TRequestInfoPtr requestInfo);
     void HandleHttpInfo_FastShardLayout(
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -989,11 +989,30 @@ void TIndexTabletActor::HandleHttpInfo(
     }};
 
     static const THttpHandlers getActions {{
-        {"dumpRange",       &TIndexTabletActor::HandleHttpInfo_DumpCompactionRange },
-        {"dirViewer",       &TIndexTabletActor::HandleHttpInfo_DirViewer },
-        {"locks",           &TIndexTabletActor::HandleHttpInfo_Locks },
-        {"fastShardLayout", &TIndexTabletActor::HandleHttpInfo_FastShardLayout },
-        {"diagnostics",     &TIndexTabletActor::HandleHttpInfo_Diagnostics },
+        {
+            "dumpRange",
+            &TIndexTabletActor::HandleHttpInfo_DumpCompactionRange
+        },
+        {
+            "dirViewer",
+            &TIndexTabletActor::HandleHttpInfo_DirViewer
+        },
+        {
+            "locks",
+            &TIndexTabletActor::HandleHttpInfo_Locks
+        },
+        {
+            "fastShardLayoutJson",
+            &TIndexTabletActor::HandleHttpInfo_FastShardLayoutJson
+        },
+        {
+            "fastShardLayout",
+            &TIndexTabletActor::HandleHttpInfo_FastShardLayout
+        },
+        {
+            "diagnostics",
+            &TIndexTabletActor::HandleHttpInfo_Diagnostics
+        },
     }};
 
     const auto* msg = ev->Get();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_directory_viewer.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_directory_viewer.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/tablet/model/monpage_helpers.h>
 #include <cloud/filestore/libs/storage/tablet/tablet_state.h>
 
 #include <cloud/storage/core/libs/common/simple_template.h>
@@ -96,17 +97,6 @@ void DumpDirViewerPage(IOutputStream& out, ui64 tabletId, ui32 nodeId)
         {"JS", NResource::Find("js/dir-viewer.js")},
         {"TABLET_ID", ToString(tabletId)},
         {"ROOT_NODE_ID", ToString(nodeId)}}, out);
-}
-
-TString JsonError(const NProto::TError& e)
-{
-    TStringStream ss;
-    NJsonWriter::TBuf writer(NJsonWriter::HEM_DONT_ESCAPE_HTML, &ss);
-    writer.BeginObject();
-    writer.WriteKey("error");
-    writer.WriteString(FormatError(e));
-    writer.EndObject();
-    return ss.Str();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_fastshard_layout.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_fastshard_layout.cpp
@@ -1,5 +1,7 @@
 #include "tablet_actor.h"
 
+#include <cloud/filestore/libs/storage/tablet/model/monpage_helpers.h>
+
 #include <util/stream/str.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -8,6 +10,49 @@ using namespace NActors;
 using namespace NActors::NMon;
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleHttpInfo_FastShardLayoutJson(
+    const NActors::TActorContext& ctx,
+    const TCgiParameters& params,
+    TRequestInfoPtr requestInfo)
+{
+    Y_UNUSED(params);
+
+    //
+    // The layout page exists only for fast shards (Adapter mode). The
+    // FastShard check protects against a race with state loading: the
+    // shard instance appears only after CompleteAdapterLoadState.
+    //
+
+    if (!GetFileSystem().GetIsFastShard() || !FastShard) {
+        const TString message = "tablet is not a fast shard";
+        LOG_ERROR_S(
+            ctx,
+            TFileStoreComponents::TABLET,
+            LogTag << " " << message);
+
+        NCloud::Reply(
+            ctx,
+            *requestInfo,
+            std::make_unique<TEvRemoteJsonInfoRes>(
+                JsonError(MakeError(E_INVALID_STATE, message))));
+        return;
+    }
+
+    //
+    // DumpLayoutHtml is synchronous and does no IO - the layout is
+    // fixed after the shard construction - so no worker actor is
+    // needed here, unlike in the Directory Viewer.
+    //
+
+    TStringStream out;
+    FastShard->DumpLayoutJson(out);
+
+    NCloud::Reply(
+        ctx,
+        *requestInfo,
+        std::make_unique<TEvRemoteJsonInfoRes>(std::move(out.Str())));
+}
 
 void TIndexTabletActor::HandleHttpInfo_FastShardLayout(
     const NActors::TActorContext& ctx,

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
@@ -13,3 +13,61 @@
     "list-wlat-us": true,
     "errors": false
 }
+{
+    "components": [
+        {
+            "name": "NodeTable",
+            "offsetBytes": 0,
+            "sizeBytes": 9752576,
+            "slotSize": 96,
+            "slotCount": 100002
+        },
+        {
+            "name": "NameTable",
+            "offsetBytes": 9752576,
+            "sizeBytes": 4820992,
+            "slotSize": 48,
+            "slotCount": 100045
+        },
+        {
+            "name": "HandleTable",
+            "offsetBytes": 14573568,
+            "sizeBytes": 16003072,
+            "slotSize": 16,
+            "slotCount": 1000192
+        },
+        {
+            "name": "PageIndex",
+            "offsetBytes": 30576640,
+            "sizeBytes": 757760,
+            "slotSize": 24,
+            "slotCount": 31450
+        },
+        {
+            "name": "PageAllocatorBitmap",
+            "offsetBytes": 31334400,
+            "sizeBytes": 4096,
+            "slotSize": 0,
+            "slotCount": 29492
+        },
+        {
+            "name": "DataPages",
+            "offsetBytes": 31358976,
+            "sizeBytes": 966393856,
+            "slotSize": 32768,
+            "slotCount": 29492
+        }
+    ],
+    "storageGroups": [
+        {
+            "type": "E_SG_MIRROR",
+            "devices": [
+                {
+                    "host": "localhost",
+                    "port": true,
+                    "deviceId": "3400a1bfdf724d36b3fd934cc8dcb020"
+                }
+            ]
+        }
+    ]
+}

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
@@ -65,7 +65,7 @@
                 {
                     "host": "localhost",
                     "port": true,
-                    "deviceId": "3400a1bfdf724d36b3fd934cc8dcb020"
+                    "deviceId": true
                 }
             ]
         }

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/test.py
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/test.py
@@ -120,6 +120,7 @@ def do_test(test_name, aux_params):
         for sg in layout["storageGroups"]:
             for d in sg["devices"]:
                 d["port"] = d.get("port", 0) != 0
+                d["deviceId"] = len(d["deviceId"]) > 0
 
         result = json.dumps(layout, indent=4)
 

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/test.py
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-naive-mirrored-test/test.py
@@ -3,7 +3,12 @@ import os
 
 import yatest.common as common
 
-from cloud.filestore.tests.python.lib.fastshard import configure_fastshard
+from cloud.filestore.tests.python.lib.client import FilestoreCliClient
+
+from cloud.filestore.tests.python.lib.fastshard import (
+    configure_fastshard,
+    fetch_layout,
+)
 from cloud.storage.core.tools.testing.qemu.lib.common import (
     env_with_guest_index,
     SshToGuest,
@@ -60,7 +65,7 @@ def do_test(test_name, aux_params):
     # which is a bit excessive for this test.
     #
 
-    configure_fastshard(
+    file_shard_ids = configure_fastshard(
         shard_count=2,
         file_shard_count=1,
         fast_shard_config=fast_shard_config)
@@ -89,6 +94,37 @@ def do_test(test_name, aux_params):
     with open(results_path, 'w') as results:
         results.write(json.dumps(report, indent=4))
         results.write("\n")
+
+    #
+    # Dumping layout.
+    #
+
+    port = os.getenv("NFS_SERVER_PORT")
+    binary_path = common.binary_path(
+        "cloud/filestore/apps/client/filestore-client")
+    client = FilestoreCliClient(
+        binary_path,
+        port,
+        cwd=common.output_path())
+
+    for shard_id in file_shard_ids:
+        shard = json.loads(client.describe(shard_id))
+        # MainTabletId for a shard is actually its own IndexTabletId
+        tablet_id = shard["FileStore"]["MainTabletId"]
+        layout = fetch_layout(tablet_id)
+
+        #
+        # Masking unstable fields.
+        #
+
+        for sg in layout["storageGroups"]:
+            for d in sg["devices"]:
+                d["port"] = d.get("port", 0) != 0
+
+        result = json.dumps(layout, indent=4)
+
+        with open(results_path, 'a') as results:
+            results.write('{}\n'.format(result))
 
     ret = common.canonical_file(results_path, local=True)
     return ret

--- a/cloud/filestore/tests/python/lib/fastshard.py
+++ b/cloud/filestore/tests/python/lib/fastshard.py
@@ -3,6 +3,7 @@ import os
 import yatest.common as common
 
 from cloud.filestore.tests.python.lib.client import FilestoreCliClient
+from cloud.filestore.tests.python.lib.fs import request_tablet
 
 
 def configure_fastshard(shard_count, file_shard_count, fast_shard_config):
@@ -49,3 +50,10 @@ def configure_fastshard(shard_count, file_shard_count, fast_shard_config):
             "DirectoryCreationInShardsEnabled": True,
         },
     )
+
+    return file_shard_ids
+
+
+def fetch_layout(tablet_id):
+    response = request_tablet(tablet_id, f"action=fastShardLayoutJson")
+    return response.json()

--- a/cloud/filestore/tests/python/lib/fastshard.py
+++ b/cloud/filestore/tests/python/lib/fastshard.py
@@ -55,5 +55,5 @@ def configure_fastshard(shard_count, file_shard_count, fast_shard_config):
 
 
 def fetch_layout(tablet_id):
-    response = request_tablet(tablet_id, f"action=fastShardLayoutJson")
+    response = request_tablet(tablet_id, "action=fastShardLayoutJson")
     return response.json()


### PR DESCRIPTION
### Notes
* monpage with layout in json format is useful for scripts
* dumping it at the end of the fastshard e2e test suite - to test this monpage and for potential test failure debugging as well 

### Issue
https://github.com/ydb-platform/nbs/issues/5895
