### PR TITLE
[Filestore] add HasOverrides metric to tablet counters

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -646,6 +646,7 @@ void TIndexTabletActor::RegisterStatCounters(TInstant now)
         now.MicroSeconds());
     Metrics->TabletId.store(TabletID());
     Metrics->TabletGeneration.store(GetGeneration());
+    Metrics->HasOverrides.store(StorageConfigOverride.ByteSize() ? 1 : 0);
 
     Metrics->Register(
         fsId,

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -301,6 +301,7 @@ void TTabletMetrics::Register(
     REGISTER_LOCAL(TabletStartTimestamp, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(TabletId, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(TabletGeneration, EMetricType::MT_ABSOLUTE);
+    REGISTER_LOCAL(HasOverrides, EMetricType::MT_ABSOLUTE);
 
     REGISTER_AGGREGATABLE_SUM(AllocatedCompactionRangesCount, EMetricType::MT_ABSOLUTE);
     REGISTER_AGGREGATABLE_SUM(UsedCompactionRangesCount, EMetricType::MT_ABSOLUTE);

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -247,6 +247,7 @@ struct TTabletMetrics: TAtomicRefCount<TTabletMetrics>
     std::atomic<i64> TabletStartTimestamp{0};
     std::atomic<i64> TabletId{0};
     std::atomic<i64> TabletGeneration{0};
+    std::atomic<i64> HasOverrides{0};
 
     // Blob compression stats
     std::atomic<i64> UncompressedBytesWritten{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -908,7 +908,47 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
              {
                  return val > 0;
              }},
+            {{{"sensor", "HasOverrides"}, {"filesystem", "test"}},
+             [](i64 val)
+             {
+                 return val == 0;
+             }},
         });
+    }
+
+    Y_UNIT_TEST(ShouldReportHasOverrides)
+    {
+        TTestEnv env;
+        auto registry = env.GetRegistry();
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.RebootTablet();
+        tablet.InitSession("client", "session");
+
+        {
+            TTestRegistryVisitor visitor;
+            registry->Visit(TInstant::Zero(), visitor);
+            visitor.ValidateExpectedCounters({
+                {{{"sensor", "HasOverrides"}, {"filesystem", "test"}}, 0},
+            });
+        }
+
+        NProto::TStorageConfig patch;
+        patch.SetNewCleanupEnabled(true);
+        tablet.ChangeStorageConfig(std::move(patch));
+        tablet.RebootTablet();
+        tablet.InitSession("client", "session");
+
+        {
+            TTestRegistryVisitor visitor;
+            registry->Visit(TInstant::Zero(), visitor);
+            visitor.ValidateExpectedCounters({
+                {{{"sensor", "HasOverrides"}, {"filesystem", "test"}}, 1},
+            });
+        }
     }
 
     Y_UNIT_TEST(ShouldReportDirectHandleMetrics)


### PR DESCRIPTION
### Notes
This sensor might be a useful indicator of the fact that something is customly configured for this filesystem

### Issue
Small change – no issue
