### PR TITLE
[Filestore] support filestore-client alter; teach filestore-client executeaction to fail in case of an error

### DIFF
--- a/cloud/filestore/apps/client/lib/alter.cpp
+++ b/cloud/filestore/apps/client/lib/alter.cpp
@@ -1,0 +1,69 @@
+#include "command.h"
+
+namespace NCloud::NFileStore::NClient {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TAlterCommand final
+    : public TFileStoreCommand
+{
+private:
+    TString CloudId;
+    TString FolderId;
+    ui32 ConfigVersion = 0;
+
+public:
+    TAlterCommand()
+    {
+        Opts.AddLongOption("cloud")
+            .Required()
+            .RequiredArgument("STR")
+            .Help("new cloud id")
+            .StoreResult(&CloudId);
+
+        Opts.AddLongOption("folder")
+            .Required()
+            .RequiredArgument("STR")
+            .Help("new folder id")
+            .StoreResult(&FolderId);
+
+        Opts.AddLongOption("config-version")
+            .RequiredArgument("NUM")
+            .StoreResult(&ConfigVersion);
+    }
+
+    bool Execute() override
+    {
+        auto callContext = PrepareCallContext();
+
+        auto request = std::make_shared<NProto::TAlterFileStoreRequest>();
+        request->SetFileSystemId(FileSystemId);
+        request->SetCloudId(CloudId);
+        request->SetFolderId(FolderId);
+        request->SetConfigVersion(ConfigVersion);
+
+        auto response = WaitFor(
+            Client->AlterFileStore(
+                std::move(callContext),
+                std::move(request)));
+
+        if (HasError(response)) {
+            STORAGE_THROW_SERVICE_ERROR(response.GetError());
+        }
+
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCommandPtr NewAlterCommand()
+{
+    return std::make_shared<TAlterCommand>();
+}
+
+}   // namespace NCloud::NFileStore::NClient

--- a/cloud/filestore/apps/client/lib/execute_action.cpp
+++ b/cloud/filestore/apps/client/lib/execute_action.cpp
@@ -67,7 +67,8 @@ public:
 
         if (HasError(result)) {
             Cout << FormatError(result.GetError()) << Endl;
-            return true;
+            ProgramShouldContinue.ShouldStop(1);
+            return false;
         }
 
         Cout << result.GetOutput() << Endl;

--- a/cloud/filestore/apps/client/lib/factory.cpp
+++ b/cloud/filestore/apps/client/lib/factory.cpp
@@ -10,6 +10,7 @@ namespace NCloud::NFileStore::NClient {
 ////////////////////////////////////////////////////////////////////////////////
 
 TCommandPtr NewAddClusterNodeCommand();
+TCommandPtr NewAlterCommand();
 TCommandPtr NewCreateCommand();
 TCommandPtr NewDescribeCommand();
 TCommandPtr NewDestroyCommand();
@@ -59,6 +60,7 @@ using TFactoryMap = TMap<TString, TFactoryFunc>;
 static const TMap<TString, TFactoryFunc> Commands = {
     { "acquirelock", NewAcquireLockCommand },
     { "addclusternode", NewAddClusterNodeCommand },
+    { "alter", NewAlterCommand },
     { "create", NewCreateCommand },
     { "createsession", NewCreateSessionCommand },
     { "describe", NewDescribeCommand },

--- a/cloud/filestore/apps/client/lib/ya.make
+++ b/cloud/filestore/apps/client/lib/ya.make
@@ -2,6 +2,7 @@ LIBRARY(filestore-apps-client-lib)
 
 SRCS(
     add_cluster_node.cpp
+    alter.cpp
     app.cpp
     bootstrap.cpp
     command.cpp

--- a/cloud/filestore/tests/client_sharded/test.py
+++ b/cloud/filestore/tests/client_sharded/test.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+import pytest
 import yatest.common as common
 
 from cloud.filestore.tests.python.lib.client import FilestoreCliClient
@@ -46,6 +47,13 @@ def __process_stat(node):
     return node
 
 
+def __execute_action_expecting_failure(client, action, request):
+    with pytest.raises(common.ExecutionError) as e:
+        client.execute_action(action, request)
+    # error description is printed to stdout and is a part of canonical output
+    return e.value.execution_result.stdout
+
+
 def __exec_ls(client, *args):
     output = str(client.ls(*args, "--json"), 'utf-8')
     nodes: list = json.loads(output)['content']
@@ -77,9 +85,10 @@ def test_shard_autoaddition():
     client.create_session("fs0", "session0", "client0")
     out += client.execute_action("describesessions", {"FileSystemId": "fs0"})
     out += client.execute_action("describesessions", {"FileSystemId": "fs0_s1"})
-    out += client.execute_action("describesessions", {"FileSystemId": "fs0_s2"})
-    out += client.execute_action("describesessions", {"FileSystemId": "fs0_s3"})
-    out += client.execute_action("describesessions", {"FileSystemId": "fs0_s4"})
+    # shards fs0_s2..fs0_s4 don't exist yet
+    for shard_id in ["fs0_s2", "fs0_s3", "fs0_s4"]:
+        out += __execute_action_expecting_failure(
+            client, "describesessions", {"FileSystemId": shard_id})
     client.destroy_session("fs0", "session0", "client0")
 
     client.create_session("fs0", "session0", "client0")
@@ -101,7 +110,9 @@ def test_shard_autoaddition():
     out += client.execute_action("describesessions", {"FileSystemId": "fs0_s1"})
     out += client.execute_action("describesessions", {"FileSystemId": "fs0_s2"})
     out += client.execute_action("describesessions", {"FileSystemId": "fs0_s3"})
-    out += client.execute_action("describesessions", {"FileSystemId": "fs0_s4"})
+    # shard fs0_s4 doesn't exist
+    out += __execute_action_expecting_failure(
+        client, "describesessions", {"FileSystemId": "fs0_s4"})
     client.destroy_session("fs0", "session0", "client0")
 
     out += client.destroy("fs0")
@@ -129,8 +140,10 @@ def test_explicit_shard_count_addition():
     client.create_session("fs0", "session0", "client0")
     out = client.execute_action("describesessions", {"FileSystemId": "fs0"})
     out += client.execute_action("describesessions", {"FileSystemId": "fs0_s1"})
-    out += client.execute_action("describesessions", {"FileSystemId": "fs0_s2"})
-    out += client.execute_action("describesessions", {"FileSystemId": "fs0_s3"})
+    # shards fs0_s2, fs0_s3 don't exist yet
+    for shard_id in ["fs0_s2", "fs0_s3"]:
+        out += __execute_action_expecting_failure(
+            client, "describesessions", {"FileSystemId": shard_id})
     client.destroy_session("fs0", "session0", "client0")
 
     out += client.resize("fs0", int(SHARD_SIZE / BLOCK_SIZE), shard_count=3)

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -157,6 +157,20 @@ class FilestoreCliClient:
         logger.info("resizing filestore: " + " ".join(cmd))
         return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
 
+    def alter(self, fs, cloud, folder, config_version=None):
+        cmd = [
+            self.__binary_path, "alter",
+            "--filesystem", fs,
+            "--cloud", cloud,
+            "--folder", folder,
+        ] + self.__cmd_opts()
+
+        if config_version is not None:
+            cmd += ["--config-version", str(config_version)]
+
+        logger.info("altering filestore: " + " ".join(cmd))
+        return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
+
     def list_filestores(self):
         cmd = [
             self.__binary_path, "listfilestores",

--- a/cloud/filestore/tests/scheme_cache/test.py
+++ b/cloud/filestore/tests/scheme_cache/test.py
@@ -77,16 +77,7 @@ def test_should_resize_and_alter():
     client.resize("fs0", shard_count * int(SHARD_SIZE / BLOCK_SIZE))
     verify_filesystem_topology(client, "fs0", shard_count)
 
-    client.execute_action(
-        "alterfilesystem",
-        {
-            "FileSystemId": "fs0",
-            "Config": {
-                "CloudId": "new_test_cloud",
-                "FolderId": "new_test_folder",
-            },
-        },
-    )
+    client.alter("fs0", "new_test_cloud", "new_test_folder")
 
     verify_io(client, "fs0")
 


### PR DESCRIPTION
### Notes
Added alter command, by analogy with resize:
```
filestore-client alter --filesystem <fs-id> --cloud <cloud-id> --folder <folder-id> [--config-version N]
```

`TExecuteActionCommand::Execute` printed the error and returned exit code 0, so a failed action was indistinguishable from a successful one for scripts and tests. 
It now sets exit code 1 in case of an error by analogy with `filestore-client create`: https://github.com/ydb-platform/nbs/blob/bbbe4dcbc3c664e619f4f3037475dccdd576ddac/cloud/filestore/apps/client/lib/create.cpp#L110

### Issue
Put links to the related issues here
