### PR TITLE
#6956: fastshard: Extract TJournalledDevice from TJournalledDeviceHandler

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -194,7 +194,9 @@ private:
     NProto::TError UpdateControlPlaneRequestNumber(
         TControlPlaneRequestNumber controlPlaneRequestNumber);
 
-    void StartJournalledDeviceTcpServer(const NActors::TActorContext& ctx);
+    void StartJournalledDeviceTcpServer(
+        const NActors::TActorContext& ctx,
+        THashMap<TString, IJournalledDevicePtr> devices);
 
 private:
     STFUNC(StateInit);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/diagnostics/request_stats.h>
 #include <cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.h>
 #include <cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_handler.h>
+#include <cloud/blockstore/libs/storage/disk_agent/journalled_device.h>
 
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/format.h>
@@ -170,7 +171,17 @@ void TDiskAgentActor::HandleInitAgentCompleted(
         }
     }
 
-    StartJournalledDeviceTcpServer(ctx);
+    if (State) {
+        THashMap<TString, IJournalledDevicePtr> devices;
+
+        for (const auto& deviceId: State->GetDeviceIds()) {
+            devices.emplace(
+                deviceId,
+                CreateJournalledDevice(deviceId, State->GetDeviceClient()));
+        }
+
+        StartJournalledDeviceTcpServer(ctx, std::move(devices));
+    }
 
     LOG_INFO(ctx, TBlockStoreComponents::DISK_AGENT, "Ready to work");
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_journalled_device_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_journalled_device_ut.cpp
@@ -238,521 +238,11 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
         }
     }
 
-    Y_UNIT_TEST_F(ShouldValidateWriteLogRecordRequest, TFixture)
-    {
-        const TString clientId = "client-id";
-        const TString uuid = "unknown";
-
-        auto env =
-            TTestEnvBuilder(*Runtime).With(CreateDiskAgentConfig()).Build();
-
-        TDiskAgentClient diskAgent(*Runtime);
-        diskAgent.WaitReady();
-
-        TTestClient client{Port};
-
-        using TPrepareFunc =
-            std::function<void(NCloud::NProto::TWriteLogRecordRequest&)>;
-
-        const std::tuple<TPrepareFunc, NProto::TError> testCases[]{
-            {[&](auto&) {}, MakeError(E_ARGUMENT, "empty device UUID")},
-            {[&](auto& proto) { proto.SetDeviceUUID(uuid); },
-             MakeError(E_ARGUMENT, "nothing to write")},
-            {[&](auto& proto)
-             {
-                 proto.SetDeviceUUID(uuid);
-                 proto.SetLogSequenceNumber(1);
-                 proto.MutablePageGroups()->Add();
-             },
-             MakeError(E_ARGUMENT, "empty page group")},
-            {[&](auto& proto)
-             {
-                 proto.SetDeviceUUID(uuid);
-                 proto.SetLogSequenceNumber(1);
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add();   // an empty block
-                 }
-             },
-             MakeError(
-                 E_ARGUMENT,
-                 "invalid page data: block must not be empty")},
-            {[&](auto& proto)
-             {
-                 proto.SetDeviceUUID(uuid);
-                 proto.SetLogSequenceNumber(1);
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(4_KB, 'A');
-                 }
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x20);
-                     group.MutableContent()->Add()->resize(4_KB, 'A');
-                     group.MutableContent()->Add();   // an empty block
-                     group.MutableContent()->Add()->resize(4_KB, 'A');
-                 }
-             },
-             MakeError(
-                 E_ARGUMENT,
-                 "invalid page data: block must not be empty")},
-            {[&](auto& proto)
-             {
-                 proto.SetDeviceUUID(uuid);
-                 proto.SetLogSequenceNumber(1);
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(4_KB, 'A');
-                     group.MutableContent()->Add()->resize(8_KB, 'B');
-                 }
-             },
-             MakeError(E_ARGUMENT, "invalid page data: block size mismatch")},
-            {[&](auto& proto)
-             {
-                 // the client id is checked after the device is found
-                 proto.SetDeviceUUID(FileDevices[0].GetDeviceId());
-                 proto.SetLogSequenceNumber(1);
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'A');
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'B');
-                 }
-             },
-             MakeError(E_ARGUMENT, "empty client id")},
-            {[&](auto& proto)
-             {
-                 proto.MutableHeaders()->SetClientId(clientId);
-                 proto.SetDeviceUUID(uuid);
-                 proto.SetLogSequenceNumber(1);
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'A');
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'B');
-                 }
-             },
-             MakeError(E_NOT_FOUND, "Device " + uuid.Quote() + " not found")},
-            {[&](auto& proto)
-             {
-                 proto.MutableHeaders()->SetClientId(clientId);
-                 proto.SetDeviceUUID(FileDevices[0].GetDeviceId());
-                 proto.SetLogSequenceNumber(1);
-
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'A');
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'B');
-                 }
-             },
-             MakeError(E_BS_INVALID_SESSION, "not acquired by client")},
-            {[&](auto& proto)
-             {
-                 proto.MutableHeaders()->SetClientId(clientId);
-                 proto.SetDeviceUUID(uuid);
-                 // LogSequenceNumber is not set
-
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'A');
-                 }
-             },
-             MakeError(E_ARGUMENT, "invalid lsn: 0")},
-            {[&](auto& proto)
-             {
-                 proto.MutableHeaders()->SetClientId(clientId);
-                 proto.SetDeviceUUID(uuid);
-                 proto.SetLogSequenceNumber(10);
-                 proto.SetPrevLogSequenceNumber(10);
-
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'A');
-                 }
-             },
-             MakeError(
-                 E_ARGUMENT,
-                 "invalid lsn: 10, must be greater than the prev one: 10")},
-        };
-
-        for (ui64 i = 0; i != std::size(testCases); ++i) {
-            const auto& [prepare, _] = testCases[i];
-
-            NCloud::NProto::TDeviceProtocolRequest request;
-            request.SetRequestId(i + 1);
-            auto& proto = *request.MutableWriteLogRecord();
-            prepare(proto);
-            client.Send(request);
-        }
-
-        Runtime->DispatchEvents(TDispatchOptions(), 10ms);
-
-        TVector<std::pair<ui64, NProto::TError>> errors(std::size(testCases));
-        std::generate_n(
-            errors.begin(),
-            std::size(testCases),
-            [&]
-            {
-                auto response = client.Receive();
-                UNIT_ASSERT_EQUAL(
-                    NProto::TDeviceProtocolResponse::ResponseCase::
-                        kWriteLogRecord,
-                    response.GetResponseCase());
-
-                return std::make_pair(
-                    response.GetRequestId(),
-                    response.GetWriteLogRecord().GetError());
-            });
-
-        SortBy(errors, [](const auto& p) { return p.first; });
-
-        for (size_t i = 0; i != errors.size(); ++i) {
-            const auto& [requestId, error] = errors[i];
-            UNIT_ASSERT_VALUES_EQUAL(i + 1, requestId);
-
-            const auto& [_, expectedError] = testCases[i];
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                expectedError.GetCode(),
-                error.GetCode(),
-                "#" << (i + 1) << ": " << FormatError(expectedError) << " !~ "
-                    << FormatError(error));
-
-            UNIT_ASSERT_STRING_CONTAINS_C(
-                error.GetMessage(),
-                expectedError.GetMessage(),
-                "#" << (i + 1) << ": " << FormatError(expectedError) << " !~ "
-                    << FormatError(error));
-        }
-    }
-
-    Y_UNIT_TEST_F(ShouldValidateReadPagesRequest, TFixture)
-    {
-        const TString clientId = "client-id";
-        const TString uuid = "unknown";
-
-        auto env =
-            TTestEnvBuilder(*Runtime).With(CreateDiskAgentConfig()).Build();
-
-        TDiskAgentClient diskAgent(*Runtime);
-        diskAgent.WaitReady();
-
-        TTestClient client{Port};
-
-        using TPrepareFunc =
-            std::function<void(NCloud::NProto::TReadPagesRequest&)>;
-
-        const std::tuple<TPrepareFunc, NProto::TError> testCases[]{
-            {[&](auto&) {}, MakeError(E_ARGUMENT, "empty device UUID")},
-            {[&](auto& proto) { proto.SetDeviceUUID(uuid); },
-             MakeError(E_ARGUMENT, "nothing to read")},
-            {[&](auto& proto)
-             {
-                 proto.SetDeviceUUID(uuid);
-                 proto.MutablePageGroupRefs()->Add();
-             },
-             MakeError(
-                 E_ARGUMENT,
-                 "page group ref must contain at least one page")},
-            {[&](auto& proto)
-             {
-                 proto.SetDeviceUUID(uuid);
-                 auto& groups = *proto.MutablePageGroupRefs();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(1);
-                 }
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x20);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(0);
-                 }
-             },
-             MakeError(
-                 E_ARGUMENT,
-                 "page group ref must contain at least one page")},
-            {[&](auto& proto)
-             {
-                 proto.SetDeviceUUID(uuid);
-                 auto& groups = *proto.MutablePageGroupRefs();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(1);
-                 }
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x20);
-                     group.SetPageSize(0);
-                     group.SetPageCount(1);
-                 }
-             },
-             MakeError(E_ARGUMENT, "page size must be greater than zero")},
-            {[&](auto& proto)
-             {
-                 proto.SetDeviceUUID(uuid);
-                 auto& groups = *proto.MutablePageGroupRefs();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(1);
-                 }
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x20);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(1);
-                 }
-             },
-             MakeError(E_ARGUMENT, "empty client id")},
-            {[&](auto& proto)
-             {
-                 proto.MutableHeaders()->SetClientId(clientId);
-                 proto.SetDeviceUUID(uuid);
-
-                 auto& groups = *proto.MutablePageGroupRefs();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(1);
-                 }
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x20);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(1);
-                 }
-             },
-             MakeError(E_NOT_FOUND, "Device " + uuid.Quote() + " not found")},
-            {[&](auto& proto)
-             {
-                 proto.MutableHeaders()->SetClientId(clientId);
-                 proto.SetDeviceUUID(FileDevices[0].GetDeviceId());
-
-                 auto& groups = *proto.MutablePageGroupRefs();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(1);
-                 }
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x20);
-                     group.SetPageSize(DefaultBlockSize);
-                     group.SetPageCount(1);
-                 }
-             },
-             MakeError(E_BS_INVALID_SESSION, "not acquired by client")},
-        };
-
-        for (ui64 i = 0; i != std::size(testCases); ++i) {
-            const auto& [prepare, _] = testCases[i];
-
-            NCloud::NProto::TDeviceProtocolRequest request;
-            request.SetRequestId(i + 1);
-            auto& proto = *request.MutableReadPages();
-            prepare(proto);
-            client.Send(request);
-        }
-
-        Runtime->DispatchEvents(TDispatchOptions(), 10ms);
-
-        TVector<std::pair<ui64, NProto::TError>> errors(std::size(testCases));
-        std::generate_n(
-            errors.begin(),
-            std::size(testCases),
-            [&]
-            {
-                auto response = client.Receive();
-                UNIT_ASSERT_EQUAL(
-                    NProto::TDeviceProtocolResponse::ResponseCase::kReadPages,
-                    response.GetResponseCase());
-
-                return std::make_pair(
-                    response.GetRequestId(),
-                    response.GetReadPages().GetError());
-            });
-
-        SortBy(errors, [](const auto& p) { return p.first; });
-
-        for (size_t i = 0; i != errors.size(); ++i) {
-            const auto& [requestId, error] = errors[i];
-            UNIT_ASSERT_VALUES_EQUAL(i + 1, requestId);
-
-            const auto& [_, expectedError] = testCases[i];
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                expectedError.GetCode(),
-                error.GetCode(),
-                "#" << (i + 1) << ": " << FormatError(expectedError) << " !~ "
-                    << FormatError(error));
-
-            UNIT_ASSERT_STRING_CONTAINS_C(
-                error.GetMessage(),
-                expectedError.GetMessage(),
-                "#" << (i + 1) << ": " << FormatError(expectedError) << " !~ "
-                    << FormatError(error));
-        }
-    }
-
-    Y_UNIT_TEST_F(ShouldWriteLogRecord, TFixture)
-    {
-        const TString clientId = "client-id";
-        const ui64 requestId = 42;
-        const TString uuid = FileDevices[0].GetDeviceId();
-
-        auto env =
-            TTestEnvBuilder(*Runtime).With(CreateDiskAgentConfig()).Build();
-
-        TDiskAgentClient diskAgent(*Runtime);
-        diskAgent.WaitReady();
-
-        TTestClient client{Port};
-
-        const auto writeLogRecordRequest = [&]
-        {
-            NCloud::NProto::TDeviceProtocolRequest request;
-            request.SetRequestId(requestId);
-            auto& proto = *request.MutableWriteLogRecord();
-            proto.MutableHeaders()->SetClientId(clientId);
-            proto.SetDeviceUUID(uuid);
-            proto.SetLogSequenceNumber(1);
-            auto& groups = *proto.MutablePageGroups();
-
-            {
-                auto& group = *groups.Add();
-                group.SetFirstPageNo(0x10);
-                group.MutableContent()->Add()->resize(DefaultBlockSize, 'A');
-                group.MutableContent()->Add()->resize(DefaultBlockSize, 'B');
-            }
-
-            {
-                auto& group = *groups.Add();
-                group.SetFirstPageNo(0x20);
-                group.MutableContent()->Add()->resize(DefaultBlockSize, 'X');
-                group.MutableContent()->Add()->resize(DefaultBlockSize, 'Y');
-            }
-            return request;
-        }();
-
-        client.Send(writeLogRecordRequest);
-        Runtime->DispatchEvents(TDispatchOptions(), 10ms);
-
-        {
-            auto response = client.Receive();
-            UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
-            UNIT_ASSERT_EQUAL(
-                NProto::TDeviceProtocolResponse::ResponseCase::kWriteLogRecord,
-                response.GetResponseCase());
-
-            const auto& error = response.GetWriteLogRecord().GetError();
-
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                E_BS_INVALID_SESSION,
-                error.GetCode(),
-                FormatError(error));
-        }
-
-        {
-            NCloud::NProto::TDeviceProtocolRequest request;
-            request.SetRequestId(requestId);
-            auto& proto = *request.MutableAcquireDevices();
-            proto.MutableHeaders()->SetClientId(clientId);
-            *proto.MutableDeviceUUIDs()->Add() = uuid;
-            client.Send(request);
-        }
-
-        Runtime->DispatchEvents(TDispatchOptions(), 10ms);
-
-        {
-            auto response = client.Receive();
-            UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
-            UNIT_ASSERT_EQUAL(
-                NProto::TDeviceProtocolResponse::ResponseCase::kAcquireDevices,
-                response.GetResponseCase());
-
-            const auto& error = response.GetAcquireDevices().GetError();
-
-            UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-        }
-
-        client.Send(writeLogRecordRequest);
-        Runtime->DispatchEvents(TDispatchOptions(), 10ms);
-
-        {
-            auto response = client.Receive();
-            UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
-            UNIT_ASSERT_EQUAL(
-                NProto::TDeviceProtocolResponse::ResponseCase::kWriteLogRecord,
-                response.GetResponseCase());
-
-            const auto& error = response.GetWriteLogRecord().GetError();
-
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                S_OK,
-                error.GetCode(),
-                FormatError(error));
-        }
-    }
-
-    Y_UNIT_TEST_F(ShouldValidateLogSequenceNumber, TFixture)
+    Y_UNIT_TEST_F(ShouldRouteRequestsToDevices, TFixture)
     {
         const TString clientId = "client-id";
         const TString uuid = FileDevices[0].GetDeviceId();
+        const TString unknownUuid = "unknown";
 
         auto env =
             TTestEnvBuilder(*Runtime).With(CreateDiskAgentConfig()).Build();
@@ -789,16 +279,15 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
 
         ui64 requestId = 0;
 
-        const auto writeLogRecord = [&](ui64 lsn, ui64 prevLsn)
+        const auto writeLogRecord = [&](const TString& deviceUUID)
         {
             NCloud::NProto::TDeviceProtocolRequest request;
             request.SetRequestId(++requestId);
 
             auto& proto = *request.MutableWriteLogRecord();
             proto.MutableHeaders()->SetClientId(clientId);
-            proto.SetDeviceUUID(uuid);
-            proto.SetLogSequenceNumber(lsn);
-            proto.SetPrevLogSequenceNumber(prevLsn);
+            proto.SetDeviceUUID(deviceUUID);
+            proto.SetLogSequenceNumber(1);
 
             auto& group = *proto.MutablePageGroups()->Add();
             group.SetFirstPageNo(0x10);
@@ -817,145 +306,23 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
             return response.GetWriteLogRecord().GetError();
         };
 
-        // the very first record is accepted with any prev lsn
-
-        {
-            const auto error = writeLogRecord(10, 5);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                S_OK,
-                error.GetCode(),
-                FormatError(error));
-        }
-
-        {
-            const auto error = writeLogRecord(11, 10);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                S_OK,
-                error.GetCode(),
-                FormatError(error));
-        }
-
-        // a gap in the log
-
-        {
-            const auto error = writeLogRecord(20, 15);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                E_REJECTED,
-                error.GetCode(),
-                FormatError(error));
-            UNIT_ASSERT_STRING_CONTAINS(
-                error.GetMessage(),
-                "Wrong lsn: 15, expected 11");
-        }
-
-        // an outdated record
-
-        {
-            const auto error = writeLogRecord(13, 5);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                E_INVALID_STATE,
-                error.GetCode(),
-                FormatError(error));
-            UNIT_ASSERT_STRING_CONTAINS(
-                error.GetMessage(),
-                "Wrong lsn: 5, expected 11");
-        }
-
-        // the rejected records have not changed the state
-
-        {
-            const auto error = writeLogRecord(12, 11);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                S_OK,
-                error.GetCode(),
-                FormatError(error));
-        }
-    }
-
-    Y_UNIT_TEST_F(ShouldReadPages, TFixture)
-    {
-        const TString clientId = "client-id";
-        const auto& device = FileDevices[0];
-        const ui64 blocksCount = device.GetFileSize() / device.GetBlockSize();
-        const ui32 requestsCount = 100;
-
-        auto env =
-            TTestEnvBuilder(*Runtime).With(CreateDiskAgentConfig()).Build();
-
-        TDiskAgentClient diskAgent(*Runtime);
-        diskAgent.WaitReady();
-
-        TTestClient client{Port};
-
-        auto blockData = [](ui64 blockIndex)
-        {
-            return 'A' + blockIndex % 26;
-        };
-
-        // Prepare data
-        {
-            auto block = std::make_unique<char[]>(device.GetBlockSize());
-
-            TFile file(device.GetPath(), EOpenModeFlag::OpenExisting);
-
-            for (ui64 i = 0; i != blocksCount; ++i) {
-                std::memset(block.get(), blockData(i), device.GetBlockSize());
-                file.Write(block.get(), device.GetBlockSize());
-            }
-        }
-
-        // Acquire device
-
+        const auto readPages = [&](const TString& deviceUUID)
         {
             NCloud::NProto::TDeviceProtocolRequest request;
-            auto& proto = *request.MutableAcquireDevices();
+            request.SetRequestId(++requestId);
+
+            auto& proto = *request.MutableReadPages();
             proto.MutableHeaders()->SetClientId(clientId);
-            *proto.MutableDeviceUUIDs()->Add() = device.GetDeviceId();
-            client.Send(request);
-        }
+            proto.SetDeviceUUID(deviceUUID);
 
-        Runtime->DispatchEvents(TDispatchOptions(), 10ms);
-
-        {
-            auto response = client.Receive();
-            UNIT_ASSERT_EQUAL(
-                NProto::TDeviceProtocolResponse::ResponseCase::kAcquireDevices,
-                response.GetResponseCase());
-            const auto& error = response.GetAcquireDevices().GetError();
-            UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
-        }
-
-        for (ui32 i = 0; i != requestsCount; ++i) {
-            // Send request
-
-            const ui64 requestId = i + 1;
-
-            NCloud::NProto::TDeviceProtocolRequest request;
-            request.SetRequestId(requestId);
-
-            auto& readPagesRequest = *request.MutableReadPages();
-
-            readPagesRequest.MutableHeaders()->SetClientId(clientId);
-            readPagesRequest.SetDeviceUUID(device.GetDeviceId());
-
-            const ui64 groupsCount = 1 + RandomNumber<ui64>(8);
-
-            auto& groupRefs = *readPagesRequest.MutablePageGroupRefs();
-            for (ui64 j = 0; j != groupsCount; ++j) {
-                auto& group = *groupRefs.Add();
-
-                group.SetFirstPageNo(RandomNumber<ui64>(blocksCount));
-                group.SetPageSize(device.GetBlockSize());
-                group.SetPageCount(
-                    1 +
-                    RandomNumber<ui64>(blocksCount - group.GetFirstPageNo()));
-            }
+            auto& group = *proto.MutablePageGroupRefs()->Add();
+            group.SetFirstPageNo(0x10);
+            group.SetPageSize(DefaultBlockSize);
+            group.SetPageCount(1);
 
             client.Send(request);
 
             Runtime->DispatchEvents(TDispatchOptions(), 10ms);
-
-            // Check response
 
             auto response = client.Receive();
             UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
@@ -963,45 +330,52 @@ Y_UNIT_TEST_SUITE(TDiskAgentJournalledDeviceTest)
                 NProto::TDeviceProtocolResponse::ResponseCase::kReadPages,
                 response.GetResponseCase());
 
-            const auto& readPagesResponse = response.GetReadPages();
-            const auto& error = readPagesResponse.GetError();
-            const auto& groups = readPagesResponse.GetPageGroups();
+            return response.GetReadPages().GetError();
+        };
 
+        // the requests reach the device hosted by this agent
+
+        {
+            const auto error = writeLogRecord(uuid);
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),
                 FormatError(error));
+        }
 
-            UNIT_ASSERT_VALUES_EQUAL(
-                groupsCount,
-                readPagesResponse.PageGroupsSize());
+        {
+            const auto error = readPages(uuid);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
 
-            for (size_t i = 0; i != groupsCount; ++i) {
-                const auto& groupRef = groupRefs[i];
-                const auto& group = groups[i];
+        // an unknown device is rejected before the request is validated
 
-                UNIT_ASSERT_VALUES_EQUAL(
-                    groupRef.GetFirstPageNo(),
-                    group.GetFirstPageNo());
+        for (const auto& error: {
+                 writeLogRecord(unknownUuid),
+                 readPages(unknownUuid)})
+        {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_NOT_FOUND,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "Device " + unknownUuid.Quote() + " not found");
+        }
 
-                UNIT_ASSERT_VALUES_EQUAL(
-                    groupRef.GetPageCount(),
-                    group.ContentSize());
+        // a request without a device is rejected as well
 
-                for (ui64 j = 0; j != group.ContentSize(); ++j) {
-                    const ui64 blockIndex = group.GetFirstPageNo() + j;
-
-                    TStringBuf block = group.GetContent(j);
-
-                    UNIT_ASSERT_VALUES_EQUAL(
-                        groupRef.GetPageSize(),
-                        block.size());
-
-                    UNIT_ASSERT_VALUES_EQUAL(
-                        block.size(),
-                        std::ranges::count(block, blockData(blockIndex)));
-                }
-            }
+        for (const auto& error: {writeLogRecord({}), readPages({})}) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "empty device UUID");
         }
     }
 }

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
@@ -1,6 +1,6 @@
 #include "disk_agent_actor.h"
 
-#include <cloud/blockstore/libs/storage/disk_agent/model/device_client.h>
+#include "journalled_device.h"
 
 #include <cloud/storage/core/libs/coroutine/executor.h>
 #include <cloud/storage/core/libs/journalled_device_tcp_server/server.h>
@@ -10,7 +10,7 @@
 #include <contrib/ydb/library/actors/core/hfunc.h>
 #include <contrib/ydb/library/actors/core/log.h>
 
-#include <atomic>
+#include <util/generic/hash.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -38,115 +38,6 @@ void CopyHeaders(
     dst.SetRequestTimeout(src.GetRequestTimeout());
 }
 
-auto CreateWriteBlocksRequest(
-    NCloud::NProto::TDevicePageGroup&& group,
-    ui32 blockSize) -> std::shared_ptr<NProto::TWriteBlocksRequest>
-{
-    auto request = std::make_shared<NProto::TWriteBlocksRequest>();
-
-    request->SetStartIndex(group.GetFirstPageNo());
-    request->SetBlockSize(blockSize);
-
-    NProto::TIOVector& blocks = *request->MutableBlocks();
-    *blocks.MutableBuffers() = std::move(*group.MutableContent());
-
-    return request;
-}
-
-auto CreateReadBlocksRequest(const NCloud::NProto::TDevicePageGroupRef& group)
-    -> std::shared_ptr<NProto::TReadBlocksRequest>
-{
-    auto request = std::make_shared<NProto::TReadBlocksRequest>();
-
-    request->SetStartIndex(group.GetFirstPageNo());
-    request->SetBlocksCount(group.GetPageCount());
-    request->SetBlockSize(group.GetPageSize());
-
-    return request;
-}
-
-auto ValidateWriteLogRecordRequest(
-    const NCloud::NProto::TWriteLogRecordRequest& request)
-    -> TResultOrError<ui32>
-{
-    ui32 blockSize = 0;
-
-    if (request.GetDeviceUUID().empty()) {
-        return MakeError(E_ARGUMENT, "empty device UUID");
-    }
-
-    if (request.PageGroupsSize() == 0) {
-        return MakeError(E_ARGUMENT, "nothing to write");
-    }
-
-    if (request.GetLogSequenceNumber() <= request.GetPrevLogSequenceNumber()) {
-        return MakeError(E_ARGUMENT, TStringBuilder()
-                << "invalid lsn: " << request.GetLogSequenceNumber()
-                << ", must be greater than the prev one: "
-                << request.GetPrevLogSequenceNumber());
-    }
-
-    for (const auto& group: request.GetPageGroups()) {
-        if (group.ContentSize() == 0) {
-            return MakeError(E_ARGUMENT, "empty page group");
-        }
-
-        for (TStringBuf block: group.GetContent()) {
-            if (block.empty()) {
-                return MakeError(
-                    E_ARGUMENT,
-                    "invalid page data: block must not be empty");
-            }
-
-            if (blockSize == 0) {
-                blockSize = block.size();
-                continue;
-            }
-
-            if (blockSize != block.size()) {
-                return MakeError(E_ARGUMENT, TStringBuilder()
-                    << "invalid page data: block size mismatch: expected "
-                    << blockSize << ", got " << block.size());
-            }
-        }
-    }
-
-    return blockSize;
-}
-
-auto ValidateReadPagesRequest(const NCloud::NProto::TReadPagesRequest& request)
-    -> NProto::TError
-{
-    if (request.GetDeviceUUID().empty()) {
-        return MakeError(E_ARGUMENT, "empty device UUID");
-    }
-
-    if (request.PageGroupRefsSize() == 0) {
-        return MakeError(E_ARGUMENT, "nothing to read");
-    }
-
-    for (const auto& group: request.GetPageGroupRefs()) {
-        if (group.GetPageCount() == 0) {
-            return MakeError(
-                E_ARGUMENT,
-                "page group ref must contain at least one page");
-        }
-
-        if (group.GetPageSize() == 0) {
-            return MakeError(E_ARGUMENT, "page size must be greater than zero");
-        }
-    }
-
-    return {};
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TJournalledState
-{
-    std::atomic<ui64> LastLsn = 0;
-};
-
 ////////////////////////////////////////////////////////////////////////////////
 
 class TJournalledDeviceHandler final: public IServerBackend
@@ -154,24 +45,17 @@ class TJournalledDeviceHandler final: public IServerBackend
 private:
     TActorSystem* ActorSystem = nullptr;
     const TActorId DiskAgentActorId;
-    const TDeviceClientPtr DeviceClient;
-
-    THashMap<TString, TJournalledState> JournalledStateByDevice;
+    const THashMap<TString, IJournalledDevicePtr> Devices;
 
 public:
     TJournalledDeviceHandler(
         TActorSystem* actorSystem,
         const TActorId& diskAgentActorId,
-        TDeviceClientPtr deviceClient,
-        const TVector<TString>& deviceUUIDs)
+        THashMap<TString, IJournalledDevicePtr> devices)
         : ActorSystem(actorSystem)
         , DiskAgentActorId(diskAgentActorId)
-        , DeviceClient(std::move(deviceClient))
-    {
-        for (const auto& uuid: deviceUUIDs) {
-            JournalledStateByDevice[uuid];
-        }
-    }
+        , Devices(std::move(devices))
+    {}
 
     // IServerBackend
 
@@ -244,68 +128,13 @@ public:
         NCloud::NProto::TReadPagesRequest request)
         -> TFuture<NCloud::NProto::TReadPagesResponse> final
     {
-        if (auto error = ValidateReadPagesRequest(request); HasError(error)) {
-            return MakeFuture<NCloud::NProto::TReadPagesResponse>(
-                TErrorResponse(error));
-        }
-
-        auto [storageAdapter, error] = DeviceClient->AccessDevice(
-            request.GetDeviceUUID(),
-            request.GetHeaders().GetClientId(),
-            DefaultAccessMode);
-
+        auto [device, error] = GetDevice(request.GetDeviceUUID());
         if (HasError(error)) {
             return MakeFuture<NCloud::NProto::TReadPagesResponse>(
                 TErrorResponse(error));
         }
 
-        auto response = std::make_shared<NCloud::NProto::TReadPagesResponse>();
-
-        TVector<TFuture<NProto::TReadBlocksResponse>> futures;
-        futures.reserve(request.PageGroupRefsSize());
-
-        for (const auto& group: request.GetPageGroupRefs()) {
-            futures.push_back(storageAdapter->ReadBlocks(
-                now,
-                CreateCallContext(),
-                CreateReadBlocksRequest(group),
-                group.GetPageSize(),
-                TStringBuf()   // dataBuffer
-                ));
-        }
-
-        auto all = WaitAll(futures);
-
-        return all.Apply(
-            [futures,
-             request = std::move(request)](const TFuture<void>& future) mutable
-                -> NCloud::NProto::TReadPagesResponse
-            {
-                if (future.HasException()) {
-                    return TErrorResponse(ResultOrError(future).GetError());
-                }
-
-                NCloud::NProto::TReadPagesResponse response;
-                auto& groups = *response.MutablePageGroups();
-                groups.Reserve(futures.size());
-
-                for (size_t i = 0; i != futures.size(); ++i) {
-                    NProto::TReadBlocksResponse sub = futures[i].ExtractValue();
-                    if (HasError(sub)) {
-                        return TErrorResponse(sub.GetError());
-                    }
-
-                    auto& group = *groups.Add();
-
-                    group.SetFirstPageNo(
-                        request.GetPageGroupRefs(i).GetFirstPageNo());
-
-                    *group.MutableContent() =
-                        std::move(*sub.MutableBlocks()->MutableBuffers());
-                }
-
-                return response;
-            });
+        return device->ReadPages(now, std::move(request));
     }
 
     [[nodiscard]] auto WriteLogRecord(
@@ -313,82 +142,13 @@ public:
         NCloud::NProto::TWriteLogRecordRequest request)
         -> TFuture<NCloud::NProto::TWriteLogRecordResponse> final
     {
-        ui32 requestBlockSize = 0;
-        if (auto [bs, error] = ValidateWriteLogRecordRequest(request);
-            HasError(error))
-        {
-            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
-                TErrorResponse(error));
-        } else {
-            requestBlockSize = bs;
-        }
-
-        const auto& deviceUUID = request.GetDeviceUUID();
-        auto* state = JournalledStateByDevice.FindPtr(deviceUUID);
-
-        if (!state) {
-            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
-                TErrorResponse(E_NOT_FOUND, TStringBuilder()
-                    << "Device " << deviceUUID.Quote() << " not found"));
-        }
-
-        const ui64 lastLsn = state->LastLsn.load(std::memory_order_relaxed);
-        const ui64 lsn = request.GetLogSequenceNumber();
-        const ui64 prevLsn = request.GetPrevLogSequenceNumber();
-
-        // TODO(#6956): allow to handle request with wrong lsn order
-        if (lastLsn != 0 && prevLsn != lastLsn) {
-            const auto code = prevLsn > lastLsn ? E_REJECTED : E_INVALID_STATE;
-
-            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
-                TErrorResponse(code, TStringBuilder()
-                    << "Wrong lsn: " << prevLsn << ", expected " << lastLsn));
-        }
-
-        auto [storageAdapter, error] = DeviceClient->AccessDevice(
-            deviceUUID,
-            request.GetHeaders().GetClientId(),
-            DefaultAccessMode);
-
+        auto [device, error] = GetDevice(request.GetDeviceUUID());
         if (HasError(error)) {
             return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
                 TErrorResponse(error));
         }
 
-        TVector<TFuture<NProto::TWriteBlocksResponse>> futures;
-        futures.reserve(request.PageGroupsSize());
-
-        for (auto& group: *request.MutablePageGroups()) {
-            futures.push_back(storageAdapter->WriteBlocks(
-                now,
-                CreateCallContext(),
-                CreateWriteBlocksRequest(std::move(group), requestBlockSize),
-                requestBlockSize,
-                TStringBuf()   // dataBuffer
-                ));
-        }
-
-        auto all = WaitAll(futures);
-
-        return all.Apply(
-            [futures, state, lsn](const TFuture<void>& future) mutable
-                -> NCloud::NProto::TWriteLogRecordResponse
-            {
-                if (future.HasException()) {
-                    return TErrorResponse(ResultOrError(future).GetError());
-                }
-
-                for (const auto& future: futures) {
-                    const auto& sub = future.GetValue();
-                    if (HasError(sub)) {
-                        return TErrorResponse(sub.GetError());
-                    }
-                }
-
-                state->LastLsn.store(lsn, std::memory_order_relaxed);
-
-                return {};
-            });
+        return device->WriteLogRecord(now, std::move(request));
     }
 
     [[nodiscard]] auto ReadJournalTail(
@@ -396,11 +156,13 @@ public:
         NCloud::NProto::TReadJournalTailRequest request)
         -> TFuture<NCloud::NProto::TReadJournalTailResponse> final
     {
-        // TODO(#6956): implement journal tail reading
-        Y_UNUSED(now, request);
+        auto [device, error] = GetDevice(request.GetDeviceUUID());
+        if (HasError(error)) {
+            return MakeFuture<NCloud::NProto::TReadJournalTailResponse>(
+                TErrorResponse(error));
+        }
 
-        return MakeFuture<NCloud::NProto::TReadJournalTailResponse>(
-            TErrorResponse(E_NOT_IMPLEMENTED, "ReadJournalTail"));
+        return device->ReadJournalTail(now, std::move(request));
     }
 
     [[nodiscard]] auto AdvanceLsnLowWatermark(
@@ -408,11 +170,30 @@ public:
         NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
         -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> final
     {
-        // TODO(#6956): implement lsn low watermark advancing
-        Y_UNUSED(now, request);
+        auto [device, error] = GetDevice(request.GetDeviceUUID());
+        if (HasError(error)) {
+            return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
+                TErrorResponse(error));
+        }
 
-        return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
-            TErrorResponse(E_NOT_IMPLEMENTED, "AdvanceLsnLowWatermark"));
+        return device->AdvanceLsnLowWatermark(now, std::move(request));
+    }
+
+private:
+    TResultOrError<IJournalledDevicePtr> GetDevice(
+        const TString& deviceUUID) const
+    {
+        if (deviceUUID.empty()) {
+            return MakeError(E_ARGUMENT, "empty device UUID");
+        }
+
+        auto* device = Devices.FindPtr(deviceUUID);
+        if (!device) {
+            return MakeError(E_NOT_FOUND, TStringBuilder()
+                << "Device " << deviceUUID.Quote() << " not found");
+        }
+
+        return *device;
     }
 };
 
@@ -434,12 +215,9 @@ TNetworkAddress CreateNetworkAddress(TStringBuf s)
 ////////////////////////////////////////////////////////////////////////////////
 
 void TDiskAgentActor::StartJournalledDeviceTcpServer(
-    const NActors::TActorContext& ctx)
+    const NActors::TActorContext& ctx,
+    THashMap<TString, IJournalledDevicePtr> devices)
 {
-    if (!State) {
-        return;
-    }
-
     if (AgentConfig->GetJournalledDeviceTcpServerListenAddress().empty()) {
         return;
     }
@@ -465,8 +243,7 @@ void TDiskAgentActor::StartJournalledDeviceTcpServer(
             std::make_shared<TJournalledDeviceHandler>(
                 TActivationContext::ActorSystem(),
                 ctx.SelfID,
-                State->GetDeviceClient(),
-                State->GetDeviceIds()));
+                std::move(devices)));
 
         JournalledDeviceTcpServer->Start();
 

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device.cpp
@@ -1,0 +1,327 @@
+#include "journalled_device.h"
+
+#include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/device_client.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/generic/hash_set.h>
+#include <util/string/builder.h>
+
+#include <atomic>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr NProto::EVolumeAccessMode DefaultAccessMode =
+    NProto::VOLUME_ACCESS_READ_WRITE;
+
+////////////////////////////////////////////////////////////////////////////////
+
+auto CreateWriteBlocksRequest(
+    NCloud::NProto::TDevicePageGroup&& group,
+    ui32 blockSize) -> std::shared_ptr<NProto::TWriteBlocksRequest>
+{
+    auto request = std::make_shared<NProto::TWriteBlocksRequest>();
+
+    request->SetStartIndex(group.GetFirstPageNo());
+    request->SetBlockSize(blockSize);
+
+    NProto::TIOVector& blocks = *request->MutableBlocks();
+    *blocks.MutableBuffers() = std::move(*group.MutableContent());
+
+    return request;
+}
+
+auto CreateReadBlocksRequest(const NCloud::NProto::TDevicePageGroupRef& group)
+    -> std::shared_ptr<NProto::TReadBlocksRequest>
+{
+    auto request = std::make_shared<NProto::TReadBlocksRequest>();
+
+    request->SetStartIndex(group.GetFirstPageNo());
+    request->SetBlocksCount(group.GetPageCount());
+    request->SetBlockSize(group.GetPageSize());
+
+    return request;
+}
+
+TResultOrError<ui32> ValidateWriteLogRecordRequest(
+    const NCloud::NProto::TWriteLogRecordRequest& request)
+{
+    ui32 blockSize = 0;
+
+    if (request.GetDeviceUUID().empty()) {
+        return MakeError(E_ARGUMENT, "empty device UUID");
+    }
+
+    if (request.PageGroupsSize() == 0) {
+        return MakeError(E_ARGUMENT, "nothing to write");
+    }
+
+    if (request.GetLogSequenceNumber() <= request.GetPrevLogSequenceNumber()) {
+        return MakeError(E_ARGUMENT, TStringBuilder()
+                << "invalid lsn: " << request.GetLogSequenceNumber()
+                << ", must be greater than the prev one: "
+                << request.GetPrevLogSequenceNumber());
+    }
+
+    for (const auto& group: request.GetPageGroups()) {
+        if (group.ContentSize() == 0) {
+            return MakeError(E_ARGUMENT, "empty page group");
+        }
+
+        for (TStringBuf block: group.GetContent()) {
+            if (block.empty()) {
+                return MakeError(
+                    E_ARGUMENT,
+                    "invalid page data: block must not be empty");
+            }
+
+            if (blockSize == 0) {
+                blockSize = block.size();
+                continue;
+            }
+
+            if (blockSize != block.size()) {
+                return MakeError(E_ARGUMENT, TStringBuilder()
+                    << "invalid page data: block size mismatch: expected "
+                    << blockSize << ", got " << block.size());
+            }
+        }
+    }
+
+    return blockSize;
+}
+
+NProto::TError ValidateReadPagesRequest(
+    const NCloud::NProto::TReadPagesRequest& request)
+{
+    if (request.GetDeviceUUID().empty()) {
+        return MakeError(E_ARGUMENT, "empty device UUID");
+    }
+
+    if (request.PageGroupRefsSize() == 0) {
+        return MakeError(E_ARGUMENT, "nothing to read");
+    }
+
+    for (const auto& group: request.GetPageGroupRefs()) {
+        if (group.GetPageCount() == 0) {
+            return MakeError(
+                E_ARGUMENT,
+                "page group ref must contain at least one page");
+        }
+
+        if (group.GetPageSize() == 0) {
+            return MakeError(E_ARGUMENT, "page size must be greater than zero");
+        }
+    }
+
+    return {};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TJournalledDevice final
+    : public IJournalledDevice
+    , public std::enable_shared_from_this<TJournalledDevice>
+{
+private:
+    const TString DeviceUUID;
+    const TDeviceClientPtr DeviceClient;
+
+    std::atomic<ui64> LastLsn = 0;
+
+public:
+    TJournalledDevice(TString deviceUUID, TDeviceClientPtr deviceClient)
+        : DeviceUUID(std::move(deviceUUID))
+        , DeviceClient(std::move(deviceClient))
+    {}
+
+    // IJournalledDevice
+
+    [[nodiscard]] auto ReadPages(
+        TInstant now,
+        NCloud::NProto::TReadPagesRequest request)
+        -> TFuture<NCloud::NProto::TReadPagesResponse> final
+    {
+        if (auto error = ValidateReadPagesRequest(request); HasError(error)) {
+            return MakeFuture<NCloud::NProto::TReadPagesResponse>(
+                TErrorResponse(error));
+        }
+
+        auto [storageAdapter, error] = DeviceClient->AccessDevice(
+            DeviceUUID,
+            request.GetHeaders().GetClientId(),
+            DefaultAccessMode);
+
+        if (HasError(error)) {
+            return MakeFuture<NCloud::NProto::TReadPagesResponse>(
+                TErrorResponse(error));
+        }
+
+        TVector<TFuture<NProto::TReadBlocksResponse>> futures;
+        futures.reserve(request.PageGroupRefsSize());
+
+        for (const auto& group: request.GetPageGroupRefs()) {
+            futures.push_back(storageAdapter->ReadBlocks(
+                now,
+                CreateCallContext(),
+                CreateReadBlocksRequest(group),
+                group.GetPageSize(),
+                TStringBuf()   // dataBuffer
+                ));
+        }
+
+        auto all = WaitAll(futures);
+
+        return all.Apply(
+            [futures,
+             request = std::move(request)](const TFuture<void>& future) mutable
+                -> NCloud::NProto::TReadPagesResponse
+            {
+                if (future.HasException()) {
+                    return TErrorResponse(ResultOrError(future).GetError());
+                }
+
+                NCloud::NProto::TReadPagesResponse response;
+                auto& groups = *response.MutablePageGroups();
+                groups.Reserve(futures.size());
+
+                for (size_t i = 0; i != futures.size(); ++i) {
+                    NProto::TReadBlocksResponse sub = futures[i].ExtractValue();
+                    if (HasError(sub)) {
+                        return TErrorResponse(sub.GetError());
+                    }
+
+                    auto& group = *groups.Add();
+
+                    group.SetFirstPageNo(
+                        request.GetPageGroupRefs(i).GetFirstPageNo());
+
+                    *group.MutableContent() =
+                        std::move(*sub.MutableBlocks()->MutableBuffers());
+                }
+
+                return response;
+            });
+    }
+
+    [[nodiscard]] auto WriteLogRecord(
+        TInstant now,
+        NCloud::NProto::TWriteLogRecordRequest request)
+        -> TFuture<NCloud::NProto::TWriteLogRecordResponse> final
+    {
+        ui32 requestBlockSize = 0;
+        if (auto [bs, error] = ValidateWriteLogRecordRequest(request);
+            HasError(error))
+        {
+            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(error));
+        } else {
+            requestBlockSize = bs;
+        }
+
+        const ui64 lastLsn = LastLsn.load(std::memory_order_relaxed);
+        const ui64 lsn = request.GetLogSequenceNumber();
+        const ui64 prevLsn = request.GetPrevLogSequenceNumber();
+
+        // TODO(#6956): allow to handle request with wrong lsn order
+        if (lastLsn != 0 && prevLsn != lastLsn) {
+            const auto code = prevLsn > lastLsn ? E_REJECTED : E_INVALID_STATE;
+
+            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(code, TStringBuilder()
+                    << "Wrong lsn: " << prevLsn << ", expected " << lastLsn));
+        }
+
+        auto [storageAdapter, error] = DeviceClient->AccessDevice(
+            DeviceUUID,
+            request.GetHeaders().GetClientId(),
+            DefaultAccessMode);
+
+        if (HasError(error)) {
+            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(error));
+        }
+
+        TVector<TFuture<NProto::TWriteBlocksResponse>> futures;
+        futures.reserve(request.PageGroupsSize());
+
+        for (auto& group: *request.MutablePageGroups()) {
+            futures.push_back(storageAdapter->WriteBlocks(
+                now,
+                CreateCallContext(),
+                CreateWriteBlocksRequest(std::move(group), requestBlockSize),
+                requestBlockSize,
+                TStringBuf()   // dataBuffer
+                ));
+        }
+
+        auto all = WaitAll(futures);
+
+        return all.Apply(
+            [futures, self = shared_from_this(), lsn](
+                const TFuture<void>& future) mutable
+                -> NCloud::NProto::TWriteLogRecordResponse
+            {
+                if (future.HasException()) {
+                    return TErrorResponse(ResultOrError(future).GetError());
+                }
+
+                for (const auto& future: futures) {
+                    const auto& sub = future.GetValue();
+                    if (HasError(sub)) {
+                        return TErrorResponse(sub.GetError());
+                    }
+                }
+
+                self->LastLsn.store(lsn, std::memory_order_relaxed);
+
+                return {};
+            });
+    }
+
+    [[nodiscard]] auto ReadJournalTail(
+        TInstant now,
+        NCloud::NProto::TReadJournalTailRequest request)
+        -> TFuture<NCloud::NProto::TReadJournalTailResponse> final
+    {
+        // TODO(#6956): implement journal tail reading
+        Y_UNUSED(now, request);
+
+        return MakeFuture<NCloud::NProto::TReadJournalTailResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "ReadJournalTail"));
+    }
+
+    [[nodiscard]] auto AdvanceLsnLowWatermark(
+        TInstant now,
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> final
+    {
+        // TODO(#6956): implement lsn low watermark advancing
+        Y_UNUSED(now, request);
+
+        return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "AdvanceLsnLowWatermark"));
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IJournalledDevicePtr CreateJournalledDevice(
+    TString deviceUUID,
+    TDeviceClientPtr deviceClient)
+{
+    return std::make_shared<TJournalledDevice>(
+        std::move(deviceUUID),
+        std::move(deviceClient));
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device.h
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <library/cpp/threading/future/future.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IJournalledDevice
+{
+    virtual ~IJournalledDevice() = default;
+
+    [[nodiscard]] virtual auto ReadPages(
+        TInstant now,
+        NCloud::NProto::TReadPagesRequest request)
+        -> NThreading::TFuture<NCloud::NProto::TReadPagesResponse> = 0;
+
+    [[nodiscard]] virtual auto WriteLogRecord(
+        TInstant now,
+        NCloud::NProto::TWriteLogRecordRequest request)
+        -> NThreading::TFuture<NCloud::NProto::TWriteLogRecordResponse> = 0;
+
+    [[nodiscard]] virtual auto ReadJournalTail(
+        TInstant now,
+        NCloud::NProto::TReadJournalTailRequest request)
+        -> NThreading::TFuture<NCloud::NProto::TReadJournalTailResponse> = 0;
+
+    [[nodiscard]] virtual auto AdvanceLsnLowWatermark(
+        TInstant now,
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> NThreading::TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+IJournalledDevicePtr CreateJournalledDevice(
+    TString deviceUUID,
+    TDeviceClientPtr deviceClient);
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device_ut.cpp
@@ -1,0 +1,618 @@
+#include "journalled_device.h"
+
+#include <cloud/blockstore/libs/rdma_test/memory_test_storage.h>
+#include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/service/storage.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/device_client.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+#include <util/random/random.h>
+
+#include <chrono>
+#include <functional>
+#include <ranges>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace std::chrono_literals;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 DefaultBlockSize = 4_KB;
+constexpr ui64 DefaultBlockCount = 1_MB / DefaultBlockSize;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    const TString ClientId = "client-id";
+    const TString DeviceUUID = "uuid-1";
+    const TInstant Now = TInstant::Seconds(1);
+
+    ILoggingServicePtr Logging = CreateLoggingService("console");
+
+    std::shared_ptr<TMemoryTestStorage> Storage;
+    TStorageAdapterPtr StorageAdapter;
+    TDeviceClientPtr DeviceClient;
+    IJournalledDevicePtr Device;
+
+    void SetUp(NUnitTest::TTestContext& /*context*/) override
+    {
+        Storage = std::make_shared<TMemoryTestStorage>(
+            DefaultBlockCount * DefaultBlockSize);
+
+        StorageAdapter = std::make_shared<TStorageAdapter>(
+            Storage,
+            DefaultBlockSize,
+            false,                    // normalize
+            TDuration::Seconds(1),    // maxRequestDuration
+            TDuration::Seconds(1));   // shutdownTimeout
+
+        DeviceClient = std::make_shared<TDeviceClient>(
+            10s,   // releaseInactiveSessionsTimeout
+            TVector<std::pair<TString, TStorageAdapterPtr>>{
+                {DeviceUUID, StorageAdapter}},
+            Logging->CreateLog("BLOCKSTORE_DISK_AGENT"),
+            false   // kickOutOldClientsEnabled
+        );
+
+        // the device is not acquired here: some of the tests observe the
+        // behaviour of an unacquired device
+        Device = CreateJournalledDevice(DeviceUUID, DeviceClient);
+    }
+
+    void AcquireDevice()
+    {
+        const auto result = DeviceClient->AcquireDevices(
+            {DeviceUUID},
+            ClientId,
+            Now,
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            0,    // mountSeqNumber
+            {},   // diskId
+            0     // volumeGeneration
+        );
+
+        UNIT_ASSERT_C(
+            !HasError(result.GetError()),
+            FormatError(result.GetError()));
+    }
+
+    static char BlockData(ui64 blockIndex)
+    {
+        return static_cast<char>('A' + blockIndex % 26);
+    }
+
+    void FillDevice()
+    {
+        auto request = std::make_shared<NProto::TWriteBlocksRequest>();
+        request->SetStartIndex(0);
+        request->SetBlockSize(DefaultBlockSize);
+
+        auto& buffers = *request->MutableBlocks()->MutableBuffers();
+        for (ui64 i = 0; i != DefaultBlockCount; ++i) {
+            buffers.Add()->resize(DefaultBlockSize, BlockData(i));
+        }
+
+        const auto response = StorageAdapter->WriteBlocks(
+            Now,
+            CreateCallContext(),
+            std::move(request),
+            DefaultBlockSize,
+            TStringBuf()   // dataBuffer
+        ).GetValueSync();
+
+        UNIT_ASSERT_C(!HasError(response), FormatError(response.GetError()));
+    }
+
+    NProto::TError WriteLogRecord(
+        NCloud::NProto::TWriteLogRecordRequest request)
+    {
+        return Device->WriteLogRecord(Now, std::move(request))
+            .GetValueSync()
+            .GetError();
+    }
+
+    NProto::TError WriteLogRecord(ui64 lsn, ui64 prevLsn)
+    {
+        NCloud::NProto::TWriteLogRecordRequest request;
+        request.MutableHeaders()->SetClientId(ClientId);
+        request.SetDeviceUUID(DeviceUUID);
+        request.SetLogSequenceNumber(lsn);
+        request.SetPrevLogSequenceNumber(prevLsn);
+
+        auto& group = *request.MutablePageGroups()->Add();
+        group.SetFirstPageNo(0x10);
+        group.MutableContent()->Add()->resize(DefaultBlockSize, 'A');
+
+        return WriteLogRecord(std::move(request));
+    }
+
+    auto ReadPages(NCloud::NProto::TReadPagesRequest request)
+    {
+        return Device->ReadPages(Now, std::move(request)).GetValueSync();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
+{
+    Y_UNIT_TEST_F(ShouldValidateWriteLogRecordRequest, TFixture)
+    {
+        using TPrepareFunc =
+            std::function<void(NCloud::NProto::TWriteLogRecordRequest&)>;
+
+        const std::tuple<TPrepareFunc, NProto::TError> testCases[]{
+            {[&](auto&) {}, MakeError(E_ARGUMENT, "empty device UUID")},
+            {[&](auto& proto) { proto.SetDeviceUUID(DeviceUUID); },
+             MakeError(E_ARGUMENT, "nothing to write")},
+            {[&](auto& proto)
+             {
+                 proto.SetDeviceUUID(DeviceUUID);
+                 proto.SetLogSequenceNumber(1);
+                 proto.MutablePageGroups()->Add();
+             },
+             MakeError(E_ARGUMENT, "empty page group")},
+            {[&](auto& proto)
+             {
+                 proto.SetDeviceUUID(DeviceUUID);
+                 proto.SetLogSequenceNumber(1);
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add();   // an empty block
+                 }
+             },
+             MakeError(
+                 E_ARGUMENT,
+                 "invalid page data: block must not be empty")},
+            {[&](auto& proto)
+             {
+                 proto.SetDeviceUUID(DeviceUUID);
+                 proto.SetLogSequenceNumber(1);
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add()->resize(4_KB, 'A');
+                 }
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x20);
+                     group.MutableContent()->Add()->resize(4_KB, 'A');
+                     group.MutableContent()->Add();   // an empty block
+                     group.MutableContent()->Add()->resize(4_KB, 'A');
+                 }
+             },
+             MakeError(
+                 E_ARGUMENT,
+                 "invalid page data: block must not be empty")},
+            {[&](auto& proto)
+             {
+                 proto.SetDeviceUUID(DeviceUUID);
+                 proto.SetLogSequenceNumber(1);
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add()->resize(4_KB, 'A');
+                     group.MutableContent()->Add()->resize(8_KB, 'B');
+                 }
+             },
+             MakeError(E_ARGUMENT, "invalid page data: block size mismatch")},
+            {[&](auto& proto)
+             {
+                 // the client id is checked after the device is found
+                 proto.SetDeviceUUID(DeviceUUID);
+                 proto.SetLogSequenceNumber(1);
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add()->resize(
+                         DefaultBlockSize,
+                         'A');
+                     group.MutableContent()->Add()->resize(
+                         DefaultBlockSize,
+                         'B');
+                 }
+             },
+             MakeError(E_ARGUMENT, "empty client id")},
+            {[&](auto& proto)
+             {
+                 proto.MutableHeaders()->SetClientId(ClientId);
+                 proto.SetDeviceUUID(DeviceUUID);
+                 proto.SetLogSequenceNumber(1);
+
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add()->resize(
+                         DefaultBlockSize,
+                         'A');
+                     group.MutableContent()->Add()->resize(
+                         DefaultBlockSize,
+                         'B');
+                 }
+             },
+             MakeError(E_BS_INVALID_SESSION, "not acquired by client")},
+            {[&](auto& proto)
+             {
+                 proto.MutableHeaders()->SetClientId(ClientId);
+                 proto.SetDeviceUUID(DeviceUUID);
+                 // LogSequenceNumber is not set
+
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add()->resize(
+                         DefaultBlockSize,
+                         'A');
+                 }
+             },
+             MakeError(E_ARGUMENT, "invalid lsn: 0")},
+            {[&](auto& proto)
+             {
+                 proto.MutableHeaders()->SetClientId(ClientId);
+                 proto.SetDeviceUUID(DeviceUUID);
+                 proto.SetLogSequenceNumber(10);
+                 proto.SetPrevLogSequenceNumber(10);
+
+                 auto& groups = *proto.MutablePageGroups();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.MutableContent()->Add()->resize(
+                         DefaultBlockSize,
+                         'A');
+                 }
+             },
+             MakeError(
+                 E_ARGUMENT,
+                 "invalid lsn: 10, must be greater than the prev one: 10")},
+        };
+
+        for (size_t i = 0; i != std::size(testCases); ++i) {
+            const auto& [prepare, expectedError] = testCases[i];
+
+            NCloud::NProto::TWriteLogRecordRequest request;
+            prepare(request);
+
+            const auto error = WriteLogRecord(std::move(request));
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                expectedError.GetCode(),
+                error.GetCode(),
+                "#" << (i + 1) << ": " << FormatError(expectedError) << " !~ "
+                    << FormatError(error));
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                expectedError.GetMessage(),
+                "#" << (i + 1) << ": " << FormatError(expectedError) << " !~ "
+                    << FormatError(error));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldValidateReadPagesRequest, TFixture)
+    {
+        using TPrepareFunc =
+            std::function<void(NCloud::NProto::TReadPagesRequest&)>;
+
+        const std::tuple<TPrepareFunc, NProto::TError> testCases[]{
+            {[&](auto&) {}, MakeError(E_ARGUMENT, "empty device UUID")},
+            {[&](auto& proto) { proto.SetDeviceUUID(DeviceUUID); },
+             MakeError(E_ARGUMENT, "nothing to read")},
+            {[&](auto& proto)
+             {
+                 proto.SetDeviceUUID(DeviceUUID);
+                 proto.MutablePageGroupRefs()->Add();
+             },
+             MakeError(
+                 E_ARGUMENT,
+                 "page group ref must contain at least one page")},
+            {[&](auto& proto)
+             {
+                 proto.SetDeviceUUID(DeviceUUID);
+                 auto& groups = *proto.MutablePageGroupRefs();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.SetPageSize(DefaultBlockSize);
+                     group.SetPageCount(1);
+                 }
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x20);
+                     group.SetPageSize(DefaultBlockSize);
+                     group.SetPageCount(0);
+                 }
+             },
+             MakeError(
+                 E_ARGUMENT,
+                 "page group ref must contain at least one page")},
+            {[&](auto& proto)
+             {
+                 proto.SetDeviceUUID(DeviceUUID);
+                 auto& groups = *proto.MutablePageGroupRefs();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.SetPageSize(DefaultBlockSize);
+                     group.SetPageCount(1);
+                 }
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x20);
+                     group.SetPageSize(0);
+                     group.SetPageCount(1);
+                 }
+             },
+             MakeError(E_ARGUMENT, "page size must be greater than zero")},
+            {[&](auto& proto)
+             {
+                 proto.SetDeviceUUID(DeviceUUID);
+                 auto& groups = *proto.MutablePageGroupRefs();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.SetPageSize(DefaultBlockSize);
+                     group.SetPageCount(1);
+                 }
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x20);
+                     group.SetPageSize(DefaultBlockSize);
+                     group.SetPageCount(1);
+                 }
+             },
+             MakeError(E_ARGUMENT, "empty client id")},
+            {[&](auto& proto)
+             {
+                 proto.MutableHeaders()->SetClientId(ClientId);
+                 proto.SetDeviceUUID(DeviceUUID);
+
+                 auto& groups = *proto.MutablePageGroupRefs();
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x10);
+                     group.SetPageSize(DefaultBlockSize);
+                     group.SetPageCount(1);
+                 }
+
+                 {
+                     auto& group = *groups.Add();
+                     group.SetFirstPageNo(0x20);
+                     group.SetPageSize(DefaultBlockSize);
+                     group.SetPageCount(1);
+                 }
+             },
+             MakeError(E_BS_INVALID_SESSION, "not acquired by client")},
+        };
+
+        for (size_t i = 0; i != std::size(testCases); ++i) {
+            const auto& [prepare, expectedError] = testCases[i];
+
+            NCloud::NProto::TReadPagesRequest request;
+            prepare(request);
+
+            const auto error = ReadPages(std::move(request)).GetError();
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                expectedError.GetCode(),
+                error.GetCode(),
+                "#" << (i + 1) << ": " << FormatError(expectedError) << " !~ "
+                    << FormatError(error));
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                expectedError.GetMessage(),
+                "#" << (i + 1) << ": " << FormatError(expectedError) << " !~ "
+                    << FormatError(error));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldWriteLogRecord, TFixture)
+    {
+        const auto makeRequest = [&]
+        {
+            NCloud::NProto::TWriteLogRecordRequest request;
+            request.MutableHeaders()->SetClientId(ClientId);
+            request.SetDeviceUUID(DeviceUUID);
+            request.SetLogSequenceNumber(1);
+
+            auto& groups = *request.MutablePageGroups();
+
+            {
+                auto& group = *groups.Add();
+                group.SetFirstPageNo(0x10);
+                group.MutableContent()->Add()->resize(DefaultBlockSize, 'A');
+                group.MutableContent()->Add()->resize(DefaultBlockSize, 'B');
+            }
+
+            {
+                auto& group = *groups.Add();
+                group.SetFirstPageNo(0x20);
+                group.MutableContent()->Add()->resize(DefaultBlockSize, 'X');
+                group.MutableContent()->Add()->resize(DefaultBlockSize, 'Y');
+            }
+
+            return request;
+        };
+
+        // the device has not been acquired yet
+
+        {
+            const auto error = WriteLogRecord(makeRequest());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_BS_INVALID_SESSION,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        AcquireDevice();
+
+        {
+            const auto error = WriteLogRecord(makeRequest());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldValidateLogSequenceNumber, TFixture)
+    {
+        AcquireDevice();
+
+        // the very first record is accepted with any prev lsn
+
+        {
+            const auto error = WriteLogRecord(10, 5);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            const auto error = WriteLogRecord(11, 10);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        // a gap in the log
+
+        {
+            const auto error = WriteLogRecord(20, 15);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "Wrong lsn: 15, expected 11");
+        }
+
+        // an outdated record
+
+        {
+            const auto error = WriteLogRecord(13, 5);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_INVALID_STATE,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "Wrong lsn: 5, expected 11");
+        }
+
+        // the rejected records have not changed the state
+
+        {
+            const auto error = WriteLogRecord(12, 11);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldReadPages, TFixture)
+    {
+        constexpr ui32 requestCount = 100;
+
+        FillDevice();
+        AcquireDevice();
+
+        for (ui32 i = 0; i != requestCount; ++i) {
+            NCloud::NProto::TReadPagesRequest request;
+            request.MutableHeaders()->SetClientId(ClientId);
+            request.SetDeviceUUID(DeviceUUID);
+
+            const ui64 groupCount = 1 + RandomNumber<ui64>(8);
+
+            auto& groupRefs = *request.MutablePageGroupRefs();
+            for (ui64 j = 0; j != groupCount; ++j) {
+                auto& group = *groupRefs.Add();
+
+                group.SetFirstPageNo(RandomNumber<ui64>(DefaultBlockCount));
+                group.SetPageSize(DefaultBlockSize);
+                group.SetPageCount(
+                    1 + RandomNumber<ui64>(
+                            DefaultBlockCount - group.GetFirstPageNo()));
+            }
+
+            const auto response = ReadPages(request);
+
+            const auto& error = response.GetError();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+
+            UNIT_ASSERT_VALUES_EQUAL(groupCount, response.PageGroupsSize());
+
+            const auto& groups = response.GetPageGroups();
+
+            for (size_t j = 0; j != groupCount; ++j) {
+                const auto& groupRef = groupRefs[j];
+                const auto& group = groups[j];
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    groupRef.GetFirstPageNo(),
+                    group.GetFirstPageNo());
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    groupRef.GetPageCount(),
+                    group.ContentSize());
+
+                for (ui64 k = 0; k != group.ContentSize(); ++k) {
+                    const ui64 blockIndex = group.GetFirstPageNo() + k;
+
+                    TStringBuf block = group.GetContent(k);
+
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        groupRef.GetPageSize(),
+                        block.size());
+
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        block.size(),
+                        std::ranges::count(block, BlockData(blockIndex)));
+                }
+            }
+        }
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/public.h
+++ b/cloud/blockstore/libs/storage/disk_agent/public.h
@@ -3,3 +3,14 @@
 #include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 
 #include <util/generic/strbuf.h>
+
+#include <memory>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IJournalledDevice;
+using IJournalledDevicePtr = std::shared_ptr<IJournalledDevice>;
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/ut/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/ut/ya.make
@@ -8,6 +8,7 @@ ENDIF()
 
 SRCS(
     disk_agent_state_ut.cpp
+    journalled_device_ut.cpp
     rdma_target_ut.cpp
     recent_blocks_tracker_ut.cpp
     spdk_initializer_ut.cpp

--- a/cloud/blockstore/libs/storage/disk_agent/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/ya.make
@@ -24,6 +24,7 @@ SRCS(
     disk_agent_state.cpp
     disk_agent.cpp
     hash_table_storage.cpp
+    journalled_device.cpp
     rdma_target.cpp
     recent_blocks_tracker.cpp
     spdk_initializer.cpp


### PR DESCRIPTION
### Notes
Pure refactoring, no behavior changes intended.

`TJournalledDeviceHandler` held both the transport-level concerns and the whole per-device journal logic in a single file.

  This PR splits those apart:

  * New `IJournalledDevice` interface (`journalled_device.h`) with the four per-device
    operations: `ReadPages`, `WriteLogRecord`, `ReadJournalTail`, `AdvanceLsnLowWatermark`.
  * `TJournalledDeviceHandler` keeps only the transport/actor-system glue: `AcquireDevices` /
    `ReleaseDevices` forwarding to the disk agent actor, and `GetDevice()` routing by UUID
    into a `THashMap<TString, IJournalledDevicePtr>` passed in at construction.
  * Tests split accordingly: per-device journal behavior moves to the new
    `journalled_device_ut.cpp`; `disk_agent_actor_journalled_device_ut.cpp` keeps the
    server-level cases, with `ShouldRouteRequestsToDevices` rewritten against the new routing.

### Issue
https://github.com/ydb-platform/nbs/issues/6956
