### PR TITLE
[Filestore] add confirmation to filestore-client destroy

### DIFF
--- a/cloud/filestore/apps/client/lib/destroy.cpp
+++ b/cloud/filestore/apps/client/lib/destroy.cpp
@@ -1,5 +1,8 @@
 #include "command.h"
 
+#include <util/stream/input.h>
+#include <util/stream/output.h>
+
 namespace NCloud::NFileStore::NClient {
 
 namespace {
@@ -20,6 +23,15 @@ public:
 
     bool Execute() override
     {
+        Cerr << "Confirm filesystem destruction by typing filesystem id to stdin"
+             << Endl;
+        TString confirmation;
+        Cin >> confirmation;
+        Y_ENSURE(
+            confirmation == FileSystemId,
+            "Confirmation failed: " << confirmation.Quote()
+                << " != " << FileSystemId.Quote());
+
         auto callContext = PrepareCallContext();
 
         auto request = std::make_shared<NProto::TDestroyFileStoreRequest>();

--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import tempfile
 import time
 import uuid
 
@@ -1103,3 +1104,35 @@ def test_client_should_not_crash_on_shutdown_while_listing_endpoints():
     errors = process_recipe_err_files(log_files["stderr_file"])
     if errors:
         raise RuntimeError("Recipe found errors in the log files: " + "\n".join(errors))
+
+
+def test_should_destroy_with_confirmation():
+    client, _ = __init_test()
+
+    client.create("fs0", "test_cloud", "test_folder", BLOCK_SIZE, BLOCKS_COUNT)
+
+    binary_path = common.binary_path("cloud/filestore/apps/client/filestore-client")
+    cmd = [
+        binary_path, "destroy",
+        "--filesystem", "fs0",
+        "--server-address", "localhost",
+        "--server-port", os.getenv("NFS_SERVER_PORT"),
+    ]
+
+    with tempfile.NamedTemporaryFile(mode="w+") as confirmation:
+        confirmation.write("not-fs0")
+        confirmation.flush()
+        confirmation.seek(0)
+
+        result = common.execute(cmd, stdin=confirmation, check_exit_code=False)
+
+    assert result.returncode != 0
+
+    # a failed confirmation should leave the filesystem intact
+    client.describe("fs0")
+    assert "fs0" in client.list_filestores()
+
+    client.destroy("fs0")
+    # client.destroy does the confirmation under the hood, and the filesystem
+    # should actually be destroyed
+    assert "fs0" not in client.list_filestores()

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -91,8 +91,18 @@ class FilestoreCliClient:
             "--filesystem", fs,
         ] + self.__cmd_opts()
 
-        logger.info("destroying filestore: " + " ".join(cmd))
-        return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout
+        # destroy asks to confirm by typing the filesystem id to stdin
+        with tempfile.NamedTemporaryFile(mode="w+") as confirmation:
+            confirmation.write(fs)
+            confirmation.flush()
+            confirmation.seek(0)
+
+            logger.info("destroying filestore: " + " ".join(cmd))
+            return common.execute(
+                cmd,
+                env=self.__env,
+                stdin=confirmation,
+                check_exit_code=self.__check_exit_code).stdout
 
     def mount(self, fs, path, mount_seqno=0, readonly=False):
         cmd = [


### PR DESCRIPTION
`filestore-client destroy` currently destroys the filesystem immediately, with no safeguard against a mistyped or wrong `--filesystem` id. This adds the same confirmation step that `blockstore-client destroyvolume` already has: the command prints a prompt and reads the filesystem id from stdin; if it doesn't match `--filesystem`, the command fails with exit code 1 and no request is sent.

