### PR TITLE
issue-5895: introduced TFilestoreBlobID to get rid of the cloud/filestore/private -> ydb/core/protos dep

### DIFF
--- a/cloud/filestore/libs/storage/core/blob_id.cpp
+++ b/cloud/filestore/libs/storage/core/blob_id.cpp
@@ -1,0 +1,73 @@
+#include "blob_id.h"
+
+#include <contrib/ydb/core/protos/base.pb.h>
+
+#include <type_traits>
+#include <utility>
+
+namespace NCloud::NFileStore::NProtoPrivate {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// TFileStoreBlobID is a local copy of NKikimrProto.TLogoBlobID. The two
+// messages must stay wire-compatible: same field numbers and same scalar
+// field types (checked via the getter return types).
+//
+
+static_assert(
+    TFileStoreBlobID::kRawX1FieldNumber ==
+    NKikimrProto::TLogoBlobID::kRawX1FieldNumber);
+static_assert(
+    TFileStoreBlobID::kRawX2FieldNumber ==
+    NKikimrProto::TLogoBlobID::kRawX2FieldNumber);
+static_assert(
+    TFileStoreBlobID::kRawX3FieldNumber ==
+    NKikimrProto::TLogoBlobID::kRawX3FieldNumber);
+
+static_assert(std::is_same_v<
+    decltype(std::declval<const TFileStoreBlobID&>().GetRawX1()),
+    decltype(std::declval<const NKikimrProto::TLogoBlobID&>().GetRawX1())>);
+static_assert(std::is_same_v<
+    decltype(std::declval<const TFileStoreBlobID&>().GetRawX2()),
+    decltype(std::declval<const NKikimrProto::TLogoBlobID&>().GetRawX2())>);
+static_assert(std::is_same_v<
+    decltype(std::declval<const TFileStoreBlobID&>().GetRawX3()),
+    decltype(std::declval<const NKikimrProto::TLogoBlobID&>().GetRawX3())>);
+
+////////////////////////////////////////////////////////////////////////////////
+
+NKikimr::TLogoBlobID LogoBlobIDFromLogoBlobID(const TFileStoreBlobID& proto)
+{
+    return NKikimr::TLogoBlobID(
+        proto.GetRawX1(),
+        proto.GetRawX2(),
+        proto.GetRawX3());
+}
+
+void LogoBlobIDFromLogoBlobID(
+    const NKikimr::TLogoBlobID& id,
+    TFileStoreBlobID* proto)
+{
+    const ui64* raw = id.GetRaw();
+    proto->SetRawX1(raw[0]);
+    proto->SetRawX2(raw[1]);
+    proto->SetRawX3(raw[2]);
+}
+
+}   // namespace NCloud::NFileStore::NProtoPrivate
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void Convert(
+    const NProtoPrivate::TFileStoreBlobID& blobId,
+    NKikimrProto::TLogoBlobID& to)
+{
+    to.SetRawX1(blobId.GetRawX1());
+    to.SetRawX2(blobId.GetRawX2());
+    to.SetRawX3(blobId.GetRawX3());
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/blob_id.h
+++ b/cloud/filestore/libs/storage/core/blob_id.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
+
+#include <contrib/ydb/core/base/logoblob.h>
+
+namespace NCloud::NFileStore::NProtoPrivate {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Converters between NKikimr::TLogoBlobID and its local proto copy
+// NProtoPrivate::TFileStoreBlobID. Defined in the proto namespace so that
+// unqualified calls resolve via argument-dependent lookup, mirroring the
+// NKikimr helpers for NKikimrProto.TLogoBlobID.
+//
+
+/**
+ * Parses a blob id from its proto representation.
+ *
+ * @param proto - Proto representation of the blob id.
+ * @return - The parsed blob id.
+ */
+NKikimr::TLogoBlobID LogoBlobIDFromLogoBlobID(const TFileStoreBlobID& proto);
+
+/**
+ * Serializes a blob id into its proto representation.
+ *
+ * @param id - Blob id to serialize.
+ * @param proto - (out) Proto representation of the blob id.
+ */
+void LogoBlobIDFromLogoBlobID(
+    const NKikimr::TLogoBlobID& id,
+    TFileStoreBlobID* proto);
+
+}   // namespace NCloud::NFileStore::NProtoPrivate
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Merge the blob id converters for both proto representations into one
+// overload set so that unqualified calls work for either of them.
+//
+
+using NKikimr::LogoBlobIDFromLogoBlobID;
+using NProtoPrivate::LogoBlobIDFromLogoBlobID;
+
+/**
+ * Copies a blob id between its two proto representations.
+ *
+ * @param blobId - Local proto representation of the blob id.
+ * @param to - (out) ydb proto representation of the blob id.
+ */
+void Convert(
+    const NProtoPrivate::TFileStoreBlobID& blobId,
+    NKikimrProto::TLogoBlobID& to);
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/ya.make
+++ b/cloud/filestore/libs/storage/core/ya.make
@@ -1,6 +1,7 @@
 LIBRARY(filestore-libs-storage-core)
 
 SRCS(
+    blob_id.cpp
     config.cpp
     cpu_timer.cpp
     helpers.cpp

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -10,6 +10,7 @@
 #include <cloud/filestore/libs/service/context.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/core/blob_id.h>
 #include <cloud/filestore/libs/storage/core/probes.h>
 #include <cloud/filestore/libs/storage/model/block_buffer.h>
 #include <cloud/filestore/libs/storage/tablet/model/sparse_segment.h>

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -9,6 +9,7 @@
 #include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/core/blob_id.h>
 #include <cloud/filestore/libs/storage/core/helpers.h>
 #include <cloud/filestore/libs/storage/core/probes.h>
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -12,6 +12,7 @@
 #include <cloud/filestore/libs/diagnostics/public.h>
 #include <cloud/filestore/libs/storage/api/service.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
+#include <cloud/filestore/libs/storage/core/blob_id.h>
 #include <cloud/filestore/libs/storage/core/config.h>
 #include <cloud/filestore/libs/storage/core/system_counters.h>
 #include <cloud/filestore/libs/storage/core/tablet.h>
@@ -278,7 +279,7 @@ private:
         const auto count = Min<int>(blobIds.size(), flags.size());
         for (int i = 0; i < count; ++i) {
             const auto blobId =
-                NKikimr::LogoBlobIDFromLogoBlobID(blobIds.Get(i));
+                LogoBlobIDFromLogoBlobID(blobIds.Get(i));
             const double share = i < shares.size() ? shares.Get(i) : 0;
             RegisterEvPutResult(
                 ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -58,7 +58,7 @@ NProto::TUnconfirmedData BuildUnconfirmedData(
     data.SetOffset(offset);
     data.SetLength(end - offset);
     for (const auto& blob: generateResponse.GetBlobs()) {
-        *data.AddBlobIds() = blob.GetBlobId();
+        Convert(blob.GetBlobId(), *data.AddBlobIds());
     }
     return data;
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -411,7 +411,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             auto response = Tablet->GenerateBlobIds(id, handle, 0, sz);
             TVector<NKikimr::TLogoBlobID> blobIds;
             for (const auto& blobId: response->Record.GetBlobs()) {
-                auto blob = NKikimr::LogoBlobIDFromLogoBlobID(blobId.GetBlobId());
+                auto blob = LogoBlobIDFromLogoBlobID(blobId.GetBlobId());
                 blobIds.push_back(blob);
             }
             Tablet->AddData(id, handle, 0, sz, blobIds, response->Record.GetCommitId());

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5423,7 +5423,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         const auto& blobPieces = response->Record.GetBlobPieces();
         /*
         for (const auto& p: blobPieces) {
-            Cerr << NKikimr::LogoBlobIDFromLogoBlobID(p.GetBlobId())
+            Cerr << LogoBlobIDFromLogoBlobID(p.GetBlobId())
                 << " " << p.GetBSGroupId() << Endl;
 
             for (const auto& r: p.GetRanges()) {
@@ -5436,7 +5436,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL(2, blobPieces.size());
 
         const auto blobId0 =
-            NKikimr::LogoBlobIDFromLogoBlobID(blobPieces[0].GetBlobId());
+            LogoBlobIDFromLogoBlobID(blobPieces[0].GetBlobId());
         UNIT_ASSERT_VALUES_EQUAL(tabletId, blobId0.TabletID());
         UNIT_ASSERT_VALUES_EQUAL(2, blobId0.Generation());
         UNIT_ASSERT_VALUES_EQUAL(4, blobId0.Step());
@@ -5470,7 +5470,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             blobPieces[0].GetRanges(1).GetLength());
 
         const auto blobId1 =
-            NKikimr::LogoBlobIDFromLogoBlobID(blobPieces[1].GetBlobId());
+            LogoBlobIDFromLogoBlobID(blobPieces[1].GetBlobId());
         UNIT_ASSERT_VALUES_EQUAL(tabletId, blobId1.TabletID());
         UNIT_ASSERT_VALUES_EQUAL(2, blobId1.Generation());
         UNIT_ASSERT_VALUES_EQUAL(11, blobId1.Step());
@@ -5553,7 +5553,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL(1, blobPieces.size());
 
         const auto blobId0 =
-            NKikimr::LogoBlobIDFromLogoBlobID(blobPieces[0].GetBlobId());
+            LogoBlobIDFromLogoBlobID(blobPieces[0].GetBlobId());
         UNIT_ASSERT_VALUES_EQUAL(tabletId, blobId0.TabletID());
         UNIT_ASSERT_VALUES_EQUAL(2, blobId0.Generation());
         UNIT_ASSERT_VALUES_EQUAL(6, blobId0.Step());

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -5,6 +5,7 @@
 
 #include <cloud/filestore/libs/storage/api/service.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
+#include <cloud/filestore/libs/storage/core/blob_id.h>
 #include <cloud/filestore/libs/storage/core/config.h>
 #include <cloud/filestore/libs/storage/model/channel_data_kind.h>
 #include <cloud/filestore/libs/storage/tablet/events/tablet_private.h>
@@ -1020,7 +1021,7 @@ public:
         request->Record.SetOffset(offset);
         request->Record.SetLength(length);
         for (const auto& blobId: blobIds) {
-            NKikimr::LogoBlobIDFromLogoBlobID(
+            LogoBlobIDFromLogoBlobID(
                 blobId,
                 request->Record.MutableBlobIds()->Add());
         }

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -8,8 +8,6 @@ import "cloud/filestore/public/api/protos/node.proto";
 import "cloud/filestore/public/api/protos/quota.proto";
 import "cloud/filestore/config/storage.proto";
 
-import "contrib/ydb/core/protos/base.proto";
-
 package NCloud.NFileStore.NProtoPrivate;
 
 option go_package = "github.com/ydb-platform/nbs/cloud/filestore/private/api/protos";
@@ -416,6 +414,17 @@ message TDescribeDataRequest
     uint64 Length = 6;
 }
 
+// Copy of NKikimrProto.TLogoBlobID from contrib/ydb/core/protos/base.proto.
+// Kept local to avoid a dependency on ydb core protos. Wire-compatible with
+// the original - checked by static assertions in
+// cloud/filestore/libs/storage/core/blob_id.cpp.
+message TFileStoreBlobID
+{
+    fixed64 RawX1 = 1;
+    fixed64 RawX2 = 2;
+    fixed64 RawX3 = 3;
+}
+
 // Represents actual data - for the data that is not stored in data channels as
 // blobs yet.
 message TFreshDataRange
@@ -440,7 +449,7 @@ message TRangeInBlob
 message TBlobPiece
 {
     // Blob id.
-    NKikimrProto.TLogoBlobID BlobId = 1;
+    TFileStoreBlobID BlobId = 1;
 
     // Group id.
     uint32 BSGroupId = 2;
@@ -537,7 +546,7 @@ message TGenerateBlobIdsRequest
 message TGeneratedBlob
 {
     // Blob id.
-    NKikimrProto.TLogoBlobID BlobId = 1;
+    TFileStoreBlobID BlobId = 1;
 
     // Offset
     uint64 Offset = 2;
@@ -591,7 +600,7 @@ message TAddDataRequest
     uint64 Length = 6;
 
     // Blob ids to be added. Ordered by the offset in the original data.
-    repeated NKikimrProto.TLogoBlobID BlobIds = 7;
+    repeated TFileStoreBlobID BlobIds = 7;
 
     // Commit id.
     uint64 CommitId = 8;

--- a/cloud/filestore/private/api/protos/ya.make
+++ b/cloud/filestore/private/api/protos/ya.make
@@ -7,8 +7,6 @@ PEERDIR(
     cloud/filestore/config
     cloud/filestore/public/api/protos
     cloud/storage/core/protos
-
-    contrib/ydb/core/protos
 )
 
 SRCS(


### PR DESCRIPTION
### Notes
cloud/filestore/private depends on ydb/core/protos which makes its build much heavier and time-consuming

at the same time there's a lot of code that needs to depend on the api schemas (including cloud/filestore/private) but doesn't depend on ydb at all

the dependency exists only because we need `TLogoBlobID`

this PR simply introduces a wire-compatible `TFileStoreBlobID` data structure to use in cloud/filestore/private and eliminates the dependency on ydb/core/protos

the added "compatibility layer" (cloud/filestore/libs/storage/core/blob_id.[h,cpp]) `static_assert`s that the two data structures have the same layout

### Issue
https://github.com/ydb-platform/nbs/issues/5895
