### PR TITLE
[NBS] False positive critical event fix in merge_tablet_boot_info_backups

### DIFF
--- a/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
@@ -50,12 +50,12 @@ bool LoadPathDescriptionBackup(
 
     TNullOutput warningStream;
 
-    if(IsUtf(fileContent)){
-        if(TryParseFromTextFormat(
-            input,
-            *backupProto,
-            EParseFromTextFormatOption::AllowUnknownField,
-            &warningStream))
+    if (IsUtf(fileContent)) {
+        if (TryParseFromTextFormat(
+                input,
+                *backupProto,
+                EParseFromTextFormatOption::AllowUnknownField,
+                &warningStream))
         {
             return true;
         }

--- a/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
@@ -7,6 +7,7 @@
 
 #include <library/cpp/protobuf/util/pb_io.h>
 
+#include <util/charset/utf8.h>
 #include <util/datetime/base.h>
 #include <util/folder/path.h>
 #include <util/generic/map.h>
@@ -48,12 +49,19 @@ bool LoadPathDescriptionBackup(
     auto input = TStringInput(fileContent);
 
     TNullOutput warningStream;
-    return TryParseFromTextFormat(
-               input,
-               *backupProto,
-               EParseFromTextFormatOption::AllowUnknownField,
-               &warningStream) ||
-           backupProto->MergeFromString(fileContent);
+
+    if(IsUtf(fileContent)){
+        if(TryParseFromTextFormat(
+            input,
+            *backupProto,
+            EParseFromTextFormatOption::AllowUnknownField,
+            &warningStream))
+        {
+            return true;
+        }
+    }
+
+    return backupProto->MergeFromString(fileContent);
 }
 
 void ProcessDir(

--- a/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
@@ -50,6 +50,7 @@ bool LoadPathDescriptionBackup(
 
     TNullOutput warningStream;
 
+    //This if statement supresses false-positive error logs on non-utf input
     if (IsUtf(fileContent)) {
         if (TryParseFromTextFormat(
                 input,

--- a/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_path_description_backups/main.cpp
@@ -50,7 +50,7 @@ bool LoadPathDescriptionBackup(
 
     TNullOutput warningStream;
 
-    //This if statement supresses false-positive error logs on non-utf input
+    // This if statement supresses false-positive error logs on non-utf input
     if (IsUtf(fileContent)) {
         if (TryParseFromTextFormat(
                 input,

--- a/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
@@ -1,7 +1,7 @@
+#include "cloud/storage/core/libs/hive_proxy/protos/tablet_boot_info_backup.pb.h"
 #include "options.h"
 
 #include <cloud/storage/core/libs/common/format.h>
-#include "cloud/storage/core/libs/hive_proxy/protos/tablet_boot_info_backup.pb.h"
 
 #include <library/cpp/protobuf/util/pb_io.h>
 
@@ -45,14 +45,14 @@ bool LoadTabletBootInfoBackup(
     TString fileContent = TUnbufferedFileInput(file).ReadAll();
     auto input = TStringInput(fileContent);
 
-    if(IsUtf(fileContent)){
-        if(TryMergeFromTextFormat(
-               input,
-               *backupProto,
-               EParseFromTextFormatOption::AllowUnknownField))
-               {
-                    return true;
-               }
+    if (IsUtf(fileContent)) {
+        if (TryMergeFromTextFormat(
+                input,
+                *backupProto,
+                EParseFromTextFormatOption::AllowUnknownField))
+        {
+            return true;
+        }
     }
 
     return backupProto->MergeFromString(fileContent);

--- a/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
@@ -5,6 +5,7 @@
 
 #include <library/cpp/protobuf/util/pb_io.h>
 
+#include <util/charset/utf8.h>
 #include <util/datetime/base.h>
 #include <util/folder/path.h>
 #include <util/generic/map.h>
@@ -44,11 +45,17 @@ bool LoadTabletBootInfoBackup(
     TString fileContent = TUnbufferedFileInput(file).ReadAll();
     auto input = TStringInput(fileContent);
 
-    return TryMergeFromTextFormat(
+    if(IsUtf(fileContent)){
+        if(TryMergeFromTextFormat(
                input,
                *backupProto,
-               EParseFromTextFormatOption::AllowUnknownField) ||
-           backupProto->MergeFromString(fileContent);
+               EParseFromTextFormatOption::AllowUnknownField))
+               {
+                    return true;
+               }
+    }
+
+    return backupProto->MergeFromString(fileContent);
 }
 
 void ProcessDir(

--- a/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
@@ -45,6 +45,7 @@ bool LoadTabletBootInfoBackup(
     TString fileContent = TUnbufferedFileInput(file).ReadAll();
     auto input = TStringInput(fileContent);
 
+    //This if statement supresses false-positive error logs on non-utf input
     if (IsUtf(fileContent)) {
         if (TryMergeFromTextFormat(
                 input,

--- a/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
@@ -1,7 +1,7 @@
-#include "cloud/storage/core/libs/hive_proxy/protos/tablet_boot_info_backup.pb.h"
 #include "options.h"
 
 #include <cloud/storage/core/libs/common/format.h>
+#include "cloud/storage/core/libs/hive_proxy/protos/tablet_boot_info_backup.pb.h"
 
 #include <library/cpp/protobuf/util/pb_io.h>
 

--- a/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
+++ b/cloud/blockstore/tools/disaster_recovery/merge_tablet_boot_info_backups/main.cpp
@@ -45,7 +45,7 @@ bool LoadTabletBootInfoBackup(
     TString fileContent = TUnbufferedFileInput(file).ReadAll();
     auto input = TStringInput(fileContent);
 
-    //This if statement supresses false-positive error logs on non-utf input
+    // This if statement supresses false-positive error logs on non-utf input
     if (IsUtf(fileContent)) {
         if (TryMergeFromTextFormat(
                 input,


### PR DESCRIPTION
### Notes
Fixed a false positive critical event message by checking if the contents of a file are of a text format by using IsUTF. Besides the check, the behaviour of the LoadTabletBootInfoBackup is the same as before - in case of TryMergeFromTextFormat failing, we still run through the MergeFromString and only then return the status.

### Issue
https://github.com/ydb-platform/nbs/issues/6987
