### PR TITLE
[NBS] manually_preempted_volumes atomic write and empty file handling

### DIFF
--- a/cloud/blockstore/libs/storage/core/manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/core/manually_preempted_volumes.cpp
@@ -12,8 +12,8 @@
 
 #include <util/folder/path.h>
 #include <util/generic/hash.h>
-#include <util/stream/str.h>
 #include <util/stream/file.h>
+#include <util/stream/str.h>
 #include <util/string/builder.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -44,7 +44,8 @@ NProto::TError InitializeFromFile(
         } catch (...) {
             return MakeError(
                 E_INVALID_STATE,
-                TStringBuilder() << "failed to initialize preempted volumes"
+                TStringBuilder()
+                    << "failed to initialize preempted volumes"
                     << " file with error: " << CurrentExceptionMessage());
         }
     }
@@ -67,7 +68,7 @@ NProto::TError InitializeFromFile(
 void TManuallyPreemptedVolumes::AddVolume(const TString& diskId, TInstant now)
 {
     Volumes[diskId] = {now};
-};
+}
 
 void TManuallyPreemptedVolumes::RemoveVolume(const TString& diskId)
 {
@@ -84,8 +85,8 @@ ui32 TManuallyPreemptedVolumes::GetSize() const
     return Volumes.size();
 }
 
-std::optional<TManuallyPreemptedVolumeInfo> TManuallyPreemptedVolumes::GetVolume(
-    const TString& diskId) const
+std::optional<TManuallyPreemptedVolumeInfo>
+TManuallyPreemptedVolumes::GetVolume(const TString& diskId) const
 {
     if (auto it = Volumes.find(diskId); it != Volumes.end()) {
         return it->second;
@@ -105,17 +106,15 @@ TVector<TString> TManuallyPreemptedVolumes::GetVolumes() const
 TString TManuallyPreemptedVolumes::Serialize() const
 {
     NJsonWriter::TBuf result;
-    auto list = result
-        .BeginObject()
-        .WriteKey("Volumes")
-        .BeginList();
+    auto list = result.BeginObject().WriteKey("Volumes").BeginList();
     for (const auto& p: Volumes) {
         ui64 mcsUpdate = p.second.LastUpdate.MicroSeconds();
         list.BeginObject()
-            .WriteKey("DiskId").WriteString(p.first)
-            .WriteKey("Timestamp").WriteULongLong(mcsUpdate)
+            .WriteKey("DiskId")
+            .WriteString(p.first)
+            .WriteKey("Timestamp")
+            .WriteULongLong(mcsUpdate)
             .EndObject();
-
     };
     list.EndList().EndObject();
     return result.Str();
@@ -124,9 +123,9 @@ TString TManuallyPreemptedVolumes::Serialize() const
 NProto::TError TManuallyPreemptedVolumes::Deserialize(const TString& input)
 {
     try {
-        if (std::ranges::all_of(input, [](const unsigned char ch ){
-                return std::isspace(ch);
-            }))
+        if (std::ranges::all_of(
+                input,
+                [](const unsigned char ch) { return std::isspace(ch); }))
         {
             return {};
         }
@@ -169,9 +168,8 @@ TManuallyPreemptedVolumesPtr CreateManuallyPreemptedVolumes(
         criticalEventsStorage.emplace_back(
             GetCriticalEventForManuallyPreemptedVolumesFileError());
         STORAGE_ERROR(
-            TStringBuilder()
-                << "Failed to load manually preempted volumes: "
-                << status.GetMessage());
+            TStringBuilder() << "Failed to load manually preempted volumes: "
+                             << status.GetMessage());
         return result;
     }
 
@@ -198,9 +196,9 @@ TManuallyPreemptedVolumesPtr CreateManuallyPreemptedVolumes(
     TVector<TString>& criticalEventsStorage)
 {
     return CreateManuallyPreemptedVolumes(
-        !storageConfig->GetDisableManuallyPreemptedVolumesTracking() ?
-            storageConfig->GetManuallyPreemptedVolumesFile() :
-            "",
+        !storageConfig->GetDisableManuallyPreemptedVolumesTracking()
+            ? storageConfig->GetManuallyPreemptedVolumesFile()
+            : "",
         log,
         criticalEventsStorage);
 }

--- a/cloud/blockstore/libs/storage/core/manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/core/manually_preempted_volumes.cpp
@@ -124,7 +124,10 @@ TString TManuallyPreemptedVolumes::Serialize() const
 NProto::TError TManuallyPreemptedVolumes::Deserialize(const TString& input)
 {
     try {
-        if (input.empty()) {
+        if (std::ranges::all_of(input, [](const unsigned char ch ){
+                return std::isspace(ch);
+            }))
+        {
             return {};
         }
 

--- a/cloud/blockstore/libs/storage/core/manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/core/manually_preempted_volumes.cpp
@@ -12,8 +12,8 @@
 
 #include <util/folder/path.h>
 #include <util/generic/hash.h>
-#include <util/stream/file.h>
 #include <util/stream/str.h>
+#include <util/stream/file.h>
 #include <util/string/builder.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -44,8 +44,7 @@ NProto::TError InitializeFromFile(
         } catch (...) {
             return MakeError(
                 E_INVALID_STATE,
-                TStringBuilder()
-                    << "failed to initialize preempted volumes"
+                TStringBuilder() << "failed to initialize preempted volumes"
                     << " file with error: " << CurrentExceptionMessage());
         }
     }
@@ -68,7 +67,7 @@ NProto::TError InitializeFromFile(
 void TManuallyPreemptedVolumes::AddVolume(const TString& diskId, TInstant now)
 {
     Volumes[diskId] = {now};
-}
+};
 
 void TManuallyPreemptedVolumes::RemoveVolume(const TString& diskId)
 {
@@ -85,8 +84,8 @@ ui32 TManuallyPreemptedVolumes::GetSize() const
     return Volumes.size();
 }
 
-std::optional<TManuallyPreemptedVolumeInfo>
-TManuallyPreemptedVolumes::GetVolume(const TString& diskId) const
+std::optional<TManuallyPreemptedVolumeInfo> TManuallyPreemptedVolumes::GetVolume(
+    const TString& diskId) const
 {
     if (auto it = Volumes.find(diskId); it != Volumes.end()) {
         return it->second;
@@ -106,15 +105,17 @@ TVector<TString> TManuallyPreemptedVolumes::GetVolumes() const
 TString TManuallyPreemptedVolumes::Serialize() const
 {
     NJsonWriter::TBuf result;
-    auto list = result.BeginObject().WriteKey("Volumes").BeginList();
+    auto list = result
+        .BeginObject()
+        .WriteKey("Volumes")
+        .BeginList();
     for (const auto& p: Volumes) {
         ui64 mcsUpdate = p.second.LastUpdate.MicroSeconds();
         list.BeginObject()
-            .WriteKey("DiskId")
-            .WriteString(p.first)
-            .WriteKey("Timestamp")
-            .WriteULongLong(mcsUpdate)
+            .WriteKey("DiskId").WriteString(p.first)
+            .WriteKey("Timestamp").WriteULongLong(mcsUpdate)
             .EndObject();
+
     };
     list.EndList().EndObject();
     return result.Str();
@@ -123,9 +124,9 @@ TString TManuallyPreemptedVolumes::Serialize() const
 NProto::TError TManuallyPreemptedVolumes::Deserialize(const TString& input)
 {
     try {
-        if (std::ranges::all_of(
-                input,
-                [](const unsigned char ch) { return std::isspace(ch); }))
+        if (std::ranges::all_of(input, [](const unsigned char ch ){
+                return std::isspace(ch);
+            }))
         {
             return {};
         }
@@ -168,8 +169,9 @@ TManuallyPreemptedVolumesPtr CreateManuallyPreemptedVolumes(
         criticalEventsStorage.emplace_back(
             GetCriticalEventForManuallyPreemptedVolumesFileError());
         STORAGE_ERROR(
-            TStringBuilder() << "Failed to load manually preempted volumes: "
-                             << status.GetMessage());
+            TStringBuilder()
+                << "Failed to load manually preempted volumes: "
+                << status.GetMessage());
         return result;
     }
 
@@ -196,9 +198,9 @@ TManuallyPreemptedVolumesPtr CreateManuallyPreemptedVolumes(
     TVector<TString>& criticalEventsStorage)
 {
     return CreateManuallyPreemptedVolumes(
-        !storageConfig->GetDisableManuallyPreemptedVolumesTracking()
-            ? storageConfig->GetManuallyPreemptedVolumesFile()
-            : "",
+        !storageConfig->GetDisableManuallyPreemptedVolumesTracking() ?
+            storageConfig->GetManuallyPreemptedVolumesFile() :
+            "",
         log,
         criticalEventsStorage);
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
@@ -67,9 +67,8 @@ void WriteFile(TString filePath, TString data, const TActorContext& ctx)
             LOG_WARN_S(
                 ctx,
                 TBlockStoreComponents::SERVICE,
-                "ServiceActorSyncManuallyPreemptedVolumes: failed to delete "
-                "temporary file: "
-                    << CurrentExceptionMessage());
+                "ServiceActorSyncManuallyPreemptedVolumes: failed to delete temporary file: "
+                << CurrentExceptionMessage());
         }
     }
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
@@ -10,6 +10,8 @@
 #include <contrib/ydb/core/base/appdata.h>
 #include <contrib/ydb/core/mon/mon.h>
 
+#include <util/system/file_lock.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -20,10 +22,54 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void WriteFile(TString filePath, TString data)
+void WriteFile(TString filePath, TString data, const TActorContext& ctx)
 {
-    TFile file(filePath, EOpenModeFlag::CreateAlways | EOpenModeFlag::WrOnly);
-    TFileOutput(file).Write(std::move(data));
+    TFsPath tmpFilePath = filePath + ".tmp";
+
+    NProto::TError error;
+
+    try {
+        TFileLock lock(tmpFilePath);
+
+        if (lock.TryAcquire()) {
+            Y_DEFER {
+                lock.Release();
+            };
+
+            TFile file(tmpFilePath, EOpenModeFlag::CreateAlways | EOpenModeFlag::WrOnly);
+            TFileOutput(file).Write(std::move(data));
+
+            tmpFilePath.RenameTo(filePath);
+        } else {
+            auto message = TStringBuilder()
+                << "failed to acquire lock on file: " << tmpFilePath;
+            error = MakeError(E_IO, std::move(message));
+        }
+    } catch (...) {
+        error = MakeError(E_FAIL, CurrentExceptionMessage());
+    }
+
+    if (!SUCCEEDED(error.GetCode()))
+    {
+
+        LOG_ERROR_S(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            TStringBuilder()
+                << "Failed to write manually preempted volumes: "
+                << error);
+        ReportManuallyPreemptedVolumesFileError(error.GetMessage());
+
+        try {
+            tmpFilePath.DeleteIfExists();
+        } catch (...) {
+            LOG_WARN_S(ctx,
+                TBlockStoreComponents::SERVICE,
+                "ServiceActorSyncManuallyPreemptedVolumes: failed to delete temporary file: "
+                << CurrentExceptionMessage());
+        }
+
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -54,17 +100,7 @@ TSyncManuallyPreemptedVolumesActor::TSyncManuallyPreemptedVolumesActor(
 
 void TSyncManuallyPreemptedVolumesActor::Bootstrap(const TActorContext& ctx)
 {
-    try {
-        WriteFile(std::move(FilePath), std::move(Data));
-    } catch (...) {
-        LOG_ERROR_S(
-            ctx,
-            TBlockStoreComponents::SERVICE,
-            TStringBuilder()
-                << "Failed to write manually preempted volumes: "
-                << CurrentExceptionMessage());
-        ReportManuallyPreemptedVolumesFileError(CurrentExceptionMessage());
-    }
+    WriteFile(std::move(FilePath), std::move(Data), ctx);
 
     using TResponse = TEvServicePrivate::TEvSyncManuallyPreemptedVolumesComplete;
 

--- a/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
@@ -49,26 +49,25 @@ void WriteFile(TString filePath, TString data, const TActorContext& ctx)
         error = MakeError(E_FAIL, CurrentExceptionMessage());
     }
 
-    if (!SUCCEEDED(error.GetCode()))
-    {
+    if (HasError(error)) {
 
         LOG_ERROR_S(
             ctx,
             TBlockStoreComponents::SERVICE,
             TStringBuilder()
-                << "Failed to write manually preempted volumes: "
-                << error);
+                << "Failed to write manually preempted volumes: " << error);
         ReportManuallyPreemptedVolumesFileError(error.GetMessage());
 
         try {
             tmpFilePath.DeleteIfExists();
         } catch (...) {
-            LOG_WARN_S(ctx,
+            LOG_WARN_S(
+                ctx,
                 TBlockStoreComponents::SERVICE,
-                "ServiceActorSyncManuallyPreemptedVolumes: failed to delete temporary file: "
-                << CurrentExceptionMessage());
+                "ServiceActorSyncManuallyPreemptedVolumes: failed to delete "
+                "temporary file: "
+                    << CurrentExceptionMessage());
         }
-
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
@@ -32,7 +32,8 @@ void WriteFile(TString filePath, TString data, const TActorContext& ctx)
         TFileLock lock(tmpFilePath);
 
         if (lock.TryAcquire()) {
-            Y_DEFER {
+            Y_DEFER
+            {
                 lock.Release();
             };
 
@@ -43,32 +44,32 @@ void WriteFile(TString filePath, TString data, const TActorContext& ctx)
         } else {
             auto message = TStringBuilder()
                 << "failed to acquire lock on file: " << tmpFilePath;
+
             error = MakeError(E_IO, std::move(message));
         }
     } catch (...) {
         error = MakeError(E_FAIL, CurrentExceptionMessage());
     }
 
-    if (!SUCCEEDED(error.GetCode()))
-    {
-
+    if (HasError(error)) {
         LOG_ERROR_S(
-            ctx,
+                ctx,
             TBlockStoreComponents::SERVICE,
             TStringBuilder()
                 << "Failed to write manually preempted volumes: "
                 << error);
+
         ReportManuallyPreemptedVolumesFileError(error.GetMessage());
 
         try {
             tmpFilePath.DeleteIfExists();
         } catch (...) {
-            LOG_WARN_S(ctx,
+            LOG_WARN_S(
+                ctx,
                 TBlockStoreComponents::SERVICE,
                 "ServiceActorSyncManuallyPreemptedVolumes: failed to delete temporary file: "
                 << CurrentExceptionMessage());
         }
-
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_sync_manually_preempted_volumes.cpp
@@ -45,7 +45,7 @@ void WriteFile(TString filePath, TString data, const TActorContext& ctx)
             auto message = TStringBuilder()
                 << "failed to acquire lock on file: " << tmpFilePath;
 
-            error = MakeError(E_IO, std::move(message));
+            error = MakeError(E_INVALID_STATE, std::move(message));
         }
     } catch (...) {
         error = MakeError(E_FAIL, CurrentExceptionMessage());


### PR DESCRIPTION
### Notes
Fixed critical error caused by an empty file being read in `manually_preempted_volumes.cpp` by checking if all of the characters are space characters, instead of a simple `input.empty() `check, which should prevent, for example incomplete files made of spaces or breaks from passing the check.

Made `WriteFile` function in `service_actor_sync_manually_preempted_volumes.cpp` use an atomic write instead of a regular write for better reliability. Writing into a temporary file first should prevent issues in case of crash, such as the one in a fix. The exception mechanism was mostly moved to a `WriteFile`, because of the need to handle the potential atomic write exceptions, but the old functionality remains unchanged.

### Issue
https://github.com/ydb-platform/nbs/issues/6988
