### PR TITLE
[NBS] Add RequestTimeout parameter to TCreateRootKmsClientParams

### DIFF
--- a/cloud/blockstore/apps/server/main.cpp
+++ b/cloud/blockstore/apps/server/main.cpp
@@ -92,7 +92,9 @@ int main(int argc, char** argv)
                 {.Address = config.GetAddress(),
                  .RootCertsFile = config.GetRootCertsFile(),
                  .CertChainFile = config.GetCertChainFile(),
-                 .PrivateKeyFile = config.GetPrivateKeyFile()});
+                 .PrivateKeyFile = config.GetPrivateKeyFile(),
+                 .RequestTimeout =
+                     TDuration::MilliSeconds(config.GetRequestTimeout())});
         }
 
         return NCloud::NBlockStore::CreateRootKmsClientStub();

--- a/cloud/blockstore/config/root_kms.proto
+++ b/cloud/blockstore/config/root_kms.proto
@@ -18,4 +18,7 @@ message TRootKmsConfig
     optional string RootCertsFile = 3;
     optional string CertChainFile = 4;
     optional string PrivateKeyFile = 5;
+
+    // Request timeout (in milliseconds).
+    optional uint32 RequestTimeout = 6;
 }

--- a/cloud/blockstore/libs/root_kms/impl/client.cpp
+++ b/cloud/blockstore/libs/root_kms/impl/client.cpp
@@ -273,7 +273,7 @@ auto TRootKmsClient::Decrypt(const TString& keyId, const TString& ciphertext)
     STORAGE_DEBUG("Decrypt DEK with key " << keyId.Quote());
 
     auto requestHandler = std::make_unique<TDecryptDataKeyHandler>(
-        DefaultTimeout,
+        Params.RequestTimeout,
         keyId,
         ciphertext);
 
@@ -291,7 +291,7 @@ auto TRootKmsClient::GenerateDataEncryptionKey(const TString& keyId)
     STORAGE_DEBUG("Generate DEK with key " << keyId.Quote());
 
     auto requestHandler = std::make_unique<TGenerateDataKeyRequestHandler>(
-        DefaultTimeout,
+        Params.RequestTimeout,
         keyId);
 
     auto future = requestHandler->Execute(*Service, CQ);
@@ -323,6 +323,10 @@ IRootKmsClientPtr CreateRootKmsClient(
     ILoggingServicePtr logging,
     TCreateRootKmsClientParams params)
 {
+    if (!params.RequestTimeout) {
+        params.RequestTimeout = DefaultTimeout;
+    }
+
     return std::make_shared<TRootKmsClient>(
         std::move(logging),
         std::move(params));

--- a/cloud/blockstore/libs/root_kms/impl/client.h
+++ b/cloud/blockstore/libs/root_kms/impl/client.h
@@ -14,6 +14,7 @@ struct TCreateRootKmsClientParams
     TString RootCertsFile;
     TString CertChainFile;
     TString PrivateKeyFile;
+    TDuration RequestTimeout;
 };
 
 IRootKmsClientPtr CreateRootKmsClient(

--- a/cloud/blockstore/libs/root_kms/impl/client_ut.cpp
+++ b/cloud/blockstore/libs/root_kms/impl/client_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/blockstore/libs/encryption/encryption_key.h>
 #include <cloud/blockstore/libs/root_kms/iface/client.h>
+
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <library/cpp/string_utils/base64/base64.h>
@@ -20,33 +21,45 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TFixture
-    : NUnitTest::TBaseFixture
+struct TFixture: NUnitTest::TBaseFixture
 {
     const TString KekId = "nbs";
-    const ILoggingServicePtr Logging =
-        CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
 
+    ILoggingServicePtr Logging;
     IRootKmsClientPtr Client;
 
     void SetUp(NUnitTest::TTestContext&) override
+    {
+        Logging =
+            CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
+        Logging->Start();
+    }
+
+    void TearDown(NUnitTest::TTestContext&) override
+    {
+        UNIT_ASSERT(Client);
+
+        Client->Stop();
+        Logging->Stop();
+    }
+
+    void StartClient(TDuration requestTimeout = {})
     {
         Client = CreateRootKmsClient(
             Logging,
             {.Address = "localhost:" + GetEnv("FAKE_ROOT_KMS_PORT"),
              .RootCertsFile = GetEnv("FAKE_ROOT_KMS_CA"),
              .CertChainFile = GetEnv("FAKE_ROOT_KMS_CLIENT_CRT"),
-             .PrivateKeyFile = GetEnv("FAKE_ROOT_KMS_CLIENT_KEY")});
+             .PrivateKeyFile = GetEnv("FAKE_ROOT_KMS_CLIENT_KEY"),
+             .RequestTimeout = requestTimeout});
         Client->Start();
+    }
 
+    void WaitReady() const
+    {
         while (!IsRootKmsAlive()) {
             Sleep(1s);
         }
-    }
-
-    void TearDown(NUnitTest::TTestContext&) override
-    {
-        Client->Stop();
     }
 
     bool IsRootKmsAlive() const
@@ -62,11 +75,13 @@ struct TFixture
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
 Y_UNIT_TEST_SUITE(TRootKmsClientTest)
 {
     Y_UNIT_TEST_F(ShouldGenerateAndDecryptDEK, TFixture)
     {
+        StartClient();
+        WaitReady();
+
         {
             auto gen = Client->GenerateDataEncryptionKey(KekId);
 
@@ -105,6 +120,21 @@ Y_UNIT_TEST_SUITE(TRootKmsClientTest)
                 error.GetCode(),
                 error);
         }
+    }
+
+    Y_UNIT_TEST_F(ShouldReturnDeadlineExceededOnRequestTimeout, TFixture)
+    {
+        constexpr TDuration requestTimeout = 1ms;
+
+        StartClient(requestTimeout);
+
+        const auto future = Client->Decrypt(TString(), TString());
+        const auto& [_, error] = future.GetValueSync();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_GRPC_DEADLINE_EXCEEDED,
+            error.GetCode(),
+            error);
     }
 }
 


### PR DESCRIPTION
Added a `RequestTimeout` parameter to `TRootKmsConfig` and `TCreateRootKmsClientParams`, allowing the request timeout for the Root KMS service to be configured.