### PR TITLE
issue-6996: side-channel shouldn't crash upon RST or any other non-graceful connection termination

### DIFF
--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -222,15 +222,27 @@ public:
         ](IAsyncEndpointPtr e, ui32 generation, TResponse r) mutable
         {
             TResp resp;
-            bool shardMoved = false;
+            bool dropEndpoint = false;
             if (r.HasError()) {
                 if (r.GetError().GetCode() == E_NOT_FOUND) {
-                    shardMoved = true;
+                    //
+                    // Shard moved - the connection points to the wrong host.
+                    //
+
+                    dropEndpoint = true;
                     *resp.MutableError() = MakeError(
                         E_REJECTED,
                         TStringBuilder() << "shard moved: "
                             << FormatError(r.GetError()));
                 } else {
+                    //
+                    // E_UNAVAILABLE is reported by the client for transport
+                    // failures - the connection is broken and must not be
+                    // reused.
+                    //
+
+                    dropEndpoint =
+                        r.GetError().GetCode() == E_UNAVAILABLE;
                     *resp.MutableError() = r.GetError();
                 }
             } else {
@@ -238,7 +250,7 @@ public:
             }
             response.SetValue(std::move(resp));
 
-            if (!shardMoved) {
+            if (!dropEndpoint) {
                 ep->Push(std::move(e), generation);
             }
         };

--- a/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
@@ -349,6 +349,68 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldDropBrokenEndpoints)
+    {
+        auto logging = CreateLoggingService("console", { TLOG_DEBUG });
+        auto client = std::make_shared<TTestAsyncClient>();
+        auto profileLog = std::make_shared<TTestProfileLog>();
+        auto timer = std::make_shared<TTestTimer>();
+        auto sideChannel =
+            CreateTCPSideChannel(*logging, profileLog, timer, client);
+
+        sideChannel->Update(BackendInfo());
+
+        TConnInfo connInfo;
+        auto e = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e);
+
+        //
+        // A top-level E_UNAVAILABLE response means the connection is broken -
+        // the error should be propagated and the endpoint should not go back
+        // to the pool.
+        //
+
+        auto writeResponse = NewPromise<NProto::TWriteDataResponse>();
+        bool success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(1, 0, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(success);
+
+        NProtoSrv::TResponse brokenResp;
+        *brokenResp.MutableError() =
+            MakeError(E_UNAVAILABLE, "recv length failed: 104");
+        UNIT_ASSERT(e->Reply(std::move(brokenResp)));
+
+        UNIT_ASSERT(writeResponse.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_UNAVAILABLE,
+            writeResponse.GetValue().GetError().GetCode());
+
+        //
+        // The next request should not reuse the broken endpoint - it should
+        // trigger a new connection attempt instead.
+        //
+
+        auto readResponse = NewPromise<NProto::TReadDataResponse>();
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            ReadReq(1, 0, 1_KB),
+            readResponse);
+        UNIT_ASSERT(success);
+        UNIT_ASSERT(!e->RequestReceived);
+
+        auto e2 = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e2);
+        UNIT_ASSERT(e2->RequestReceived);
+
+        UNIT_ASSERT(e2->Reply(ReadResp(MakeError(S_OK), TString(1_KB, 'b'))));
+        UNIT_ASSERT(readResponse.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            readResponse.GetValue().GetError().GetCode());
+    }
+
     Y_UNIT_TEST(ShouldProcessRequestsBeforeConnectionCompletes)
     {
         auto logging = CreateLoggingService("console", { TLOG_DEBUG });

--- a/cloud/filestore/libs/storage/fastshard/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client.cpp
@@ -2,10 +2,13 @@
 
 #include <cloud/filestore/libs/storage/fastshard/ipc/ipc.h>
 
+#include <cloud/storage/core/libs/common/error.h>
+
 #include <silk/fibers/fiber.h>
 
 #include <util/generic/scope.h>
 #include <util/generic/string.h>
+#include <util/string/builder.h>
 
 #include <arpa/inet.h>
 #include <fcntl.h>
@@ -28,6 +31,7 @@ namespace {
 struct TEndpoint: IEndpoint
 {
     int Fd;
+    bool Broken = false;
 
     explicit TEndpoint(int fd)
         : Fd(fd)
@@ -40,28 +44,61 @@ struct TEndpoint: IEndpoint
 
     TResponse Send(const TRequest& req) override
     {
+        if (Broken) {
+            return ErrorResponse("endpoint is broken", 0 /* err */);
+        }
+
         TString reqBuf;
         Y_PROTOBUF_SUPPRESS_NODISCARD req.SerializeToString(&reqBuf);
 
         ui32 lenBe = htonl(static_cast<ui32>(reqBuf.size()));
         int r = SendAll(Fd, &lenBe, sizeof(lenBe));
-        // TODO(#5894): don't abort, return error in resp instead
-        Y_ABORT_UNLESS(r == 0, "send length failed: %d", r);
+        if (r != 0) {
+            return BreakEndpoint("send length failed", r);
+        }
+
         r = SendAll(Fd, reqBuf.data(), reqBuf.size());
-        Y_ABORT_UNLESS(r == 0, "send body failed: %d", r);
+        if (r != 0) {
+            return BreakEndpoint("send body failed", r);
+        }
 
         ui32 respLenBe = 0;
         r = RecvAll(Fd, &respLenBe, sizeof(respLenBe));
-        Y_ABORT_UNLESS(r == 0, "recv length failed: %d", r);
+        if (r != 0) {
+            return BreakEndpoint("recv length failed", r);
+        }
         ui32 respLen = ntohl(respLenBe);
 
         TString respBuf;
         respBuf.ReserveAndResize(respLen);
         r = RecvAll(Fd, respBuf.begin(), respLen);
-        Y_ABORT_UNLESS(r == 0, "recv body failed: %d", r);
+        if (r != 0) {
+            return BreakEndpoint("recv body failed", r);
+        }
 
         TResponse resp;
         Y_PROTOBUF_SUPPRESS_NODISCARD resp.ParseFromString(respBuf);
+        return resp;
+    }
+
+private:
+    TResponse BreakEndpoint(const char* op, int err)
+    {
+        //
+        // A partial send/recv loses the message framing, so no other request
+        // may reuse this connection - all subsequent Send calls fail fast.
+        //
+
+        Broken = true;
+        return ErrorResponse(op, err);
+    }
+
+    static TResponse ErrorResponse(const char* op, int err)
+    {
+        TResponse resp;
+        *resp.MutableError() = MakeError(
+            E_UNAVAILABLE,
+            TStringBuilder() << op << ": " << err);
         return resp;
     }
 };

--- a/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
@@ -189,6 +189,59 @@ TEST(ServerTest, CreateNodeAndGetAttr)
     EXPECT_EQ(result, 0);
 }
 
+TEST(ServerTest, ClientReportsErrorWhenConnectionBreaks)
+{
+    int result = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            NCloud::NFileStore::NProtoPrivate::TMemFastShardConfig cfg;
+            cfg.SetCreateNodeUponAccess(true);
+            auto shard = CreateMemFileSystemShard(1, cfg);
+
+            TServerFixture fixture;
+            fixture.StartServer(shard);
+
+            TClient client;
+            auto endpoint = client.Connect("localhost", fixture.Port);
+            EXPECT_NE(endpoint, nullptr);
+
+            {
+                TRequest req;
+                req.SetFileSystemId("test-fs");
+                auto* body = req.MutableCreateNode();
+                body->SetNodeId(1);
+                body->MutableFile()->SetMode(0644);
+                body->SetName("hello.txt");
+                auto resp = endpoint->Send(req);
+                EXPECT_TRUE(resp.HasCreateNode());
+            }
+
+            fixture.StopServer();
+
+            //
+            // The connection is dead - Send must report E_UNAVAILABLE instead
+            // of aborting the process, and every subsequent Send on this
+            // endpoint must fail fast with the same code.
+            //
+
+            for (ui32 i = 0; i < 2; ++i) {
+                TRequest req;
+                req.SetFileSystemId("test-fs");
+                auto* body = req.MutableGetNodeAttr();
+                body->SetNodeId(1);
+                body->SetName("hello.txt");
+                auto resp = endpoint->Send(req);
+                EXPECT_TRUE(resp.HasError());
+                EXPECT_EQ(NCloud::E_UNAVAILABLE, resp.GetError().GetCode());
+            }
+
+            return 0;
+        },
+        0);
+
+    EXPECT_EQ(result, 0);
+}
+
 TEST(ServerTest, UnknownShardReturnsEmptyResponse)
 {
     int result = FiberScheduler::run(


### PR DESCRIPTION
### Notes
`TCPSideChannel` used to do `abort()` upon any non-graceful mid-transfer connection termination - e.g. an RST from the host running `FastShardServer`. Fixing this.

### Issue
https://github.com/ydb-platform/nbs/issues/6996