### PR TITLE
Add new eternal tests image to fake images for unit tests

### DIFF
--- a/cloud/blockstore/pylibs/ycp/fake-responses/fake-image-list.json
+++ b/cloud/blockstore/pylibs/ycp/fake-responses/fake-image-list.json
@@ -16,6 +16,10 @@
     "name": "ubuntu-2204-eternal"
   },
   {
+    "id": "fake-id5",
+    "name": "ubuntu-2604-eternal"
+  },
+  {
     "id": "fake-id3",
     "name": "fake-name1"
   }


### PR DESCRIPTION
We updated the test image, so we need a new image name to be present in the list of fake images for unit tests on test runners.