### PR TITLE
[NBS] Preserve skipped compaction counters

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1496,6 +1496,19 @@ void TPartitionActor::HandleUpdateResourceMetrics(
     State->UpdateWithThreadSafeStats(SharedState->PartStats);
 }
 
+void TPartitionActor::HandleGetCompactionCounters(
+    const TEvPartitionPrivate::TEvGetCompactionCountersRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    auto response = std::make_unique<
+        TEvPartitionPrivate::TEvGetCompactionCountersResponse>(
+        State->GetCompactionMap().Get(msg->BlockIndex));
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
 void TPartitionActor::HandleGetFreshChannelsInfo(
     const TEvPartitionCommonPrivate::TEvGetFreshChannelsInfoRequest::TPtr& ev,
     const NActors::TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -116,9 +116,9 @@ public:
                 const auto& cm = State.GetCompactionMap();
                 const auto blockIndex = cm.GetRangeStart(BlockIndex(blob, 0));
                 auto& rangeInfo = CompactionCounters[blockIndex];
-                rangeInfo.BlobsSkippedByCompaction =
+                rangeInfo.BlobsSkippedByCompaction +=
                     Args.MixedBlobCompactionInfos[i].BlobsSkippedByCompaction;
-                rangeInfo.BlocksSkippedByCompaction =
+                rangeInfo.BlocksSkippedByCompaction +=
                     Args.MixedBlobCompactionInfos[i].BlocksSkippedByCompaction;
             }
         }
@@ -143,9 +143,9 @@ public:
                 Y_DEBUG_ABORT_UNLESS(
                     blockIndex == cm.GetRangeStart(blob.BlockRange.End));
                 auto& rangeInfo = CompactionCounters[blockIndex];
-                rangeInfo.BlobsSkippedByCompaction =
+                rangeInfo.BlobsSkippedByCompaction +=
                     Args.MergedBlobCompactionInfos[i].BlobsSkippedByCompaction;
-                rangeInfo.BlocksSkippedByCompaction =
+                rangeInfo.BlocksSkippedByCompaction +=
                     Args.MergedBlobCompactionInfos[i].BlocksSkippedByCompaction;
             }
         }

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -8,6 +8,7 @@
 #include <cloud/blockstore/libs/kikimr/events.h>
 #include <cloud/blockstore/libs/storage/core/channel_permissions.h>
 #include <cloud/blockstore/libs/storage/core/compaction_options.h>
+#include <cloud/blockstore/libs/storage/core/compaction_policy.h>
 #include <cloud/blockstore/libs/storage/core/compaction_type.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/channel_data_kind.h>
@@ -195,6 +196,7 @@ using TFlushedCommitIds = TVector<TFlushedCommitId>;
     xxx(AddBlobs,                  __VA_ARGS__)                                \
     xxx(Flush,                     __VA_ARGS__)                                \
     xxx(Compaction,                __VA_ARGS__)                                \
+    xxx(GetCompactionCounters,     __VA_ARGS__)                                \
     xxx(CompactionReadBlobInfo,    __VA_ARGS__)                                \
     xxx(MetadataRebuildUsedBlocks, __VA_ARGS__)                                \
     xxx(MetadataRebuildBlockCount, __VA_ARGS__)                                \
@@ -366,6 +368,30 @@ struct TEvPartitionPrivate
 
     struct TCompactionResponse
     {
+    };
+
+    //
+    // GetCompactionCounters
+    //
+
+    struct TGetCompactionCountersRequest
+    {
+        ui32 BlockIndex = 0;
+
+        explicit TGetCompactionCountersRequest(ui32 blockIndex)
+            : BlockIndex(blockIndex)
+        {}
+    };
+
+    struct TGetCompactionCountersResponse
+    {
+        TRangeStat Counters;
+
+        TGetCompactionCountersResponse() = default;
+
+        explicit TGetCompactionCountersResponse(TRangeStat counters)
+            : Counters(std::move(counters))
+        {}
     };
 
     //

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -6195,7 +6195,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         bool firstCompactionRequestCaptured = false;
         bool compactionResultObserved = false;
 
-        runtime->SetObserverFunc(
+        auto observer = runtime->AddObserver(
             [&](TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
@@ -6203,7 +6203,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                         if (!firstCompactionRequestCaptured) {
                             firstCompactionRequestCaptured = true;
                             firstCompactionRequest.reset(event.Release());
-                            return TTestActorRuntime::EEventAction::DROP;
+                            return;
                         }
                         break;
                     }
@@ -6237,8 +6237,6 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                         break;
                     }
                 }
-
-                return TTestActorRuntime::DefaultObserverFunc(event);
             });
 
         partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
@@ -6254,15 +6252,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         UNIT_ASSERT(compactionResultObserved);
 
-        auto response = partition.RemoteHttpInfo(BuildRemoteHttpQuery(
-            TestTabletId,
-            {{"action", "describe"}, {"range", "0"}}));
-        UNIT_ASSERT_C(
-            response->Html.Contains("<td>BlobCount</td><td>3</td>"),
-            response->Html);
-        UNIT_ASSERT_C(
-            response->Html.Contains("<td>BlockCount</td><td>1018</td>"),
-            response->Html);
+        const auto counters = partition.GetCompactionCounters(0);
+        UNIT_ASSERT_VALUES_EQUAL(3, counters->Counters.BlobCount);
+        UNIT_ASSERT_VALUES_EQUAL(1018, counters->Counters.BlockCount);
     }
 
     Y_UNIT_TEST(ShouldPreserveSkippedCountersForMixedCompactionResults)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -6173,6 +6173,108 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         DoTestIncrementalCompaction(std::move(config), NProto::STORAGE_MEDIA_HYBRID, true);
     }
 
+    void DoShouldPreserveSkippedCountersWhenCompactionCreatesTwoBlobs(
+        bool compactToMixed)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+        config.SetHDDMaxBlobsPerRange(3);
+        config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+        if (compactToMixed) {
+            config.SetCompactionMergedBlobThresholdHDD(1_MB);
+        }
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> firstCompactionRequest;
+        bool firstCompactionRequestCaptured = false;
+        bool compactionResultObserved = false;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (!firstCompactionRequestCaptured) {
+                            firstCompactionRequestCaptured = true;
+                            firstCompactionRequest.reset(event.Release());
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode != EAddBlobMode::ADD_COMPACTION_RESULT ||
+                            compactionResultObserved)
+                        {
+                            break;
+                        }
+
+                        compactionResultObserved = true;
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            compactToMixed ? 2 : 0,
+                            msg->MixedBlobs.size());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            compactToMixed ? 0 : 2,
+                            msg->MergedBlobs.size());
+
+                        const auto& compactionInfos = compactToMixed
+                            ? msg->MixedBlobCompactionInfos
+                            : msg->MergedBlobCompactionInfos;
+                        UNIT_ASSERT_VALUES_EQUAL(2, compactionInfos.size());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            1,
+                            compactionInfos[0].BlobsSkippedByCompaction);
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            0,
+                            compactionInfos[1].BlobsSkippedByCompaction);
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5));
+        partition.WriteBlocks(TBlockRange32::WithLength(10, 5));
+
+        UNIT_ASSERT(firstCompactionRequest);
+
+        partition.ZeroBlocks(TBlockRange32::WithLength(20, 6));
+
+        runtime->Send(firstCompactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        UNIT_ASSERT(compactionResultObserved);
+
+        auto response = partition.RemoteHttpInfo(BuildRemoteHttpQuery(
+            TestTabletId,
+            {{"action", "describe"}, {"range", "0"}}));
+        UNIT_ASSERT_C(
+            response->Html.Contains("<td>BlobCount</td><td>3</td>"),
+            response->Html);
+        UNIT_ASSERT_C(
+            response->Html.Contains("<td>BlockCount</td><td>1018</td>"),
+            response->Html);
+    }
+
+    Y_UNIT_TEST(ShouldPreserveSkippedCountersForMixedCompactionResults)
+    {
+        DoShouldPreserveSkippedCountersWhenCompactionCreatesTwoBlobs(true);
+    }
+
+    Y_UNIT_TEST(ShouldPreserveSkippedCountersForMergedCompactionResults)
+    {
+        DoShouldPreserveSkippedCountersWhenCompactionCreatesTwoBlobs(false);
+    }
+
     Y_UNIT_TEST(ShouldNotCompactIncrementallyIfSsdDiskGarbageLevelIsTooHigh)
     {
         auto config = DefaultConfig();

--- a/cloud/blockstore/libs/storage/testlib/part_client.cpp
+++ b/cloud/blockstore/libs/storage/testlib/part_client.cpp
@@ -310,6 +310,13 @@ TPartitionClient::CreateTrimFreshLogRequest()
         TEvPartitionCommonPrivate::TEvTrimFreshLogRequest>();
 }
 
+std::unique_ptr<TEvPartitionPrivate::TEvGetCompactionCountersRequest>
+TPartitionClient::CreateGetCompactionCountersRequest(ui32 blockIndex)
+{
+    return std::make_unique<
+        TEvPartitionPrivate::TEvGetCompactionCountersRequest>(blockIndex);
+}
+
 std::unique_ptr<TEvPartitionPrivate::TEvMetadataRebuildBlockCountRequest>
 TPartitionClient::CreateMetadataRebuildBlockCountRequest(
     TPartialBlobId blobId,

--- a/cloud/blockstore/libs/storage/testlib/part_client.h
+++ b/cloud/blockstore/libs/storage/testlib/part_client.h
@@ -155,6 +155,9 @@ public:
     std::unique_ptr<TEvPartitionCommonPrivate::TEvTrimFreshLogRequest>
     CreateTrimFreshLogRequest();
 
+    std::unique_ptr<TEvPartitionPrivate::TEvGetCompactionCountersRequest>
+    CreateGetCompactionCountersRequest(ui32 blockIndex);
+
     template <typename... TArgs>
     std::unique_ptr<TEvPartitionPrivate::TEvCompactionRequest>
     CreateCompactionRequest(TArgs&&... args)


### PR DESCRIPTION
### Notes
Changed `=` -> `+=` here
https://github.com/ydb-platform/nbs/blob/e0051499b61fdf66557329ff5942a24cfda7b84b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp#L119-L122
and  here
https://github.com/ydb-platform/nbs/blob/e0051499b61fdf66557329ff5942a24cfda7b84b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp#L146-L149
because when a range compaction yields both a DataBlobId and a ZeroBlobId, both go into the same list (same ChannelDataKind), data first with {N, M}, then zero with {0, 0} (because of the !rc.DataBlobId guard in part_actor_compaction.cpp). With =, the zero blob overwrote the skipped counts with 0, so the compaction map under-counted BlobCount/BlockCount for such ranges. += fixes that.
