### PR TITLE
[NBS] Fix compaction map counters concurrent updates in compaction\addblobs routines

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1689,4 +1689,8 @@ message TStorageServiceConfig
     // If true, QueryAvailableStorage includes suspended devices that are
     // resuming after secure erase.
     optional bool QueryAvailableStorageForResumingDevicesEnabled = 528;
+
+    // Use the number of blobs and blocks processed by compaction to update the
+    // compaction map instead of the number skipped by incremental compaction.
+    optional bool UseNewCompactionMapCounters = 529;
 }

--- a/cloud/blockstore/libs/storage/core/compaction_map.h
+++ b/cloud/blockstore/libs/storage/core/compaction_map.h
@@ -53,7 +53,7 @@ public:
     TCompactionMap(ui32 rangeSize, ICompactionPolicyPtr policy);
     ~TCompactionMap();
 
-    static void UpdateCompactionCounter(ui32 source, ui16* target)
+    static void UpdateCompactionCounter(ui64 source, ui16* target)
     {
         *target = source > Max<ui16>() ? Max<ui16>() : source;
     }

--- a/cloud/blockstore/libs/storage/core/compaction_map_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map_ut.cpp
@@ -231,6 +231,16 @@ void AssertRangeStatEqual(const TRangeStat& expected, const TRangeStat& actual)
 
 Y_UNIT_TEST_SUITE(TCompactionMapTest)
 {
+    Y_UNIT_TEST(ShouldSaturateCompactionCountersFromUi64)
+    {
+        ui16 counter = 0;
+
+        TCompactionMap::UpdateCompactionCounter(
+            static_cast<ui64>(Max<ui32>()) + 1, &counter);
+
+        UNIT_ASSERT_VALUES_EQUAL(Max<ui16>(), counter);
+    }
+
     Y_UNIT_TEST(ShouldBeEmptyAtStart)
     {
         TCompactionMap map(RangeSize, BuildDefaultCompactionPolicy(5));

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -735,6 +735,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MixedBlocksFilterAllowedCpuTimePerSecond,   TDuration,  MSeconds(10)  )\
     xxx(CheckpointAwareCleanupEnabled,              bool,       false         )\
     xxx(UseBlobChannelDataKindForCounters,          bool,       false         )\
+    xxx(UseNewCompactionMapCounters,                bool,       false         )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -969,6 +969,8 @@ public:
     [[nodiscard]] bool GetCheckpointAwareCleanupEnabled() const;
 
     [[nodiscard]] bool GetUseBlobChannelDataKindForCounters() const;
+
+    [[nodiscard]] bool GetUseNewCompactionMapCounters() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1496,6 +1496,19 @@ void TPartitionActor::HandleUpdateResourceMetrics(
     State->UpdateWithThreadSafeStats(SharedState->PartStats);
 }
 
+void TPartitionActor::HandleGetCompactionCounters(
+    const TEvPartitionPrivate::TEvGetCompactionCountersRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    auto response = std::make_unique<
+        TEvPartitionPrivate::TEvGetCompactionCountersResponse>(
+        State->GetCompactionMap().Get(msg->BlockIndex));
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
 void TPartitionActor::HandleGetFreshChannelsInfo(
     const TEvPartitionCommonPrivate::TEvGetFreshChannelsInfoRequest::TPtr& ev,
     const NActors::TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -130,8 +130,13 @@ public:
         UpdateUsedFreshBlocks(db);
 
         for (const auto& blob: Args.FreshBlobs) {
-            ProcessNewBlob(ctx, db, blob);
-            UpdateCompactionCounters(blob);
+            bool isInCleanupQueue = ProcessNewBlob(ctx, db, blob);
+            // Doesn't increment compaction counters for blobs in cleanup queue,
+            // because they can be delted before any compaction and no one will
+            // decrement them.
+            if (!isInCleanupQueue) {
+                UpdateCompactionCounters(blob);
+            }
         }
 
         if (Args.Mode == ADD_COMPACTION_RESULT) {
@@ -396,7 +401,8 @@ private:
         State.ConfirmedBlobsAdded(db, Args.CommitId);
     }
 
-    void ProcessNewBlob(
+    // return true if blob is already in cleanup queue
+    bool ProcessNewBlob(
         const TActorContext& ctx,
         TPartitionDatabase& db,
         const TAddFreshBlob& blob)
@@ -450,25 +456,34 @@ private:
             blockMask.Set(blobOffset);
         }
 
+        // we don't mask overwritten blocks yet, to allow compaction to
+        // decrement counters correctly.
+        TBlockMask blockMaskAfterOverwrittenBlocks = blockMask;
         // mask overwritten blocks (there could be multiple block versions)
         ui16 blobOffset = 0;
         for (const auto& block: blob.Blocks) {
             ui64 lastCommitId = OverwrittenBlocks[block.BlockIndex];
             if (lastCommitId > block.CommitId) {
-                blockMask.Set(blobOffset);
+                blockMaskAfterOverwrittenBlocks.Set(blobOffset);
             }
             ++blobOffset;
         }
 
-        db.WriteBlockMask(blob.BlobId, blockMask);
-
-        if (IsBlockMaskFull(blockMask, MaxBlocksInBlob)) {
+        if (IsBlockMaskFull(blockMaskAfterOverwrittenBlocks, MaxBlocksInBlob))
+        {
+            // If blob is already totally overwritten, it can be deleted before
+            // any compaction, so we should persist full block mask here, to
+            // follow the invariant fullBlockMask -> blob is in cleanup queue
+            // and should be deleted eventually.
+            blockMask = blockMaskAfterOverwrittenBlocks;
             // blob already could be garbage, but we should keep it
             // as there could be active readers (or even checkpoint)
             db.WriteCleanupQueue(blob.BlobId, DeletionCommitId);
             State.GetCleanupQueue().Add(
                 {blob.BlobId, DeletionCommitId, blobMeta});
         }
+
+        db.WriteBlockMask(blob.BlobId, blockMask);
 
         // move blocks from FreshBlocks to MixedBlocks
         blobOffset = 0;
@@ -496,6 +511,8 @@ private:
             blob.BlobId,
             EChannelDataKind::Mixed,
             blob.Blocks.size());
+
+        return IsBlockMaskFull(blockMask, MaxBlocksInBlob);
     }
 
     void ProcessOverwrittenBlocks(const TAddFreshBlob& blob)

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -62,13 +62,17 @@ private:
     const ui64 DeletionCommitId;
     const ui32 MaxBlocksInBlob;
     const bool UseFlushCommitIdAsTrimFreshLogToCommitId;
+    const bool UseNewCompactionMapCounters;
     TChildLogTitle LogTitle;
 
     struct TRangeInfo
     {
         TRangeStat Stat;
+        bool Initialized = false;
         ui32 BlobsSkippedByCompaction = 0;
         ui32 BlocksSkippedByCompaction = 0;
+        ui16 BlocksCountCompactedInRange = 0;
+        ui16 BlobsFullyCompactedForRange = 0;
     };
 
     TDenseHash<ui32, TRangeInfo> CompactionCounters{
@@ -84,6 +88,7 @@ public:
             ui64 deletionCommitId,
             ui32 maxBlocksInBlob,
             bool useFlushCommitIdAsTrimFreshLogToCommitId,
+            bool useNewCompactionMapCounters,
             TChildLogTitle logTitle)
         : State(state)
         , Args(args)
@@ -93,16 +98,13 @@ public:
         , MaxBlocksInBlob(maxBlocksInBlob)
         , UseFlushCommitIdAsTrimFreshLogToCommitId(
               useFlushCommitIdAsTrimFreshLogToCommitId)
+        , UseNewCompactionMapCounters(useNewCompactionMapCounters)
         , LogTitle(std::move(logTitle))
     {}
 
     void Execute(const TActorContext& ctx, TPartitionDatabase& db)
     {
-        if (Args.Mode == ADD_COMPACTION_RESULT) {
-            Y_ABORT_UNLESS(
-                Args.MixedBlobs.size() ==
-                Args.MixedBlobCompactionInfos.size());
-        }
+        InitCompactionCounters();
 
         for (ui32 i = 0; i < Args.MixedBlobs.size(); ++i) {
             const auto& blob = Args.MixedBlobs[i];
@@ -111,22 +113,6 @@ public:
             if (Args.Mode == EAddBlobMode::ADD_WRITE_RESULT) {
                 UpdateUsedBlocks(db, blob);
             }
-
-            if (Args.Mode == ADD_COMPACTION_RESULT) {
-                const auto& cm = State.GetCompactionMap();
-                const auto blockIndex = cm.GetRangeStart(BlockIndex(blob, 0));
-                auto& rangeInfo = CompactionCounters[blockIndex];
-                rangeInfo.BlobsSkippedByCompaction =
-                    Args.MixedBlobCompactionInfos[i].BlobsSkippedByCompaction;
-                rangeInfo.BlocksSkippedByCompaction =
-                    Args.MixedBlobCompactionInfos[i].BlocksSkippedByCompaction;
-            }
-        }
-
-        if (Args.Mode == ADD_COMPACTION_RESULT) {
-            Y_ABORT_UNLESS(
-                Args.MergedBlobs.size() ==
-                Args.MergedBlobCompactionInfos.size());
         }
 
         for (ui32 i = 0; i < Args.MergedBlobs.size(); ++i) {
@@ -135,18 +121,6 @@ public:
             UpdateCompactionCounters(blob);
             if (Args.Mode == EAddBlobMode::ADD_WRITE_RESULT) {
                 UpdateUsedBlocks(db, blob);
-            }
-
-            if (Args.Mode == ADD_COMPACTION_RESULT) {
-                const auto& cm = State.GetCompactionMap();
-                const auto blockIndex = cm.GetRangeStart(blob.BlockRange.Start);
-                Y_DEBUG_ABORT_UNLESS(
-                    blockIndex == cm.GetRangeStart(blob.BlockRange.End));
-                auto& rangeInfo = CompactionCounters[blockIndex];
-                rangeInfo.BlobsSkippedByCompaction =
-                    Args.MergedBlobCompactionInfos[i].BlobsSkippedByCompaction;
-                rangeInfo.BlocksSkippedByCompaction =
-                    Args.MergedBlobCompactionInfos[i].BlocksSkippedByCompaction;
             }
         }
 
@@ -209,7 +183,8 @@ private:
                 break;
             default:
                 Y_ABORT(
-                    "Unexpected index kind: %u", static_cast<ui32>(indexKind));
+                    "Unexpected index kind: %u",
+                    static_cast<ui32>(indexKind));
         }
 
         // Deletion markers do not have a data channel.
@@ -238,6 +213,54 @@ private:
                 Y_ABORT(
                     "Unexpected blob channel data kind: %u",
                     static_cast<ui32>(countersKind));
+        }
+    }
+
+    void UpdateCompactionInfo(
+        ui32 blockIndex,
+        const TBlobCompactionInfo& compactionInfo)
+    {
+        auto& rangeInfo = CompactionCounters[blockIndex];
+        rangeInfo.BlobsSkippedByCompaction +=
+            compactionInfo.BlobsSkippedByCompaction;
+        rangeInfo.BlocksSkippedByCompaction +=
+            compactionInfo.BlocksSkippedByCompaction;
+
+        TCompactionMap::UpdateCompactionCounter(
+            rangeInfo.BlocksCountCompactedInRange +
+                compactionInfo.BlocksCountCompactedInRange,
+            &rangeInfo.BlocksCountCompactedInRange);
+        TCompactionMap::UpdateCompactionCounter(
+            rangeInfo.BlobsFullyCompactedForRange +
+                compactionInfo.BlobsFullyCompactedForRange,
+            &rangeInfo.BlobsFullyCompactedForRange);
+    }
+
+    void InitCompactionCounters()
+    {
+        if (Args.Mode != ADD_COMPACTION_RESULT) {
+            return;
+        }
+
+        Y_ABORT_UNLESS(
+            Args.MixedBlobs.size() == Args.MixedBlobCompactionInfos.size());
+        Y_ABORT_UNLESS(
+            Args.MergedBlobs.size() == Args.MergedBlobCompactionInfos.size());
+
+        const auto& cm = State.GetCompactionMap();
+
+        for (ui32 i = 0; i < Args.MixedBlobs.size(); ++i) {
+            const auto blockIndex =
+                cm.GetRangeStart(BlockIndex(Args.MixedBlobs[i], 0));
+            UpdateCompactionInfo(blockIndex, Args.MixedBlobCompactionInfos[i]);
+        }
+
+        for (ui32 i = 0; i < Args.MergedBlobs.size(); ++i) {
+            const auto& blob = Args.MergedBlobs[i];
+            const auto blockIndex = cm.GetRangeStart(blob.BlockRange.Start);
+            Y_DEBUG_ABORT_UNLESS(
+                blockIndex == cm.GetRangeStart(blob.BlockRange.End));
+            UpdateCompactionInfo(blockIndex, Args.MergedBlobCompactionInfos[i]);
         }
     }
 
@@ -494,8 +517,25 @@ private:
         const auto& cm = State.GetCompactionMap();
         auto& rangeInfo = CompactionCounters[blockIndex];
 
-        if (!rangeInfo.Stat.BlobCount && Args.Mode != ADD_COMPACTION_RESULT) {
-            rangeInfo.Stat = cm.Get(blockIndex);
+        if (!rangeInfo.Initialized) {
+            if (Args.Mode != ADD_COMPACTION_RESULT ||
+                UseNewCompactionMapCounters)
+            {
+                rangeInfo.Stat = cm.Get(blockIndex);
+            }
+
+            if (Args.Mode == ADD_COMPACTION_RESULT &&
+                UseNewCompactionMapCounters)
+            {
+                rangeInfo.Stat.BlobCount -=
+                    Min(rangeInfo.Stat.BlobCount,
+                        rangeInfo.BlobsFullyCompactedForRange);
+                rangeInfo.Stat.BlockCount -=
+                    Min(rangeInfo.Stat.BlockCount,
+                        rangeInfo.BlocksCountCompactedInRange);
+            }
+
+            rangeInfo.Initialized = true;
         }
 
         return rangeInfo.Stat;
@@ -582,6 +622,15 @@ private:
     void UpdateCompactionMap(TPartitionDatabase& db)
     {
         for (const auto& kv: CompactionCounters) {
+            ui32 blobCount = kv.second.Stat.BlobCount;
+            ui32 blockCount = kv.second.Stat.BlockCount;
+            if (Args.Mode == ADD_COMPACTION_RESULT &&
+                !UseNewCompactionMapCounters)
+            {
+                blobCount += kv.second.BlobsSkippedByCompaction;
+                blockCount += kv.second.BlocksSkippedByCompaction;
+            }
+
             const auto usedBlockCount = State.GetUsedBlocks().Count(
                 kv.first,
                 Min(static_cast<ui64>(
@@ -604,18 +653,10 @@ private:
                     newlyZeroedBlocksDiff,
                 0L)));
 
-            db.WriteCompactionMap(
-                kv.first,
-                kv.second.Stat.BlobCount + kv.second.BlobsSkippedByCompaction,
-                kv.second.Stat.BlockCount +
-                    kv.second.BlocksSkippedByCompaction);
-            State.GetCompactionMap().Update(
-                kv.first,
-                kv.second.Stat.BlobCount + kv.second.BlobsSkippedByCompaction,
-                kv.second.Stat.BlockCount + kv.second.BlocksSkippedByCompaction,
-                usedBlockCount,
-                newlyZeroedBlocks,
-                Args.Mode == ADD_COMPACTION_RESULT);
+            db.WriteCompactionMap(kv.first, blobCount, blockCount);
+            State.GetCompactionMap().Update(kv.first, blobCount, blockCount,
+                                            usedBlockCount, newlyZeroedBlocks,
+                                            Args.Mode == ADD_COMPACTION_RESULT);
         }
     }
 
@@ -855,6 +896,7 @@ void TPartitionActor::ExecuteAddBlobs(
         State->GetMaxBlocksInBlob(),
         Config
             ->GetWaitForFreshWritesBeforeFlushEnabled(),   // useFlushCommitIdAsTrimFreshLogToCommitId
+        Config->GetUseNewCompactionMapCounters(),
         LogTitle.GetChild(GetCycleCount()));
     executor.Execute(ctx, db);
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -86,6 +86,7 @@ void FillRangeCompactionInfos(
                 continue;
             }
             ab->BlockMask = blockMask;
+            ab->BlockMaskWasRead = true;
         }
     }
 }
@@ -765,6 +766,8 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
         const TVector<std::optional<ui32>>& blockChecksums,
         ui32 blobsSkipped,
         ui32 blocksSkipped,
+        ui16 blocksCountCompactedInRange,
+        ui16 blobsFullyCompactedForRange,
         EChannelDataKind channelDataKind)
     {
         while (skipMask.Get(range.End - range.Start)) {
@@ -785,7 +788,11 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
                 range,
                 skipMask,
                 std::move(ensuredBlockChecksums));
-            mergedBlobCompactionInfos.push_back({blobsSkipped, blocksSkipped});
+            mergedBlobCompactionInfos.push_back(
+                {blobsSkipped,
+                 blocksSkipped,
+                 blocksCountCompactedInRange,
+                 blobsFullyCompactedForRange});
         } else if (channelDataKind == EChannelDataKind::Mixed) {
             TVector<ui32> blockIndices(Reserve(range.Size()));
             for (auto blockIndex = range.Start; blockIndex <= range.End;
@@ -800,7 +807,11 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
                 std::move(blockIndices),
                 std::move(ensuredBlockChecksums),
                 0);   // unknown blob alignment
-            mixedBlobCompactionInfos.push_back({blobsSkipped, blocksSkipped});
+            mixedBlobCompactionInfos.push_back(
+                {blobsSkipped,
+                 blocksSkipped,
+                 blocksCountCompactedInRange,
+                 blobsFullyCompactedForRange});
         } else {
             LOG_ERROR(
                 ctx,
@@ -812,6 +823,8 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
     };
 
     for (auto& rc: RangeCompactionInfos) {
+        UpdateCompactionMapCounters(CommitId, rc);
+
         if (rc.DataBlobId) {
             addBlob(
                 rc.DataBlobId,
@@ -820,16 +833,22 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
                 rc.BlockChecksums,
                 rc.BlobsSkippedByCompaction,
                 rc.BlocksSkippedByCompaction,
+                rc.BlocksCountCompactedInRange,
+                rc.BlobsFullyCompactedForRange,
                 rc.ChannelDataKind);
         }
 
         if (rc.ZeroBlobId) {
             ui32 blobsSkipped = 0;
             ui32 blocksSkipped = 0;
+            ui16 blocksCountCompactedInRange = 0;
+            ui16 blobsFullyCompactedForRange = 0;
 
             if (!rc.DataBlobId) {
                 blobsSkipped = rc.BlobsSkippedByCompaction;
                 blocksSkipped = rc.BlocksSkippedByCompaction;
+                blocksCountCompactedInRange = rc.BlocksCountCompactedInRange;
+                blobsFullyCompactedForRange = rc.BlobsFullyCompactedForRange;
             }
 
             addBlob(
@@ -839,6 +858,8 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
                 rc.BlockChecksums,
                 blobsSkipped,
                 blocksSkipped,
+                blocksCountCompactedInRange,
+                blobsFullyCompactedForRange,
                 rc.ChannelDataKind);
         }
 

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -100,6 +100,52 @@ void ApplyChecksumFixups(TRangeCompactionInfo& rc)
     }
 }
 
+void UpdateCompactionMapCounters(
+    ui64 commitId,
+    TRangeCompactionInfo& rangeCompactionInfo)
+{
+    rangeCompactionInfo.BlocksCountCompactedInRange = 0;
+    rangeCompactionInfo.BlobsFullyCompactedForRange = 0;
+
+    for (const auto& [blobId, ab]: rangeCompactionInfo.AffectedBlobs) {
+        Y_ABORT_UNLESS(ab.MinCommitIdInCompactionRange <= commitId);
+
+        if (ab.BlobAlreadyInCleanupQueue) {
+            continue;
+        }
+
+        Y_ABORT_UNLESS(ab.BlockMask);
+        const auto& blockMask = ab.BlockMask.GetRef();
+
+        TBlockMask blocksCompactedInRange;
+        for (const ui16 blobOffset: ab.Offsets) {
+            // A mask is not read only when the blob is fully available and
+            // has no blocks compacted by an earlier compaction.
+            if (!ab.BlockMaskWasRead || !blockMask.Get(blobOffset)) {
+                blocksCompactedInRange.Set(blobOffset);
+            }
+        }
+
+        const ui64 compactedOffsetsCount = blocksCompactedInRange.Count();
+        if (!compactedOffsetsCount) {
+            continue;
+        }
+
+        if (!IsDeletionMarker(blobId)) {
+            TCompactionMap::UpdateCompactionCounter(
+                rangeCompactionInfo.BlocksCountCompactedInRange +
+                    compactedOffsetsCount,
+                &rangeCompactionInfo.BlocksCountCompactedInRange);
+        }
+
+        if (ab.MaxCommitIdInCompactionRange <= commitId) {
+            TCompactionMap::UpdateCompactionCounter(
+                rangeCompactionInfo.BlobsFullyCompactedForRange + 1,
+                &rangeCompactionInfo.BlobsFullyCompactedForRange);
+        }
+    }
+}
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
@@ -52,6 +52,8 @@ struct TRangeCompactionInfo
     const TBlockMask ZeroBlobSkipMask;
     const ui32 BlobsSkippedByCompaction;
     const ui32 BlocksSkippedByCompaction;
+    ui16 BlocksCountCompactedInRange = 0;
+    ui16 BlobsFullyCompactedForRange = 0;
     TVector<std::optional<ui32>> BlockChecksums;
     const EChannelDataKind ChannelDataKind;
 
@@ -83,6 +85,10 @@ struct TRangeCompactionInfo
 };
 
 void ApplyChecksumFixups(TRangeCompactionInfo& rc);
+
+void UpdateCompactionMapCounters(
+    ui64 commitId,
+    TRangeCompactionInfo& rangeCompactionInfo);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -191,6 +191,16 @@ TPrepareCompleteResult RunPrepareAndComplete(
         rangeCompactionInfos,
         0);
 
+    for (auto& [blobId, ab]: rangeCompactionInfos.back().AffectedBlobs) {
+        if (blobsToReadBlockMasks.contains(blobId)) {
+            ab.BlockMask = TBlockMask{};
+            ab.BlockMaskWasRead = true;
+        }
+    }
+    UpdateCompactionMapCounters(
+        compactionCommitId,
+        rangeCompactionInfos.back());
+
     return {
         ready,
         std::move(rangeCompactionInfos),
@@ -368,6 +378,133 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         UNIT_ASSERT(blobsToReadBlockMasks.empty());
     }
 
+    Y_UNIT_TEST(ShouldIgnoreAlreadyCompactedDataInCompactionMapCounters)
+    {
+        TAffectedBlobs affectedBlobs;
+
+        auto addBlob = [&] (
+            const TPartialBlobId& blobId,
+            TVector<ui16> offsets,
+            TBlockMask blockMask,
+            bool alreadyInCleanupQueue)
+        {
+            TAffectedBlob blob;
+            blob.MinCommitIdInCompactionRange = CommitId;
+            blob.MaxCommitIdInCompactionRange = CommitId;
+            blob.Offsets = std::move(offsets);
+            if (!alreadyInCleanupQueue) {
+                blob.BlockMask = blockMask;
+                blob.BlockMaskWasRead = true;
+            }
+            blob.BlobAlreadyInCleanupQueue = alreadyInCleanupQueue;
+            affectedBlobs.emplace(blobId, std::move(blob));
+        };
+
+        addBlob(
+            TPartialBlobId(1, 1, 3, 2 * DefaultBlockSize, 1, 0),
+            {0, 1},
+            TBlockMask{},
+            true);   // already in cleanup queue
+
+        TBlockMask fullyCompactedMask;
+        fullyCompactedMask.Set(0);
+        fullyCompactedMask.Set(1);
+        addBlob(
+            TPartialBlobId(1, 1, 3, 2 * DefaultBlockSize, 2, 0),
+            {0, 1},
+            fullyCompactedMask,
+            false);   // every block in this range is already compacted
+
+        TBlockMask partiallyCompactedMask;
+        partiallyCompactedMask.Set(1);
+        addBlob(
+            TPartialBlobId(1, 1, 3, 3 * DefaultBlockSize, 3, 0),
+            {0, 1, 2},
+            partiallyCompactedMask,
+            false);   // only offsets 0 and 2 are newly compacted
+
+        TAffectedBlob fullyAvailableBlob;
+        fullyAvailableBlob.MinCommitIdInCompactionRange = CommitId;
+        fullyAvailableBlob.MaxCommitIdInCompactionRange = CommitId;
+        fullyAvailableBlob.Offsets = {0, 1};
+        fullyAvailableBlob.BlockMask = GetFullBlockMask(MaxBlocksCount);
+        affectedBlobs.emplace(
+            TPartialBlobId(1, 1, 3, 2 * DefaultBlockSize, 4, 0),
+            std::move(fullyAvailableBlob));
+
+        TRangeCompactionInfo rangeCompactionInfo(
+            TBlockRange32::MakeClosedInterval(0, 7),
+            {},   // originalBlobId
+            {},   // dataBlobId
+            {},   // dataBlobSkipMask
+            {},   // zeroBlobId
+            {},   // zeroBlobSkipMask
+            0,    // blobsSkippedByCompaction
+            0,    // blocksSkippedByCompaction
+            {},   // blockChecksums
+            EChannelDataKind::Merged,
+            {},   // blobContent
+            {},   // zeroBlocks
+            std::move(affectedBlobs),
+            {},   // affectedBlocks
+            {});  // checksumFixups
+
+        UpdateCompactionMapCounters(CommitId, rangeCompactionInfo);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            rangeCompactionInfo.BlocksCountCompactedInRange);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            rangeCompactionInfo.BlobsFullyCompactedForRange);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountDeletionMarkerOffsetsAsCompactedBlocks)
+    {
+        const TPartialBlobId deletionMarker(
+            1,
+            1,
+            3,
+            0,   // blobSize
+            1,
+            0);
+
+        TAffectedBlob blob;
+        blob.MinCommitIdInCompactionRange = CommitId;
+        blob.MaxCommitIdInCompactionRange = CommitId;
+        blob.Offsets = {0};
+        blob.BlockMask = GetFullBlockMask(MaxBlocksCount);
+
+        TAffectedBlobs affectedBlobs;
+        affectedBlobs.emplace(deletionMarker, std::move(blob));
+
+        TRangeCompactionInfo rangeCompactionInfo(
+            TBlockRange32::MakeClosedInterval(0, 7),
+            {},   // originalBlobId
+            {},   // dataBlobId
+            {},   // dataBlobSkipMask
+            {},   // zeroBlobId
+            {},   // zeroBlobSkipMask
+            0,    // blobsSkippedByCompaction
+            0,    // blocksSkippedByCompaction
+            {},   // blockChecksums
+            EChannelDataKind::Merged,
+            {},   // blobContent
+            {},   // zeroBlocks
+            std::move(affectedBlobs),
+            {},   // affectedBlocks
+            {});  // checksumFixups
+
+        UpdateCompactionMapCounters(CommitId, rangeCompactionInfo);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            rangeCompactionInfo.BlocksCountCompactedInRange);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            rangeCompactionInfo.BlobsFullyCompactedForRange);
+    }
+
     // PrepareRangeCompaction: a blob spanning two compaction ranges has
     // CompactionRangeCount > 1 and must go into blobsToReadBlockMasks even
     // when optimization is enabled.
@@ -419,8 +556,8 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         UNIT_ASSERT(blobsToReadBlockMasks.contains(blobId));
     }
 
-    // PrepareRangeCompaction: a blob already in the cleanup queue gets a full
-    // block mask assigned in-place and is NOT put into blobsToReadBlockMasks.
+    // PrepareRangeCompaction: a blob already in the cleanup queue is flagged
+    // in-place and is NOT put into blobsToReadBlockMasks.
     Y_UNIT_TEST(PrepareSkipsBlockMasksForCleanupQueueBlob)
     {
         auto state = MakeState();
@@ -768,6 +905,11 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         UNIT_ASSERT_VALUES_EQUAL(blockRange.Start, mergedBlocks.GetStart());
         UNIT_ASSERT_VALUES_EQUAL(blockRange.End, mergedBlocks.GetEnd());
         UNIT_ASSERT_VALUES_EQUAL(skipMask.Count(), mergedBlocks.GetSkipped());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1, result.RangeCompactionInfos[0].BlobsFullyCompactedForRange);
+        UNIT_ASSERT_VALUES_EQUAL(
+            blockRange.Size() - skipMask.Count(),
+            result.RangeCompactionInfos[0].BlocksCountCompactedInRange);
     }
 
     // PrepareRangeCompaction + CompleteRangeCompaction: fully-available mixed
@@ -811,6 +953,11 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         UNIT_ASSERT_VALUES_EQUAL(
             blockIndices.size(),
             mixedBlocks.CommitIdsSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1, result.RangeCompactionInfos[0].BlobsFullyCompactedForRange);
+        UNIT_ASSERT_VALUES_EQUAL(
+            blockIndices.size(),
+            result.RangeCompactionInfos[0].BlocksCountCompactedInRange);
 
         for (size_t i = 0; i < blockIndices.size(); ++i) {
             UNIT_ASSERT_VALUES_EQUAL(blockIndices[i], mixedBlocks.GetBlocks(i));
@@ -893,6 +1040,10 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         UNIT_ASSERT_VALUES_EQUAL(1, ab.CompactionRangeCount);
         UNIT_ASSERT(ab.MaxCommitIdInCompactionRange > compactionCommitId);
         UNIT_ASSERT(!ab.RecreatedBlobMeta);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0, result.RangeCompactionInfos[0].BlobsFullyCompactedForRange);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1, result.RangeCompactionInfos[0].BlocksCountCompactedInRange);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -8,6 +8,7 @@
 #include <cloud/blockstore/libs/kikimr/events.h>
 #include <cloud/blockstore/libs/storage/core/channel_permissions.h>
 #include <cloud/blockstore/libs/storage/core/compaction_options.h>
+#include <cloud/blockstore/libs/storage/core/compaction_policy.h>
 #include <cloud/blockstore/libs/storage/core/compaction_type.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/model/channel_data_kind.h>
@@ -152,6 +153,9 @@ struct TAffectedBlob
     TVector<ui16> Offsets;
 
     TMaybe<TBlockMask> BlockMask;
+    // False when a full mask was synthesized for a blob that is fully
+    // available for compaction.
+    bool BlockMaskWasRead = false;
 
     bool BlobAlreadyInCleanupQueue = false;
 
@@ -172,6 +176,20 @@ struct TBlobCompactionInfo
 {
     const ui32 BlobsSkippedByCompaction = 0;
     const ui32 BlocksSkippedByCompaction = 0;
+
+    const ui16 BlocksCountCompactedInRange = 0;
+    const ui16 BlobsFullyCompactedForRange = 0;
+
+    TBlobCompactionInfo(
+        ui32 blobsSkippedByCompaction,
+        ui32 blocksSkippedByCompaction,
+        ui16 blocksCountCompactedInRange,
+        ui16 blobsFullyCompactedForRange)
+        : BlobsSkippedByCompaction(blobsSkippedByCompaction)
+        , BlocksSkippedByCompaction(blocksSkippedByCompaction)
+        , BlocksCountCompactedInRange(blocksCountCompactedInRange)
+        , BlobsFullyCompactedForRange(blobsFullyCompactedForRange)
+    {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -195,6 +213,7 @@ using TFlushedCommitIds = TVector<TFlushedCommitId>;
     xxx(AddBlobs,                  __VA_ARGS__)                                \
     xxx(Flush,                     __VA_ARGS__)                                \
     xxx(Compaction,                __VA_ARGS__)                                \
+    xxx(GetCompactionCounters,     __VA_ARGS__)                                \
     xxx(CompactionReadBlobInfo,    __VA_ARGS__)                                \
     xxx(MetadataRebuildUsedBlocks, __VA_ARGS__)                                \
     xxx(MetadataRebuildBlockCount, __VA_ARGS__)                                \
@@ -366,6 +385,30 @@ struct TEvPartitionPrivate
 
     struct TCompactionResponse
     {
+    };
+
+    //
+    // GetCompactionCounters
+    //
+
+    struct TGetCompactionCountersRequest
+    {
+        ui32 BlockIndex = 0;
+
+        explicit TGetCompactionCountersRequest(ui32 blockIndex)
+            : BlockIndex(blockIndex)
+        {}
+    };
+
+    struct TGetCompactionCountersResponse
+    {
+        TRangeStat Counters;
+
+        TGetCompactionCountersResponse() = default;
+
+        explicit TGetCompactionCountersResponse(TRangeStat counters)
+            : Counters(std::move(counters))
+        {}
     };
 
     //

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -5936,6 +5936,463 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldPassNewCompactionCountersToAddBlobs)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetUseNewCompactionMapCounters(true);
+        config.SetSplitCompactionTxEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        bool addBlobsRequestObserved = false;
+        ui32 blocksCountCompactedInRange = 0;
+        ui32 blobsFullyCompactedForRange = 0;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvAddBlobsRequest)
+                {
+                    const auto* msg =
+                        event->Get<TEvPartitionPrivate::TEvAddBlobsRequest>();
+                    if (msg->Mode == ADD_COMPACTION_RESULT) {
+                        addBlobsRequestObserved = true;
+
+                        const auto collect = [&](const auto& compactionInfos)
+                        {
+                            for (const auto& info: compactionInfos) {
+                                blocksCountCompactedInRange +=
+                                    info.BlocksCountCompactedInRange;
+                                blobsFullyCompactedForRange +=
+                                    info.BlobsFullyCompactedForRange;
+                            }
+                        };
+
+                        collect(msg->MixedBlobCompactionInfos);
+                        collect(msg->MergedBlobCompactionInfos);
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Compaction();
+
+        UNIT_ASSERT(addBlobsRequestObserved);
+        UNIT_ASSERT_VALUES_EQUAL(3, blocksCountCompactedInRange);
+        UNIT_ASSERT_VALUES_EQUAL(3, blobsFullyCompactedForRange);
+    }
+
+    Y_UNIT_TEST(ShouldAccountForConcurrentWritesInCompactionMapCounters)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetUseNewCompactionMapCounters(true);
+        config.SetSplitCompactionTxEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        bool interceptCompactionAddBlobs = true;
+        TAutoPtr<IEventHandle> compactionAddBlobsRequest;
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvAddBlobsRequest)
+                {
+                    const auto* msg =
+                        event->Get<TEvPartitionPrivate::TEvAddBlobsRequest>();
+                    if (msg->Mode == ADD_COMPACTION_RESULT &&
+                        interceptCompactionAddBlobs)
+                    {
+                        interceptCompactionAddBlobs = false;
+                        compactionAddBlobsRequest = event.Release();
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendCompactionRequest();
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(compactionAddBlobsRequest);
+
+        partition.WriteBlocks(1, 11);
+
+        runtime->Send(compactionAddBlobsRequest.Release());
+
+        auto compactionResponse = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, compactionResponse->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(11),
+            GetBlockContent(partition.ReadBlocks(1)));
+
+        const auto counters = partition.GetCompactionCounters(0);
+        UNIT_ASSERT_VALUES_EQUAL(2, counters->Counters.BlobCount);
+        UNIT_ASSERT_VALUES_EQUAL(4, counters->Counters.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(3, counters->Counters.UsedBlockCount);
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreAlreadyCompactedBlobsInCompactionMapCounters)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetCleanupThreshold(1);
+        config.SetUseNewCompactionMapCounters(true);
+        config.SetSplitCompactionTxEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        struct TCompactionCounters
+        {
+            ui32 Blocks = 0;
+            ui32 Blobs = 0;
+        };
+
+        TVector<TCompactionCounters> compactionCounters;
+        bool cleanupRequestDropped = false;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        const auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode != ADD_COMPACTION_RESULT) {
+                            break;
+                        }
+
+                        TCompactionCounters counters;
+                        const auto collect = [&](const auto& compactionInfos)
+                        {
+                            for (const auto& info: compactionInfos) {
+                                counters.Blocks +=
+                                    info.BlocksCountCompactedInRange;
+                                counters.Blobs +=
+                                    info.BlobsFullyCompactedForRange;
+                            }
+                        };
+
+                        collect(msg->MixedBlobCompactionInfos);
+                        collect(msg->MergedBlobCompactionInfos);
+                        compactionCounters.push_back(counters);
+                        break;
+                    }
+                    case TEvPartitionPrivate::EvCleanupRequest:
+                        cleanupRequestDropped = true;
+                        return true;
+                }
+
+                return false;
+            });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        partition.Compaction();
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(cleanupRequestDropped);
+
+        partition.WriteBlocks(1, 11);
+        partition.Compaction();
+
+        UNIT_ASSERT_VALUES_EQUAL(2, compactionCounters.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(3, compactionCounters[0].Blocks);
+        UNIT_ASSERT_VALUES_EQUAL(3, compactionCounters[0].Blobs);
+
+        UNIT_ASSERT_VALUES_EQUAL(4, compactionCounters[1].Blocks);
+        UNIT_ASSERT_VALUES_EQUAL(2, compactionCounters[1].Blobs);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(11),
+            GetBlockContent(partition.ReadBlocks(1)));
+
+        const auto counters = partition.GetCompactionCounters(0);
+        UNIT_ASSERT_VALUES_EQUAL(1, counters->Counters.BlobCount);
+        UNIT_ASSERT_VALUES_EQUAL(3, counters->Counters.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(3, counters->Counters.UsedBlockCount);
+
+        const auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(6, stats.GetMergedBlobsCount());
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreAlreadyCompactedBlocksInCompactionMapCounters)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetCleanupThreshold(1);
+        config.SetUseNewCompactionMapCounters(true);
+        config.SetSplitCompactionTxEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2 * MaxBlocksCount);
+
+        struct TCompactionCounters
+        {
+            ui32 Blocks = 0;
+            ui32 Blobs = 0;
+        };
+
+        TVector<TCompactionCounters> compactionCounters;
+        bool cleanupRequestDropped = false;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        const auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode != ADD_COMPACTION_RESULT) {
+                            break;
+                        }
+
+                        TCompactionCounters counters;
+                        const auto collect = [&](const auto& compactionInfos)
+                        {
+                            for (const auto& info: compactionInfos) {
+                                counters.Blocks +=
+                                    info.BlocksCountCompactedInRange;
+                                counters.Blobs +=
+                                    info.BlobsFullyCompactedForRange;
+                            }
+                        };
+
+                        collect(msg->MixedBlobCompactionInfos);
+                        collect(msg->MergedBlobCompactionInfos);
+                        compactionCounters.push_back(counters);
+                        break;
+                    }
+                    case TEvPartitionPrivate::EvCleanupRequest:
+                        cleanupRequestDropped = true;
+                        return true;
+                }
+
+                return false;
+            });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto writeRange = TBlockRange32::WithLength(
+            MaxBlocksCount / 2,
+            MaxBlocksCount);
+        partition.WriteBlocks(writeRange, 1);
+
+        partition.Compaction(0);
+        partition.Compaction(0);
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(cleanupRequestDropped);
+
+        partition.Compaction(0);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, compactionCounters.size());
+        for (const auto& counters: compactionCounters) {
+            UNIT_ASSERT_VALUES_EQUAL(MaxBlocksCount / 2, counters.Blocks);
+            UNIT_ASSERT_VALUES_EQUAL(1, counters.Blobs);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(1, writeRange.Size()),
+            GetBlocksContent(partition.ReadBlocks(writeRange)));
+
+        const auto firstRangeCounters = partition.GetCompactionCounters(0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            firstRangeCounters->Counters.BlobCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxBlocksCount / 2,
+            firstRangeCounters->Counters.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxBlocksCount / 2,
+            firstRangeCounters->Counters.UsedBlockCount);
+
+        const auto secondRangeCounters =
+            partition.GetCompactionCounters(MaxBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            secondRangeCounters->Counters.BlobCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxBlocksCount / 2,
+            secondRangeCounters->Counters.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxBlocksCount / 2,
+            secondRangeCounters->Counters.UsedBlockCount);
+
+        const auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+    }
+
+    Y_UNIT_TEST(
+        ShouldNotCountMixedBlobAsFullyCompactedWhenItContainsNewerBlocks)
+    {
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetUseNewCompactionMapCounters(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2 * MaxBlocksCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(0, MaxBlocksCount),
+            'A');
+        partition.WriteBlocks(0, '0');
+
+        std::unique_ptr<IEventHandle> writeBlobRequest;
+        bool interceptWriteBlobRequest = true;
+
+        ui64 compactionCommitId = 0;
+        TVector<TVector<ui64>> mixedBlobBlockCommitIds;
+        ui32 blocksCountCompactedInRange = 0;
+        ui32 blobsFullyCompactedForRange = 0;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::EvWriteBlobRequest &&
+                    interceptWriteBlobRequest)
+                {
+                    writeBlobRequest.reset(event.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvAddBlobsRequest)
+                {
+                    const auto* msg =
+                        event->Get<TEvPartitionPrivate::TEvAddBlobsRequest>();
+
+                    if (msg->Mode == ADD_FLUSH_RESULT) {
+                        for (const auto& blob: msg->FreshBlobs) {
+                            mixedBlobBlockCommitIds.emplace_back();
+                            for (const auto& block: blob.Blocks) {
+                                mixedBlobBlockCommitIds.back().push_back(
+                                    block.CommitId);
+                            }
+                        }
+                    } else if (msg->Mode == ADD_COMPACTION_RESULT) {
+                        compactionCommitId = msg->CommitId;
+
+                        const auto collect = [&](const auto& compactionInfos)
+                        {
+                            for (const auto& info: compactionInfos) {
+                                blocksCountCompactedInRange +=
+                                    info.BlocksCountCompactedInRange;
+                                blobsFullyCompactedForRange +=
+                                    info.BlobsFullyCompactedForRange;
+                            }
+                        };
+
+                        collect(msg->MixedBlobCompactionInfos);
+                        collect(msg->MergedBlobCompactionInfos);
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendWriteBlocksRequest(1, '1');
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(writeBlobRequest);
+        interceptWriteBlobRequest = false;
+
+        partition.SendCompactionRequest();
+        runtime->DispatchEvents({}, 10ms);
+
+        partition.WriteBlocks(2, '2');
+        partition.Flush();
+        partition.TrimFreshLog();
+
+        runtime->SendAsync(writeBlobRequest.release());
+
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+        UNIT_ASSERT(compactionCommitId);
+
+        bool mixedBlobStraddlesCompactionCommit = false;
+        for (const auto& commitIds: mixedBlobBlockCommitIds) {
+            bool hasVisibleBlock = false;
+            bool hasNewerBlock = false;
+            for (const ui64 commitId: commitIds) {
+                hasVisibleBlock |= commitId <= compactionCommitId;
+                hasNewerBlock |= commitId > compactionCommitId;
+            }
+            mixedBlobStraddlesCompactionCommit |=
+                hasVisibleBlock && hasNewerBlock;
+        }
+
+        UNIT_ASSERT(mixedBlobStraddlesCompactionCommit);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxBlocksCount + 1,
+            blocksCountCompactedInRange);
+        UNIT_ASSERT_VALUES_EQUAL(1, blobsFullyCompactedForRange);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('0'),
+            GetBlockContent(partition.ReadBlocks(0)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('1'),
+            GetBlockContent(partition.ReadBlocks(1)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('2'),
+            GetBlockContent(partition.ReadBlocks(2)));
+
+        const auto counters = partition.GetCompactionCounters(0);
+        UNIT_ASSERT_VALUES_EQUAL(2, counters->Counters.BlobCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxBlocksCount + 1,
+            counters->Counters.BlockCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxBlocksCount,
+            counters->Counters.UsedBlockCount);
+
+        const auto statsResponse = partition.StatPartition();
+        const auto& stats = statsResponse->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+    }
+
     Y_UNIT_TEST(ShouldProduceSparseMergedBlobsUponCompaction)
     {
         auto config = DefaultConfig();

--- a/cloud/blockstore/libs/storage/testlib/part_client.cpp
+++ b/cloud/blockstore/libs/storage/testlib/part_client.cpp
@@ -310,6 +310,13 @@ TPartitionClient::CreateTrimFreshLogRequest()
         TEvPartitionCommonPrivate::TEvTrimFreshLogRequest>();
 }
 
+std::unique_ptr<TEvPartitionPrivate::TEvGetCompactionCountersRequest>
+TPartitionClient::CreateGetCompactionCountersRequest(ui32 blockIndex)
+{
+    return std::make_unique<
+        TEvPartitionPrivate::TEvGetCompactionCountersRequest>(blockIndex);
+}
+
 std::unique_ptr<TEvPartitionPrivate::TEvMetadataRebuildBlockCountRequest>
 TPartitionClient::CreateMetadataRebuildBlockCountRequest(
     TPartialBlobId blobId,

--- a/cloud/blockstore/libs/storage/testlib/part_client.h
+++ b/cloud/blockstore/libs/storage/testlib/part_client.h
@@ -163,6 +163,9 @@ public:
             std::forward<TArgs>(args)...);
     }
 
+    std::unique_ptr<TEvPartitionPrivate::TEvGetCompactionCountersRequest>
+    CreateGetCompactionCountersRequest(ui32 blockIndex);
+
     std::unique_ptr<TEvPartitionPrivate::TEvMetadataRebuildBlockCountRequest>
     CreateMetadataRebuildBlockCountRequest(
         TPartialBlobId blobId,


### PR DESCRIPTION
### Notes
Before this fix, the following race was possible:

1. Start range compaction.
2. Prepare, execute, and complete the compaction transaction.
3. Receive a new WriteBlocks request for the same range.
4. Execute AddBlobs for the WriteBlocks request.
5. Execute AddBlobs for the compaction request.

As a result, the compaction map would contain counters that did not account
for the write request from step 3. This could prevent garbage from being
selected for compaction.

Previously, the compaction transaction passed the numbers of skipped blobs
and blocks to the AddBlobs transaction. The transaction then set the counters
to the numbers of skipped blobs and blocks plus the blobs and blocks produced
by compaction. Consequently, all blocks written after compaction started were
excluded from these counters.

This fix passes the numbers of compacted blobs and blocks instead. The
AddBlobs transaction subtracts these numbers from the current values stored
in the compaction map, preserving counters for concurrent writes.

Some leakage is still possible if the block or blob counters overflow. This
is very unlikely. It could be prevented by using wider counter types in the
compaction map (ui32 or ui64 instead of ui16), at the cost of increased memory
consumption for large disks. Another option would be to track concurrent
writes explicitly, but that would introduce significantly more complexity.
