### PR TITLE
[Filestore] change error code in collect_garbage

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_collectgarbage.cpp
@@ -409,7 +409,7 @@ void TIndexTabletActor::HandleCollectGarbage(
             ctx,
             *ev,
             std::move(profileLogRequest),
-            MakeError(S_ALREADY, "CollectGarbage is in progress"));
+            MakeError(E_TRY_AGAIN, "CollectGarbage is in progress"));
         return;
     }
 


### PR DESCRIPTION
### Notes
This PR changes error code returned when a collect_garbage operation is started while already running. It aligns behaviour of collect_garbage with other operations such as flush, flush_bytes, cleanup, compaction.

Additionally, currently the same S_ALREADY code is returned for "already running" and "nothing to collect" cases.

This should be a safe change because it only affects TEvCollectGarbageResponse sent when the requestor is a different actor than TIndexTabletActor. Strangely, I could not find any receiver of this event except for some test.

### Issue
https://github.com/ydb-platform/nbs/issues/4115
