### PR TITLE
Retry local disk allocation after secure erase

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
@@ -283,7 +283,16 @@ void TDestroyVolumeActor::HandleWaitReadyResponse(
     const auto* msg = ev->Get();
     const auto& error = msg->GetError();
 
-    if (HasError(error)) {
+    if (error.GetCode() == E_TRY_AGAIN) {
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "Volume %s is waiting for allocation: %s",
+            DiskId.Quote().c_str(),
+            error.GetMessage().Quote().c_str());
+
+        ReplyAndDie(ctx, error);
+    } else if (HasError(error)) {
         LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
             "Volume %s WaitReady error %s",
             DiskId.Quote().c_str(),

--- a/cloud/blockstore/libs/storage/service/service_ut_create.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_create.cpp
@@ -1596,6 +1596,16 @@ Y_UNIT_TEST_SUITE(TServiceCreateVolumeTest)
 
         service.DescribeVolume();
 
+        error.SetCode(E_TRY_AGAIN);
+
+        service.SendDestroyVolumeRequest(DefaultDiskId, true);
+        {
+            auto response = service.RecvDestroyVolumeResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+        }
+
+        service.DescribeVolume();
+
         error.SetCode(E_BS_RESOURCE_EXHAUSTED);
 
         service.SendDestroyVolumeRequest(DefaultDiskId, true);

--- a/cloud/blockstore/libs/storage/service/service_ut_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_destroy.cpp
@@ -165,6 +165,58 @@ Y_UNIT_TEST_SUITE(TServiceDestroyTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldNotDestroyVolumeWaitingForAllocation)
+    {
+        TTestEnv env;
+        const ui32 nodeIdx = SetupTestEnv(env);
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateVolume();
+
+        ui32 destroyVolumeRequests = 0;
+        runtime.SetObserverFunc(
+            [&] (TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvVolume::EvWaitReadyRequest: {
+                        auto response = std::make_unique<
+                            TEvVolume::TEvWaitReadyResponse>(
+                                MakeError(
+                                    E_TRY_AGAIN,
+                                    "disk allocation is pending"));
+                        runtime.Send(
+                            new IEventHandle(
+                                event->Sender,
+                                event->Recipient,
+                                response.release(),
+                                0,   // flags
+                                event->Cookie),
+                            nodeIdx);
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+
+                    case TEvSSProxy::EvModifyVolumeRequest:
+                        ++destroyVolumeRequests;
+                        break;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        service.SendDestroyVolumeRequest(DefaultDiskId, true);
+        {
+            auto response = service.RecvDestroyVolumeResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "disk allocation is pending",
+                response->GetErrorReason());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(0, destroyVolumeRequests);
+        service.DescribeVolume();
+    }
+
     Y_UNIT_TEST(ShouldOnlyDestroyDisksWithSpecificDiskIdPrefixes)
     {
         TTestEnv env;

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -1037,6 +1037,9 @@ private:
     void HandleAllocateDiskError(
         const NActors::TActorContext& ctx,
         NProto::TError error);
+    void ReplyToPendingWaitReadyRequests(
+        const NActors::TActorContext& ctx);
+    void ClearStorageAllocationResultForLocalDisk();
 
     void HandleAddOutdatedLaggingDevicesResponse(
         const TEvDiskRegistry::TEvAddOutdatedLaggingDevicesResponse::TPtr& ev,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -7,6 +7,7 @@
 #include <cloud/blockstore/libs/storage/volume/model/helpers.h>
 #include <cloud/storage/core/libs/common/media.h>
 
+#include <util/generic/algorithm.h>
 #include <util/generic/scope.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -36,6 +37,16 @@ ui64 GetBlocks(const NKikimrBlockStore::TVolumeConfig& config)
 {
     Y_ABORT_UNLESS(config.PartitionsSize() == 1);
     return config.GetPartitions(0).GetBlockCount();
+}
+
+bool IsLocalDiskAllocationRetry(
+    const TStorageConfig& config,
+    const NProto::TError& error,
+    NProto::EStorageMediaKind mediaKind)
+{
+    return config.GetLocalDiskAsyncDeallocationEnabled() &&
+        error.GetCode() == E_TRY_AGAIN &&
+        IsDiskRegistryLocalMediaKind(mediaKind);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -280,20 +291,28 @@ void TVolumeActor::HandleAllocateDiskIfNeeded(
     const TEvVolumePrivate::TEvAllocateDiskIfNeeded::TPtr& ev,
     const TActorContext& ctx)
 {
+    Y_UNUSED(ev);
+
+    DiskAllocationScheduled = false;
+
     if (UpdateVolumeConfigInProgress) {
         return;
     }
 
-    if (HasError(StorageAllocationResult)) {
+    Y_ABORT_UNLESS(State);
+    const auto& config = State->GetMeta().GetVolumeConfig();
+    const auto mediaKind = static_cast<NProto::EStorageMediaKind>(
+        config.GetStorageMediaKind());
+
+    if (HasError(StorageAllocationResult) &&
+        !IsLocalDiskAllocationRetry(
+            *Config,
+            StorageAllocationResult,
+            mediaKind))
+    {
         return;
     }
 
-    DiskAllocationScheduled = false;
-
-    Y_UNUSED(ev);
-
-    Y_ABORT_UNLESS(State);
-    const auto& config = State->GetMeta().GetVolumeConfig();
     const auto blocks = GetBlocks(config);
     auto expectedSize = blocks * config.GetBlockSize();
     auto actualSize = GetSize(State->GetMeta().GetDevices());
@@ -340,6 +359,48 @@ void TVolumeActor::ScheduleAllocateDiskIfNeeded(const TActorContext& ctx)
     }
 }
 
+void TVolumeActor::ReplyToPendingWaitReadyRequests(const TActorContext& ctx)
+{
+    auto replyToWaitReadyRequest = [&](const TPendingRequest& request)
+    {
+        if (request.Event->GetTypeRewrite() != TEvVolume::EvWaitReadyRequest) {
+            return false;
+        }
+
+        NCloud::Reply(
+            ctx,
+            *request.RequestInfo,
+            std::make_unique<TEvVolume::TEvWaitReadyResponse>(
+                StorageAllocationResult));
+        return true;
+    };
+
+    EraseIf(PendingRequests, replyToWaitReadyRequest);
+}
+
+void TVolumeActor::ClearStorageAllocationResultForLocalDisk()
+{
+    if (!State) {
+        return;
+    }
+
+    const auto& config = State->GetMeta().GetVolumeConfig();
+    const auto mediaKind = static_cast<NProto::EStorageMediaKind>(
+        config.GetStorageMediaKind());
+    if (!IsLocalDiskAllocationRetry(
+            *Config,
+            StorageAllocationResult,
+            mediaKind))
+    {
+        return;
+    }
+
+    const ui64 expectedSize = GetBlocks(config) * config.GetBlockSize();
+    if (expectedSize <= GetSize(State->GetMeta().GetDevices())) {
+        StorageAllocationResult.Clear();
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TVolumeActor::HandleAllocateDiskError(
@@ -372,9 +433,7 @@ void TVolumeActor::HandleAllocateDiskError(
     const auto mediaKind = static_cast<NProto::EStorageMediaKind>(
         GetNewestConfig().GetStorageMediaKind());
     const bool localDiskAllocationRetry =
-        Config->GetLocalDiskAsyncDeallocationEnabled() &&
-        error.GetCode() == E_TRY_AGAIN &&
-        IsDiskRegistryLocalMediaKind(mediaKind);
+        IsLocalDiskAllocationRetry(*Config, error, mediaKind);
 
     if (error.GetCode() != E_BS_RESOURCE_EXHAUSTED && !localDiskAllocationRetry)
     {
@@ -392,6 +451,14 @@ void TVolumeActor::HandleAllocateDiskError(
         FormatError(error).c_str());
 
     StorageAllocationResult = std::move(error);
+
+    if (localDiskAllocationRetry) {
+        // OnStarted() is not reached while the volume has no devices, so
+        // requests queued before this allocation attempt must be released
+        // here with E_TRY_AGAIN instead of waiting for allocation to succeed.
+        ReplyToPendingWaitReadyRequests(ctx);
+        ScheduleAllocateDiskIfNeeded(ctx);
+    }
 }
 
 void TVolumeActor::HandleAllocateDiskResponse(
@@ -690,6 +757,10 @@ void TVolumeActor::CompleteUpdateDevices(
     const TActorContext& ctx,
     TTxVolume::TUpdateDevices& args)
 {
+    // The allocated devices are committed to the volume metadata now. We can
+    // safely clear the storage allocation result.
+    ClearStorageAllocationResultForLocalDisk();
+
     LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
@@ -382,6 +382,10 @@ void TVolumeActor::CompleteUpdateConfig(
         RegisterVolume(ctx);
     }
 
+    // The allocated devices are committed to the volume metadata now. We can
+    // safely clear the storage allocation result.
+    ClearStorageAllocationResultForLocalDisk();
+
     HasPerformanceProfileModifications =
         State->HasPerformanceProfileModifications(*Config);
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -2612,6 +2612,153 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(0, diskAllocationFailureCounter->Val());
     }
 
+    Y_UNIT_TEST(ShouldRetryLocalDiskAllocationAfterTryAgain)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetLocalDiskAsyncDeallocationEnabled(true);
+
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        state->CurrentErrorCode = E_TRY_AGAIN;
+        auto runtime = PrepareTestActorRuntime(config, state);
+
+        TVolumeClient volume(*runtime);
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL,
+            DefaultDeviceBlockCount * DefaultDeviceBlockSize /
+                DefaultBlockSize,
+            "fail");
+
+        auto assertWaitReadyTryAgain = [&]
+        {
+            volume.SendWaitReadyRequest();
+            auto response = volume.RecvWaitReadyResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+        };
+
+        assertWaitReadyTryAgain();
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        assertWaitReadyTryAgain();
+
+        volume.RebootTablet();
+        volume.SendWaitReadyRequest();
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        {
+            auto response = volume.RecvWaitReadyResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+        }
+
+        state->CurrentErrorCode = S_OK;
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        volume.ReconnectPipe();
+        volume.WaitReady();
+
+        auto stat = volume.StatVolume();
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            stat->Record.GetVolume().GetDevices().size());
+    }
+
+    Y_UNIT_TEST(ShouldClearTryAgainAfterSuccessfulReallocation)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetLocalDiskAsyncDeallocationEnabled(true);
+
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        state->CurrentErrorCode = E_TRY_AGAIN;
+        auto runtime = PrepareTestActorRuntime(config, state);
+
+        TVolumeClient volume(*runtime);
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL,
+            DefaultDeviceBlockCount * DefaultDeviceBlockSize /
+                DefaultBlockSize,
+            "fail");
+
+        volume.SendWaitReadyRequest();
+        {
+            auto response = volume.RecvWaitReadyResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+        }
+
+        state->CurrentErrorCode = S_OK;
+        volume.ReallocateDisk();
+        volume.WaitReady();
+
+        auto stat = volume.StatVolume();
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            stat->Record.GetVolume().GetDevices().size());
+    }
+
+    Y_UNIT_TEST(ShouldClearTryAgainAfterAllocationDuringUpdateVolumeConfig)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetLocalDiskAsyncDeallocationEnabled(true);
+
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        state->CurrentErrorCode = E_TRY_AGAIN;
+        auto runtime = PrepareTestActorRuntime(config, state);
+
+        const ui64 blockCount =
+            DefaultDeviceBlockCount * DefaultDeviceBlockSize /
+            DefaultBlockSize;
+
+        TVolumeClient volume(*runtime);
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL,
+            blockCount,
+            "fail");
+
+        volume.SendWaitReadyRequest();
+        {
+            auto response = volume.RecvWaitReadyResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+        }
+
+        state->CurrentErrorCode = S_OK;
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            2,
+            NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL,
+            blockCount,
+            "fail");
+
+        volume.WaitReady();
+
+        auto stat = volume.StatVolume();
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            stat->Record.GetVolume().GetDevices().size());
+    }
+
     Y_UNIT_TEST(ShouldTryToReallocateDiskAfterReboot)
     {
         NProto::TStorageServiceConfig config;


### PR DESCRIPTION
### Notes
This is the first part of the fix for the async local disk creation feature.

There is a race with broken-disk cleanup: a `DestroyIfBroken` request could interpret any `WaitReady` error as proof that the volume is broken and destroy the tablet while allocation was still pending. The desctuction causes NBS to reply with a "path not found" error, which fails the allocation in the DiskManager.

This change makes the VolumeActor keep retrying DiskRegistry allocations in the background. Pending and new WaitReady requests return `E_TRY_AGAIN` until allocation succeeds. The stored error is cleared after the allocated devices are committed through either device reallocation or volume configuration update.

There will be a second PR, which should fix the deallocation of volume tablet from the DR's side.

### Issue
#2945
