### PR TITLE
Use idempotency key for secure erase requests

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -235,14 +235,13 @@ void TDiskAgentActor::HandlePoisonPill(
 
     State->StopTarget();
 
-    for (auto& [uuid, pendingRequests]: SecureErasePendingRequests) {
-        for (auto& requestInfo: pendingRequests) {
+    for (const auto& [uuid, erase]: SecureEraseState.GetSecureErases()) {
+        for (auto& requestInfo: erase.Requests) {
             NCloud::Reply(
                 ctx,
                 *requestInfo,
                 std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceResponse>(
-                    MakeError(E_REJECTED, "DiskAgent is dead")
-                ));
+                    MakeError(E_REJECTED, "DiskAgent is dead")));
         }
     }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp
@@ -235,14 +235,12 @@ void TDiskAgentActor::HandlePoisonPill(
 
     State->StopTarget();
 
-    for (const auto& [uuid, erase]: SecureEraseState.GetSecureErases()) {
-        for (auto& requestInfo: erase.Requests) {
-            NCloud::Reply(
-                ctx,
-                *requestInfo,
-                std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceResponse>(
-                    MakeError(E_REJECTED, "DiskAgent is dead")));
-        }
+    for (const auto& requestInfo: SecureEraseState.GetRequests()) {
+        NCloud::Reply(
+            ctx,
+            *requestInfo,
+            std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceResponse>(
+                MakeError(E_REJECTED, "DiskAgent is dead")));
     }
 
     for (const auto& actor: IOParserActors) {

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -168,9 +168,7 @@ private:
     void RenderDevices(IOutputStream& out) const;
     void RenderNVMeDevices(IOutputStream& out) const;
 
-    bool CanStartSecureErase(const TString& uuid) const;
-
-    void SecureErase(
+    bool SecureErase(
         const NActors::TActorContext& ctx,
         const TString& deviceId);
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -5,6 +5,7 @@
 #include "disk_agent_counters.h"
 #include "disk_agent_private.h"
 #include "disk_agent_state.h"
+#include "secure_erase_state.h"
 
 #include <cloud/blockstore/config/disk.pb.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
@@ -43,18 +44,18 @@ class TDiskAgentActor final: public NActors::TActorBootstrapped<TDiskAgentActor>
     using TControlPlaneRequestNumber =
         TEvDiskAgentPrivate::TControlPlaneRequestNumber;
 
-    struct TPostponedRequest
-    {
-        ui64 VolumeRequestId = 0;
-        TBlockRange64 Range;
-        NActors::IEventHandlePtr Event;
-    };
-
     enum class ERegistrationState
     {
         NotStarted,
         InProgress,
         Registered,
+    };
+
+    struct TPostponedRequest
+    {
+        ui64 VolumeRequestId = 0;
+        TBlockRange64 Range;
+        NActors::IEventHandlePtr Event;
     };
 
 private:
@@ -89,8 +90,7 @@ private:
     NActors::TActorId StatsActor;
     TOldRequestCounters OldRequestCounters;
 
-    THashMap<TString, TDeque<TRequestInfoPtr>> SecureErasePendingRequests;
-    THashSet<TString> SecureEraseDevicesNames;
+    TSecureEraseState SecureEraseState;
 
     const bool RejectLateRequestsAtDiskAgentEnabled =
         Config->GetRejectLateRequestsAtDiskAgentEnabled();
@@ -168,7 +168,7 @@ private:
     void RenderDevices(IOutputStream& out) const;
     void RenderNVMeDevices(IOutputStream& out) const;
 
-    bool CanStartSecureErase(const TString& uuid);
+    bool CanStartSecureErase(const TString& uuid) const;
 
     void SecureErase(
         const NActors::TActorContext& ctx,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -204,7 +204,7 @@ void TDiskAgentActor::PerformIO(
         deviceUUID.c_str(),
         clientId.c_str());
 
-    if (SecureErasePendingRequests.contains(deviceUUID)) {
+    if (SecureEraseState.IsInProgress(deviceUUID)) {
         const bool isHealthCheckRead =
             IsReadDeviceMethod<TMethod> && clientId == CheckHealthClientId;
         const bool isBackgroundOpsRead =

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp
@@ -204,7 +204,7 @@ void TDiskAgentActor::PerformIO(
         deviceUUID.c_str(),
         clientId.c_str());
 
-    if (SecureEraseState.IsInProgress(deviceUUID)) {
+    if (SecureEraseState.ApproveIo(deviceUUID) == EIoApproveStatus::Decline) {
         const bool isHealthCheckRead =
             IsReadDeviceMethod<TMethod> && clientId == CheckHealthClientId;
         const bool isBackgroundOpsRead =

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_secure_erase.cpp
@@ -10,22 +10,23 @@ using namespace NActors;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TDiskAgentActor::CanStartSecureErase(const TString& uuid) const
-{
-    return SecureEraseState.CanStart(
-        uuid,
-        State->GetDeviceName(uuid),
-        AgentConfig->GetMaxParallelSecureErasesAllowed());
-}
-
-void TDiskAgentActor::SecureErase(
+bool TDiskAgentActor::SecureErase(
     const NActors::TActorContext& ctx,
     const TString& deviceId)
 {
+    const auto& deviceName = State->GetDeviceName(deviceId);
+    if (!SecureEraseState.CanStart(
+            deviceId,
+            deviceName,
+            AgentConfig->GetMaxParallelSecureErasesAllowed()))
+    {
+        return false;
+    }
+
     LOG_INFO_S(ctx, TBlockStoreComponents::DISK_AGENT,
         "Start secure erase for " << deviceId.Quote());
 
-    SecureEraseState.Start(deviceId, State->GetDeviceName(deviceId));
+    SecureEraseState.Start(deviceId, deviceName);
 
     auto* actorSystem = ctx.ActorSystem();
     auto replyTo = ctx.SelfID;
@@ -48,7 +49,7 @@ void TDiskAgentActor::SecureErase(
         reply(MakeError(E_REJECTED, TStringBuilder()
                 << "SecureErase with inflight ios present for device "
                 << deviceId));
-        return;
+        return true;
     }
 
     try {
@@ -70,6 +71,8 @@ void TDiskAgentActor::SecureErase(
 
         reply(MakeError(e.GetCode(), e.what()));
     }
+
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -128,9 +131,7 @@ void TDiskAgentActor::HandleSecureEraseDevice(
     }
     erase.Status = ESecureEraseStatus::Wait;
 
-    if (CanStartSecureErase(deviceId)) {
-        SecureErase(ctx, deviceId);
-    } else {
+    if (!SecureErase(ctx, deviceId)) {
         LOG_INFO_S(
             ctx,
             TBlockStoreComponents::DISK_AGENT,
@@ -174,12 +175,8 @@ void TDiskAgentActor::HandleSecureEraseCompleted(
     erase.Requests.clear();
 
     // erase next device
-    for (const auto& [deviceUUID, erase]: SecureEraseState.GetSecureErases()) {
-        if (erase.Status == ESecureEraseStatus::Wait &&
-            CanStartSecureErase(deviceUUID))
-        {
-            SecureErase(ctx, deviceUUID);
-        }
+    for (const auto& deviceUUID: SecureEraseState.GetDevicesToErase()) {
+        SecureErase(ctx, deviceUUID);
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_secure_erase.cpp
@@ -108,22 +108,20 @@ void TDiskAgentActor::HandleSecureEraseDevice(
         TBlockStoreComponents::DISK_AGENT,
         "Secure erase device " << deviceId.Quote());
 
-    auto& erase = SecureEraseState.GetOrAdd(deviceId);
-
-    const bool eraseWithThisIdempotencyKeyAlreadyCompleted =
-        request.GetIdempotencyKey() != 0 &&
-        erase.IdempotencyKey == request.GetIdempotencyKey() &&
-        erase.Status == ESecureEraseStatus::Completed;
-    if (eraseWithThisIdempotencyKeyAlreadyCompleted) {
+    if (auto error = SecureEraseState.HandleRequest(
+            deviceId,
+            request.GetGeneration(),
+            request.GetIdempotencyKey()))
+    {
         NCloud::Reply(
             ctx,
             *ev,
             std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceResponse>(
-                erase.Error));
+                std::move(*error)));
         return;
     }
 
-    erase.IdempotencyKey = request.GetIdempotencyKey();
+    auto& erase = SecureEraseState.GetOrAdd(deviceId);
     erase.Requests.emplace_back(
         CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext));
     if (SecureEraseState.IsInProgress(deviceId)) {

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_secure_erase.cpp
@@ -10,12 +10,12 @@ using namespace NActors;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TDiskAgentActor::CanStartSecureErase(const TString& uuid)
+bool TDiskAgentActor::CanStartSecureErase(const TString& uuid) const
 {
-    const auto& name = State->GetDeviceName(uuid);
-    return !SecureEraseDevicesNames.contains(name) &&
-           SecureEraseDevicesNames.size() <
-               AgentConfig->GetMaxParallelSecureErasesAllowed();
+    return SecureEraseState.CanStart(
+        uuid,
+        State->GetDeviceName(uuid),
+        AgentConfig->GetMaxParallelSecureErasesAllowed());
 }
 
 void TDiskAgentActor::SecureErase(
@@ -25,7 +25,7 @@ void TDiskAgentActor::SecureErase(
     LOG_INFO_S(ctx, TBlockStoreComponents::DISK_AGENT,
         "Start secure erase for " << deviceId.Quote());
 
-    SecureEraseDevicesNames.emplace(State->GetDeviceName(deviceId));
+    SecureEraseState.Start(deviceId, State->GetDeviceName(deviceId));
 
     auto* actorSystem = ctx.ActorSystem();
     auto replyTo = ctx.SelfID;
@@ -105,22 +105,37 @@ void TDiskAgentActor::HandleSecureEraseDevice(
         TBlockStoreComponents::DISK_AGENT,
         "Secure erase device " << deviceId.Quote());
 
-    auto& pendingRequests = SecureErasePendingRequests[deviceId];
+    auto& erase = SecureEraseState.GetOrAdd(deviceId);
 
-    pendingRequests.emplace_back(
-        CreateRequestInfo(
-            ev->Sender,
-            ev->Cookie,
-            ev->Get()->CallContext));
-
-    if (!CanStartSecureErase(deviceId)) {
-        LOG_INFO_S(ctx, TBlockStoreComponents::DISK_AGENT,
-            "Postpone secure erase for " << deviceId.Quote());
-
+    const bool eraseWithThisIdempotencyKeyAlreadyCompleted =
+        request.GetIdempotencyKey() != 0 &&
+        erase.IdempotencyKey == request.GetIdempotencyKey() &&
+        erase.Status == ESecureEraseStatus::Completed;
+    if (eraseWithThisIdempotencyKeyAlreadyCompleted) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceResponse>(
+                erase.Error));
         return;
     }
 
-    SecureErase(ctx, deviceId);
+    erase.IdempotencyKey = request.GetIdempotencyKey();
+    erase.Requests.emplace_back(
+        CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext));
+    if (SecureEraseState.IsInProgress(deviceId)) {
+        return;
+    }
+    erase.Status = ESecureEraseStatus::Wait;
+
+    if (CanStartSecureErase(deviceId)) {
+        SecureErase(ctx, deviceId);
+    } else {
+        LOG_INFO_S(
+            ctx,
+            TBlockStoreComponents::DISK_AGENT,
+            "Postpone secure erase for " << deviceId.Quote());
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -147,38 +162,24 @@ void TDiskAgentActor::HandleSecureEraseCompleted(
 
     // send responses
 
-    if (auto it = SecureErasePendingRequests.find(msg->DeviceId);
-        it != SecureErasePendingRequests.end())
-    {
-        for (auto& requestInfo: it->second) {
-            NCloud::Reply(
-                ctx,
-                *requestInfo,
-                std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceResponse>(error));
-        }
+    auto& erase = SecureEraseState.Complete(msg->DeviceId, error);
 
-        SecureErasePendingRequests.erase(it);
+    for (auto& requestInfo: erase.Requests) {
+        NCloud::Reply(
+            ctx,
+            *requestInfo,
+            std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceResponse>(
+                error));
     }
-    SecureEraseDevicesNames.erase(State->GetDeviceName(msg->DeviceId));
+    erase.Requests.clear();
 
     // erase next device
-
-    TVector<TString> devicesToErase;
-    for (const auto& [deviceUUID, pendingRequests]: SecureErasePendingRequests) {
-        Y_DEBUG_ABORT_UNLESS(!pendingRequests.empty());
-
-        if (pendingRequests.empty()) {
-            devicesToErase.emplace_back(deviceUUID);
-            continue;
-        }
-
-        if (CanStartSecureErase(deviceUUID)) {
+    for (const auto& [deviceUUID, erase]: SecureEraseState.GetSecureErases()) {
+        if (erase.Status == ESecureEraseStatus::Wait &&
+            CanStartSecureErase(deviceUUID))
+        {
             SecureErase(ctx, deviceUUID);
         }
-    }
-
-    for (const auto& uuid: devicesToErase) {
-        SecureErasePendingRequests.erase(uuid);
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_secure_erase.cpp
@@ -124,7 +124,7 @@ void TDiskAgentActor::HandleSecureEraseDevice(
     auto& erase = SecureEraseState.GetOrAdd(deviceId);
     erase.Requests.emplace_back(
         CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext));
-    if (SecureEraseState.IsInProgress(deviceId)) {
+    if (SecureEraseState.IsEraseInProgress(deviceId)) {
         return;
     }
     erase.Status = ESecureEraseStatus::Wait;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -3908,6 +3908,36 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         UNIT_ASSERT_VALUES_EQUAL(2, AtomicGet(spdk->SecureEraseCount));
     }
 
+    Y_UNIT_TEST(ShouldRejectSecureEraseRequestFromOutdatedGeneration)
+    {
+        TTestBasicRuntime runtime;
+
+        auto env = TTestEnvBuilder(runtime)
+            .With(DiskAgentConfig({"foo", "bar"}))
+            .Build();
+
+        TDiskAgentClient diskAgent(runtime);
+        diskAgent.WaitReady();
+
+        diskAgent.SendSecureEraseDeviceRequest("foo", 0, 2);
+        auto response = diskAgent.RecvSecureEraseDeviceResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->Record.GetError().GetCode());
+
+        diskAgent.SendSecureEraseDeviceRequest("bar", 0, 1);
+        response = diskAgent.RecvSecureEraseDeviceResponse();
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            response->Record.GetError().GetCode());
+
+        diskAgent.SendSecureEraseDeviceRequest("bar", 0, 0);
+        response = diskAgent.RecvSecureEraseDeviceResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->Record.GetError().GetCode());
+
+        diskAgent.SendSecureEraseDeviceRequest("bar", 0, 1);
+        response = diskAgent.RecvSecureEraseDeviceResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->Record.GetError().GetCode());
+    }
+
     Y_UNIT_TEST(ShouldRejectSecureEraseRequestsOnPoisonPill)
     {
         TTestBasicRuntime runtime;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -3771,6 +3771,53 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
         secureErase(S_OK);
     }
 
+    Y_UNIT_TEST(ShouldRetryFailedSecureEraseWithSameIdempotencyKey)
+    {
+        TTestBasicRuntime runtime;
+
+        const TString deviceId = "MemoryDevice1";
+        const TString clientId = "client-1";
+        constexpr ui64 idempotencyKey = 42;
+        constexpr ui32 generation = 1;
+
+        auto env = TTestEnvBuilder(runtime)
+            .With(DiskAgentConfig({deviceId}))
+            .Build();
+
+        TDiskAgentClient diskAgent(runtime);
+        diskAgent.WaitReady();
+
+        diskAgent.AcquireDevices(
+            TVector<TString>{deviceId},
+            clientId,
+            NProto::VOLUME_ACCESS_READ_WRITE);
+
+        auto secureErase = [&] (auto expectedErrorCode) {
+            diskAgent.SendSecureEraseDeviceRequest(
+                deviceId,
+                idempotencyKey,
+                generation);
+
+            auto response = diskAgent.RecvSecureEraseDeviceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                expectedErrorCode,
+                response->Record.GetError().GetCode());
+        };
+
+        secureErase(E_INVALID_STATE);
+
+        runtime.AdvanceCurrentTime(TDuration::Seconds(10));
+
+        secureErase(S_OK);
+
+        diskAgent.AcquireDevices(
+            TVector<TString>{deviceId},
+            clientId,
+            NProto::VOLUME_ACCESS_READ_WRITE);
+
+        secureErase(S_OK);
+    }
+
     Y_UNIT_TEST(ShouldRegisterDevices)
     {
         TVector<NProto::TDeviceConfig> devices;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_ut_large.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_ut_large.cpp
@@ -19,8 +19,10 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
     void ShouldSecureEraseUnitImpl(
         NProto::EDiskAgentBackendType backend,
         ui64 totalSize,
+        ui64 firstIdempotencyKey,
         ui64 secondIdempotencyKey,
-        ui64 expectedEraseCount)
+        ui64 expectedEraseCount,
+        ui32 generation)
     {
         const ui32 blockSize = 4_KB;
         const ui64 totalBlockCount = totalSize / blockSize;
@@ -136,16 +138,15 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
         // erase
 
         diskAgent.ReleaseDevices(TVector{uuid}, sessionId);
-        const ui64 idempotencyKey = 42;
         auto secureErase = [&] (ui64 key) {
-            diskAgent.SendSecureEraseDeviceRequest(uuid, key);
+            diskAgent.SendSecureEraseDeviceRequest(uuid, key, generation);
             auto response = diskAgent.RecvSecureEraseDeviceResponse(TDuration::Max());
             UNIT_ASSERT_VALUES_EQUAL(
                 S_OK,
                 response->GetError().GetCode());
         };
 
-        secureErase(idempotencyKey);
+        secureErase(firstIdempotencyKey);
         secureErase(secondIdempotencyKey);
 
         diskAgent.AcquireDevices(
@@ -197,8 +198,10 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
         ShouldSecureEraseUnitImpl(
             NProto::DISK_AGENT_BACKEND_AIO,
             5_GB,
-            42,
-            1);
+            /* firstIdempotencyKey */ 42,
+            /* secondIdempotencyKey */ 42,
+            /* expectedEraseCount */ 1,
+            /* generation */ 1);
     }
 
     Y_UNIT_TEST(ShouldSecureErase5GiBUnitIoUring)
@@ -206,8 +209,10 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
         ShouldSecureEraseUnitImpl(
             NProto::DISK_AGENT_BACKEND_IO_URING,
             5_GB,
-            42,
-            1);
+            /* firstIdempotencyKey */ 42,
+            /* secondIdempotencyKey */ 42,
+            /* expectedEraseCount */ 1,
+            /* generation */ 1);
     }
 
     Y_UNIT_TEST(ShouldSecureEraseAgainAfterIdempotencyKeyChanged)
@@ -215,8 +220,32 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
         ShouldSecureEraseUnitImpl(
             NProto::DISK_AGENT_BACKEND_AIO,
             4_MB,
-            43,
-            2);
+            /* firstIdempotencyKey */ 42,
+            /* secondIdempotencyKey */ 43,
+            /* expectedEraseCount */ 2,
+            /* generation */ 1);
+    }
+
+    Y_UNIT_TEST(ShouldUseZeroIdempotencyKeyWithGeneration)
+    {
+        ShouldSecureEraseUnitImpl(
+            NProto::DISK_AGENT_BACKEND_AIO,
+            4_MB,
+            /* firstIdempotencyKey */ 0,
+            /* secondIdempotencyKey */ 0,
+            /* expectedEraseCount */ 1,
+            /* generation */ 1);
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreIdempotencyKeyWithoutGeneration)
+    {
+        ShouldSecureEraseUnitImpl(
+            NProto::DISK_AGENT_BACKEND_AIO,
+            4_MB,
+            /* firstIdempotencyKey */ 42,
+            /* secondIdempotencyKey */ 42,
+            /* expectedEraseCount */ 2,
+            /* generation */ 0);
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_ut_large.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_ut_large.cpp
@@ -16,9 +16,12 @@ using namespace NDiskAgentTest;
 
 Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
 {
-    void ShouldSecureErase5GiBUnitImpl(NProto::EDiskAgentBackendType backend)
+    void ShouldSecureEraseUnitImpl(
+        NProto::EDiskAgentBackendType backend,
+        ui64 totalSize,
+        ui64 secondIdempotencyKey,
+        ui64 expectedEraseCount)
     {
-        const ui64 totalSize = 5_GB;
         const ui32 blockSize = 4_KB;
         const ui64 totalBlockCount = totalSize / blockSize;
         const TString uuid = "FileDevice-1";
@@ -133,13 +136,18 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
         // erase
 
         diskAgent.ReleaseDevices(TVector{uuid}, sessionId);
-        {
-            diskAgent.SendSecureEraseDeviceRequest("FileDevice-1");
+        const ui64 idempotencyKey = 42;
+        auto secureErase = [&] (ui64 key) {
+            diskAgent.SendSecureEraseDeviceRequest(uuid, key);
             auto response = diskAgent.RecvSecureEraseDeviceResponse(TDuration::Max());
             UNIT_ASSERT_VALUES_EQUAL(
                 S_OK,
                 response->GetError().GetCode());
-        }
+        };
+
+        secureErase(idempotencyKey);
+        secureErase(secondIdempotencyKey);
+
         diskAgent.AcquireDevices(
             TVector{uuid},
             sessionId,
@@ -154,7 +162,9 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
             UNIT_ASSERT_VALUES_EQUAL(1, stats.DeviceStatsSize());
             auto& deviceStats = stats.GetDeviceStats(0);
             UNIT_ASSERT_VALUES_EQUAL("FileDevice-1", deviceStats.GetDeviceUUID());
-            UNIT_ASSERT_VALUES_EQUAL(1, deviceStats.GetNumEraseOps());
+            UNIT_ASSERT_VALUES_EQUAL(
+                expectedEraseCount,
+                deviceStats.GetNumEraseOps());
         }
 
         for (ui64 i = 0; i < totalBlockCount; i += blocksPerChunk) {
@@ -184,12 +194,29 @@ Y_UNIT_TEST_SUITE(TDiskAgentLargeTest)
 
     Y_UNIT_TEST(ShouldSecureErase5GiBUnitAio)
     {
-        ShouldSecureErase5GiBUnitImpl(NProto::DISK_AGENT_BACKEND_AIO);
+        ShouldSecureEraseUnitImpl(
+            NProto::DISK_AGENT_BACKEND_AIO,
+            5_GB,
+            42,
+            1);
     }
 
     Y_UNIT_TEST(ShouldSecureErase5GiBUnitIoUring)
     {
-        ShouldSecureErase5GiBUnitImpl(NProto::DISK_AGENT_BACKEND_IO_URING);
+        ShouldSecureEraseUnitImpl(
+            NProto::DISK_AGENT_BACKEND_IO_URING,
+            5_GB,
+            42,
+            1);
+    }
+
+    Y_UNIT_TEST(ShouldSecureEraseAgainAfterIdempotencyKeyChanged)
+    {
+        ShouldSecureEraseUnitImpl(
+            NProto::DISK_AGENT_BACKEND_AIO,
+            4_MB,
+            43,
+            2);
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
@@ -1,5 +1,7 @@
 #include "secure_erase_state.h"
 
+#include <util/string/builder.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,6 +35,38 @@ TVector<TRequestInfoPtr> TSecureEraseState::GetRequests() const
     return requests;
 }
 
+std::optional<NProto::TError> TSecureEraseState::HandleRequest(
+    const TString& deviceId,
+    ui32 generation,
+    ui64 idempotencyKey)
+{
+    if (generation != 0 && generation < CurrentGeneration) {
+        return MakeError(
+            E_REJECTED,
+            TStringBuilder()
+                << "Secure erase request generation " << generation
+                << " is less than current generation " << CurrentGeneration);
+    }
+
+    CurrentGeneration = generation;
+    if (generation == 0) {
+        idempotencyKey = 0;
+    }
+
+    auto& erase = GetOrAdd(deviceId);
+    const bool eraseWithThisIdempotencyKeyAlreadyCompleted =
+        generation != 0 && erase.Generation == generation &&
+        erase.IdempotencyKey == idempotencyKey &&
+        erase.Status == ESecureEraseStatus::Completed;
+    if (eraseWithThisIdempotencyKeyAlreadyCompleted) {
+        return erase.Error;
+    }
+
+    erase.Generation = generation;
+    erase.IdempotencyKey = idempotencyKey;
+    return std::nullopt;
+}
+
 TSecureErase* TSecureEraseState::Find(const TString& deviceId)
 {
     return SecureErases.FindPtr(deviceId);
@@ -53,9 +87,10 @@ bool TSecureEraseState::IsInProgress(const TString& deviceId) const
     return DevicesInProgress.contains(deviceId);
 }
 
-bool TSecureEraseState::CanStart(const TString& deviceId,
-                                 const TString& deviceName,
-                                 ui32 maxParallelSecureErases) const
+bool TSecureEraseState::CanStart(
+    const TString& deviceId,
+    const TString& deviceName,
+    ui32 maxParallelSecureErases) const
 {
     const auto* erase = Find(deviceId);
     return erase && erase->Status == ESecureEraseStatus::Wait &&
@@ -64,8 +99,9 @@ bool TSecureEraseState::CanStart(const TString& deviceId,
            DevicesInProgress.size() < maxParallelSecureErases;
 }
 
-void TSecureEraseState::Start(const TString& deviceId,
-                              const TString& deviceName)
+void TSecureEraseState::Start(
+    const TString& deviceId,
+    const TString& deviceName)
 {
     auto* erase = Find(deviceId);
     Y_ABORT_UNLESS(erase);
@@ -82,8 +118,9 @@ void TSecureEraseState::Start(const TString& deviceId,
     erase->Status = ESecureEraseStatus::InProgress;
 }
 
-TSecureErase& TSecureEraseState::Complete(const TString& deviceId,
-                                          const NProto::TError& error)
+TSecureErase& TSecureEraseState::Complete(
+    const TString& deviceId,
+    const NProto::TError& error)
 {
     auto* erase = Find(deviceId);
     Y_ABORT_UNLESS(erase);

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
@@ -1,0 +1,79 @@
+#include "secure_erase_state.h"
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const THashMap<TString, TSecureErase>&
+TSecureEraseState::GetSecureErases() const
+{
+    return SecureErases;
+}
+
+TSecureErase* TSecureEraseState::Find(const TString& deviceId)
+{
+    return SecureErases.FindPtr(deviceId);
+}
+
+const TSecureErase* TSecureEraseState::Find(const TString& deviceId) const
+{
+    return SecureErases.FindPtr(deviceId);
+}
+
+TSecureErase& TSecureEraseState::GetOrAdd(const TString& deviceId)
+{
+    return SecureErases[deviceId];
+}
+
+bool TSecureEraseState::IsInProgress(const TString& deviceId) const
+{
+    return DevicesInProgress.contains(deviceId);
+}
+
+bool TSecureEraseState::CanStart(const TString& deviceId,
+                                 const TString& deviceName,
+                                 ui32 maxParallelSecureErases) const
+{
+    const auto* erase = Find(deviceId);
+    return erase && erase->Status == ESecureEraseStatus::Wait &&
+           !DevicesInProgress.contains(deviceId) &&
+           !DevicesNamesInProgress.contains(deviceName) &&
+           DevicesInProgress.size() < maxParallelSecureErases;
+}
+
+void TSecureEraseState::Start(const TString& deviceId,
+                              const TString& deviceName)
+{
+    auto* erase = Find(deviceId);
+    Y_ABORT_UNLESS(erase);
+    Y_ABORT_UNLESS(erase->Status == ESecureEraseStatus::Wait);
+
+    const auto deviceInsertResult = DevicesInProgress.insert(deviceId);
+    Y_ABORT_UNLESS(deviceInsertResult.second);
+
+    const auto deviceNameInsertResult =
+        DevicesNamesInProgress.insert(deviceName);
+    Y_ABORT_UNLESS(deviceNameInsertResult.second);
+
+    erase->DeviceName = deviceName;
+    erase->Status = ESecureEraseStatus::InProgress;
+}
+
+TSecureErase& TSecureEraseState::Complete(const TString& deviceId,
+                                          const NProto::TError& error)
+{
+    auto* erase = Find(deviceId);
+    Y_ABORT_UNLESS(erase);
+    Y_ABORT_UNLESS(erase->Status == ESecureEraseStatus::InProgress);
+
+    DevicesInProgress.erase(deviceId);
+    DevicesNamesInProgress.erase(erase->DeviceName);
+
+    erase->Status = ESecureEraseStatus::Completed;
+    erase->Error = error;
+    return *erase;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
@@ -4,10 +4,33 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const THashMap<TString, TSecureErase>&
-TSecureEraseState::GetSecureErases() const
+TVector<TString> TSecureEraseState::GetDevicesToErase() const
 {
-    return SecureErases;
+    TVector<TString> devices;
+    devices.reserve(SecureErases.size());
+
+    for (const auto& [deviceId, erase]: SecureErases) {
+        if (erase.Status == ESecureEraseStatus::Wait) {
+            devices.push_back(deviceId);
+        }
+    }
+
+    return devices;
+}
+
+TVector<TRequestInfoPtr> TSecureEraseState::GetRequests() const
+{
+    TVector<TRequestInfoPtr> requests;
+
+    for (const auto& entry: SecureErases) {
+        const auto& erase = entry.second;
+        requests.insert(
+            requests.end(),
+            erase.Requests.begin(),
+            erase.Requests.end());
+    }
+
+    return requests;
 }
 
 TSecureErase* TSecureEraseState::Find(const TString& deviceId)

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
@@ -54,11 +54,12 @@ std::optional<NProto::TError> TSecureEraseState::HandleRequest(
     }
 
     auto& erase = GetOrAdd(deviceId);
-    const bool eraseWithThisIdempotencyKeyAlreadyCompleted =
+    const bool eraseWithThisIdempotencyKeyAlreadyCompletedSuccessfully =
         generation != 0 && erase.Generation == generation &&
         erase.IdempotencyKey == idempotencyKey &&
-        erase.Status == ESecureEraseStatus::Completed;
-    if (eraseWithThisIdempotencyKeyAlreadyCompleted) {
+        erase.Status == ESecureEraseStatus::Completed &&
+        !HasError(erase.Error);
+    if (eraseWithThisIdempotencyKeyAlreadyCompletedSuccessfully) {
         return erase.Error;
     }
 

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.cpp
@@ -83,7 +83,7 @@ TSecureErase& TSecureEraseState::GetOrAdd(const TString& deviceId)
     return SecureErases[deviceId];
 }
 
-bool TSecureEraseState::IsInProgress(const TString& deviceId) const
+bool TSecureEraseState::IsEraseInProgress(const TString& deviceId) const
 {
     return DevicesInProgress.contains(deviceId);
 }
@@ -98,6 +98,22 @@ bool TSecureEraseState::CanStart(
            !DevicesInProgress.contains(deviceId) &&
            !DevicesNamesInProgress.contains(deviceName) &&
            DevicesInProgress.size() < maxParallelSecureErases;
+}
+
+EIoApproveStatus TSecureEraseState::ApproveIo(const TString& deviceId)
+{
+    const auto it = SecureErases.find(deviceId);
+    if (it == SecureErases.end()) {
+        return EIoApproveStatus::Allow;
+    }
+
+    if (it->second.Status != ESecureEraseStatus::Completed) {
+        return EIoApproveStatus::Decline;
+    }
+
+    SecureErases.erase(it);
+
+    return EIoApproveStatus::Allow;
 }
 
 void TSecureEraseState::Start(

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.h
@@ -8,6 +8,7 @@
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/string.h>
+#include <util/generic/vector.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -41,8 +42,8 @@ private:
 public:
     TSecureEraseState() = default;
 
-    [[nodiscard]] const THashMap<TString, TSecureErase>&
-    GetSecureErases() const;
+    [[nodiscard]] TVector<TString> GetDevicesToErase() const;
+    [[nodiscard]] TVector<TRequestInfoPtr> GetRequests() const;
 
     [[nodiscard]] TSecureErase* Find(const TString& deviceId);
     [[nodiscard]] const TSecureErase* Find(const TString& deviceId) const;

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.h
@@ -10,6 +10,8 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
+#include <optional>
+
 namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -25,6 +27,7 @@ struct TSecureErase
 {
     TString DeviceName;
     ESecureEraseStatus Status = ESecureEraseStatus::Wait;
+    ui32 Generation = 0;
     ui64 IdempotencyKey = 0;
     TDeque<TRequestInfoPtr> Requests;
     NProto::TError Error;
@@ -38,25 +41,34 @@ private:
     THashMap<TString, TSecureErase> SecureErases;
     THashSet<TString> DevicesInProgress;
     THashSet<TString> DevicesNamesInProgress;
+    ui32 CurrentGeneration = 0;
 
 public:
     TSecureEraseState() = default;
 
     [[nodiscard]] TVector<TString> GetDevicesToErase() const;
     [[nodiscard]] TVector<TRequestInfoPtr> GetRequests() const;
+    [[nodiscard]] std::optional<NProto::TError> HandleRequest(
+        const TString& deviceId,
+        ui32 generation,
+        ui64 idempotencyKey);
 
     [[nodiscard]] TSecureErase* Find(const TString& deviceId);
     [[nodiscard]] const TSecureErase* Find(const TString& deviceId) const;
     TSecureErase& GetOrAdd(const TString& deviceId);
 
     [[nodiscard]] bool IsInProgress(const TString& deviceId) const;
-    [[nodiscard]] bool CanStart(const TString& deviceId,
-                                const TString& deviceName,
-                                ui32 maxParallelSecureErases) const;
+    [[nodiscard]] bool CanStart(
+        const TString& deviceId,
+        const TString& deviceName,
+        ui32 maxParallelSecureErases) const;
 
     void Start(const TString& deviceId, const TString& deviceName);
-    TSecureErase& Complete(const TString& deviceId,
-                           const NProto::TError& error);
+    TSecureErase& Complete(
+        const TString& deviceId,
+        const NProto::TError& error);
 };
+
+////////////////////////////////////////////////////////////////////////////////
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cloud/blockstore/libs/storage/core/request_info.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/generic/deque.h>
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/string.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class ESecureEraseStatus
+{
+    Wait,
+    InProgress,
+    Completed,
+};
+
+struct TSecureErase
+{
+    TString DeviceName;
+    ESecureEraseStatus Status = ESecureEraseStatus::Wait;
+    ui64 IdempotencyKey = 0;
+    TDeque<TRequestInfoPtr> Requests;
+    NProto::TError Error;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSecureEraseState
+{
+private:
+    THashMap<TString, TSecureErase> SecureErases;
+    THashSet<TString> DevicesInProgress;
+    THashSet<TString> DevicesNamesInProgress;
+
+public:
+    TSecureEraseState() = default;
+
+    [[nodiscard]] const THashMap<TString, TSecureErase>&
+    GetSecureErases() const;
+
+    [[nodiscard]] TSecureErase* Find(const TString& deviceId);
+    [[nodiscard]] const TSecureErase* Find(const TString& deviceId) const;
+    TSecureErase& GetOrAdd(const TString& deviceId);
+
+    [[nodiscard]] bool IsInProgress(const TString& deviceId) const;
+    [[nodiscard]] bool CanStart(const TString& deviceId,
+                                const TString& deviceName,
+                                ui32 maxParallelSecureErases) const;
+
+    void Start(const TString& deviceId, const TString& deviceName);
+    TSecureErase& Complete(const TString& deviceId,
+                           const NProto::TError& error);
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.h
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state.h
@@ -18,9 +18,20 @@ namespace NCloud::NBlockStore::NStorage {
 
 enum class ESecureEraseStatus
 {
+    // Secure erase is scheduled and waiting to start.
     Wait,
+    // Secure erase is currently running on the device.
     InProgress,
+    // Secure erase has finished and its result is stored in the record.
     Completed,
+};
+
+enum class EIoApproveStatus
+{
+    // I/O may proceed because secure erase is absent or completed.
+    Allow,
+    // I/O must be rejected because secure erase is waiting or in progress.
+    Decline,
 };
 
 struct TSecureErase
@@ -57,11 +68,15 @@ public:
     [[nodiscard]] const TSecureErase* Find(const TString& deviceId) const;
     TSecureErase& GetOrAdd(const TString& deviceId);
 
-    [[nodiscard]] bool IsInProgress(const TString& deviceId) const;
+    [[nodiscard]] bool IsEraseInProgress(const TString& deviceId) const;
     [[nodiscard]] bool CanStart(
         const TString& deviceId,
         const TString& deviceName,
         ui32 maxParallelSecureErases) const;
+
+    // Rejects I/O while secure erase is waiting or in progress. A completed
+    // secure erase record is removed before allowing I/O.
+    [[nodiscard]] EIoApproveStatus ApproveIo(const TString& deviceId);
 
     void Start(const TString& deviceId, const TString& deviceName);
     TSecureErase& Complete(

--- a/cloud/blockstore/libs/storage/disk_agent/secure_erase_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/secure_erase_state_ut.cpp
@@ -1,0 +1,210 @@
+#include "secure_erase_state.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <algorithm>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void AssertStatus(
+    const TSecureEraseState& state,
+    const TString& deviceId,
+    ESecureEraseStatus expected)
+{
+    const auto* erase = state.Find(deviceId);
+    UNIT_ASSERT(erase);
+    UNIT_ASSERT(erase->Status == expected);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TSecureEraseStateTest)
+{
+    Y_UNIT_TEST(ShouldAddAndFindSecureErase)
+    {
+        TSecureEraseState state;
+
+        UNIT_ASSERT(!state.Find("device-1"));
+        auto& erase = state.GetOrAdd("device-1");
+        erase.Generation = 42;
+
+        UNIT_ASSERT_VALUES_EQUAL(42, state.Find("device-1")->Generation);
+
+        const auto& constState = state;
+        UNIT_ASSERT_VALUES_EQUAL(
+            42,
+            constState.Find("device-1")->Generation);
+        UNIT_ASSERT(&erase == &state.GetOrAdd("device-1"));
+    }
+
+    Y_UNIT_TEST(ShouldReturnWaitingDevices)
+    {
+        TSecureEraseState state;
+        state.GetOrAdd("waiting-1");
+        state.GetOrAdd("waiting-2");
+        state.GetOrAdd("completed").Status = ESecureEraseStatus::Completed;
+
+        const auto devices = state.GetDevicesToErase();
+        THashSet<TString> actual(devices.begin(), devices.end());
+
+        UNIT_ASSERT_VALUES_EQUAL(2, actual.size());
+        UNIT_ASSERT(actual.contains("waiting-1"));
+        UNIT_ASSERT(actual.contains("waiting-2"));
+    }
+
+    Y_UNIT_TEST(ShouldReturnAllRequests)
+    {
+        TSecureEraseState state;
+        auto request1 = MakeIntrusive<TRequestInfo>();
+        auto request2 = MakeIntrusive<TRequestInfo>();
+        state.GetOrAdd("device-1").Requests.push_back(request1);
+        state.GetOrAdd("device-2").Requests.push_back(request2);
+
+        const auto requests = state.GetRequests();
+
+        UNIT_ASSERT_VALUES_EQUAL(2, requests.size());
+        UNIT_ASSERT(
+            std::find(requests.begin(), requests.end(), request1) !=
+            requests.end());
+        UNIT_ASSERT(
+            std::find(requests.begin(), requests.end(), request2) !=
+            requests.end());
+    }
+
+    Y_UNIT_TEST(ShouldHandleGenerationAndIdempotencyKey)
+    {
+        TSecureEraseState state;
+
+        UNIT_ASSERT(!state.HandleRequest("device-1", 2, 10));
+        const auto* erase = state.Find("device-1");
+        UNIT_ASSERT(erase);
+        UNIT_ASSERT_VALUES_EQUAL(2, erase->Generation);
+        UNIT_ASSERT_VALUES_EQUAL(10, erase->IdempotencyKey);
+
+        auto error = state.HandleRequest("device-2", 1, 20);
+        UNIT_ASSERT(error);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, error->GetCode());
+        UNIT_ASSERT(!state.Find("device-2"));
+
+        UNIT_ASSERT(!state.HandleRequest("legacy-device", 0, 123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            state.Find("legacy-device")->IdempotencyKey);
+    }
+
+    Y_UNIT_TEST(ShouldReturnSuccessfulIdempotentResult)
+    {
+        TSecureEraseState state;
+        UNIT_ASSERT(!state.HandleRequest("device-1", 1, 10));
+        state.Start("device-1", "device-name-1");
+        state.Complete("device-1", {});
+
+        auto error = state.HandleRequest("device-1", 1, 10);
+
+        UNIT_ASSERT(error);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, error->GetCode());
+    }
+
+    Y_UNIT_TEST(ShouldRetryFailedOrNonIdempotentRequest)
+    {
+        TSecureEraseState state;
+        UNIT_ASSERT(!state.HandleRequest("device-1", 1, 10));
+        state.Start("device-1", "device-name-1");
+        state.Complete("device-1", MakeError(E_IO, "erase failed"));
+
+        UNIT_ASSERT(!state.HandleRequest("device-1", 1, 10));
+        UNIT_ASSERT(!state.HandleRequest("device-1", 1, 11));
+    }
+
+    Y_UNIT_TEST(ShouldCheckWhetherSecureEraseCanStart)
+    {
+        TSecureEraseState state;
+        state.GetOrAdd("device-1");
+        state.GetOrAdd("device-2");
+        state.GetOrAdd("device-3");
+
+        UNIT_ASSERT(state.CanStart("device-1", "name-1", 2));
+        UNIT_ASSERT(!state.CanStart("unknown", "unknown-name", 2));
+
+        state.Start("device-1", "name-1");
+        UNIT_ASSERT(!state.CanStart("device-1", "name-1", 2));
+        UNIT_ASSERT(!state.CanStart("device-2", "name-1", 2));
+        UNIT_ASSERT(state.CanStart("device-2", "name-2", 2));
+
+        state.Start("device-2", "name-2");
+        UNIT_ASSERT(!state.CanStart("device-3", "name-3", 2));
+    }
+
+    Y_UNIT_TEST(ShouldStartAndCompleteSecureErase)
+    {
+        TSecureEraseState state;
+        state.GetOrAdd("device-1");
+
+        state.Start("device-1", "device-name-1");
+
+        UNIT_ASSERT(state.IsEraseInProgress("device-1"));
+        AssertStatus(state, "device-1", ESecureEraseStatus::InProgress);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "device-name-1",
+            state.Find("device-1")->DeviceName);
+
+        const auto error = MakeError(E_IO, "erase failed");
+        auto& erase = state.Complete("device-1", error);
+
+        UNIT_ASSERT(!state.IsEraseInProgress("device-1"));
+        AssertStatus(state, "device-1", ESecureEraseStatus::Completed);
+        UNIT_ASSERT_VALUES_EQUAL(E_IO, erase.Error.GetCode());
+        UNIT_ASSERT(!state.CanStart("device-1", "device-name-1", 1));
+    }
+
+    Y_UNIT_TEST(ShouldAllowIoWithoutSecureErase)
+    {
+        TSecureEraseState state;
+
+        UNIT_ASSERT(
+            state.ApproveIo("unknown") == EIoApproveStatus::Allow);
+    }
+
+    Y_UNIT_TEST(ShouldAllowIoAndRemoveCompletedSecureErase)
+    {
+        TSecureEraseState state;
+        state.GetOrAdd("device-1");
+        state.Start("device-1", "device-name-1");
+        state.Complete("device-1", {});
+
+        UNIT_ASSERT(
+            state.ApproveIo("device-1") == EIoApproveStatus::Allow);
+        UNIT_ASSERT(!state.Find("device-1"));
+    }
+
+    Y_UNIT_TEST(ShouldDeclineIoWhileSecureEraseIsWaiting)
+    {
+        TSecureEraseState state;
+        state.GetOrAdd("device-1");
+
+        UNIT_ASSERT(
+            state.ApproveIo("device-1") == EIoApproveStatus::Decline);
+        AssertStatus(state, "device-1", ESecureEraseStatus::Wait);
+    }
+
+    Y_UNIT_TEST(ShouldDeclineIoDuringSecureErase)
+    {
+        TSecureEraseState state;
+        state.GetOrAdd("device-1");
+        state.Start("device-1", "device-name-1");
+
+        UNIT_ASSERT(
+            state.ApproveIo("device-1") == EIoApproveStatus::Decline);
+        AssertStatus(state, "device-1", ESecureEraseStatus::InProgress);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
@@ -273,12 +273,14 @@ public:
 
     auto CreateSecureEraseDeviceRequest(
         TString uuid,
-        ui64 idempotencyKey = 0)
+        ui64 idempotencyKey = 0,
+        ui32 generation = 0)
     {
         auto request = std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceRequest>();
 
         request->Record.SetDeviceUUID(std::move(uuid));
         request->Record.SetIdempotencyKey(idempotencyKey);
+        request->Record.SetGeneration(generation);
 
         return request;
     }

--- a/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_agent/testlib/test_env.h
@@ -271,11 +271,14 @@ public:
         return request;
     }
 
-    auto CreateSecureEraseDeviceRequest(TString uuid)
+    auto CreateSecureEraseDeviceRequest(
+        TString uuid,
+        ui64 idempotencyKey = 0)
     {
         auto request = std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceRequest>();
 
         request->Record.SetDeviceUUID(std::move(uuid));
+        request->Record.SetIdempotencyKey(idempotencyKey);
 
         return request;
     }

--- a/cloud/blockstore/libs/storage/disk_agent/ut/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/ut/ya.make
@@ -11,6 +11,7 @@ SRCS(
     journalled_device_ut.cpp
     rdma_target_ut.cpp
     recent_blocks_tracker_ut.cpp
+    secure_erase_state_ut.cpp
     spdk_initializer_ut.cpp
     storage_initializer_ut.cpp
     storage_with_stats_ut.cpp

--- a/cloud/blockstore/libs/storage/disk_agent/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/ya.make
@@ -27,6 +27,7 @@ SRCS(
     journalled_device.cpp
     rdma_target.cpp
     recent_blocks_tracker.cpp
+    secure_erase_state.cpp
     spdk_initializer.cpp
     storage_initializer.cpp
     storage_with_stats.cpp

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -51,6 +51,7 @@ private:
 
     const TChildLogTitle LogTitle;
     const TActorId Owner;
+    const ui32 Generation;
     const TRequestInfoPtr Request;
     const TDuration RequestTimeout;
 
@@ -65,6 +66,7 @@ public:
     TSecureEraseActor(
         const TLogTitle& logTitle,
         const TActorId& owner,
+        ui32 generation,
         TRequestInfoPtr request,
         TDuration requestTimeout,
         TString poolName,
@@ -107,6 +109,7 @@ private:
 TSecureEraseActor::TSecureEraseActor(
         const TLogTitle& logTitle,
         const TActorId& owner,
+        ui32 generation,
         TRequestInfoPtr request,
         TDuration requestTimeout,
         TString poolName,
@@ -116,6 +119,7 @@ TSecureEraseActor::TSecureEraseActor(
           GetCycleCount(),
           {{"pool", TStringBuf(poolName)}}))
     , Owner(owner)
+    , Generation(generation)
     , Request(std::move(request))
     , RequestTimeout(requestTimeout)
     , PoolName(std::move(poolName))
@@ -134,6 +138,7 @@ void TSecureEraseActor::Bootstrap(const TActorContext& ctx)
 
         auto request = std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceRequest>();
         request->Record.SetDeviceUUID(device.GetDeviceUUID());
+        request->Record.SetGeneration(Generation);
         if (const auto* key =
                 EraseIdempotencyKeys.FindPtr(device.GetDeviceUUID()))
         {
@@ -483,6 +488,7 @@ void TDiskRegistryActor::HandleSecureErase(
         ctx,
         LogTitle,
         ctx.SelfID,
+        Executor()->Generation(),
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
         msg->RequestTimeout,
         msg->PoolName,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -46,6 +46,9 @@ class TSecureEraseActor final
     : public TActorBootstrapped<TSecureEraseActor>
 {
 private:
+    using TDeviceId = TDeviceList::TDeviceId;
+    using TEraseIdempotencyKey = TDeviceList::TEraseIdempotencyKey;
+
     const TChildLogTitle LogTitle;
     const TActorId Owner;
     const TRequestInfoPtr Request;
@@ -53,6 +56,7 @@ private:
 
     const TString PoolName;
     TVector<NProto::TDeviceConfig> Devices;
+    const THashMap<TDeviceId, TEraseIdempotencyKey> EraseIdempotencyKeys;
     TVector<TString> CleanDevices;
 
     int PendingRequests = 0;
@@ -64,7 +68,8 @@ public:
         TRequestInfoPtr request,
         TDuration requestTimeout,
         TString poolName,
-        TVector<NProto::TDeviceConfig> devicesToClean);
+        TVector<NProto::TDeviceConfig> devicesToClean,
+        THashMap<TDeviceId, TEraseIdempotencyKey> eraseIdempotencyKeys);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -105,7 +110,8 @@ TSecureEraseActor::TSecureEraseActor(
         TRequestInfoPtr request,
         TDuration requestTimeout,
         TString poolName,
-        TVector<NProto::TDeviceConfig> devicesToClean)
+        TVector<NProto::TDeviceConfig> devicesToClean,
+        THashMap<TDeviceId, TEraseIdempotencyKey> eraseIdempotencyKeys)
     : LogTitle(logTitle.GetChildWithTags(
           GetCycleCount(),
           {{"pool", TStringBuf(poolName)}}))
@@ -114,17 +120,25 @@ TSecureEraseActor::TSecureEraseActor(
     , RequestTimeout(requestTimeout)
     , PoolName(std::move(poolName))
     , Devices(std::move(devicesToClean))
+    , EraseIdempotencyKeys(std::move(eraseIdempotencyKeys))
 {}
 
 void TSecureEraseActor::Bootstrap(const TActorContext& ctx)
 {
     Become(&TThis::StateErase);
 
+    Y_DEBUG_ABORT_UNLESS(EraseIdempotencyKeys.size() == Devices.size());
+
     for (ui64 i = 0; i != Devices.size(); ++i) {
         auto& device = Devices[i];
 
         auto request = std::make_unique<TEvDiskAgent::TEvSecureEraseDeviceRequest>();
         request->Record.SetDeviceUUID(device.GetDeviceUUID());
+        if (const auto* key =
+                EraseIdempotencyKeys.FindPtr(device.GetDeviceUUID()))
+        {
+            request->Record.SetIdempotencyKey(*key);
+        }
 
         auto event = std::make_unique<IEventHandle>(
             MakeDiskAgentServiceId(device.GetNodeId()),
@@ -454,8 +468,15 @@ void TDiskRegistryActor::HandleSecureErase(
         LogTitle.GetWithTime().c_str(),
         MakeDevicesNamesString(msg->DirtyDevices).c_str());
 
+    THashMap<TDeviceList::TDeviceId, TDeviceList::TEraseIdempotencyKey>
+        eraseIdempotencyKeys;
+
     for (const auto& device: msg->DirtyDevices) {
-        DeviceEraseStartTs[device.GetDeviceUUID()] = ctx.Now();
+        const auto& deviceId = device.GetDeviceUUID();
+        DeviceEraseStartTs[deviceId] = ctx.Now();
+        eraseIdempotencyKeys.emplace(
+            deviceId,
+            State->GetEraseIdempotencyKey(deviceId));
     }
 
     auto actor = NCloud::Register<TSecureEraseActor>(
@@ -465,7 +486,8 @@ void TDiskRegistryActor::HandleSecureErase(
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
         msg->RequestTimeout,
         msg->PoolName,
-        std::move(msg->DirtyDevices));
+        std::move(msg->DirtyDevices),
+        std::move(eraseIdempotencyKeys));
     Actors.insert(actor);
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -4174,6 +4174,12 @@ TVector<NProto::TDeviceConfig> TDiskRegistryState::GetDirtyDevices() const
     return DeviceList.GetDirtyDevices();
 }
 
+TDeviceList::TEraseIdempotencyKey
+TDiskRegistryState::GetEraseIdempotencyKey(const TDeviceId& deviceId) const
+{
+    return DeviceList.GetEraseIdempotencyKey(deviceId);
+}
+
 bool TDiskRegistryState::IsKnownDevice(const TString& uuid) const
 {
     return std::any_of(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -529,6 +529,8 @@ public:
     TVector<NProto::TDeviceConfig> GetBrokenDevices() const;
 
     TVector<NProto::TDeviceConfig> GetDirtyDevices() const;
+    TDeviceList::TEraseIdempotencyKey GetEraseIdempotencyKey(
+        const TDeviceId& deviceId) const;
 
     /// Mark selected device as clean and remove it
     /// from lists of suspended/dirty/pending cleanup devices

--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list.cpp
@@ -4,6 +4,7 @@
 
 #include <util/generic/algorithm.h>
 #include <util/generic/iterator_range.h>
+#include <util/random/random.h>
 #include <util/string/builder.h>
 #include <util/string/printf.h>
 
@@ -95,12 +96,15 @@ TDeviceList::TDeviceList(
     : AllocatedDevices(
           std::make_move_iterator(allocatedDevices.begin()),
           std::make_move_iterator(allocatedDevices.end()))
-    , DirtyDevices(
-          std::make_move_iterator(dirtyDevices.begin()),
-          std::make_move_iterator(dirtyDevices.end()))
     , AlwaysAllocateLocalDisks(alwaysAllocateLocalDisks)
     , AttachDetachPathsEnabled(attachDetachPathsEnabled)
 {
+    for (auto& deviceId: dirtyDevices) {
+        DirtyDevices.emplace(
+            std::move(deviceId),
+            RandomNumber<TEraseIdempotencyKey>());
+    }
+
     for (auto& device: suspendedDevices) {
         auto id = device.GetId();
         SuspendedDevices.emplace(std::move(id), std::move(device));
@@ -716,7 +720,7 @@ bool TDeviceList::ReleaseDevice(const TDeviceId& id)
         return false;
     }
 
-    DirtyDevices.insert(id);
+    DirtyDevices.emplace(id, RandomNumber<TEraseIdempotencyKey>());
 
     return true;
 }
@@ -733,7 +737,9 @@ bool TDeviceList::MarkDeviceAsClean(const TDeviceId& id)
 
 void TDeviceList::MarkDeviceAsDirty(const TDeviceId& id)
 {
-    DirtyDevices.insert(id);
+    if (!DirtyDevices.contains(id)) {
+        DirtyDevices.emplace(id, RandomNumber<TEraseIdempotencyKey>());
+    }
     RemoveDeviceFromFreeList(id);
 }
 
@@ -783,7 +789,7 @@ TVector<NProto::TDeviceConfig> TDeviceList::GetDirtyDevices() const
     TVector<NProto::TDeviceConfig> devices;
     devices.reserve(DirtyDevices.size());
 
-    for (const auto& id: DirtyDevices) {
+    for (const auto& [id, _]: DirtyDevices) {
         auto it = SuspendedDevices.find(id);
         if (it != SuspendedDevices.end() && !it->second.GetResumeAfterErase()) {
             continue;
@@ -800,12 +806,26 @@ TVector<NProto::TDeviceConfig> TDeviceList::GetDirtyDevices() const
 
 TVector<TString> TDeviceList::GetDirtyDevicesId() const
 {
-    return {DirtyDevices.begin(), DirtyDevices.end()};
+    TVector<TString> result;
+    result.reserve(DirtyDevices.size());
+    for (const auto& [deviceId, _]: DirtyDevices) {
+        result.push_back(deviceId);
+    }
+    return result;
 }
 
 bool TDeviceList::IsDirtyDevice(const TDeviceId& uuid) const
 {
     return DirtyDevices.contains(uuid);
+}
+
+TDeviceList::TEraseIdempotencyKey TDeviceList::GetEraseIdempotencyKey(
+    const TDeviceId& deviceId) const
+{
+    if (const auto* key = DirtyDevices.FindPtr(deviceId)) {
+        return *key;
+    }
+    return 0;
 }
 
 NProto::EDeviceState TDeviceList::GetDeviceState(const TDeviceId& uuid) const

--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list.h
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list.h
@@ -25,7 +25,11 @@ using TDevicePoolConfigs = THashMap<TString, NProto::TDevicePoolConfig>;
 
 class TDeviceList
 {
+public:
     using TDeviceId = TString;
+    using TEraseIdempotencyKey = ui64;
+
+private:
     using TDiskId = TString;
     using TNodeId = ui32;
 
@@ -64,7 +68,7 @@ private:
     THashMap<TDeviceId, NProto::TDeviceConfig> AllDevices;
     THashMap<TNodeId, TNodeDevices> NodeDevices;
     THashMap<TDeviceId, TDiskId> AllocatedDevices;
-    THashSet<TDeviceId> DirtyDevices;
+    THashMap<TDeviceId, TEraseIdempotencyKey> DirtyDevices;
     THashMap<TDeviceId, NProto::TSuspendedDevice> SuspendedDevices;
     THashMap<NProto::EDevicePoolKind, TVector<TString>> PoolKind2PoolNames;
     THashMap<TString, ui32> PoolName2DeviceCount;
@@ -163,6 +167,8 @@ public:
     void MarkDeviceAsDirty(const TDeviceId& uuid);
 
     [[nodiscard]] bool IsDirtyDevice(const TDeviceId& uuid) const;
+    [[nodiscard]] TEraseIdempotencyKey GetEraseIdempotencyKey(
+        const TDeviceId& deviceId) const;
     [[nodiscard]] NProto::EDeviceState GetDeviceState(const TDeviceId& uuid) const;
 
     void SuspendDevice(const TDeviceId& ids);

--- a/cloud/blockstore/libs/storage/disk_registry/model/device_list_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/model/device_list_ut.cpp
@@ -91,6 +91,23 @@ TDevicePoolConfigs CreateDevicePoolConfigs(
 
 Y_UNIT_TEST_SUITE(TDeviceListTest)
 {
+    Y_UNIT_TEST(ShouldKeepEraseIdempotencyKeyWhileDeviceIsDirty)
+    {
+        TDeviceList deviceList(
+            {"uuid"},
+            {},
+            {},
+            false,
+            false);
+
+        const auto key = deviceList.GetEraseIdempotencyKey("uuid");
+        deviceList.MarkDeviceAsDirty("uuid");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            key,
+            deviceList.GetEraseIdempotencyKey("uuid"));
+    }
+
     Y_UNIT_TEST(ShouldAllocateSingleDevice)
     {
         const auto poolConfigs = CreateDevicePoolConfigs({});

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -1172,6 +1172,9 @@ message TSecureEraseDeviceRequest
     // If a request contains a key and an erase with the same key has already
     // completed, the result of that erase is returned immediately.
     uint64 IdempotencyKey = 3;
+
+    // Disk Registry tablet generation.
+    uint32 Generation = 4;
 }
 
 message TSecureEraseDeviceResponse

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -1168,6 +1168,10 @@ message TSecureEraseDeviceRequest
     THeaders Headers = 1;
 
     string DeviceUUID = 2;
+
+    // If a request contains a key and an erase with the same key has already
+    // completed, the result of that erase is returned immediately.
+    uint64 IdempotencyKey = 3;
 }
 
 message TSecureEraseDeviceResponse


### PR DESCRIPTION
### Notes
Add idempotency support for device secure erase requests.
- Propagate erase idempotency keys from DiskRegistry to DiskAgent.
- Track queued, running, and completed erases in a dedicated state class.
- Prevent concurrent erases for the same device or device name.
- Cache completed erase results for repeated requests with the same key.

### Issue
https://github.com/ydb-platform/nbs/issues/6974
