### PR TITLE
[NBS] Remove EF_SILENT flag for fresh hard limit rejects

### DIFF
--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -1006,8 +1006,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
             E_REJECTED,
             response->GetStatus(),
             response->GetErrorReason());
-        UNIT_ASSERT(
-            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
 
         UNIT_ASSERT_VALUES_EQUAL(2, addFreshBlocksCount);
 
@@ -1051,9 +1049,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
             E_REJECTED,
             writeResponse->GetStatus(),
             writeResponse->GetErrorReason());
-        UNIT_ASSERT(HasProtoFlag(
-            writeResponse->GetError().GetFlags(),
-            NProto::EF_SILENT));
         UNIT_ASSERT_STRING_CONTAINS(
             writeResponse->GetErrorReason(),
             "FreshLogicalBlocksByteCountHardLimit");
@@ -1064,9 +1059,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
             E_REJECTED,
             zeroResponse->GetStatus(),
             zeroResponse->GetErrorReason());
-        UNIT_ASSERT(HasProtoFlag(
-            zeroResponse->GetError().GetFlags(),
-            NProto::EF_SILENT));
         UNIT_ASSERT_STRING_CONTAINS(
             writeResponse->GetErrorReason(),
             "FreshLogicalBlocksByteCountHardLimit");
@@ -1772,8 +1764,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
             E_REJECTED,
             response->GetStatus(),
             response->GetErrorReason());
-        UNIT_ASSERT(
-            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
 
         fbwClient.Drain();
     }

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -10283,8 +10283,6 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             E_REJECTED,
             response->GetStatus(),
             response->GetErrorReason());
-        UNIT_ASSERT(
-            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
 
         partition.Flush();
 
@@ -10318,9 +10316,6 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             E_REJECTED,
             zeroResponse->GetStatus(),
             zeroResponse->GetErrorReason());
-        UNIT_ASSERT(HasProtoFlag(
-            zeroResponse->GetError().GetFlags(),
-            NProto::EF_SILENT));
         UNIT_ASSERT_STRING_CONTAINS(
             zeroResponse->GetErrorReason(),
             "FreshLogicalBlocksByteCountHardLimit");
@@ -10331,9 +10326,6 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             E_REJECTED,
             writeResponse->GetStatus(),
             writeResponse->GetErrorReason());
-        UNIT_ASSERT(HasProtoFlag(
-            writeResponse->GetError().GetFlags(),
-            NProto::EF_SILENT));
         UNIT_ASSERT_STRING_CONTAINS(
             writeResponse->GetErrorReason(),
             "FreshLogicalBlocksByteCountHardLimit");
@@ -14890,8 +14882,6 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             E_REJECTED,
             response->GetStatus(),
             response->GetErrorReason());
-        UNIT_ASSERT(
-            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
 
         partition.Flush();
 
@@ -16692,8 +16682,6 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             E_REJECTED,
             response->GetStatus(),
             response->GetErrorReason());
-        UNIT_ASSERT(
-            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
 
         partition.Drain();
     }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writefreshblocks.cpp
@@ -462,15 +462,12 @@ void TPartitionActor::WriteFreshBlocks(
         State->GetFreshBlockCount() * State->GetBlockSize();
     if (freshByteCount >= Config->GetFreshByteCountHardLimit()) {
         for (auto& r: requestsInBuffer) {
-            ui32 flags = 0;
-            SetProtoFlag(flags, NProto::EF_SILENT);
             auto response = CreateWriteBlocksResponse(
                 r.Data.ReplyLocal,
                 MakeError(
                     E_REJECTED,
                     TStringBuilder() << "FreshByteCountHardLimit exceeded: "
-                                     << freshByteCount,
-                    flags));
+                                     << freshByteCount));
 
             LWTRACK(
                 ResponseSent_Partition,

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -7110,8 +7110,6 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
             E_REJECTED,
             response->GetStatus(),
             response->GetErrorReason());
-        UNIT_ASSERT(
-            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
 
         partition.Flush();
 

--- a/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
@@ -55,9 +55,7 @@ inline NProto::TError CheckFreshHardLimits(
         return {};
     }
 
-    ui32 flags = 0;
-    SetProtoFlag(flags, NProto::EF_SILENT);
-    return MakeError(E_REJECTED, std::move(message), flags);
+    return MakeError(E_REJECTED, std::move(message));
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
Removed EF_SILENT flag for fresh hard limit rejects because it can cause tests crash 
```
2026-09-02T02:38:04.099280Z :BLOCKSTORE_CLIENT WARN: cloud/blockstore/libs/client/durable.cpp:302: [d:vol0] WriteBlocksLocal (offset: 271469, count: 32) retry request (retries: 1, timeout: 500.000ms, error: E_REJECTED FreshByteCountHardLimit exceeded: 268513280 f@silent)
VERIFY failed (2026-09-02T02:38:04.099315Z): 
  cloud/storage/core/libs/diagnostics/request_counters.cpp:819
  AddRetryStats(): requirement false failed
```