### PR TITLE
Remove Invoke() invocation that became useless in gtest 1.18.0

### DIFF
--- a/cloud/storage/core/libs/grpc/executor_ut.cpp
+++ b/cloud/storage/core/libs/grpc/executor_ut.cpp
@@ -69,14 +69,16 @@ Y_UNIT_TEST_SUITE(TExecutorTest)
 
         void* handlerPointer = static_cast<void*>(&handler);
         EXPECT_CALL(cq, Next(_, _))
-            .WillRepeatedly(
-                DoAll(SetArgPointee<0>(handlerPointer), testing::Invoke([] {
-                          static int counter = 0;
-                          // we return `true` 10 times to emulate usual flushing
-                          // once `Shutdown()` is being called, then we return
-                          // `false` to finish shutdown call
-                          return counter++ < 10;
-                      })));
+            .WillRepeatedly(DoAll(
+                SetArgPointee<0>(handlerPointer),
+                []
+                {
+                    static int counter = 0;
+                    // we return `true` 10 times to emulate usual flushing
+                    // once `Shutdown()` is being called, then we return
+                    // `false` to finish shutdown call
+                    return counter++ < 10;
+                }));
 
         executor.Start();
         processCalled.wait(false);

--- a/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
@@ -263,7 +263,7 @@ TEST_F(TBufferPoolTest, ShouldSetLkeyAndRkeyToBuffers)
     constexpr ui32 Lkey = 1;
     constexpr ui32 Rkey = 2;
     EXPECT_CALL(*Verbs, RegisterMemoryRegion(&pd, _, 4_MB, 0))
-        .WillOnce(Invoke(
+        .WillOnce(
             [](ibv_pd* pd, void* addr, size_t length, int flags)
             {
                 Y_UNUSED(pd, flags);
@@ -274,7 +274,7 @@ TEST_F(TBufferPoolTest, ShouldSetLkeyAndRkeyToBuffers)
                 mr->addr = addr;
                 mr->length = length;
                 return mr;
-            }));
+            });
 
     const auto& stats = Pool.GetStats();
     auto buffer1 = Pool.AcquireBuffer(4_KB);


### PR DESCRIPTION
### Notes
Remove Invoke() invocation that became useless in gtest 1.18.0


