### PR TITLE
[Filestore] fix responsing to GetForcedOperationStatus for a forced operation with invalid number of ranges

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -272,15 +272,15 @@ void TIndexTabletActor::EnqueueForcedRangeOperationIfNeeded(
     }
 
     auto pendingRequest = DequeueForcedRangeOperation();
-    if (pendingRequest.Ranges.empty()) {
+    if (!pendingRequest) {
         return;
     }
 
     auto request =
         std::make_unique<TEvIndexTabletPrivate::TEvForcedRangeOperationRequest>(
-            std::move(pendingRequest.Ranges),
-            pendingRequest.Mode,
-            std::move(pendingRequest.OperationId));
+            std::move(pendingRequest->Ranges),
+            pendingRequest->Mode,
+            std::move(pendingRequest->OperationId));
     ctx.Send(ctx.SelfID, request.release());
 }
 
@@ -295,9 +295,13 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         LogTag.c_str(),
         msg->Ranges.size());
 
-    auto replyError = [&] (
-        const NProto::TError& error)
+    auto replyError = [&](const NProto::TError& error)
     {
+        AbortForcedRangeOperation(
+            msg->Mode,
+            std::move(msg->Ranges),
+            std::move(msg->OperationId));
+
         if (ev->Sender == ctx.SelfID) {
             return;
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1565,9 +1565,14 @@ public:
     TString EnqueueForcedRangeOperation(
         TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
         TVector<ui32> ranges);
-    TPendingForcedRangeOperation DequeueForcedRangeOperation();
+    TMaybe<TPendingForcedRangeOperation> DequeueForcedRangeOperation();
 
     void StartForcedRangeOperation(
+        TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
+        TVector<ui32> ranges,
+        TString operationId);
+
+    void AbortForcedRangeOperation(
         TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
         TVector<ui32> ranges,
         TString operationId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1461,7 +1461,7 @@ TString TIndexTabletState::EnqueueForcedRangeOperation(
     return operationId;
 }
 
-TIndexTabletState::TPendingForcedRangeOperation TIndexTabletState::
+TMaybe<TIndexTabletState::TPendingForcedRangeOperation> TIndexTabletState::
     DequeueForcedRangeOperation()
 {
     if (PendingForcedRangeOperations.empty()) {
@@ -1481,6 +1481,17 @@ void TIndexTabletState::StartForcedRangeOperation(
 {
     TABLET_VERIFY(!ForcedRangeOperationState.Defined());
     ForcedRangeOperationState.ConstructInPlace(
+        mode,
+        std::move(ranges),
+        std::move(operationId));
+}
+
+void TIndexTabletState::AbortForcedRangeOperation(
+    TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
+    TVector<ui32> ranges,
+    TString operationId)
+{
+    CompletedForcedRangeOperations.emplace_back(
         mode,
         std::move(ranges),
         std::move(operationId));

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -3933,6 +3933,38 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
     }
 
+    TABLET_TEST(ShouldRespondToForcedRangeOperationWithEmptyRanges)
+    {
+        TTestEnv env(testEnvConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto response = tablet.ForcedOperation(
+            NProtoPrivate::TForcedOperationRequest::E_COMPACTION);
+        UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetRangeCount());
+
+        const auto& operationId = response->Record.GetOperationId();
+        UNIT_ASSERT(!operationId.empty());
+
+        auto request =
+            std::make_unique<TEvIndexTablet::TEvForcedOperationStatusRequest>();
+        request->Record.SetOperationId(operationId);
+        tablet.SendRequest(std::move(request));
+
+        auto status = tablet.RecvForcedOperationStatusResponse();
+        UNIT_ASSERT_C(SUCCEEDED(status->GetStatus()), status->GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(0, status->Record.GetRangeCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, status->Record.GetProcessedRangeCount());
+    }
+
     TABLET_TEST(ShouldRetryForcedCompaction)
     {
         TTestEnv env(testEnvConfig);


### PR DESCRIPTION
### Notes
Before this change a forced operation with empty evaluated ranges would allocate an operationId and return a success response. However, during queue handling requests with empty responses are filtered out and silently dropped, so the client has no chance of getting status of this operation. 

### Issue
#4115 
