### PR TITLE
[NBS] Local NVMe service: reconcile NVMe device states

### DIFF
--- a/cloud/blockstore/libs/local_nvme/protos/local_nvme.proto
+++ b/cloud/blockstore/libs/local_nvme/protos/local_nvme.proto
@@ -6,6 +6,18 @@ option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/libs/local_nvm
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum ENVMeDeviceState
+{
+    // The device is operational and available for use.
+    NVME_DEVICE_STATE_ONLINE = 0;
+
+    // The device is marked for maintenance.
+    NVME_DEVICE_STATE_MAINTENANCE = 1;
+
+    // The device has failed or is unreachable.
+    NVME_DEVICE_STATE_OFFLINE = 2;
+}
+
 message TNVMeDevice
 {
     // Serial number.
@@ -34,6 +46,9 @@ message TNVMeDevice
 
     // Firmware revision of NVMe.
     string FirmwareRev = 9;
+
+    // NVMe device state.
+    ENVMeDeviceState DeviceState = 10;
 }
 
 // List of NVMe devices.

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -255,6 +255,7 @@ private:
     auto RefreshDevice(const TSerialNumber& serialNumber)
         -> TResultOrError<NProto::TNVMeDevice>;
     auto UpdateDevices() -> NProto::TError;
+    void ReconcileDevices(TVector<NProto::TNVMeDevice> fetchedDevices);
     bool TryRestoreStateFromCache();
     void UpdateStateCache();
     auto CreateStateSnapshot() const -> NProto::TLocalNVMeServiceState;
@@ -316,7 +317,7 @@ TLocalNVMeService::TLocalNVMeService(
 
 void TLocalNVMeService::InitDevices()
 {
-    // Save the InitDevices continuation so Stop() can interrupt it.
+    // Allow Stop() to interrupt initialization and subsequent polling.
     InitDevicesCont = RunningCont();
     Y_DEBUG_ABORT_UNLESS(InitDevicesCont);
 
@@ -331,16 +332,19 @@ void TLocalNVMeService::InitDevices()
         return;
     }
 
-    // Initialization is complete; publish the Running state.
-    EServiceState state = EServiceState::Initializing;
-    if (!ServiceState.compare_exchange_strong(state, EServiceState::Running)) {
-        Y_DEBUG_ABORT_UNLESS(state == EServiceState::Stopped);
+    // Initialization is complete; Transition to Running unless Stop() completed
+    // concurrently.
+    EServiceState expectedState = EServiceState::Initializing;
+    if (!ServiceState.compare_exchange_strong(
+            expectedState,
+            EServiceState::Running))
+    {
+        Y_DEBUG_ABORT_UNLESS(expectedState == EServiceState::Stopped);
         return;
     }
 
-    // The service is already running, but devices may appear later. Keep
-    // polling the provider until at least one device becomes available.
-    while (Devices.empty()) {
+    // Refresh the device list periodically until Stop() interrupts the sleep.
+    for (;;) {
         if (!SleepCont(Config->GetUpdateDevicesInterval())) {
             return;
         }
@@ -362,6 +366,30 @@ void TLocalNVMeService::UpdateCounters()
         auto revisionCounter = fwGroup->GetCounter("revision", false);
         *revisionCounter = 1;
     }
+
+    ui32 onlineDevices = 0;
+    ui32 offlineDevices = 0;
+    ui32 maintenanceDevices = 0;
+
+    for (auto& [_, device]: Devices) {
+        switch (device.GetDeviceState()) {
+            case NProto::NVME_DEVICE_STATE_ONLINE:
+                ++onlineDevices;
+                break;
+            case NProto::NVME_DEVICE_STATE_MAINTENANCE:
+                ++maintenanceDevices;
+                break;
+            case NProto::NVME_DEVICE_STATE_OFFLINE:
+                ++offlineDevices;
+                break;
+            default:
+                break;
+        }
+    }
+
+    Counters->GetCounter("DevicesInOnlineState")->Set(onlineDevices);
+    Counters->GetCounter("DevicesInOfflineState")->Set(offlineDevices);
+    Counters->GetCounter("DevicesInMaintenanceState")->Set(maintenanceDevices);
 }
 
 void TLocalNVMeService::UpdateCountersLoop()
@@ -594,17 +622,67 @@ auto TLocalNVMeService::EnsureIsReady(
     return service;
 }
 
+void TLocalNVMeService::ReconcileDevices(
+    TVector<NProto::TNVMeDevice> fetchedDevices)
+{
+    SortBy(fetchedDevices, std::mem_fn(&NProto::TNVMeDevice::GetSerialNumber));
+
+    // Add newly discovered devices and refresh the state of known ones.
+    for (const auto& fetchedDevice: fetchedDevices) {
+        auto [it, inserted] =
+            Devices.try_emplace(fetchedDevice.GetSerialNumber(), fetchedDevice);
+
+        auto& device = it->second;
+
+        if (inserted) {
+            STORAGE_INFO(
+                "Discovered NVMe device "
+                << device.GetSerialNumber().Quote() << ", state: "
+                << NProto::ENVMeDeviceState_Name(device.GetDeviceState()));
+        } else {
+            const auto oldState = device.GetDeviceState();
+            const auto newState = fetchedDevice.GetDeviceState();
+
+            if (oldState != newState) {
+                STORAGE_INFO(
+                    "NVMe device "
+                    << device.GetSerialNumber().Quote() << " changed state: "
+                    << NProto::ENVMeDeviceState_Name(oldState) << " -> "
+                    << NProto::ENVMeDeviceState_Name(newState));
+            }
+
+            device.SetDeviceState(newState);
+        }
+    }
+
+    // Keep missing devices in the registry, but mark them as offline.
+    for (auto& [sn, device]: Devices) {
+        const bool found = std::ranges::binary_search(
+            fetchedDevices,
+            sn,
+            std::ranges::less{},
+            &NProto::TNVMeDevice::GetSerialNumber);
+
+        if (!found &&
+            device.GetDeviceState() != NProto::NVME_DEVICE_STATE_OFFLINE)
+        {
+            STORAGE_WARN(
+                "NVMe device " << sn.Quote()
+                               << " is no longer reported; marking it offline");
+
+            device.SetDeviceState(NProto::NVME_DEVICE_STATE_OFFLINE);
+        }
+    }
+}
+
 auto TLocalNVMeService::UpdateDevices() -> NProto::TError
 {
-    auto [devices, error] = FetchDevices();
+    auto [fetchedDevices, error] = FetchDevices();
     if (HasError(error)) {
         return error;
     }
 
-    Devices.clear();
-    for (auto& d: devices) {
-        Devices[d.GetSerialNumber()] = std::move(d);
-    }
+    ReconcileDevices(std::move(fetchedDevices));
 
     UpdateStateCache();
 
@@ -703,6 +781,8 @@ auto TLocalNVMeService::FetchDevices() const
                 << ": " << src << ": " << FormatError(error));
             continue;
         }
+
+        device.SetDeviceState(src.GetDeviceState());
 
         result.push_back(std::move(device));
     }

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -372,6 +372,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
                 DeviceId: 0x400
                 Model: "Test NVMe 2"
                 FirmwareRev: "FW4243"
+                DeviceState: NVME_DEVICE_STATE_MAINTENANCE
             }
             Devices {
                 SerialNumber: "NVME_2"
@@ -506,6 +507,8 @@ struct TFixture: public TFixtureBase
 
             // chop "0000:"
             device.SetPCIAddress(src.GetPCIAddress().substr(5));
+
+            device.SetDeviceState(src.GetDeviceState());
         }
 
         // Add some noise
@@ -523,7 +526,7 @@ struct TFixture: public TFixtureBase
         return devices;
     }
 
-    void SetProviderReady()
+    void SetProviderReady() const
     {
         DeviceProvider->ListNVMeDevicesImpl.SetValue(
             [&] { return MakeFuture(CreateDeviceList()); });
@@ -1701,6 +1704,16 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         auto counters = rootGroup->FindSubgroup("component", "local_nvme");
         UNIT_ASSERT(counters);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            counters->GetCounter("DevicesInOnlineState")->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            counters->GetCounter("DevicesInOfflineState")->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter("DevicesInMaintenanceState")->Val());
 
         for (const auto& d: Devices) {
             auto deviceGroup =

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -1960,6 +1960,180 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         }
     }
 
+    Y_UNIT_TEST_F(ShouldReconcileDevices, TFixture)
+    {
+        TVector<NProto::TNVMeDevice> providedDeviceList;
+        std::mutex mutex;
+        std::condition_variable deviceListFetched;
+        ui32 publishedVersion = 0;
+        ui32 fetchedVersion = 0;
+
+        auto publishDeviceList = [&](const auto& devices)
+        {
+            std::unique_lock lock{mutex};
+
+            providedDeviceList = devices;
+            ++publishedVersion;
+
+            // Do not continue until the service has fetched this exact
+            // version.
+            deviceListFetched.wait(
+                lock,
+                [&] { return fetchedVersion == publishedVersion; });
+        };
+
+        DeviceProvider->ListNVMeDevicesImpl.SetValue(
+            [&]
+            {
+                TVector<NProto::TNVMeDevice> devices;
+                {
+                    std::unique_lock lock{mutex};
+                    devices = providedDeviceList;
+                    fetchedVersion = publishedVersion;
+                }
+
+                deviceListFetched.notify_one();
+                return MakeFuture(std::move(devices));
+            });
+
+        struct TTestCase
+        {
+            TStringBuf Name;
+            TVector<NProto::TNVMeDevice> ProvidedList;
+            TVector<NProto::TNVMeDevice> ExpectedList;
+        };
+
+        auto online = [](auto device)
+        {
+            device.SetDeviceState(NProto::NVME_DEVICE_STATE_ONLINE);
+            return device;
+        };
+
+        auto maintenance = [](auto device)
+        {
+            device.SetDeviceState(NProto::NVME_DEVICE_STATE_MAINTENANCE);
+            return device;
+        };
+
+        auto offline = [](auto device)
+        {
+            device.SetDeviceState(NProto::NVME_DEVICE_STATE_OFFLINE);
+            return device;
+        };
+
+        const TTestCase testCases[]{
+            {
+                .Name = "empty device list",
+                .ProvidedList = {},
+                .ExpectedList = {},
+            },
+            // NVME_0: online
+            {
+                .Name = "discover online device",
+                .ProvidedList = {online(Devices[0])},
+                .ExpectedList = {online(Devices[0])},
+            },
+            // NVME_0: online
+            // NVME_1: new, maintenance
+            // NVME_2: new, online
+            {
+                .Name = "discover online and maintenance devices",
+                .ProvidedList =
+                    {
+                        online(Devices[0]),
+                        maintenance(Devices[1]),
+                        online(Devices[2]),
+                    },
+                .ExpectedList =
+                    {
+                        online(Devices[0]),
+                        maintenance(Devices[1]),
+                        online(Devices[2]),
+                    },
+            },
+            // NVME_0: online
+            // NVME_1: lost, maintenance -> offline
+            // NVME_2: online -> maintenance
+            {
+                .Name = "mark missing device offline and update device state",
+                .ProvidedList =
+                    {
+                        online(Devices[0]),
+                        maintenance(Devices[2]),
+                    },
+                .ExpectedList =
+                    {
+                        online(Devices[0]),
+                        offline(Devices[1]),
+                        maintenance(Devices[2]),
+                    },
+            },
+            // NVME_0: online
+            // NVME_1: offline -> online
+            // NVME_2: maintenance -> offline
+            // NVME_3: new, online
+            {
+                .Name = "restore offline device, mark missing device offline, "
+                        "and discover new device",
+                .ProvidedList =
+                    {
+                        online(Devices[0]),
+                        online(Devices[1]),
+                        online(Devices[3]),
+                    },
+                .ExpectedList =
+                    {
+                        online(Devices[0]),
+                        online(Devices[1]),
+                        offline(Devices[2]),
+                        online(Devices[3]),
+                    },
+            },
+            // NVME_0: online -> offline
+            // NVME_1: online -> offline
+            // NVME_2: offline
+            // NVME_3: online -> offline
+            {
+                .Name = "mark all missing devices offline",
+                .ProvidedList = {},
+                .ExpectedList =
+                    {
+                        offline(Devices[0]),
+                        offline(Devices[1]),
+                        offline(Devices[2]),
+                        offline(Devices[3]),
+                    },
+            },
+        };
+
+        for (ui32 i = 0; i != std::size(testCases); ++i) {
+            const auto& t = testCases[i];
+
+            publishDeviceList(t.ProvidedList);
+
+            const auto [devices, error] = ListNVMeDevices();
+            const auto caseInfo = TStringBuilder()
+                                  << "Case #" << i << " (" << t.Name << ")";
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                caseInfo << ": " << FormatError(error));
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                t.ExpectedList.size(),
+                devices.size(),
+                caseInfo);
+
+            for (size_t j = 0; j != devices.size(); ++j) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    t.ExpectedList[j].DebugString(),
+                    devices[j].DebugString(),
+                    caseInfo << ", device #" << j);
+            }
+        }
+    }
+
     Y_UNIT_TEST_F(ShouldGetDevicesFromInfra, TFixtureInfra)
     {
         auto [devices, error] = ListNVMeDevices();

--- a/cloud/blockstore/libs/local_nvme/test_grpc_device_provider.cpp
+++ b/cloud/blockstore/libs/local_nvme/test_grpc_device_provider.cpp
@@ -32,6 +32,20 @@ struct TTestServiceTrait
     }
 };
 
+auto GetDeviceState(const NTest::NProto::EDeviceState state)
+{
+    switch (state) {
+        case NTest::NProto::DEVICE_STATE_ACTIVE:
+            return NProto::NVME_DEVICE_STATE_ONLINE;
+        case NTest::NProto::DEVICE_STATE_INACTIVE:
+            return NProto::NVME_DEVICE_STATE_OFFLINE;
+        case NTest::NProto::DEVICE_STATE_DECOMMISSIONED:
+            return NProto::NVME_DEVICE_STATE_MAINTENANCE;
+        default:
+            return NProto::NVME_DEVICE_STATE_OFFLINE;
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TTestGrpcDeviceProvider: ILocalNVMeDeviceProvider
@@ -77,6 +91,7 @@ struct TTestGrpcDeviceProvider: ILocalNVMeDeviceProvider
                         auto& dst = devices.emplace_back();
                         dst.SetPCIAddress(src.GetPCIeAddress());
                         dst.SetSerialNumber(src.GetSerialNumber());
+                        dst.SetDeviceState(GetDeviceState(src.GetState()));
                     }
 
                     return devices;

--- a/cloud/blockstore/libs/local_nvme/ut_infra/devices.yaml
+++ b/cloud/blockstore/libs/local_nvme/ut_infra/devices.yaml
@@ -4,6 +4,7 @@ devices:
     owner: nbs
   - pci: 0000:31:00.0
     serial: NVME_1
+    state: decommissioned
     owner: nbs
   - pci: 0000:33:00.0
     serial: NVME_2

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_monitoring.cpp
@@ -116,6 +116,8 @@ void TDiskAgentActor::RenderNVMeDevices(IOutputStream& out) const
                     TABLEH() { out << "IOMMU group"; }
                     TABLEH() { out << "VFIO device"; }
                     TABLEH() { out << "NUMA node"; }
+                    TABLEH() { out << "F/W Rev"; }
+                    TABLEH() { out << "State"; }
                 }
 
                 for (const auto& d: devices) {
@@ -130,17 +132,30 @@ void TDiskAgentActor::RenderNVMeDevices(IOutputStream& out) const
                         TABLED () {
                             if (d.HasIOMMUGroup()) {
                                 out << d.GetIOMMUGroup();
+                            } else {
+                                out << "N/A";
                             }
                         }
                         TABLED () {
                             if (d.HasVfioDevName()) {
                                 out << d.GetVfioDevName();
+                            } else {
+                                out << "N/A";
                             }
                         }
                         TABLED () {
                             if (d.HasNumaNode()) {
                                 out << d.GetNumaNode();
+                            } else {
+                                out << "N/A";
                             }
+                        }
+                        TABLED () {
+                            out << d.GetFirmwareRev();
+                        }
+                        TABLED () {
+                            out << NProto::ENVMeDeviceState_Name(
+                                d.GetDeviceState());
                         }
                     }
                 }

--- a/cloud/blockstore/tools/testing/infra-device-provider/protos/infra.proto
+++ b/cloud/blockstore/tools/testing/infra-device-provider/protos/infra.proto
@@ -13,10 +13,17 @@ service TInfraService
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum EDeviceState {
+    DEVICE_STATE_ACTIVE = 0;
+    DEVICE_STATE_INACTIVE = 1;
+    DEVICE_STATE_DECOMMISSIONED = 2;
+}
+
 message TDevice
 {
     string PCIeAddress = 1;
     string SerialNumber = 2;
+    EDeviceState State = 3;
 }
 
 message TListDevicesRequest

--- a/cloud/blockstore/tools/testing/infra-device-provider/server/main.go
+++ b/cloud/blockstore/tools/testing/infra-device-provider/server/main.go
@@ -18,10 +18,42 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
+type deviceState int32
+
+const (
+	DeviceStateActive         deviceState = deviceState(pb.EDeviceState_DEVICE_STATE_ACTIVE)
+	DeviceStateInactive       deviceState = deviceState(pb.EDeviceState_DEVICE_STATE_INACTIVE)
+	DeviceStateDecommissioned deviceState = deviceState(pb.EDeviceState_DEVICE_STATE_DECOMMISSIONED)
+)
+
+func (s *deviceState) UnmarshalYAML(node *yaml.Node) error {
+	var value string
+	if err := node.Decode(&value); err != nil {
+		return err
+	}
+
+	switch value {
+	case "active":
+		*s = DeviceStateActive
+	case "decommissioned":
+		*s = DeviceStateDecommissioned
+	case "inactive":
+		*s = DeviceStateInactive
+	default:
+		return fmt.Errorf(
+			"unknown device state %q: expected active, inactive or decommissioned",
+			value,
+		)
+	}
+
+	return nil
+}
+
 type device struct {
-	PCIeAddress  string `yaml:"pci"`
-	SerialNumber string `yaml:"serial"`
-	OwnerId      string `yaml:"owner"`
+	PCIeAddress  string      `yaml:"pci"`
+	SerialNumber string      `yaml:"serial"`
+	OwnerId      string      `yaml:"owner"`
+	State        deviceState `yaml:"state"`
 }
 
 type config struct {
@@ -73,6 +105,7 @@ func loadDevices(path string) (map[string][]*pb.TDevice, error) {
 		devices[d.OwnerId] = append(devices[d.OwnerId], &pb.TDevice{
 			PCIeAddress:  d.PCIeAddress,
 			SerialNumber: d.SerialNumber,
+			State:        pb.EDeviceState(d.State),
 		})
 	}
 	return devices, nil


### PR DESCRIPTION
Add runtime state tracking for local NVMe devices.

* Continuously poll the device provider and reconcile device states.
* Mark missing devices as `OFFLINE`.
* Track `ONLINE`, `MAINTENANCE`, and `OFFLINE` device counts.
* Display device state and firmware revision on the Disk Agent monitoring page.
* Extend the test provider and unit tests to cover state transitions.
