### PR TITLE
[Filestore] add critical event BadDirectoryHandle

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -46,6 +46,7 @@ namespace NCloud::NFileStore{
     xxx(WriteBackCacheWritingNotAllowedInDrainingMode)                         \
     xxx(ErrorWasSentToTheGuest)                                                \
     xxx(DirectoryHandleStorageError)                                           \
+    xxx(BadDirectoryHandle)                                                    \
     xxx(CalculateChecksumsBufferOverflow)                                      \
     xxx(UnexpectedFakeDescribeDataResponse)                                    \
     xxx(CreateLinkRequestWithShardNodeNameAndNoShardId)                        \

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_cache.cpp
@@ -48,6 +48,11 @@ TDirectoryHandleCache::TDirectoryHandleCache(
     IncreaseStats(SumDirectoryHandlesStats(Handles), Handles.size());
 }
 
+bool TDirectoryHandleCache::IsPersistent() const
+{
+    return Storage != nullptr;
+}
+
 ui64 TDirectoryHandleCache::CreateHandle(fuse_ino_t ino)
 {
     ui64 handleId = 0;

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_cache.h
@@ -35,6 +35,8 @@ public:
         TDirectoryHandleStoragePtr storage,
         TDirectoryEntryVersionCachePtr directoryEntryVersionCache);
 
+    bool IsPersistent() const;
+
     ui64 CreateHandle(fuse_ino_t ino);
 
     std::shared_ptr<TDirectoryHandle> FindHandle(ui64 handleId);

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.h
@@ -425,7 +425,7 @@ private:
         fuse_req_t req,
         fuse_ino_t ino);
 
-    bool ValidateDirectoryHandle(
+    std::shared_ptr<TDirectoryHandle> ValidateAndGetDirectoryHandle(
         TCallContext& callContext,
         fuse_req_t req,
         fuse_ino_t ino,

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -1139,7 +1139,7 @@ void TFileSystem::FSyncDir(
         return;
     }
 
-    if (!ValidateDirectoryHandle(*callContext, req, ino, fi->fh)) {
+    if (!ValidateAndGetDirectoryHandle(*callContext, req, ino, fi->fh)) {
         return;
     }
 

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
@@ -3,6 +3,8 @@
 #include "fs_directory_content_format.h"
 #include "fs_directory_handle.h"
 
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
+
 #include <util/generic/cast.h>
 
 #include <sys/stat.h>
@@ -10,30 +12,6 @@
 namespace NCloud::NFileStore::NFuse {
 
 using namespace NCloud::NFileStore::NVFS;
-
-namespace {
-
-////////////////////////////////////////////////////////////////////////////////
-
-bool CheckDirectoryHandle(
-    fuse_req_t req,
-    fuse_ino_t ino,
-    const TDirectoryHandle& handle,
-    TLog& Log,
-    const char* funcName)
-{
-    if (handle.Index != ino) {
-        STORAGE_ERROR("request #" << fuse_req_unique(req)
-            << " consistency violation: " << funcName
-            << " (handle.Index != ino) : "  <<
-            "(" << handle.Index << " != " << ino << ")");
-
-        return false;
-    }
-    return true;
-}
-
-} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -79,14 +57,9 @@ void TFileSystem::ReadDir(
         << " size:" << size
         << " fh:" << fi->fh);
 
-    auto handle = DirectoryHandleCache->FindHandle(fi->fh);
+    auto handle =
+        ValidateAndGetDirectoryHandle(*callContext, req, ino, fi->fh);
     if (!handle) {
-        ReplyError(*callContext, ErrorInvalidHandle(fi->fh), req, EBADF);
-        return;
-    }
-
-    if (!CheckDirectoryHandle(req, ino, *handle, Log, __func__)) {
-        ReplyError(*callContext, ErrorInvalidHandle(fi->fh), req, EBADF);
         return;
     }
 
@@ -278,24 +251,39 @@ void TFileSystem::ReleaseDir(
     ReplyError(*callContext, {}, req, 0);
 }
 
-bool TFileSystem::ValidateDirectoryHandle(
+std::shared_ptr<TDirectoryHandle> TFileSystem::ValidateAndGetDirectoryHandle(
     TCallContext& callContext,
     fuse_req_t req,
     fuse_ino_t ino,
     uint64_t fh)
 {
+    auto replyBadHandle = [&]()
+    {
+        if (DirectoryHandleCache->IsPersistent()) {
+            ReportBadDirectoryHandle(
+                TStringBuilder() << callContext.LogString()
+                                 << " EBADF was sent to the guest, fh: " << fh
+                                 << " ino: " << ino);
+        }
+        ReplyError(callContext, ErrorInvalidHandle(fh), req, EBADF);
+    };
+
     auto handle = DirectoryHandleCache->FindHandle(fh);
     if (!handle) {
-        ReplyError(callContext, ErrorInvalidHandle(fh), req, EBADF);
-        return false;
+        replyBadHandle();
+        return nullptr;
     }
 
-    if (!CheckDirectoryHandle(req, ino, *handle, Log, __func__)) {
-        ReplyError(callContext, ErrorInvalidHandle(fh), req, EBADF);
-        return false;
+    if (handle->Index != ino) {
+        STORAGE_ERROR(
+            callContext.LogString()
+            << " consistency violation: (handle.Index != ino) : ("
+            << handle->Index << " != " << ino << ")");
+        replyBadHandle();
+        return nullptr;
     }
 
-    return true;
+    return handle;
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -1027,22 +1027,82 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT_NO_EXCEPTION(close.GetValue(WaitTimeout));
     }
 
-    Y_UNIT_TEST(ShouldHandleReadDirInvalidHandles)
+    void DoShouldHandleReadDirInvalidHandles(
+        TBootstrap& bootstrap,
+        ui64 expectedBadDirectoryHandleEvents)
     {
-        TBootstrap bootstrap;
+        bootstrap.Service->ListNodesHandler = [&](auto, auto)
+        {
+            return MakeFuture(NProto::TListNodesResponse());
+        };
+
         bootstrap.Start();
         Y_DEFER {
             bootstrap.Stop();
         };
 
+        auto badHandleCounter =
+            bootstrap.Counters
+                ->GetSubgroup("component", TString{MetricsComponent})
+                ->GetCounter("AppCriticalEvents/BadDirectoryHandle", true);
+
         const ui64 nodeId = 123;
+        const ui64 unknownHandleId = 100500;
 
-        auto read = bootstrap.Fuse->SendRequest<TReadDirRequest>(nodeId, 100500);
-        UNIT_ASSERT(read.Wait(WaitTimeout));
-        UNIT_ASSERT(read.HasException());
+        auto read = bootstrap.Fuse->SendRequest<TReadDirRequest>(
+            nodeId,
+            unknownHandleId);
+        UNIT_ASSERT_EXCEPTION(read.GetValue(WaitTimeout), yexception);
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedBadDirectoryHandleEvents,
+            badHandleCounter->Val());
 
-        auto close = bootstrap.Fuse->SendRequest<TReleaseDirRequest>(nodeId, 100500);
+        auto fsyncdir = bootstrap.Fuse->SendRequest<TFsyncDirRequest>(
+            nodeId,
+            unknownHandleId,
+            false /* no data sync */);
+        UNIT_ASSERT_EXCEPTION(fsyncdir.GetValue(WaitTimeout), yexception);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2 * expectedBadDirectoryHandleEvents,
+            badHandleCounter->Val());
+
+        auto handle = bootstrap.Fuse->SendRequest<TOpenDirRequest>(nodeId);
+        UNIT_ASSERT(handle.Wait(WaitTimeout));
+        const auto handleId = handle.GetValue();
+
+        read = bootstrap.Fuse->SendRequest<TReadDirRequest>(nodeId, handleId);
+        UNIT_ASSERT_NO_EXCEPTION(read.GetValue(WaitTimeout));
+        UNIT_ASSERT_VALUES_EQUAL(
+            2 * expectedBadDirectoryHandleEvents,
+            badHandleCounter->Val());
+
+        auto close =
+            bootstrap.Fuse->SendRequest<TReleaseDirRequest>(nodeId, handleId);
         UNIT_ASSERT_NO_EXCEPTION(close.GetValue(WaitTimeout));
+
+        close = bootstrap.Fuse->SendRequest<TReleaseDirRequest>(
+            nodeId,
+            unknownHandleId);
+        UNIT_ASSERT_NO_EXCEPTION(close.GetValue(WaitTimeout));
+        UNIT_ASSERT_VALUES_EQUAL(
+            2 * expectedBadDirectoryHandleEvents,
+            badHandleCounter->Val());
+    }
+
+    Y_UNIT_TEST(ShouldHandleReadDirInvalidHandles)
+    {
+        TBootstrap bootstrap;
+        DoShouldHandleReadDirInvalidHandles(
+            bootstrap,
+            0 /* expectedBadDirectoryHandleEvents */);
+    }
+
+    Y_UNIT_TEST(ShouldReportBadDirectoryHandleWhenHandleStorageIsEnabled)
+    {
+        auto bootstrap = TBootstrap::CreateWithHandleStorage();
+        DoShouldHandleReadDirInvalidHandles(
+            bootstrap,
+            1 /* expectedBadDirectoryHandleEvents */);
     }
 
     Y_UNIT_TEST(ShouldHandleReadDirPaging)


### PR DESCRIPTION
### Notes
Added critical even BadHandle for directory ops, that can happen due to the lost handle on vhost side. It triggers only if DirecotryHandleCache is enabled
Added ai-assisted ut for cases that viable under linux checks

### Issue
#7021
