### PR TITLE
[Filestore] add status field to TForcedOperationStatusResponse

### DIFF
--- a/cloud/filestore/apps/client/lib/forced_compaction.cpp
+++ b/cloud/filestore/apps/client/lib/forced_compaction.cpp
@@ -102,9 +102,25 @@ public:
 
             CheckResponse(statusResponse);
 
-            const auto processed = statusResponse.GetProcessedRangeCount();
-            const auto total = statusResponse.GetRangeCount();
-            if (processed >= total) {
+            using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
+            const auto status = statusResponse.GetStatus();
+            if (status == TStatus::E_PENDING) {
+                Cerr << "pending" << Endl;
+                Sleep(TDuration::Seconds(1));
+                continue;
+            }
+
+            if (status == TStatus::E_FAILED) {
+                STORAGE_THROW_SERVICE_ERROR(
+                    MakeError(E_FAIL, "forced compaction failed"));
+            }
+
+            // Older tablets do not populate Status.
+            const bool completedWithoutStatus =
+                status == TStatus::E_UNKNOWN &&
+                statusResponse.GetProcessedRangeCount() >=
+                    statusResponse.GetRangeCount();
+            if (status == TStatus::E_COMPLETED || completedWithoutStatus) {
                 // operation completed
                 Cout << "finished" << Endl;
                 break;

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -1352,6 +1352,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
 
     Y_UNIT_TEST(ShouldRunForcedOperation)
     {
+        using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
+
         NProto::TStorageConfig config;
         config.SetCompactionThreshold(1000);
         TTestEnv env({}, config);
@@ -1437,6 +1439,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 1177944066,
                 response.GetLastProcessedRangeId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(TStatus::E_RUNNING),
+                static_cast<int>(response.GetStatus()));
         }
 
         UNIT_ASSERT(completion);
@@ -1469,6 +1474,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
                 jsonResponse->Record.GetOutput(), &response).ok());
             UNIT_ASSERT_VALUES_EQUAL(4, response.GetRangeCount());
             UNIT_ASSERT_VALUES_EQUAL(4, response.GetProcessedRangeCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(TStatus::E_COMPLETED),
+                static_cast<int>(response.GetStatus()));
         }
 
         env.GetRegistry()->Update(env.GetRuntime().GetCurrentTime());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1311,6 +1311,7 @@ void TIndexTabletActor::HandleForcedOperationStatus(
     const auto& request = ev->Get()->Record;
 
     using TResponse = TEvIndexTablet::TEvForcedOperationStatusResponse;
+    using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
     auto response = std::make_unique<TResponse>();
 
     const auto* state = FindForcedRangeOperation(request.GetOperationId());
@@ -1318,11 +1319,17 @@ void TIndexTabletActor::HandleForcedOperationStatus(
         response->Record.SetRangeCount(state->RangesToCompact.size());
         response->Record.SetProcessedRangeCount(state->Current);
         response->Record.SetLastProcessedRangeId(state->GetCurrentRange());
-    } else {
+        response->Record.SetStatus(state->Status);
+        response->Record.MutableError()->CopyFrom(state->Error);
+    } else if (IsForcedRangeOperationPending(request.GetOperationId())) {
+        response->Record.SetStatus(TStatus::E_PENDING);
+    }
+    else {
+        response->Record.SetStatus(TStatus::E_UNKNOWN);
         response->Record.MutableError()->CopyFrom(MakeError(
             E_NOT_FOUND,
             TStringBuilder() << "forced operation with id "
-                << request.GetOperationId() << "not found"));
+                             << request.GetOperationId() << "not found"));
     }
 
     NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compactionforced.cpp
@@ -300,7 +300,8 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         AbortForcedRangeOperation(
             msg->Mode,
             std::move(msg->Ranges),
-            std::move(msg->OperationId));
+            std::move(msg->OperationId),
+            error);
 
         if (ev->Sender == ctx.SelfID) {
             return;
@@ -311,7 +312,12 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         NCloud::Reply(ctx, *ev, std::move(response));
     };
 
-    if (msg->Ranges.empty() || msg->Ranges.size() > Max<ui32>()) {
+    if (msg->Ranges.empty()) {
+        replyError(MakeError(S_OK));
+        return;
+    }
+
+    if (msg->Ranges.size() > Max<ui32>()) {
         replyError(ErrorInvalidArgument());
         return;
     }
@@ -322,9 +328,11 @@ void TIndexTabletActor::HandleForcedRangeOperation(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    // will lose original request info in case of enqueueing external request
     if (IsForcedRangeOperationRunning()) {
-        EnqueueForcedRangeOperation(msg->Mode, std::move(msg->Ranges));
+        EnqueueForcedRangeOperation(
+            msg->Mode,
+            std::move(msg->Ranges),
+            std::move(msg->OperationId));
         return;
     }
 
@@ -383,7 +391,7 @@ void TIndexTabletActor::HandleForcedRangeOperationCompleted(
     TABLET_VERIFY(IsForcedRangeOperationRunning());
     WorkerActors.erase(ev->Sender);
 
-    CompleteForcedRangeOperation();
+    CompleteForcedRangeOperation(msg->GetError());
     EnqueueForcedRangeOperationIfNeeded(ctx);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1525,6 +1525,9 @@ public:
 
         TInstant StartTime = TInstant::Now();
         ui32 Current = 0;
+        NProtoPrivate::TForcedOperationStatusResponse::EStatus Status =
+            NProtoPrivate::TForcedOperationStatusResponse::E_UNKNOWN;
+        NProto::TError Error;
 
         TForcedRangeOperationState(
                 TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
@@ -1564,7 +1567,8 @@ private:
 public:
     TString EnqueueForcedRangeOperation(
         TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
-        TVector<ui32> ranges);
+        TVector<ui32> ranges,
+        TString operationId = {});
     TMaybe<TPendingForcedRangeOperation> DequeueForcedRangeOperation();
 
     void StartForcedRangeOperation(
@@ -1575,9 +1579,10 @@ public:
     void AbortForcedRangeOperation(
         TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
         TVector<ui32> ranges,
-        TString operationId);
+        TString operationId,
+        const NProto::TError& error);
 
-    void CompleteForcedRangeOperation();
+    void CompleteForcedRangeOperation(const NProto::TError& error);
 
     const TForcedRangeOperationState* GetForcedRangeOperationState() const
     {
@@ -1597,6 +1602,8 @@ public:
     {
         return ForcedRangeOperationState.Defined();
     }
+
+    bool IsForcedRangeOperationPending(const TString& operationId) const;
 
     //
     // Truncate operations

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1451,9 +1451,12 @@ void TIndexTabletState::LoadCompactionMap(
 
 TString TIndexTabletState::EnqueueForcedRangeOperation(
     TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
-    TVector<ui32> ranges)
+    TVector<ui32> ranges,
+    TString operationId)
 {
-    auto operationId = CreateGuidAsString();
+    if (operationId.empty()) {
+        operationId = CreateGuidAsString();
+    }
     PendingForcedRangeOperations.emplace_back(
         mode,
         std::move(ranges),
@@ -1484,25 +1487,41 @@ void TIndexTabletState::StartForcedRangeOperation(
         mode,
         std::move(ranges),
         std::move(operationId));
+    ForcedRangeOperationState->Status =
+        NProtoPrivate::TForcedOperationStatusResponse::E_RUNNING;
 }
 
 void TIndexTabletState::AbortForcedRangeOperation(
     TEvIndexTabletPrivate::EForcedRangeOperationMode mode,
     TVector<ui32> ranges,
-    TString operationId)
+    TString operationId,
+    const NProto::TError& error)
 {
     CompletedForcedRangeOperations.emplace_back(
         mode,
         std::move(ranges),
         std::move(operationId));
+    CompletedForcedRangeOperations.back().Status =
+        HasError(error)
+            ? NProtoPrivate::TForcedOperationStatusResponse::E_FAILED
+            : NProtoPrivate::TForcedOperationStatusResponse::E_COMPLETED;
+    CompletedForcedRangeOperations.back().Error = error;
 }
 
-void TIndexTabletState::CompleteForcedRangeOperation()
+void TIndexTabletState::CompleteForcedRangeOperation(const NProto::TError& error)
 {
     Y_DEBUG_ABORT_UNLESS(ForcedRangeOperationState);
     if (ForcedRangeOperationState && ForcedRangeOperationState->OperationId) {
-        ForcedRangeOperationState->Current =
-            ForcedRangeOperationState->RangesToCompact.size();
+        ForcedRangeOperationState->Error = error;
+        if (HasError(error)) {
+            ForcedRangeOperationState->Status =
+                NProtoPrivate::TForcedOperationStatusResponse::E_FAILED;
+        } else {
+            ForcedRangeOperationState->Status =
+                NProtoPrivate::TForcedOperationStatusResponse::E_COMPLETED;
+            ForcedRangeOperationState->Current =
+                ForcedRangeOperationState->RangesToCompact.size();
+        }
         CompletedForcedRangeOperations.push_back(*ForcedRangeOperationState);
     }
     ForcedRangeOperationState.Clear();
@@ -1524,6 +1543,17 @@ auto TIndexTabletState::FindForcedRangeOperation(
     }
 
     return nullptr;
+}
+
+bool TIndexTabletState::IsForcedRangeOperationPending(
+    const TString& operationId) const
+{
+    for (auto const& op: PendingForcedRangeOperations) {
+        if (op.OperationId == operationId) {
+            return true;
+        }
+    }
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -3928,9 +3928,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL(ranges.front(), 0);
         UNIT_ASSERT_VALUES_EQUAL(ranges.back(), 9);
 
-        tablet.AssertForcedRangeOperationFailed(
+        tablet.ForcedRangeOperation(
             TVector<ui32>{},
             TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
+        UNIT_ASSERT_VALUES_EQUAL(ranges.size(), 10);
     }
 
     TABLET_TEST(ShouldRespondToForcedRangeOperationWithEmptyRanges)
@@ -3960,9 +3961,75 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         tablet.SendRequest(std::move(request));
 
         auto status = tablet.RecvForcedOperationStatusResponse();
-        UNIT_ASSERT_C(SUCCEEDED(status->GetStatus()), status->GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, status->GetStatus());
         UNIT_ASSERT_VALUES_EQUAL(0, status->Record.GetRangeCount());
         UNIT_ASSERT_VALUES_EQUAL(0, status->Record.GetProcessedRangeCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(
+                NProtoPrivate::TForcedOperationStatusResponse::E_COMPLETED),
+            static_cast<int>(status->Record.GetStatus()));
+    }
+
+    TABLET_TEST(ShouldReturnForcedOperationCompletionError)
+    {
+        TTestEnv env(testEnvConfig);
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        const auto error = MakeError(E_FAIL, "forced compaction failed");
+        env.GetRuntime().SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvIndexTabletPrivate::EvCompactionRequest)
+                {
+                    const auto* msg = event->Get<
+                        TEvIndexTabletPrivate::TEvCompactionRequest>();
+                    auto response = std::make_unique<
+                        TEvIndexTabletPrivate::TEvCompactionResponse>(
+                        msg->RangeId == 0 ? NProto::TError{} : error);
+                    env.GetRuntime().Send(
+                        new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0, // flags
+                            event->Cookie),
+                        nodeIdx);
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto request = tablet.CreateForcedRangeOperationRequest(
+            TVector<ui32>{0, 1, 2},
+            TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
+        const auto operationId = request->OperationId;
+        tablet.SendRequest(std::move(request));
+        auto response = tablet.RecvForcedRangeOperationResponse();
+        UNIT_ASSERT_VALUES_EQUAL(error.GetCode(), response->GetStatus());
+
+        auto statusRequest =
+            std::make_unique<TEvIndexTablet::TEvForcedOperationStatusRequest>();
+        statusRequest->Record.SetOperationId(operationId);
+        tablet.SendRequest(std::move(statusRequest));
+        auto status = tablet.RecvForcedOperationStatusResponse();
+        UNIT_ASSERT_VALUES_EQUAL(error.GetCode(), status->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            error.GetMessage(),
+            status->Record.GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(
+                NProtoPrivate::TForcedOperationStatusResponse::E_FAILED),
+            static_cast<int>(status->Record.GetStatus()));
+        UNIT_ASSERT_VALUES_EQUAL(3, status->Record.GetRangeCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, status->Record.GetProcessedRangeCount());
     }
 
     TABLET_TEST(ShouldRetryForcedCompaction)
@@ -4021,6 +4088,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldEnqueuePendingForcedCompaction)
     {
+        using TStatus = NProtoPrivate::TForcedOperationStatusResponse;
+
         TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -4054,19 +4123,56 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             }
         );
 
-        tablet.SendForcedRangeOperationRequest(
+        auto runningRequest = tablet.CreateForcedRangeOperationRequest(
             ::xrange(0, 1, 1),
             TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
+        const auto runningOperationId = runningRequest->OperationId;
+        tablet.SendRequest(std::move(runningRequest));
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
         UNIT_ASSERT(request);
 
-        tablet.SendForcedRangeOperationRequest(
+        auto runningStatusRequest =
+            std::make_unique<TEvIndexTablet::TEvForcedOperationStatusRequest>();
+        runningStatusRequest->Record.SetOperationId(runningOperationId);
+        tablet.SendRequest(std::move(runningStatusRequest));
+        auto runningStatus = tablet.RecvForcedOperationStatusResponse();
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(TStatus::E_RUNNING),
+            static_cast<int>(runningStatus->Record.GetStatus()));
+
+        auto pendingRequest = tablet.CreateForcedRangeOperationRequest(
             ::xrange(1, 2, 1),
             TEvIndexTabletPrivate::EForcedRangeOperationMode::Compaction);
+        const auto operationId = pendingRequest->OperationId;
+        tablet.SendRequest(std::move(pendingRequest));
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+
+        auto statusRequest =
+            std::make_unique<TEvIndexTablet::TEvForcedOperationStatusRequest>();
+        statusRequest->Record.SetOperationId(operationId);
+        tablet.SendRequest(std::move(statusRequest));
+
+        auto status = tablet.RecvForcedOperationStatusResponse();
+        UNIT_ASSERT_C(SUCCEEDED(status->GetStatus()), status->GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(TStatus::E_PENDING),
+            static_cast<int>(status->Record.GetStatus()));
+
         env.GetRuntime().Send(request.Release(), 1 /* node index */);
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
 
         UNIT_ASSERT_VALUES_EQUAL(ranges.size(), 2);
+        auto completedStatusRequest =
+            std::make_unique<TEvIndexTablet::TEvForcedOperationStatusRequest>();
+        completedStatusRequest->Record.SetOperationId(operationId);
+        tablet.SendRequest(std::move(completedStatusRequest));
+        auto completedStatus = tablet.RecvForcedOperationStatusResponse();
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(TStatus::E_COMPLETED),
+            static_cast<int>(completedStatus->Record.GetStatus()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            completedStatus->Record.GetProcessedRangeCount());
     }
 
     TABLET_TEST(ShouldForceCompactAndCleanup)
@@ -4397,10 +4503,11 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         UNIT_ASSERT_VALUES_EQUAL(requests, 15);
         UNIT_ASSERT_VALUES_EQUAL(lastCompactionMapRangeId, 199);
-        tablet.AssertForcedRangeOperationFailed(
+        tablet.ForcedRangeOperation(
             TVector<ui32>{},
             TEvIndexTabletPrivate
                 ::EForcedRangeOperationMode::DeleteZeroCompactionRanges);
+        UNIT_ASSERT_VALUES_EQUAL(requests, 15);
 
         lastCompactionMapRangeId = 0;
         tablet.RebootTablet();

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -745,6 +745,17 @@ message TForcedOperationStatusResponse
     // Last processed range id. Can be used to skip processed range ids upon
     // operation restart via the MinRangeId parameter.
     uint32 LastProcessedRangeId = 4;
+
+    // Operation status summary
+    enum EStatus
+    {
+        E_UNKNOWN = 0;
+        E_PENDING = 1;
+        E_RUNNING = 2;
+        E_COMPLETED = 3;
+        E_FAILED = 4;
+    }
+    EStatus Status = 5;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
This change adds a summary request state to TForcedOperationStatusResponse. It allows client to clearly understand the actual state of the operation.

Additionally, it fixes an issue with tablet changing operation id when re-queuing, and passes downstream operation error to the upstream (previously it was only logged).

### Issue
#4115, #6977