### PR TITLE
issue-6608: support cross-quotas RenameNode

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_quotas.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_quotas.cpp
@@ -355,6 +355,192 @@ Y_UNIT_TEST_SUITE(TStorageServiceQuotasTest)
         // has to stay comfortably under that too
         service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(fileId).SetSize(1_MB));
     }
+
+    SERVICE_TEST(ShouldRejectRenameAcrossQuotaDomains)
+    {
+        auto& service = *fixture.Service;
+        const auto& fsId = fixture.FsId;
+
+        SetQuota(service, fsId, 1, 1_GB, 100);
+        SetQuota(service, fsId, 2, 1_GB, 100);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        const auto dir1Id =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir1"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(dir1Id).SetQuotaId(1));
+
+        const auto dir2Id =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir2"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(dir2Id).SetQuotaId(2));
+
+        service.CreateNode(headers, TCreateNodeArgs::File(dir1Id, "file"));
+
+        // moving a file across a quota boundary is rejected outright, like
+        // a cross-device rename - no usage transfer, no partial recoloring
+        service.AssertRenameNodeFailed(
+            headers,
+            dir1Id,
+            "file",
+            dir2Id,
+            "file",
+            0);
+    }
+
+    SERVICE_TEST(ShouldRejectRenameOfEmptyDirectoryAcrossQuotaDomains)
+    {
+        auto& service = *fixture.Service;
+        const auto& fsId = fixture.FsId;
+
+        SetQuota(service, fsId, 1, 1_GB, 100);
+        SetQuota(service, fsId, 2, 1_GB, 100);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        const auto dir1Id =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir1"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(dir1Id).SetQuotaId(1));
+
+        const auto dir2Id =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir2"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(dir2Id).SetQuotaId(2));
+
+        // an ordinary, empty subdirectory - inherits QuotaId 1 at creation,
+        // never itself attached. Even though it's empty, crossing a quota
+        // boundary is rejected outright, same as a non-empty one.
+        service.CreateNode(headers, TCreateNodeArgs::Directory(dir1Id, "subdir"));
+
+        service.AssertRenameNodeFailed(
+            headers,
+            dir1Id,
+            "subdir",
+            dir2Id,
+            "subdir",
+            0);
+    }
+
+    SERVICE_TEST(ShouldAllowRenameWithinTheSameQuotaDomain)
+    {
+        auto& service = *fixture.Service;
+        const auto& fsId = fixture.FsId;
+
+        SetQuota(service, fsId, 1, 1_GB, 100);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        const auto dir1Id =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir1"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(dir1Id).SetQuotaId(1));
+
+        const auto dir2Id =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir2"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(dir2Id).SetQuotaId(1));
+
+        service.CreateNode(headers, TCreateNodeArgs::File(dir1Id, "file"));
+
+        // both directories are under the same quota - moving between them
+        // stays within the domain and is allowed
+        service.RenameNode(headers, dir1Id, "file", dir2Id, "file", 0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1u,
+            service.GetNodeAttr(headers, fsId, dir2Id, "file")
+                ->Record.GetNode()
+                .GetQuotaId());
+    }
+
+    SERVICE_TEST(ShouldAllowMovingAQuotaRootDirectoryAcrossQuotaDomains)
+    {
+        auto& service = *fixture.Service;
+        const auto& fsId = fixture.FsId;
+
+        SetQuota(service, fsId, 1, 1_GB, 100);
+        SetQuota(service, fsId, 2, 1_GB, 100);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        const auto rootAId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "rootA"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(rootAId).SetQuotaId(1));
+        service.CreateNode(headers, TCreateNodeArgs::File(rootAId, "file"));
+
+        const auto dir2Id =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir2"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(dir2Id).SetQuotaId(2));
+
+        // rootA is itself a quota root (attached, not inherited) - moving it
+        // under a different domain is allowed even though it's non-empty,
+        // and it keeps carrying its own QuotaId
+        service.RenameNode(headers, RootNodeId, "rootA", dir2Id, "rootA", 0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1u,
+            service.GetNodeAttr(headers, fsId, dir2Id, "rootA")
+                ->Record.GetNode()
+                .GetQuotaId());
+    }
+
+    SERVICE_TEST(ShouldRejectMovingQuotaRootUnderParentSharingItsQuota)
+    {
+        auto& service = *fixture.Service;
+        const auto& fsId = fixture.FsId;
+
+        SetQuota(service, fsId, 1, 1_GB, 100);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        // rootA is a quota root attached directly to quota 1
+        const auto rootAId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "rootA"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(rootAId).SetQuotaId(1));
+
+        // dir2 carries the same QuotaId 1
+        const auto dir2Id =
+            service
+                .CreateNode(headers, TCreateNodeArgs::Directory(RootNodeId, "dir2"))
+                ->Record.GetNode()
+                .GetId();
+        service.SetNodeAttr(headers, fsId, TSetNodeAttrArgs(dir2Id).SetQuotaId(1));
+
+        // moving rootA under dir2 would leave rootA.QuotaId == dir2.QuotaId,
+        // making rootA indistinguishable from an inherited child afterwards
+        // (the "differs from parent => explicitly attached" signal would
+        // break). Rejected to keep that signal reliable.
+        service.AssertRenameNodeFailed(
+            headers,
+            RootNodeId,
+            "rootA",
+            dir2Id,
+            "rootA",
+            0);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/helpers.h
+++ b/cloud/filestore/libs/storage/tablet/helpers.h
@@ -68,6 +68,49 @@ class TStorageConfig;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class ECrossQuotaRenameVerdict
+{
+    // Both parents belong to the same quota domain - the move changes
+    // nothing about quota attribution.
+    SameDomain,
+    // The moved node is a quota root that stays recognisable as one after
+    // the move (its QuotaId matches neither parent), so it carries its own
+    // domain with it and no usage has to be transferred.
+    AllowedQuotaRoot,
+    // The move would carry a node whose usage is attributed to the old
+    // domain across a quota boundary - rejected outright, no transfer and
+    // no recolouring.
+    Rejected,
+};
+
+// Decides what a RenameNode moving a node between two parents must do with
+// respect to directory quotas. childQuotaId is the moved node's own QuotaId.
+// Shared so the same-tablet and cross-shard rename paths cannot drift apart.
+[[nodiscard]] inline ECrossQuotaRenameVerdict ClassifyCrossQuotaRename(
+    ui32 oldParentQuotaId,
+    ui32 newParentQuotaId,
+    ui32 childQuotaId)
+{
+    if (oldParentQuotaId == newParentQuotaId) {
+        return ECrossQuotaRenameVerdict::SameDomain;
+    }
+
+    // childQuotaId != newParentQuotaId keeps the "differs from parent =>
+    // explicitly attached" signal usable after the move: landing a root
+    // under a parent that shares its QuotaId would make it indistinguishable
+    // from an inherited node afterwards.
+    const bool distinguishableQuotaRoot =
+        childQuotaId != 0
+        && childQuotaId != oldParentQuotaId
+        && childQuotaId != newParentQuotaId;
+
+    return distinguishableQuotaRoot
+        ? ECrossQuotaRenameVerdict::AllowedQuotaRoot
+        : ECrossQuotaRenameVerdict::Rejected;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 enum ECopyAttrsMode
 {
     E_CM_CTIME = 1,     // CTime

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -121,7 +121,8 @@ MakeRenameNodeInDestinationRequest(
     NProto::TRenameNodeRequest originalRequest,
     TString sourceNodeShardId,
     TString sourceNodeShardNodeName,
-    TString newParentShardId);
+    TString newParentShardId,
+    ui32 oldParentQuotaId);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -417,8 +417,21 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
             return true;
         }
 
-        // EXCHANGE allows to rename any nodes
+        // EXCHANGE allows to rename any nodes, except across a quota domain
+        // boundary - it moves two nodes into each other's domains at once,
+        // which would need both re-attributed; unsupported, same as a plain
+        // cross-domain rename.
         if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
+            if (args.ParentNode->Attrs.GetQuotaId()
+                    != args.NewParentNode->Attrs.GetQuotaId())
+            {
+                Metrics->RenameNotSupportedErrorCount.fetch_add(
+                    1,
+                    std::memory_order_relaxed);
+                args.Error = ErrorRenameNotSupported(
+                    args.ParentNodeId,
+                    args.NewParentNodeId);
+            }
             return true;
         }
 
@@ -504,6 +517,50 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
     } else if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
         args.Error = ErrorInvalidTarget(args.NewParentNodeId, args.NewName);
         return true;
+    }
+
+    // A rename that crosses a quota domain boundary is rejected outright,
+    // like a cross-device rename: the moved node's usage is neither
+    // transferred between domains nor recoloured. The one exception is a
+    // node that is itself a quota root (see ClassifyCrossQuotaRename).
+    // F_EXCHANGE is already handled above. Evaluated last, once NewChildRef
+    // is fully resolved.
+    {
+        const ui32 oldParentQuotaId = args.ParentNode->Attrs.GetQuotaId();
+        const ui32 newParentQuotaId = args.NewParentNode->Attrs.GetQuotaId();
+
+        if (oldParentQuotaId != newParentQuotaId) {
+            // From here on a null NewChildRef is legitimate: a cross-domain
+            // rename to a fresh name still runs a second pass, only to learn
+            // the moved node's QuotaId.
+            args.SecondPassForQuotaCheck = true;
+
+            ui32 childQuotaId = 0;
+            if (args.ChildNode) {
+                childQuotaId = args.ChildNode->Attrs.GetQuotaId();
+            } else if (args.IsSecondPass) {
+                childQuotaId = args.SourceNodeAttr.GetQuotaId();
+            } else {
+                // The moved node's data lives on another shard - fetch its
+                // QuotaId there before deciding.
+                args.SecondPassRequired = true;
+                return true;
+            }
+
+            if (ClassifyCrossQuotaRename(
+                    oldParentQuotaId,
+                    newParentQuotaId,
+                    childQuotaId) == ECrossQuotaRenameVerdict::Rejected)
+            {
+                Metrics->RenameNotSupportedErrorCount.fetch_add(
+                    1,
+                    std::memory_order_relaxed);
+                args.Error = ErrorRenameNotSupported(
+                    args.ParentNodeId,
+                    args.NewParentNodeId);
+                return true;
+            }
+        }
     }
 
     return true;
@@ -680,13 +737,18 @@ void TIndexTabletActor::CompleteTx_RenameNode(
 {
     bool refsValidated = false;
     if (args.SecondPassRequired || args.IsSecondPass) {
-        if (!args.NewChildRef) {
-            auto message = ReportChildRefIsNull(TStringBuilder()
-                << "RenameNode_Dst: " << args.Request.ShortDebugString());
-            args.Error = MakeError(E_INVALID_STATE, std::move(message));
-        } else if (!args.ChildRef) {
+        if (!args.ChildRef) {
             auto message = ReportChildRefIsNull(TStringBuilder()
                 << "RenameNode_Src: " << args.Request.ShortDebugString());
+            args.Error = MakeError(E_INVALID_STATE, std::move(message));
+        } else if (!args.NewChildRef && !args.SecondPassForQuotaCheck) {
+            // Outside the cross-quota-domain path a second pass is only ever
+            // requested when there is a node at the destination path, so a
+            // null NewChildRef here is an upstream invariant break. On the
+            // cross-quota-domain path it is expected (the second pass is
+            // there only to fetch the moved node's QuotaId).
+            auto message = ReportChildRefIsNull(TStringBuilder()
+                << "RenameNode_Dst: " << args.Request.ShortDebugString());
             args.Error = MakeError(E_INVALID_STATE, std::move(message));
         } else {
             refsValidated = true;
@@ -694,6 +756,13 @@ void TIndexTabletActor::CompleteTx_RenameNode(
     }
 
     if (refsValidated && args.SecondPassRequired) {
+        TString newParentShardId;
+        TString newParentShardNodeName;
+        if (args.NewChildRef) {
+            newParentShardId = args.NewChildRef->ShardId;
+            newParentShardNodeName = args.NewChildRef->ShardNodeName;
+        }
+
         RegisterGetNodeInfoAndPrepareUnlinkActor(
             ctx,
             args.RequestInfo,
@@ -703,10 +772,11 @@ void TIndexTabletActor::CompleteTx_RenameNode(
                 args.Request,
                 args.ChildRef->ShardId,
                 args.ChildRef->ShardNodeName,
-                args.NewChildRef->ShardId),
+                newParentShardId,
+                args.ParentNode->Attrs.GetQuotaId()),
             std::move(args.ProfileLogRequest),
-            std::move(args.NewChildRef->ShardId),
-            std::move(args.NewChildRef->ShardNodeName),
+            std::move(newParentShardId),
+            std::move(newParentShardNodeName),
             true /* isLocalRename */);
         return;
     }
@@ -714,6 +784,7 @@ void TIndexTabletActor::CompleteTx_RenameNode(
     if (HasError(args.Error)
             && refsValidated
             && args.IsSecondPass
+            && args.NewChildRef
             && args.DestinationNodeAttr.GetType() == NProto::E_DIRECTORY_NODE)
     {
         if (args.AbortUnlinkOpLogEntryId) {
@@ -726,7 +797,8 @@ void TIndexTabletActor::CompleteTx_RenameNode(
                     args.Request,
                     args.ChildRef->ShardId,
                     args.ChildRef->ShardNodeName,
-                    args.NewChildRef->ShardId),
+                    args.NewChildRef->ShardId,
+                    args.ParentNode->Attrs.GetQuotaId()),
                 std::move(args.ProfileLogRequest),
                 args.Error,
                 args.NewChildRef->ShardId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -579,8 +579,22 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
             return true;
         }
 
-        // EXCHANGE allows to rename any nodes
+        // EXCHANGE allows to rename any nodes, except across a quota domain
+        // boundary (see the matching guard in PrepareTx_RenameNode) - it
+        // moves two nodes into each other's domains at once, which would
+        // need both re-attributed; unsupported, same as a plain cross-domain
+        // rename.
         if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
+            if (args.Request.GetOldParentQuotaId()
+                    != args.NewParentNode->Attrs.GetQuotaId())
+            {
+                Metrics->RenameNotSupportedErrorCount.fetch_add(
+                    1,
+                    std::memory_order_relaxed);
+                args.Error = ErrorRenameNotSupported(
+                    args.Request.GetOriginalRequest().GetNodeId(),
+                    args.Request.GetNewParentId());
+            }
             return true;
         }
 
@@ -613,6 +627,43 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
     } else if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
         args.Error = ErrorInvalidTarget(args.NewParentNodeId, args.NewName);
         return true;
+    }
+
+    // A rename that crosses a quota domain boundary is rejected outright,
+    // like a cross-device rename (see PrepareTx_RenameNode for the
+    // rationale). The moved node's data never lives on this destination
+    // tablet, so its QuotaId always comes from SourceNodeAttr, fetched via
+    // the second pass. F_EXCHANGE is already handled above.
+    {
+        const ui32 oldParentQuotaId = args.Request.GetOldParentQuotaId();
+        const ui32 newParentQuotaId = args.NewParentNode->Attrs.GetQuotaId();
+
+        if (oldParentQuotaId != newParentQuotaId) {
+            // From here on a null NewChildRef is legitimate: the second pass
+            // is there only to fetch the moved node's QuotaId.
+            args.SecondPassForQuotaCheck = true;
+
+            if (!args.IsSecondPass) {
+                // Fetch the moved node's QuotaId from its shard first.
+                args.SecondPassRequired = true;
+                return true;
+            }
+
+            if (ClassifyCrossQuotaRename(
+                    oldParentQuotaId,
+                    newParentQuotaId,
+                    args.SourceNodeAttr.GetQuotaId())
+                        == ECrossQuotaRenameVerdict::Rejected)
+            {
+                Metrics->RenameNotSupportedErrorCount.fetch_add(
+                    1,
+                    std::memory_order_relaxed);
+                args.Error = ErrorRenameNotSupported(
+                    args.Request.GetOriginalRequest().GetNodeId(),
+                    args.Request.GetNewParentId());
+                return true;
+            }
+        }
     }
 
     return true;
@@ -748,25 +799,40 @@ void TIndexTabletActor::CompleteTx_RenameNodeInDestination(
     TTxIndexTablet::TRenameNodeInDestination& args)
 {
     if (args.SecondPassRequired) {
-        if (args.NewChildRef) {
+        if (!args.NewChildRef && !args.SecondPassForQuotaCheck) {
+            // Outside the cross-quota-domain path a second pass is only
+            // requested when there is a node at the destination to prepare
+            // for unlink, so a null NewChildRef here is an upstream
+            // invariant break. On the cross-quota-domain path it is
+            // expected (the second pass only fetches the moved node's
+            // QuotaId) and the request below still has to run.
+            auto message = ReportChildRefIsNull(TStringBuilder()
+                << "RenameNodeInDestination: "
+                << args.Request.ShortDebugString());
+            args.Error = MakeError(E_INVALID_STATE, std::move(message));
+        } else {
+            TString newChildShardId;
+            TString newChildShardNodeName;
+            if (args.NewChildRef) {
+                newChildShardId = args.NewChildRef->ShardId;
+                newChildShardNodeName = args.NewChildRef->ShardNodeName;
+            }
+
             RegisterGetNodeInfoAndPrepareUnlinkActor(
                 ctx,
                 args.RequestInfo,
                 args.Request,
                 std::move(args.ProfileLogRequest),
-                std::move(args.NewChildRef->ShardId),
-                std::move(args.NewChildRef->ShardNodeName),
+                std::move(newChildShardId),
+                std::move(newChildShardNodeName),
                 false /* isLocalRename */);
             return;
         }
-
-        auto message = ReportChildRefIsNull(TStringBuilder()
-            << "RenameNodeInDestination: " << args.Request.ShortDebugString());
-        args.Error = MakeError(E_INVALID_STATE, std::move(message));
     }
 
     if (HasError(args.Error)
             && args.IsSecondPass
+            && args.NewChildRef
             && args.DestinationNodeAttr.GetType() == NProto::E_DIRECTORY_NODE)
     {
         if (args.AbortUnlinkOpLogEntryId) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -502,7 +502,8 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
             args.Request,
             args.ChildRef->ShardId,
             args.ChildRef->ShardNodeName,
-            args.NewParentShardId);
+            args.NewParentShardId,
+            args.ParentNode->Attrs.GetQuotaId());
 
     WriteOpLogEntry(*db, args.OpLogEntry);
 
@@ -860,7 +861,8 @@ MakeRenameNodeInDestinationRequest(
     NProto::TRenameNodeRequest originalRequest,
     TString sourceNodeShardId,
     TString sourceNodeShardNodeName,
-    TString newParentShardId)
+    TString newParentShardId,
+    ui32 oldParentQuotaId)
 {
     NProtoPrivate::TRenameNodeInDestinationRequest request;
     auto& headers = *request.MutableHeaders();
@@ -873,6 +875,7 @@ MakeRenameNodeInDestinationRequest(
     request.SetFlags(originalRequest.GetFlags());
     request.SetSourceNodeShardId(std::move(sourceNodeShardId));
     request.SetSourceNodeShardNodeName(std::move(sourceNodeShardNodeName));
+    request.SetOldParentQuotaId(oldParentQuotaId);
     *request.MutableOriginalRequest() = std::move(originalRequest);
     return request;
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1149,6 +1149,11 @@ struct TTxIndexTablet
         TString ShardIdForUnlink;
         TString ShardNodeNameForUnlink;
         bool SecondPassRequired = false;
+        // Set once PrepareTx sees the rename cross a quota domain boundary:
+        // from that point a null NewChildRef is expected (a cross-domain
+        // rename to a fresh name still runs a second pass just to learn the
+        // moved node's QuotaId), so the NewChildRef-is-null crit is skipped.
+        bool SecondPassForQuotaCheck = false;
 
         TRenameNode(
                 TRequestInfoPtr requestInfo,
@@ -1211,6 +1216,7 @@ struct TTxIndexTablet
             ShardNodeNameForUnlink.clear();
 
             SecondPassRequired = false;
+            SecondPassForQuotaCheck = false;
 
             // deliberately not calling TProfileAware::Clear()
         }
@@ -1306,6 +1312,8 @@ struct TTxIndexTablet
         TString ShardNodeNameForUnlink;
 
         bool SecondPassRequired = false;
+        // See TRenameNode::SecondPassForQuotaCheck.
+        bool SecondPassForQuotaCheck = false;
 
         TRenameNodeInDestination(
                 TRequestInfoPtr requestInfo,
@@ -1361,6 +1369,7 @@ struct TTxIndexTablet
             ShardNodeNameForUnlink.clear();
 
             SecondPassRequired = false;
+            SecondPassForQuotaCheck = false;
 
             // deliberately not calling TProfileAware::Clear()
         }

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -1198,6 +1198,11 @@ message TRenameNodeInDestinationRequest
     // Passing the whole original request might be an overkill but it actually
     // may help with debugging.
     NProto.TRenameNodeRequest OriginalRequest = 8;
+
+    // QuotaId of the source parent directory, at the time the rename was
+    // initiated - carried over so the destination tablet can decide whether
+    // the move crosses a quota domain without a round trip back to source.
+    uint32 OldParentQuotaId = 9;
 }
 
 message TRenameNodeInDestinationResponse


### PR DESCRIPTION
### Notes
In case of a QuotaId mismatch in the source and target directories, EXDEV is provided to the client, and they are tasked with performing the non-atomic move themselves

### Issue
#6608
