### PR TITLE
[Filestore] fix: add missing atomic include in file_ring_buffer_format.cpp

### DIFF
--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -6,6 +6,8 @@
 #include <util/system/compiler.h>
 #include <util/system/yassert.h>
 
+#include <atomic>
+
 namespace NCloud {
 
 namespace {


### PR DESCRIPTION
### Notes

Include `<atomic>` directly in `file_ring_buffer_format.cpp`, which uses `std::atomic_signal_fence` and `std::memory_order_seq_cst`. Without the direct include, builds fail in arcadia

### Issue

Build fix after PR #6981

The GitHub build uses LLVM libc++ 19 (_LIBCPP_VERSION == 190000). In that version, `<memory>` indirectly includes the complete `<atomic>` header through `__memory/shared_ptr.h`, masking the missing direct include.

The Arcadia build uses LLVM libc++ 21 (_LIBCPP_VERSION == 210000). In libc++ 21, `__memory/shared_ptr.h` no longer includes the complete `<atomic>` header and only includes the internal `__atomic/memory_order.h`. As a result, `std::atomic_signal_fence` is unavailable unless `<atomic>` is included explicitly.

Adding the direct include makes the translation unit independent of libc++ transitive-include behavior and allows it to compile with both versions.

```
$(SOURCE_ROOT)/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp:190:18: error: no type named 'atomic_signal_fence' in namespace 'std'
  190 |             std::atomic_signal_fence(std::memory_order_seq_cst);
      |             ~~~~~^
$(SOURCE_ROOT)/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp:190:43: error: definition or redeclaration of 'memory_order_seq_cst' not allowed inside a function
  190 |             std::atomic_signal_fence(std::memory_order_seq_cst);
      |                                      ~~~~~^
$(SOURCE_ROOT)/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp:194:18: error: no type named 'atomic_signal_fence' in namespace 'std'
  194 |             std::atomic_signal_fence(std::memory_order_seq_cst);
      |             ~~~~~^
$(SOURCE_ROOT)/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp:194:43: error: definition or redeclaration of 'memory_order_seq_cst' not allowed inside a function
  194 |             std::atomic_signal_fence(std::memory_order_seq_cst);
      |                                      ~~~~~^
4 errors generated.
```
