### PR TITLE
[Disk Manager] add GetUserIP helper and log user IP for incoming requests

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/interceptor.go
+++ b/cloud/disk_manager/internal/pkg/facade/interceptor.go
@@ -218,7 +218,7 @@ func (i *interceptor) intercept(
 
 	logging.Debug(
 		ctx,
-		"requestName=%v, requestIP=%q received",
+		"requestName=%v, userIP=%q received",
 		requestName,
 		auth.GetUserIP(ctx),
 	)

--- a/cloud/disk_manager/internal/pkg/facade/interceptor.go
+++ b/cloud/disk_manager/internal/pkg/facade/interceptor.go
@@ -218,7 +218,7 @@ func (i *interceptor) intercept(
 
 	logging.Debug(
 		ctx,
-		"requestName=%v, userIP=%q received",
+		"requestName=%v, requestIP=%q received",
 		requestName,
 		auth.GetUserIP(ctx),
 	)

--- a/cloud/disk_manager/internal/pkg/facade/interceptor.go
+++ b/cloud/disk_manager/internal/pkg/facade/interceptor.go
@@ -216,13 +216,6 @@ func (i *interceptor) intercept(
 	ctx, span := tracing.StartSpan(ctx, requestName)
 	defer span.End()
 
-	logging.Debug(
-		ctx,
-		"requestName=%v, userIP=%q received",
-		requestName,
-		auth.GetUserIP(ctx),
-	)
-
 	start := time.Now()
 
 	resp, err := i.handleRequest(ctx, req, handler, requestName, requestStats)

--- a/cloud/disk_manager/internal/pkg/facade/interceptor.go
+++ b/cloud/disk_manager/internal/pkg/facade/interceptor.go
@@ -216,6 +216,13 @@ func (i *interceptor) intercept(
 	ctx, span := tracing.StartSpan(ctx, requestName)
 	defer span.End()
 
+	logging.Debug(
+		ctx,
+		"requestName=%v, userIP=%q received",
+		requestName,
+		auth.GetUserIP(ctx),
+	)
+
 	start := time.Now()
 
 	resp, err := i.handleRequest(ctx, req, handler, requestName, requestStats)

--- a/cloud/disk_manager/pkg/auth/auth.go
+++ b/cloud/disk_manager/pkg/auth/auth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/karlseguin/ccache/v2"
@@ -11,6 +13,14 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/headers"
 	tasks_headers "github.com/ydb-platform/nbs/cloud/tasks/headers"
 	"github.com/ydb-platform/ydb-go-sdk/v3/credentials"
+	grpc_metadata "google.golang.org/grpc/metadata"
+	grpc_peer "google.golang.org/grpc/peer"
+)
+
+const (
+	HeaderUserIP       = "x-user-ip"
+	HeaderRealIP       = "x-real-ip"
+	HeaderForwardedFor = "x-forwarded-for"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,6 +59,43 @@ func NewStubAuthorizer() Authorizer {
 
 func GetRequestID(ctx context.Context) string {
 	return tasks_headers.GetRequestID(ctx)
+}
+
+func parseUserIP(address string) string {
+	address, _, _ = strings.Cut(address, ",")
+	address = strings.TrimSpace(address)
+
+	if host, _, err := net.SplitHostPort(address); err == nil {
+		address = host
+	}
+
+	if ip := net.ParseIP(address); ip != nil {
+		return ip.String()
+	}
+
+	return ""
+}
+
+func GetUserIP(ctx context.Context) string {
+	for _, header := range []string{
+		HeaderUserIP,
+		HeaderRealIP,
+		HeaderForwardedFor,
+	} {
+		values := grpc_metadata.ValueFromIncomingContext(ctx, header)
+		if len(values) != 0 {
+			if ip := parseUserIP(values[0]); ip != "" {
+				return ip
+			}
+		}
+	}
+
+	p, ok := grpc_peer.FromContext(ctx)
+	if !ok || p.Addr == nil {
+		return ""
+	}
+
+	return parseUserIP(p.Addr.String())
 }
 
 func GetAccessToken(ctx context.Context) (string, error) {

--- a/cloud/disk_manager/pkg/auth/auth.go
+++ b/cloud/disk_manager/pkg/auth/auth.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
-	"net"
-	"strings"
 	"time"
 
 	"github.com/karlseguin/ccache/v2"
@@ -13,14 +11,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/headers"
 	tasks_headers "github.com/ydb-platform/nbs/cloud/tasks/headers"
 	"github.com/ydb-platform/ydb-go-sdk/v3/credentials"
-	grpc_metadata "google.golang.org/grpc/metadata"
 	grpc_peer "google.golang.org/grpc/peer"
-)
-
-const (
-	HeaderUserIP       = "x-user-ip"
-	HeaderRealIP       = "x-real-ip"
-	HeaderForwardedFor = "x-forwarded-for"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -61,41 +52,13 @@ func GetRequestID(ctx context.Context) string {
 	return tasks_headers.GetRequestID(ctx)
 }
 
-func parseUserIP(address string) string {
-	address, _, _ = strings.Cut(address, ",")
-	address = strings.TrimSpace(address)
-
-	if host, _, err := net.SplitHostPort(address); err == nil {
-		address = host
-	}
-
-	if ip := net.ParseIP(address); ip != nil {
-		return ip.String()
-	}
-
-	return ""
-}
-
 func GetUserIP(ctx context.Context) string {
-	for _, header := range []string{
-		HeaderUserIP,
-		HeaderRealIP,
-		HeaderForwardedFor,
-	} {
-		values := grpc_metadata.ValueFromIncomingContext(ctx, header)
-		if len(values) != 0 {
-			if ip := parseUserIP(values[0]); ip != "" {
-				return ip
-			}
-		}
-	}
-
 	p, ok := grpc_peer.FromContext(ctx)
 	if !ok || p.Addr == nil {
 		return ""
 	}
 
-	return parseUserIP(p.Addr.String())
+	return p.Addr.String()
 }
 
 func GetAccessToken(ctx context.Context) (string, error) {

--- a/cloud/disk_manager/pkg/auth/auth_test.go
+++ b/cloud/disk_manager/pkg/auth/auth_test.go
@@ -6,13 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	grpc_metadata "google.golang.org/grpc/metadata"
 	grpc_peer "google.golang.org/grpc/peer"
 )
-
-func contextWithMetadata(ctx context.Context, values ...string) context.Context {
-	return grpc_metadata.NewIncomingContext(ctx, grpc_metadata.Pairs(values...))
-}
 
 func contextWithPeer(ctx context.Context, userIP string) context.Context {
 	return grpc_peer.NewContext(ctx, &grpc_peer.Peer{
@@ -35,59 +30,14 @@ func TestGetUserIP(t *testing.T) {
 			expected: "",
 		},
 		{
-			name: "x-user-ip has highest priority",
-			ctx: contextWithMetadata(
-				contextWithPeer(context.Background(), "192.0.2.4"),
-				HeaderUserIP, "192.0.2.1",
-				HeaderRealIP, "192.0.2.2",
-				HeaderForwardedFor, "192.0.2.3, 192.0.2.5",
-			),
-			expected: "192.0.2.1",
-		},
-		{
-			name: "x-real-ip overrides x-forwarded-for and peer",
-			ctx: contextWithMetadata(
-				contextWithPeer(context.Background(), "192.0.2.4"),
-				HeaderRealIP, "192.0.2.2",
-				HeaderForwardedFor, "192.0.2.3, 192.0.2.5",
-			),
-			expected: "192.0.2.2",
-		},
-		{
-			name: "first x-forwarded-for address overrides peer",
-			ctx: contextWithMetadata(
-				contextWithPeer(context.Background(), "192.0.2.4"),
-				HeaderForwardedFor, " 192.0.2.3, 192.0.2.5",
-			),
-			expected: "192.0.2.3",
-		},
-		{
-			name:     "peer IPv4 fallback",
+			name:     "peer IPv4",
 			ctx:      contextWithPeer(context.Background(), "192.0.2.4"),
-			expected: "192.0.2.4",
+			expected: "192.0.2.4:1234",
 		},
 		{
-			name:     "peer IPv6 fallback",
+			name:     "peer IPv6",
 			ctx:      contextWithPeer(context.Background(), "2001:db8::1"),
-			expected: "2001:db8::1",
-		},
-		{
-			name: "empty headers fall back to peer",
-			ctx: contextWithMetadata(
-				contextWithPeer(context.Background(), "192.0.2.4"),
-				HeaderUserIP, "",
-				HeaderRealIP, "   ",
-				HeaderForwardedFor, "",
-			),
-			expected: "192.0.2.4",
-		},
-		{
-			name: "invalid header falls back to peer",
-			ctx: contextWithMetadata(
-				contextWithPeer(context.Background(), "192.0.2.4"),
-				HeaderUserIP, "not-an-ip",
-			),
-			expected: "192.0.2.4",
+			expected: "[2001:db8::1]:1234",
 		},
 	}
 

--- a/cloud/disk_manager/pkg/auth/auth_test.go
+++ b/cloud/disk_manager/pkg/auth/auth_test.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	grpc_metadata "google.golang.org/grpc/metadata"
+	grpc_peer "google.golang.org/grpc/peer"
+)
+
+func contextWithMetadata(ctx context.Context, values ...string) context.Context {
+	return grpc_metadata.NewIncomingContext(ctx, grpc_metadata.Pairs(values...))
+}
+
+func contextWithPeer(ctx context.Context, userIP string) context.Context {
+	return grpc_peer.NewContext(ctx, &grpc_peer.Peer{
+		Addr: &net.TCPAddr{
+			IP:   net.ParseIP(userIP),
+			Port: 1234,
+		},
+	})
+}
+
+func TestGetUserIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		expected string
+	}{
+		{
+			name:     "no user IP",
+			ctx:      context.Background(),
+			expected: "",
+		},
+		{
+			name: "x-user-ip has highest priority",
+			ctx: contextWithMetadata(
+				contextWithPeer(context.Background(), "192.0.2.4"),
+				HeaderUserIP, "192.0.2.1",
+				HeaderRealIP, "192.0.2.2",
+				HeaderForwardedFor, "192.0.2.3, 192.0.2.5",
+			),
+			expected: "192.0.2.1",
+		},
+		{
+			name: "x-real-ip overrides x-forwarded-for and peer",
+			ctx: contextWithMetadata(
+				contextWithPeer(context.Background(), "192.0.2.4"),
+				HeaderRealIP, "192.0.2.2",
+				HeaderForwardedFor, "192.0.2.3, 192.0.2.5",
+			),
+			expected: "192.0.2.2",
+		},
+		{
+			name: "first x-forwarded-for address overrides peer",
+			ctx: contextWithMetadata(
+				contextWithPeer(context.Background(), "192.0.2.4"),
+				HeaderForwardedFor, " 192.0.2.3, 192.0.2.5",
+			),
+			expected: "192.0.2.3",
+		},
+		{
+			name:     "peer IPv4 fallback",
+			ctx:      contextWithPeer(context.Background(), "192.0.2.4"),
+			expected: "192.0.2.4",
+		},
+		{
+			name:     "peer IPv6 fallback",
+			ctx:      contextWithPeer(context.Background(), "2001:db8::1"),
+			expected: "2001:db8::1",
+		},
+		{
+			name: "empty headers fall back to peer",
+			ctx: contextWithMetadata(
+				contextWithPeer(context.Background(), "192.0.2.4"),
+				HeaderUserIP, "",
+				HeaderRealIP, "   ",
+				HeaderForwardedFor, "",
+			),
+			expected: "192.0.2.4",
+		},
+		{
+			name: "invalid header falls back to peer",
+			ctx: contextWithMetadata(
+				contextWithPeer(context.Background(), "192.0.2.4"),
+				HeaderUserIP, "not-an-ip",
+			),
+			expected: "192.0.2.4",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, GetUserIP(test.ctx))
+		})
+	}
+}

--- a/cloud/disk_manager/pkg/auth/ya.make
+++ b/cloud/disk_manager/pkg/auth/ya.make
@@ -4,4 +4,8 @@ SRCS(
     auth.go
 )
 
+GO_TEST_SRCS(
+    auth_test.go
+)
+
 END()


### PR DESCRIPTION
## Notes

- add a `GetUserIP` helper to extract the server-side peer address from an incoming gRPC context
- add DEBUG logging for the server-side gRPC peer of every incoming unary Disk Manager request

Log example:

```text
requestName=DiskService.Create, userIP="192.0.2.1:1234" received
```

## Issue

need for forward value in header X-User-IP to Access Service