### PR TITLE
configure ssh forwarding and console controls for qemu in filestore example

### DIFF
--- a/cloud/filestore/README.md
+++ b/cloud/filestore/README.md
@@ -68,6 +68,20 @@ qemu@test> mkdir mnt
 qemu@test> sudo mount -t virtiofs fs0 mnt    # creates mount point for the filestore
 ```
 
+- You can also connect to the running VM via SSH from the `cloud/filestore/bin`
+  directory. Port `2222` is forwarded to the VM by default:
+```bash
+ssh -p 2222 \
+    -i ../../storage/core/tools/testing/qemu/keys/id_rsa \
+    qemu@127.0.0.1
+```
+
+- To stop QEMU from its interactive console, press `Ctrl-A`, release the keys,
+  and then press `X`. Alternatively, shut down the VM from inside the guest:
+```bash
+sudo poweroff
+```
+
 - or you can mount filestore localy
 ```bash
 ./initctl.sh mount
@@ -76,11 +90,11 @@ qemu@test> sudo mount -t virtiofs fs0 mnt    # creates mount point for the files
 To run second (third, fourth, etc.) VM:
 ```bash
 CLIENT_ID="local-qemu2" VHOST_SOCKET_PATH="/tmp/vhost2.sock" ./initctl.sh startendpoint
-QMP_PORT=4445 NET_PORT=3390 VHOST_SOCKET_PATH="/tmp/vhost2.sock" ./run_test_qemu.sh
+QMP_PORT=4445 NET_PORT=3390 SSH_PORT=2223 VHOST_SOCKET_PATH="/tmp/vhost2.sock" ./run_test_qemu.sh
 ```
 ```bash
 CLIENT_ID="local-qemu3" VHOST_SOCKET_PATH="/tmp/vhost3.sock" ./initctl.sh startendpoint
-QMP_PORT=4446 NET_PORT=3391 VHOST_SOCKET_PATH="/tmp/vhost3.sock" ./run_test_qemu.sh
+QMP_PORT=4446 NET_PORT=3391 SSH_PORT=2224 VHOST_SOCKET_PATH="/tmp/vhost3.sock" ./run_test_qemu.sh
 ```
 
 Thanks for flying NFS

--- a/cloud/filestore/bin/run_test_qemu.sh
+++ b/cloud/filestore/bin/run_test_qemu.sh
@@ -25,6 +25,7 @@ QEMU_FIRMWARE_REL=/usr/share/qemu
 
 : ${QMP_PORT:=4444}
 : ${NET_PORT:=3389}
+: ${SSH_PORT:=2222}
 : ${DISK_IMAGE:=$BIN_DIR/rootfs.img}
 : ${VHOST_SOCKET_PATH:=/tmp/vhost.sock}
 
@@ -47,7 +48,7 @@ args=(
     -object memory-backend-memfd,id=mem,size=$MEM_SIZE,share=on
     -numa node,memdev=mem
 
-    -netdev user,id=netdev0,hostfwd=tcp::$NET_PORT-:$NET_PORT
+    -netdev user,id=netdev0,hostfwd=tcp::$NET_PORT-:$NET_PORT,hostfwd=tcp:127.0.0.1:$SSH_PORT-:22
     -device virtio-net-pci,netdev=netdev0,id=net0
 
     -drive format=qcow2,file="$DISK_IMAGE",id=hdd0,if=none,aio=native,cache=none,discard=unmap
@@ -56,8 +57,10 @@ args=(
     -chardev socket,path=$VHOST_SOCKET_PATH,id=vhost0,reconnect=1
     -device vhost-user-fs-pci,chardev=vhost0,id=vhost-user-fs0,tag=fs0,num-request-queues=8,queue-size=1024
 
-    -serial stdio
-    -nographic
+    -chardev stdio,id=console,mux=on,signal=off
+    -serial chardev:console
+    -mon chardev=console,mode=readline
+    -display none
     ${KERNEL_IMAGE:+-kernel $KERNEL_IMAGE}
     ${KCMDLINE:+-append "$KCMDLINE"}
     # -s


### PR DESCRIPTION
### Notes
Added ssh port forwarding and updated console handling for the qemu. Ctrl-C is now passed to the guest, while QEMU can be stopped with Ctrl-A, then X

### Issue
Put links to the related issues here
