### PR TITLE
[NBS] Compact ranges with excessive mixed blocks

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -817,7 +817,9 @@ message TStorageServiceConfig
     optional uint32 CompactionRangeCountPerRun = 264;
 
     // Specifies whether to use CompactionRangeCountPerRun,
-    // GarbageCompactionRangeCountPerRun and ForcedCompactionRangeCountPerRun.
+    // GarbageCompactionRangeCountPerRun,
+    // MixedBlocksCountCompactionRangeCountPerRun and
+    // ForcedCompactionRangeCountPerRun.
     optional bool BatchCompactionEnabled = 265;
 
     // Timeout before allowing infra to withdraw our unavailable agents.
@@ -1693,4 +1695,23 @@ message TStorageServiceConfig
     // Maximum allowed logical size of all blocks (block count * block size) in
     // fresh after which we start to reject write and zero requests.
     optional uint64 FreshLogicalBlocksByteCountHardLimit = 529;
+
+    // Enables compaction triggered by the number of mixed blocks for HDD
+    // volumes.
+    optional bool MixedBlocksCountCompactionEnabledHDD = 530;
+
+    // Enables compaction triggered by the number of mixed blocks for SSD
+    // volumes.
+    optional bool MixedBlocksCountCompactionEnabledSSD = 531;
+
+    // Number of mixed bytes in a compaction range that triggers compaction for
+    // HDD volumes. Zero means using WriteBlobThreshold.
+    optional uint32 MixedBytesCountCompactionThresholdHDD = 532;
+
+    // Number of mixed bytes in a compaction range that triggers compaction for
+    // SSD volumes. Zero means using WriteBlobThresholdSSD.
+    optional uint32 MixedBytesCountCompactionThresholdSSD = 533;
+
+    // Number of ranges to process in a single mixed-block-count compaction run.
+    optional uint32 MixedBlocksCountCompactionRangeCountPerRun = 534;
 }

--- a/cloud/blockstore/libs/storage/core/compaction_options.h
+++ b/cloud/blockstore/libs/storage/core/compaction_options.h
@@ -12,6 +12,7 @@ enum class ECompactionOption: size_t
 {
     Full,            // non-incremental compaction
     Forced,          // compaction initiated externally
+    ForceToMerged,   // write result blobs to merged channels
     MaxFieldNumber,
 };
 

--- a/cloud/blockstore/libs/storage/core/compaction_options.h
+++ b/cloud/blockstore/libs/storage/core/compaction_options.h
@@ -12,7 +12,7 @@ enum class ECompactionOption: size_t
 {
     Full,            // non-incremental compaction
     Forced,          // compaction initiated externally
-    ForceToMerged,   // write result blobs to merged channels
+    ForceMixedBlocksCountCompaction,   // write result blobs to merged channels
     MaxFieldNumber,
 };
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -738,6 +738,11 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MixedBlocksFilterAllowedCpuTimePerSecond,   TDuration,  MSeconds(10)  )\
     xxx(CheckpointAwareCleanupEnabled,              bool,       false         )\
     xxx(UseBlobChannelDataKindForCounters,          bool,       false         )\
+    xxx(MixedBlocksCountCompactionEnabledHDD,       bool,       false         )\
+    xxx(MixedBlocksCountCompactionEnabledSSD,       bool,       false         )\
+    xxx(MixedBytesCountCompactionThresholdHDD,      ui32,       0             )\
+    xxx(MixedBytesCountCompactionThresholdSSD,      ui32,       0             )\
+    xxx(MixedBlocksCountCompactionRangeCountPerRun, ui32,       1             )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -970,6 +970,17 @@ public:
     [[nodiscard]] bool GetCheckpointAwareCleanupEnabled() const;
 
     [[nodiscard]] bool GetUseBlobChannelDataKindForCounters() const;
+
+    [[nodiscard]] bool GetMixedBlocksCountCompactionEnabledHDD() const;
+
+    [[nodiscard]] bool GetMixedBlocksCountCompactionEnabledSSD() const;
+
+    [[nodiscard]] ui32 GetMixedBytesCountCompactionThresholdHDD() const;
+
+    [[nodiscard]] ui32 GetMixedBytesCountCompactionThresholdSSD() const;
+
+    [[nodiscard]] ui32
+    GetMixedBlocksCountCompactionRangeCountPerRun() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -388,6 +388,10 @@ struct TCumulativeDiskCounters
         EPublishingPolicy::Repl,
         TCumulativeCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
+    TCounter CompactionByMixedBlockCountPerRange{
+        EPublishingPolicy::Repl,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
     TCounter CompactionByIgnoringZeroedPerDisk{
         EPublishingPolicy::Repl,
         TCumulativeCounter::ECounterType::Generic,
@@ -446,6 +450,7 @@ struct TCumulativeDiskCounters
         MakeMeta<&TCumulativeDiskCounters::CompactionByGarbageBlocksPerDisk>(),
         MakeMeta<&TCumulativeDiskCounters::CompactionByIgnoringZeroedPerRange>(),
         MakeMeta<&TCumulativeDiskCounters::CompactionByIgnoringZeroedPerDisk>(),
+        MakeMeta<&TCumulativeDiskCounters::CompactionByMixedBlockCountPerRange>(),
         MakeMeta<&TCumulativeDiskCounters::CompactionTxTime>(),
         MakeMeta<&TCumulativeDiskCounters::CompactionReadBlobsTime>(),
         MakeMeta<&TCumulativeDiskCounters::CompactionWriteBlobsTime>(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1289,6 +1289,7 @@ private:
     TRangeStat TopRangeStat;
     TRangeStat TopGarbageRangeStat;
     TRangeStat TopByGarbageIgnoringZeroed;
+    TRangeStat TopByMixedBlockCount;
 
 public:
     enum class ECompactionTriggerKind
@@ -1299,7 +1300,8 @@ public:
         ByGarbageBlocksPerDisk,
         ByGarbageBlocksPerRange,
         ByIgnoringZeroedPerDisk,
-        ByIgnoringZeroedPerRange
+        ByIgnoringZeroedPerRange,
+        ByMixedBlockCount,
     };
 
     struct TTriggerInfo
@@ -1345,6 +1347,7 @@ public:
         TopRangeStat = cm.GetTop().Stat;
         TopGarbageRangeStat = cm.GetTopByGarbageBlockCount().Stat;
         TopByGarbageIgnoringZeroed = cm.GetTopByGarbageIgnoringZeroed().Stat;
+        TopByMixedBlockCount = cm.GetTopByMixedBlockCount().Stat;
 
         auto& scoreHistory = State.GetCompactionScoreHistory();
         if (scoreHistory.LastTs() + Config->GetMaxCompactionDelay() <= now) {
@@ -1354,6 +1357,7 @@ public:
                     TopRangeStat.CompactionScore.Score,
                     TopGarbageRangeStat.GarbageBlockCount(),
                     TopByGarbageIgnoringZeroed.GarbageIgnoringZeroed(),
+                    TopByMixedBlockCount.MixedBlockCount,
                 },
             });
         }
@@ -1373,7 +1377,12 @@ public:
             return info;
         }
 
-        return TriggerGarbageCompactionIfNeeded();
+        info = TriggerGarbageCompactionIfNeeded();
+        if (info) {
+            return info;
+        }
+
+        return TriggerMixedBlockCountCompactionIfNeeded();
     }
 
 private:
@@ -1545,6 +1554,52 @@ private:
             true /* throttlingAllowed */,
             true /* fullCompaction */);
     }
+
+    [[nodiscard]] std::optional<TTriggerInfo>
+    TriggerMixedBlockCountCompactionIfNeeded() const
+    {
+        const auto mediaKind = State.GetConfig().GetStorageMediaKind();
+        const bool isSSD =
+            mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD;
+        const bool enabled =
+            isSSD
+                ? Config->GetMixedBlocksCountCompactionEnabledSSD()
+                : Config->GetMixedBlocksCountCompactionEnabledHDD();
+        if (!enabled) {
+            return std::nullopt;
+        }
+
+        ui64 threshold =
+            isSSD ? Config->GetMixedBytesCountCompactionThresholdSSD()
+                  : Config->GetMixedBytesCountCompactionThresholdHDD();
+
+        if (!threshold) {
+            threshold = GetWriteBlobThreshold(*Config, mediaKind);
+        }
+
+        const auto& rangeStat = TopByMixedBlockCount;
+
+        if (!rangeStat.BlobCount) {
+            return std::nullopt;
+        }
+
+        const bool rangeMixedBlockCountOverThreshold =
+            rangeStat.MixedBlockCount * State.GetBlockSize() >= threshold;
+
+        if (!rangeMixedBlockCountOverThreshold) {
+            return std::nullopt;
+        }
+
+        return TTriggerInfo(
+            rangeStat.MixedBlockCount,
+            threshold,
+            0,
+            0,
+            TEvPartitionPrivate::MixedBlockCountCompaction,
+            ECompactionTriggerKind::ByMixedBlockCount,
+            true /* throttlingAllowed */,
+            true /* fullCompaction */);
+    }
 };
 
 void FillBlobsInfo(
@@ -1624,6 +1679,10 @@ void IncrementCompactionCounterByTriggerKind(
         case TCompactionTriggerer::ECompactionTriggerKind::
             ByIgnoringZeroedPerRange:
             partCounters->Cumulative.CompactionByIgnoringZeroedPerRange
+                .Increment(1);
+            break;
+        case TCompactionTriggerer::ECompactionTriggerKind::ByMixedBlockCount:
+            partCounters->Cumulative.CompactionByMixedBlockCountPerRange
                 .Increment(1);
             break;
     }
@@ -1796,6 +1855,9 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
     if (info->FullCompaction) {
         request->CompactionOptions.set(ToBit(ECompactionOption::Full));
     }
+    if (info->Mode == TEvPartitionPrivate::MixedBlockCountCompaction) {
+        request->CompactionOptions.set(ToBit(ECompactionOption::ForceToMerged));
+    }
 
     auto maxCompactionExecTimePerSecond =
         Config->GetMaxCompactionExecTimePerSecond();
@@ -1938,6 +2000,16 @@ void TPartitionActor::HandleCompaction(
                 Config->GetGarbageCompactionRangeCountPerRun());
         } else {
             const auto& top = cm.GetTopByGarbageIgnoringZeroed();
+            tops.push_back({top.BlockIndex, top.Stat});
+        }
+    } else if (msg->Mode == TEvPartitionPrivate::MixedBlockCountCompaction) {
+        if (batchCompactionEnabled &&
+            Config->GetMixedBlocksCountCompactionRangeCountPerRun() > 1)
+        {
+            tops = cm.GetTopByMixedBlockCount(
+                Config->GetMixedBlocksCountCompactionRangeCountPerRun());
+        } else {
+            const auto& top = cm.GetTopByMixedBlockCount();
             tops.push_back({top.BlockIndex, top.Stat});
         }
     } else {
@@ -2241,9 +2313,11 @@ void TPartitionActor::CompleteCompaction(
     TVector<TRangeCompactionInfo> rangeCompactionInfos;
     TVector<TCompactionActor::TRequest> requests;
 
+    const bool forceToMerged =
+        args.CompactionOptions.test(ToBit(ECompactionOption::ForceToMerged));
     const auto mergedBlobThreshold =
-        PartitionConfig.GetStorageMediaKind() ==
-                NCloud::NProto::STORAGE_MEDIA_SSD
+        forceToMerged || PartitionConfig.GetStorageMediaKind() ==
+                             NCloud::NProto::STORAGE_MEDIA_SSD
             ? 0
             : Config->GetCompactionMergedBlobThresholdHDD();
     for (auto& rangeCompaction: args.RangeCompactions) {

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1382,7 +1382,7 @@ public:
             return info;
         }
 
-        return TriggerMixedBlockCountCompactionIfNeeded();
+        return TriggerMixedBlocksCountCompactionIfNeeded();
     }
 
 private:
@@ -1556,7 +1556,7 @@ private:
     }
 
     [[nodiscard]] std::optional<TTriggerInfo>
-    TriggerMixedBlockCountCompactionIfNeeded() const
+    TriggerMixedBlocksCountCompactionIfNeeded() const
     {
         const auto mediaKind = State.GetConfig().GetStorageMediaKind();
         const bool isSSD =
@@ -1598,9 +1598,9 @@ private:
         return TTriggerInfo(
             rangeMixedBytesCount,
             threshold,
-            0,
-            0,
-            TEvPartitionPrivate::MixedBlockCountCompaction,
+            0 /* perDiskCount */,
+            0 /* perDiskThreshold */,
+            TEvPartitionPrivate::MixedBlocksCountCompaction,
             ECompactionTriggerKind::ByMixedBlockCount,
             true /* throttlingAllowed */,
             true /* fullCompaction */);
@@ -1860,9 +1860,10 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
     if (info->FullCompaction) {
         request->CompactionOptions.set(ToBit(ECompactionOption::Full));
     }
-    if (info->Mode == TEvPartitionPrivate::MixedBlockCountCompaction) {
+    if (info->Mode == TEvPartitionPrivate::MixedBlocksCountCompaction) {
         // Force writes to the merged channel to avoid a compaction livelock.
-        request->CompactionOptions.set(ToBit(ECompactionOption::ForceToMerged));
+        request->CompactionOptions.set(
+            ToBit(ECompactionOption::ForceMixedBlocksCountCompaction));
     }
 
     auto maxCompactionExecTimePerSecond =
@@ -2008,7 +2009,7 @@ void TPartitionActor::HandleCompaction(
             const auto& top = cm.GetTopByGarbageIgnoringZeroed();
             tops.push_back({top.BlockIndex, top.Stat});
         }
-    } else if (msg->Mode == TEvPartitionPrivate::MixedBlockCountCompaction) {
+    } else if (msg->Mode == TEvPartitionPrivate::MixedBlocksCountCompaction) {
         if (batchCompactionEnabled &&
             Config->GetMixedBlocksCountCompactionRangeCountPerRun() > 1)
         {
@@ -2319,8 +2320,8 @@ void TPartitionActor::CompleteCompaction(
     TVector<TRangeCompactionInfo> rangeCompactionInfos;
     TVector<TCompactionActor::TRequest> requests;
 
-    const bool forceToMerged =
-        args.CompactionOptions.test(ToBit(ECompactionOption::ForceToMerged));
+    const bool forceToMerged = args.CompactionOptions.test(
+        ToBit(ECompactionOption::ForceMixedBlocksCountCompaction));
     const auto mergedBlobThreshold =
         forceToMerged || PartitionConfig.GetStorageMediaKind() ==
                              NCloud::NProto::STORAGE_MEDIA_SSD

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1583,15 +1583,20 @@ private:
             return std::nullopt;
         }
 
+        const ui64 rangeMixedBytesCount =
+            static_cast<ui64>(rangeStat.MixedBlockCount) * State.GetBlockSize();
         const bool rangeMixedBlockCountOverThreshold =
-            rangeStat.MixedBlockCount * State.GetBlockSize() >= threshold;
+            rangeMixedBytesCount >= threshold;
 
         if (!rangeMixedBlockCountOverThreshold) {
             return std::nullopt;
         }
 
+        // Use full compaction to include all mixed blocks in the range so they
+        // can be written to the merged channel. Skipping mixed blocks can cause
+        // a compaction livelock, repeatedly compacting the same blobs.
         return TTriggerInfo(
-            rangeStat.MixedBlockCount,
+            rangeMixedBytesCount,
             threshold,
             0,
             0,
@@ -1856,6 +1861,7 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
         request->CompactionOptions.set(ToBit(ECompactionOption::Full));
     }
     if (info->Mode == TEvPartitionPrivate::MixedBlockCountCompaction) {
+        // Force writes to the merged channel to avoid a compaction livelock.
         request->CompactionOptions.set(ToBit(ECompactionOption::ForceToMerged));
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -339,7 +339,8 @@ struct TEvPartitionPrivate
         GarbageCompaction,
         // Similar to GarbageCompaction, but does not treat previously used
         // blocks that are now zeroed as garbage.
-        IgnoringZeroedCompaction
+        IgnoringZeroedCompaction,
+        MixedBlockCountCompaction
     };
 
     struct TCompactionRequest

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -340,7 +340,7 @@ struct TEvPartitionPrivate
         // Similar to GarbageCompaction, but does not treat previously used
         // blocks that are now zeroed as garbage.
         IgnoringZeroedCompaction,
-        MixedBlockCountCompaction
+        MixedBlocksCountCompaction
     };
 
     struct TCompactionRequest

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -268,6 +268,7 @@ struct TCompactionScores
     float Score = 0;
     ui32 GarbageScore = 0;
     ui32 IgnoringZeroedScore = 0;
+    ui32 MixedBlockCount = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -2850,6 +2850,254 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_EQUAL(0, compactionByReadStats);
     }
 
+    Y_UNIT_TEST(ShouldAutomaticallyRunCompactionForManyMixedBlocks)
+    {
+        static constexpr ui32 mixedBlockCountThreshold = 4;
+
+        auto config = DefaultConfig(1_MB);
+        config.SetMixedBlocksCountCompactionEnabledHDD(true);
+        config.SetMixedBytesCountCompactionThresholdHDD(
+            mixedBlockCountThreshold * DefaultBlockSize);
+        config.SetWriteBlobThreshold(
+            mixedBlockCountThreshold * DefaultBlockSize);
+        config.SetMixedBytesCountCompactionThresholdSSD(
+            (mixedBlockCountThreshold + 1) * DefaultBlockSize);
+        config.SetWriteBlobThresholdSSD(
+            (mixedBlockCountThreshold + 1) * DefaultBlockSize);
+        config.SetSSDMaxBlobsPerRange(100);
+        config.SetHDDMaxBlobsPerRange(100);
+        config.SetCompactionMergedBlobThresholdHDD(1);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        bool compactionRequestObserved = false;
+        ui64 compactionByMixedBlockCount = 0;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        const auto expectedMode = static_cast<ui32>(
+                            TEvPartitionPrivate::MixedBlockCountCompaction);
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            expectedMode,
+                            static_cast<ui32>(msg->Mode));
+                        UNIT_ASSERT(msg->CompactionOptions.test(
+                            ToBit(ECompactionOption::ForceToMerged)));
+                        compactionRequestObserved = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg = event->Get<
+                            TEvStatsService::TEvVolumePartCounters>();
+                        compactionByMixedBlockCount =
+                            msg->DiskCounters->Cumulative
+                                .CompactionByMixedBlockCountPerRange.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 2), 1);
+        partition.Flush();
+        UNIT_ASSERT(!compactionRequestObserved);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(2, 2), 2);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequestObserved);
+
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlocksCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, compactionByMixedBlockCount);
+    }
+
+    Y_UNIT_TEST(ShouldProcessMultipleRangesUponMixedBlockCountCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetGarbageCompactionRangeCountPerRun(2);
+        config.SetMixedBlocksCountCompactionRangeCountPerRun(3);
+        config.SetMixedBlocksCountCompactionEnabledHDD(true);
+        config.SetMixedBytesCountCompactionThresholdHDD(1);
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetHDDMaxBlobsPerRange(100);
+        config.SetCompactionMergedBlobThresholdHDD(1);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // Keep each range large enough for mixed-block compaction after the
+        // seed blob is compacted and a sparse mixed overwrite is added.
+        const ui32 writeBlobBlockCount =
+            config.GetWriteBlobThreshold() / DefaultBlockSize;
+        for (ui32 i = 0; i < 3; ++i) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(
+                    i * 1024 * 1024,
+                    writeBlobBlockCount),
+                i + 1);
+            runtime->DispatchEvents(
+                TDispatchOptions(),
+                TDuration::Seconds(1));
+        }
+
+        TAutoPtr<IEventHandle> compactionRequest;
+        bool stealCompactionRequest = true;
+        ui32 compactedRangeCount = 0;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvCompactionRequest)
+                {
+                    auto* msg = event->Get<
+                        TEvPartitionPrivate::TEvCompactionRequest>();
+                    if (msg->Mode ==
+                            TEvPartitionPrivate::MixedBlockCountCompaction &&
+                        stealCompactionRequest)
+                    {
+                        stealCompactionRequest = false;
+                        compactionRequest = event.Release();
+                        return true;
+                    }
+                } else if (
+                    event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvCompactionCompleted)
+                {
+                    const auto* msg = event->Get<
+                        TEvPartitionPrivate::TEvCompactionCompleted>();
+                    compactedRangeCount = msg->AffectedRanges.size();
+                }
+                return false;
+            });
+
+        for (ui32 i = 0; i < 3; ++i) {
+            partition.WriteBlocks(i * 1024 * 1024, i + 1);
+            partition.Flush();
+        }
+
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.Release());
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(3, compactedRangeCount);
+    }
+
+    Y_UNIT_TEST(ShouldEnableMixedBlockCountCompactionByMediaKind)
+    {
+        const auto isCompactionTriggered = [](
+            NCloud::NProto::EStorageMediaKind mediaKind,
+            bool enabledHDD,
+            bool enabledSSD,
+            ui32 thresholdHDD,
+            ui32 thresholdSSD)
+        {
+            auto config = DefaultConfig(1_MB);
+            config.SetMixedBlocksCountCompactionEnabledHDD(enabledHDD);
+            config.SetMixedBlocksCountCompactionEnabledSSD(enabledSSD);
+            config.SetMixedBytesCountCompactionThresholdHDD(
+                thresholdHDD * DefaultBlockSize);
+            config.SetMixedBytesCountCompactionThresholdSSD(
+                thresholdSSD * DefaultBlockSize);
+            config.SetWriteBlobThresholdSSD(thresholdSSD * DefaultBlockSize);
+            config.SetWriteBlobThreshold(thresholdHDD * DefaultBlockSize);
+            config.SetSSDMaxBlobsPerRange(100);
+            config.SetHDDMaxBlobsPerRange(100);
+
+            TTestPartitionInfo partitionInfo;
+            partitionInfo.MediaKind = mediaKind;
+            auto runtime = PrepareTestActorRuntime(
+                config,
+                1024,
+                {},
+                partitionInfo);
+
+            TPartitionClient partition(*runtime);
+            partition.WaitReady();
+
+            bool compactionRequestObserved = false;
+            runtime->SetEventFilter(
+                [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+                {
+                    if (event->GetTypeRewrite() ==
+                        TEvPartitionPrivate::EvCompactionRequest)
+                    {
+                        const auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode ==
+                            TEvPartitionPrivate::MixedBlockCountCompaction)
+                        {
+                            compactionRequestObserved = true;
+                        }
+                    }
+                    return false;
+                });
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 2), 1);
+            partition.Flush();
+            partition.WriteBlocks(TBlockRange32::WithLength(2, 2), 2);
+            partition.Flush();
+            runtime->DispatchEvents(
+                TDispatchOptions(),
+                TDuration::Seconds(1));
+
+            return compactionRequestObserved;
+        };
+
+        UNIT_ASSERT(!isCompactionTriggered(
+            NCloud::NProto::STORAGE_MEDIA_DEFAULT,
+            false,
+            true,
+            4,
+            4));
+        UNIT_ASSERT(!isCompactionTriggered(
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            true,
+            false,
+            4,
+            4));
+        UNIT_ASSERT(!isCompactionTriggered(
+            NCloud::NProto::STORAGE_MEDIA_DEFAULT,
+            true,
+            false,
+            5,
+            4));
+        UNIT_ASSERT(isCompactionTriggered(
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            false,
+            true,
+            5,
+            4));
+    }
+
     Y_UNIT_TEST(ShouldAutomaticallyRunCompactionForDeletionMarkers)
     {
         static constexpr ui32 compactionThreshold = 4;
@@ -13137,6 +13385,33 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedIndexBlobsCount());
         }
+    }
+
+    Y_UNIT_TEST(CompactionShouldWriteDataToMergedChannelWhenForced)
+    {
+        auto config = DefaultConfig();
+        config.SetCompactionMergedBlobThresholdHDD(17_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config, 1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 1);
+        partition.Flush();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::ForceToMerged));
+        partition.Compaction(0, options);
+        partition.Cleanup();
+
+        const auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
     }
 
     Y_UNIT_TEST(CompactionShouldMoveDataFromMergedToMixedWhenDataSizeIsAboveTheTreshold)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -2883,12 +2883,12 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                         auto* msg = event->Get<
                             TEvPartitionPrivate::TEvCompactionRequest>();
                         const auto expectedMode = static_cast<ui32>(
-                            TEvPartitionPrivate::MixedBlockCountCompaction);
+                            TEvPartitionPrivate::MixedBlocksCountCompaction);
                         UNIT_ASSERT_VALUES_EQUAL(
                             expectedMode,
                             static_cast<ui32>(msg->Mode));
                         UNIT_ASSERT(msg->CompactionOptions.test(
-                            ToBit(ECompactionOption::ForceToMerged)));
+                            ToBit(ECompactionOption::ForceMixedBlocksCountCompaction)));
                         compactionRequestObserved = true;
                         break;
                     }
@@ -2981,7 +2981,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                     auto* msg = event->Get<
                         TEvPartitionPrivate::TEvCompactionRequest>();
                     if (msg->Mode ==
-                            TEvPartitionPrivate::MixedBlockCountCompaction &&
+                            TEvPartitionPrivate::MixedBlocksCountCompaction &&
                         stealCompactionRequest)
                     {
                         stealCompactionRequest = false;
@@ -3053,7 +3053,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                         const auto* msg = event->Get<
                             TEvPartitionPrivate::TEvCompactionRequest>();
                         if (msg->Mode ==
-                            TEvPartitionPrivate::MixedBlockCountCompaction)
+                            TEvPartitionPrivate::MixedBlocksCountCompaction)
                         {
                             compactionRequestObserved = true;
                         }
@@ -13404,7 +13404,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.Flush();
 
         TCompactionOptions options;
-        options.set(ToBit(ECompactionOption::ForceToMerged));
+        options.set(ToBit(ECompactionOption::ForceMixedBlocksCountCompaction));
         partition.Compaction(0, options);
         partition.Cleanup();
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -2935,7 +2935,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(1, compactionByMixedBlockCount);
     }
 
-    Y_UNIT_TEST(ShouldProcessMultipleRangesUponMixedBlockCountCompaction)
+    Y_UNIT_TEST(ShouldProcessMultipleRangesUponMixedBlocksCountCompaction)
     {
         auto config = DefaultConfig();
         config.SetBatchCompactionEnabled(true);
@@ -3011,7 +3011,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(3, compactedRangeCount);
     }
 
-    Y_UNIT_TEST(ShouldEnableMixedBlockCountCompactionByMediaKind)
+    Y_UNIT_TEST(ShouldEnableMixedBlocksCountCompactionByMediaKind)
     {
         const auto isCompactionTriggered = [](
             NCloud::NProto::EStorageMediaKind mediaKind,

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_actor_ydb.cpp
@@ -154,6 +154,8 @@ NYdbStats::TYdbStatsRow BuildStatsForUpload(
         BLOCKSTORE_CUMULATIVE_COUNTER(CompactionByIgnoringZeroedPerRange);
     out.CompactionByIgnoringZeroedPerDisk_Throughput =
         BLOCKSTORE_CUMULATIVE_COUNTER(CompactionByIgnoringZeroedPerDisk);
+    out.CompactionByMixedBlockCountPerRange_Throughput =
+        BLOCKSTORE_CUMULATIVE_COUNTER(CompactionByMixedBlockCountPerRange);
 
 #undef BLOCKSTORE_CUMULATIVE_COUNTER
 

--- a/cloud/blockstore/libs/ydbstats/ydbrow.h
+++ b/cloud/blockstore/libs/ydbstats/ydbrow.h
@@ -83,6 +83,7 @@ namespace NCloud::NBlockStore::NYdbStats {
     xxx(CompactionByGarbageBlocksPerDisk_Throughput,  __VA_ARGS__)             \
     xxx(CompactionByIgnoringZeroedPerRange_Throughput,  __VA_ARGS__)           \
     xxx(CompactionByIgnoringZeroedPerDisk_Throughput,   __VA_ARGS__)           \
+    xxx(CompactionByMixedBlockCountPerRange_Throughput, __VA_ARGS__)           \
 // YDB_CUMULATIVE_COUNTERS
 
 #define YDB_DEFINE_CUMULATIVE_COUNTER(name, ...)                               \


### PR DESCRIPTION
### Notes
Add media-specific configuration and byte thresholds, batch mixed-block-count compactions, force their output into merged channels, and publish the trigger counter through disk and YDB statistics.

### Issue
#6930 