### PR TITLE
issue-6958: implemented lognormal delay policy, null storage group and shard benchmark on top of those two things

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/bench/delay_policy.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/delay_policy.cpp
@@ -1,0 +1,67 @@
+#include "delay_policy.h"
+
+#include <util/system/spinlock.h>
+
+#include <cmath>
+#include <random>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TLognormalDelayPolicy final: public IDelayPolicy
+{
+private:
+    TAdaptiveLock Lock;
+    std::mt19937_64 Engine{42U /* seed */};
+    std::lognormal_distribution<double> Distribution;
+
+public:
+    TLognormalDelayPolicy(TDuration mean, TDuration stddev)
+        : Distribution(MakeDistribution(mean, stddev))
+    {}
+
+    [[nodiscard]] TDuration NextDelay() override
+    {
+        double us = 0;
+        with_lock (Lock) {
+            us = Distribution(Engine);
+        }
+
+        return TDuration::MicroSeconds(static_cast<ui64>(us));
+    }
+
+private:
+    static std::lognormal_distribution<double> MakeDistribution(
+        TDuration mean,
+        TDuration stddev)
+    {
+        //
+        // For a lognormal variable exp(N(mu, sigma^2)) with the desired
+        // mean m and standard deviation s:
+        //   sigma^2 = ln(1 + (s / m)^2)
+        //   mu = ln(m) - sigma^2 / 2
+        //
+
+        const double m = mean.MicroSeconds();
+        const double s = stddev.MicroSeconds();
+        Y_ABORT_UNLESS(m > 0, "mean must be positive");
+
+        const double sigma2 = std::log(1 + (s / m) * (s / m));
+        const double mu = std::log(m) - sigma2 / 2;
+        return std::lognormal_distribution<double>(mu, std::sqrt(sigma2));
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IDelayPolicyPtr CreateLognormalDelayPolicy(TDuration mean, TDuration stddev)
+{
+    return std::make_shared<TLognormalDelayPolicy>(mean, stddev);
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/delay_policy.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/delay_policy.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <util/datetime/base.h>
+
+#include <memory>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Source of artificial response delays for storage fakes.
+ */
+class IDelayPolicy
+{
+public:
+    virtual ~IDelayPolicy() = default;
+
+    /**
+     * Samples the delay for the next response.
+     *
+     * @return - The sampled delay.
+     */
+    [[nodiscard]] virtual TDuration NextDelay() = 0;
+};
+
+using IDelayPolicyPtr = std::shared_ptr<IDelayPolicy>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Returns a policy which samples delays from a lognormal distribution.
+ * The distribution parameters are derived so that the sampled delays
+ * have the requested mean and standard deviation.
+ *
+ * @param mean - Mean of the sampled delays.
+ * @param stddev - Standard deviation of the sampled delays.
+ * @return - The constructed policy.
+ */
+IDelayPolicyPtr CreateLognormalDelayPolicy(TDuration mean, TDuration stddev);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/naive_mirrored_bench.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/naive_mirrored_bench.cpp
@@ -1,0 +1,75 @@
+#include "delay_policy.h"
+#include "null_storage_group.h"
+#include "shard_bench.h"
+
+#include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h>
+#include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/util/init.h>
+
+#include <util/generic/size_literals.h>
+
+#include <cstdlib>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 ShardNo = 1U;
+constexpr ui64 NodesPerGroup = 256U;
+constexpr ui64 GroupCapacity = 256_MB;
+
+const TDuration StorageDelayMean = TDuration::MicroSeconds(100);
+const TDuration StorageDelayStdDev = TDuration::MicroSeconds(100);
+
+////////////////////////////////////////////////////////////////////////////////
+// The google benchmark module owns main(), so the silk runtime is
+// brought up lazily on first use and torn down via atexit: a scheduler
+// thread still running during static destruction segfaults the process.
+
+void EnsureSilk()
+{
+    static const bool initialized = [] {
+        silk::initialize();
+        silk::FiberScheduler::initialize();
+        std::atexit([] {
+            silk::FiberScheduler::destroy();
+            silk::destroy();
+        });
+        return true;
+    }();
+    Y_UNUSED(initialized);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Naive mirrored shard on top of a null storage group whose responses
+// follow a lognormal latency distribution.
+
+IFileSystemShardPtr MakeNaiveMirroredShard()
+{
+    EnsureSilk();
+
+    NProtoPrivate::TPersistentFastShardConfig config;
+    config.SetNodesPerGroup(NodesPerGroup);
+    config.SetExpectedGroupCapacity(GroupCapacity);
+
+    return CreateNaiveMirroredFileSystemShard(
+        "bench-fs",
+        ShardNo,
+        CreateNullStorageGroupFactory(CreateLognormalDelayPolicy(
+            StorageDelayMean,
+            StorageDelayStdDev)),
+        config);
+}
+
+[[maybe_unused]] const bool registered = [] {
+    RegisterShardBenchmarks("NaiveMirroredShard", MakeNaiveMirroredShard);
+    return true;
+}();
+
+}   // namespace
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/null_storage_group.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/null_storage_group.cpp
@@ -1,0 +1,112 @@
+#include "null_storage_group.h"
+
+#include <silk/fibers/fiber.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TNullStorageGroup final: public IStorageGroup
+{
+private:
+    const IDelayPolicyPtr DelayPolicy;
+
+public:
+    explicit TNullStorageGroup(IDelayPolicyPtr delayPolicy)
+        : DelayPolicy(std::move(delayPolicy))
+    {}
+
+    NCloud::NProto::TError AcquireDevices() override
+    {
+        Wait();
+        return {};
+    }
+
+    NCloud::NProto::TError ReleaseDevices() override
+    {
+        Wait();
+        return {};
+    }
+
+    NCloud::NProto::TError WriteLogRecord(
+        NCloud::NProto::TDeviceRequestHeaders headers,
+        TVector<TPageGroup> pageGroups,
+        ui64 lsn) override
+    {
+        Y_UNUSED(headers, pageGroups, lsn);
+
+        Wait();
+        return {};
+    }
+
+    NCloud::NProto::TError ReadPages(
+        NCloud::NProto::TDeviceRequestHeaders headers,
+        const TVector<TPageGroupRef>& pageGroupRefs,
+        TVector<TPageGroup>* pageGroups) override
+    {
+        Y_UNUSED(headers);
+
+        Wait();
+
+        //
+        // Nothing is ever stored, so every read observes zero-filled
+        // pages - the same thing a real group returns for untouched
+        // storage.
+        //
+
+        pageGroups->clear();
+        for (const auto& ref: pageGroupRefs) {
+            auto& pg = pageGroups->emplace_back();
+            pg.FirstPageNo = ref.FirstPageNo;
+            for (ui64 i = 0; i < ref.PageCount; ++i) {
+                pg.Content.emplace_back().Fill(0, ref.PageSize);
+            }
+        }
+
+        return {};
+    }
+
+private:
+    void Wait()
+    {
+        const TDuration delay = DelayPolicy->NextDelay();
+        if (delay) {
+            silk::FiberScheduler::sleep(delay.NanoSeconds());
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TNullStorageGroupFactory final: public IStorageGroupFactory
+{
+private:
+    const IDelayPolicyPtr DelayPolicy;
+
+public:
+    explicit TNullStorageGroupFactory(IDelayPolicyPtr delayPolicy)
+        : DelayPolicy(std::move(delayPolicy))
+    {}
+
+    IStorageGroupPtr MakeStorageGroup(
+        const NProtoPrivate::TPersistentFastShardConfig& config) override
+    {
+        Y_UNUSED(config);
+
+        return std::make_shared<TNullStorageGroup>(DelayPolicy);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IStorageGroupFactoryPtr CreateNullStorageGroupFactory(
+    IDelayPolicyPtr delayPolicy)
+{
+    return std::make_shared<TNullStorageGroupFactory>(std::move(delayPolicy));
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/null_storage_group.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/null_storage_group.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "delay_policy.h"
+
+// XXX will refactor this out of naive_mirrored separately very soon
+#include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Returns a factory which builds storage groups that do no IO: each
+ * request waits for a delay sampled from the policy and succeeds. Reads
+ * return zero-filled pages. Must be used from a fiber - the delays are
+ * implemented via fiber sleeps.
+ *
+ * @param delayPolicy - Source of the per-request delays.
+ * @return - The constructed factory.
+ */
+IStorageGroupFactoryPtr CreateNullStorageGroupFactory(
+    IDelayPolicyPtr delayPolicy);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/shard_bench.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/shard_bench.cpp
@@ -1,0 +1,273 @@
+#include "shard_bench.h"
+
+#include <cloud/filestore/libs/service/filestore.h>
+#include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+
+#include <library/cpp/threading/future/future.h>
+
+#include <util/generic/size_literals.h>
+#include <util/generic/vector.h>
+#include <util/generic/yexception.h>
+#include <util/string/cast.h>
+
+#include <benchmark/benchmark.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+using namespace NFileStore::NProto;
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 CyclesPerIteration = 4U;
+constexpr ui32 PrecreatedNodeCount = 64U;
+constexpr ui32 PagesPerNode = 16U;
+constexpr ui32 RequestSize = 4_KB;
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// The shard rejects concurrent ops which touch the same pages with
+// E_REJECTED and expects the caller to retry - so the driver retries,
+// counting the rejects. A shard implementation may be a happy-path
+// prototype: under page conflicts a rejected create/unlink may leave
+// the name in either state, so the caller-provided "already applied"
+// code (E_FS_EXIST for creates, E_FS_NOENT for unlinks) is treated as
+// success. The conflict rate stays visible through the rejects counter.
+//
+
+template <typename TResponse, typename TRequest, typename TIssue>
+void RunBatchWithRetries(
+    TVector<TRequest> requests,
+    TIssue issue,
+    ui32 alreadyAppliedCode,
+    ui64* rejectCount)
+{
+    while (!requests.empty()) {
+        TVector<NThreading::TFuture<TResponse>> futures;
+        futures.reserve(requests.size());
+        for (const auto& request: requests) {
+            futures.push_back(issue(request));
+        }
+
+        TVector<TRequest> rejected;
+        for (ui32 i = 0; i < futures.size(); ++i) {
+            const ui32 code = futures[i].GetValueSync().GetError().GetCode();
+            if (code == E_REJECTED) {
+                rejected.push_back(std::move(requests[i]));
+                ++*rejectCount;
+                continue;
+            }
+
+            if (alreadyAppliedCode && code == alreadyAppliedCode) {
+                continue;
+            }
+
+            Y_ENSURE(
+                code == S_OK,
+                FormatError(futures[i].GetValueSync().GetError()));
+        }
+
+        requests = std::move(rejected);
+    }
+}
+
+//
+// The shard is leaked deliberately: the last request fiber of an
+// implementation may still hold a reference to the shard internals
+// when the benchmark returns, and letting the shard die on such a
+// fiber races with process teardown.
+//
+
+IFileSystemShard& BuildShard(const TShardFactory& factory)
+{
+    auto* holder = new IFileSystemShardPtr(factory());
+    return **holder;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Scenario 1: create/unlink node pairs, `parallelism` requests in
+// flight at every step.
+
+void CreateUnlinkNodeBench(benchmark::State& state, const TShardFactory& factory)
+{
+    IFileSystemShard& shard = BuildShard(factory);
+    const ui32 parallelism = static_cast<ui32>(state.range(0));
+
+    ui64 rejectCount = 0;
+    for (auto _: state) {
+        for (ui32 cycle = 0; cycle < CyclesPerIteration; ++cycle) {
+            TVector<TCreateNodeRequest> creates(parallelism);
+            for (ui32 slot = 0; slot < parallelism; ++slot) {
+                creates[slot].SetNodeId(RootNodeId);
+                creates[slot].SetName("tmp-" + ToString(slot));
+                creates[slot].MutableFile()->SetMode(0644);
+            }
+            RunBatchWithRetries<TCreateNodeResponse>(
+                std::move(creates),
+                [&](const TCreateNodeRequest& request) {
+                    return shard.CreateNode(request);
+                },
+                NCloud::E_FS_EXIST,
+                &rejectCount);
+
+            TVector<TUnlinkNodeRequest> unlinks(parallelism);
+            for (ui32 slot = 0; slot < parallelism; ++slot) {
+                unlinks[slot].SetNodeId(RootNodeId);
+                unlinks[slot].SetName("tmp-" + ToString(slot));
+            }
+            RunBatchWithRetries<TUnlinkNodeResponse>(
+                std::move(unlinks),
+                [&](const TUnlinkNodeRequest& request) {
+                    return shard.UnlinkNode(request);
+                },
+                NCloud::E_FS_NOENT,
+                &rejectCount);
+        }
+    }
+
+    state.SetItemsProcessed(
+        state.iterations() * CyclesPerIteration * parallelism);
+    state.counters["rejects"] = benchmark::Counter(
+        rejectCount,
+        benchmark::Counter::kIsRate);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Scenario 2: 4K writes and reads over a set of precreated nodes,
+// `parallelism` requests in flight at every step.
+
+void WriteReadData4KBench(benchmark::State& state, const TShardFactory& factory)
+{
+    IFileSystemShard& shard = BuildShard(factory);
+    const ui32 parallelism = static_cast<ui32>(state.range(0));
+
+    //
+    // Precreate the nodes and fill every page each node is going to
+    // serve, so the benchmark loop reads real data instead of holes.
+    //
+
+    TVector<ui64> handles;
+    handles.reserve(PrecreatedNodeCount);
+    const ui32 createHandleFlags = ProtoFlag(TCreateHandleRequest::E_CREATE) |
+                                   ProtoFlag(TCreateHandleRequest::E_READ) |
+                                   ProtoFlag(TCreateHandleRequest::E_WRITE);
+    for (ui32 i = 0; i < PrecreatedNodeCount; ++i) {
+        TCreateHandleRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName("node-" + ToString(i));
+        request.SetMode(0644);
+        request.SetFlags(createHandleFlags);
+        auto response = shard.CreateHandle(std::move(request))
+            .GetValueSync();
+        Y_ENSURE(
+            response.GetError().GetCode() == S_OK,
+            FormatError(response.GetError()));
+        handles.push_back(response.GetHandle());
+    }
+
+    const TString data(RequestSize, 'x');
+    for (const ui64 handle: handles) {
+        TWriteDataRequest request;
+        request.SetHandle(handle);
+        request.SetOffset(0);
+        *request.MutableBuffer() = TString(PagesPerNode * RequestSize, 'y');
+        auto response = shard.WriteData(std::move(request))
+            .GetValueSync();
+        Y_ENSURE(
+            response.GetError().GetCode() == S_OK,
+            FormatError(response.GetError()));
+    }
+
+    ui64 counter = 0;
+    auto pickTarget = [&](ui64* handle, ui64* offset) {
+        *handle = handles[counter % PrecreatedNodeCount];
+        *offset =
+            (counter / PrecreatedNodeCount) % PagesPerNode * RequestSize;
+        ++counter;
+    };
+
+    ui64 rejectCount = 0;
+    for (auto _: state) {
+        for (ui32 cycle = 0; cycle < CyclesPerIteration; ++cycle) {
+            TVector<TWriteDataRequest> writes(parallelism);
+            for (ui32 slot = 0; slot < parallelism; ++slot) {
+                ui64 handle = 0;
+                ui64 offset = 0;
+                pickTarget(&handle, &offset);
+
+                writes[slot].SetHandle(handle);
+                writes[slot].SetOffset(offset);
+                *writes[slot].MutableBuffer() = data;
+            }
+            RunBatchWithRetries<TWriteDataResponse>(
+                std::move(writes),
+                [&](const TWriteDataRequest& request) {
+                    return shard.WriteData(request);
+                },
+                0U /* alreadyAppliedCode */,
+                &rejectCount);
+
+            TVector<TReadDataRequest> reads(parallelism);
+            for (ui32 slot = 0; slot < parallelism; ++slot) {
+                ui64 handle = 0;
+                ui64 offset = 0;
+                pickTarget(&handle, &offset);
+
+                reads[slot].SetHandle(handle);
+                reads[slot].SetOffset(offset);
+                reads[slot].SetLength(RequestSize);
+            }
+            RunBatchWithRetries<TReadDataResponse>(
+                std::move(reads),
+                [&](const TReadDataRequest& request) {
+                    return shard.ReadData(request);
+                },
+                0U /* alreadyAppliedCode */,
+                &rejectCount);
+        }
+    }
+
+    state.SetItemsProcessed(
+        state.iterations() * CyclesPerIteration * parallelism * 2);
+    state.SetBytesProcessed(
+        state.iterations() * CyclesPerIteration * parallelism * 2 *
+        RequestSize);
+    state.counters["rejects"] = benchmark::Counter(
+        rejectCount,
+        benchmark::Counter::kIsRate);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void RegisterShardBenchmarks(TString name, TShardFactory factory)
+{
+    //
+    // The requests complete on the shard implementation's own threads,
+    // not on the benchmark thread, so the meaningful clock is wall
+    // time.
+    //
+
+    benchmark::RegisterBenchmark(
+        (name + "CreateUnlinkNode").c_str(),
+        [factory](benchmark::State& state) {
+            CreateUnlinkNodeBench(state, factory);
+        })
+        ->Arg(1)->Arg(8)
+        ->Unit(benchmark::kMicrosecond)
+        ->UseRealTime();
+
+    benchmark::RegisterBenchmark(
+        (name + "WriteReadData4K").c_str(),
+        [factory](benchmark::State& state) {
+            WriteReadData4KBench(state, factory);
+        })
+        ->Arg(1)->Arg(8)
+        ->Unit(benchmark::kMicrosecond)
+        ->UseRealTime();
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/shard_bench.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/shard_bench.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/iface/public.h>
+
+#include <util/generic/string.h>
+
+#include <functional>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TShardFactory = std::function<IFileSystemShardPtr()>;
+
+/**
+ * Registers the benchmark scenarios for one IFileSystemShard
+ * implementation:
+ * - create/unlink node pairs;
+ * - 4K writes and reads over a set of precreated nodes.
+ * Each scenario runs with 1 and 8 requests in flight. The factory is
+ * invoked once per scenario run and may bring up whatever runtime the
+ * implementation needs.
+ *
+ * @param name - Prefix for the benchmark names.
+ * @param factory - Builds the shard under benchmark.
+ */
+void RegisterShardBenchmarks(TString name, TShardFactory factory);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/ya.make
@@ -1,0 +1,28 @@
+G_BENCHMARK()
+
+IF (SANITIZER_TYPE)
+    TAG(ya:manual)
+ENDIF()
+
+SRCS(
+    delay_policy.cpp
+    naive_mirrored_bench.cpp
+    null_storage_group.cpp
+    shard_bench.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/service
+    cloud/filestore/libs/storage/fastshard/iface
+    cloud/filestore/libs/storage/fastshard/impl/naive_mirrored
+    cloud/filestore/libs/storage/fastshard/sn/quorum
+    cloud/filestore/private/api/unsafe_protos
+
+    cloud/storage/core/libs/common
+
+    library/cpp/threading/future
+
+    contrib/libs/silk/src/fibers
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/impl/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/ya.make
@@ -2,3 +2,9 @@ RECURSE(
     mem
     naive_mirrored
 )
+
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    RECURSE_FOR_TESTS(
+        bench
+    )
+ENDIF()


### PR DESCRIPTION
### Notes
* delay policy iface and lognormal delay policy implementation
* null storage group that doesn't do any IO but uses a delay policy to inject random delays
* shard benchmark that uses a null storage group plus a lognormal delay policy to benchmark our current shard implementation

<img width="1673" height="182" alt="image" src="https://github.com/user-attachments/assets/77e61471-989a-4633-87da-d5db477015ac" />

```
---------------------------------------------------------------------------------------------------------
Benchmark                                               Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------
NaiveMirroredShardCreateUnlinkNode/1/real_time        883 us         25.5 us          732 items_per_second=4.52792k/s rejects=0/s
NaiveMirroredShardCreateUnlinkNode/8/real_time       4820 us          281 us          144 items_per_second=6.6392k/s rejects=9.07992k/s
NaiveMirroredShardWriteReadData4K/1/real_time         468 us         23.2 us         1508 bytes_per_second=66.7705Mi/s items_per_second=17.0932k/s rejects=0/s
NaiveMirroredShardWriteReadData4K/8/real_time        2135 us          158 us          311 bytes_per_second=117.107Mi/s items_per_second=29.9795k/s rejects=6.97824k/s
```

The results will get much better after we remove dirty page-induced E_REJECTED errors in PageStore for writes.

### Issue
https://github.com/ydb-platform/nbs/issues/6958
