### PR TITLE
fix: explicit permissions for every workflow

### DIFF
--- a/.github/workflows/approvals.yaml
+++ b/.github/workflows/approvals.yaml
@@ -5,6 +5,8 @@ on:
     issue_comment:
         types: [created]
 
+permissions: {}
+
 jobs:
     approval-check:
         runs-on: [self-hosted, "self-hosted", "runner_light"]

--- a/.github/workflows/build_and_test_proxy.yaml
+++ b/.github/workflows/build_and_test_proxy.yaml
@@ -75,6 +75,12 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/mirror-yatool-resources.yaml
+++ b/.github/workflows/mirror-yatool-resources.yaml
@@ -8,12 +8,12 @@ on:
         default: false
         description: "Upload refreshed resources to S3"
 
-permissions:
-  contents: read
-
 defaults:
   run:
     shell: bash
+
+permissions:
+  contents: read
 
 env:
   GIT_CONFIG_COUNT: "1"

--- a/.github/workflows/nightly-arm.yaml
+++ b/.github/workflows/nightly-arm.yaml
@@ -24,6 +24,12 @@ on:
         required: false
         default: ""
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   build_dispatch:
     name: Build ARM Grace using YA (relwithdebinfo) (dispatch)

--- a/.github/workflows/nightly-arm.yaml
+++ b/.github/workflows/nightly-arm.yaml
@@ -27,8 +27,6 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   build_dispatch:

--- a/.github/workflows/nightly-asan.yaml
+++ b/.github/workflows/nightly-asan.yaml
@@ -19,6 +19,12 @@ on:
         required: false
         default: ""
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   build:
     name: Build/test x86_64 using YA (release-asan) (dispatch)

--- a/.github/workflows/nightly-asan.yaml
+++ b/.github/workflows/nightly-asan.yaml
@@ -22,8 +22,6 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   build:

--- a/.github/workflows/nightly-index-rebuild.yaml
+++ b/.github/workflows/nightly-index-rebuild.yaml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/nightly-msan.yaml
+++ b/.github/workflows/nightly-msan.yaml
@@ -19,6 +19,12 @@ on:
         required: false
         default: ""
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   build:
     name: Build/test x86_64 using YA (release-msan) (dispatch)

--- a/.github/workflows/nightly-msan.yaml
+++ b/.github/workflows/nightly-msan.yaml
@@ -22,8 +22,6 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   build:

--- a/.github/workflows/nightly-packer-build.yaml
+++ b/.github/workflows/nightly-packer-build.yaml
@@ -9,6 +9,9 @@ on:
     - cron: "0 5 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build VM Image using Packer (dispatch)

--- a/.github/workflows/nightly-tsan.yaml
+++ b/.github/workflows/nightly-tsan.yaml
@@ -22,8 +22,6 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   build:

--- a/.github/workflows/nightly-tsan.yaml
+++ b/.github/workflows/nightly-tsan.yaml
@@ -19,6 +19,12 @@ on:
         required: false
         default: ""
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   build:
     name: Build/test x86_64 using YA (release-tsan) (dispatch)

--- a/.github/workflows/nightly-ubsan.yaml
+++ b/.github/workflows/nightly-ubsan.yaml
@@ -19,6 +19,12 @@ on:
         required: false
         default: ""
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   build:
     name: Build/test x86_64 using YA (release-ubsan) (dispatch)

--- a/.github/workflows/nightly-ubsan.yaml
+++ b/.github/workflows/nightly-ubsan.yaml
@@ -22,8 +22,6 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   build:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -36,8 +36,6 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   build_dispatch:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,6 +33,12 @@ on:
 
 
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   build_dispatch:
     name: Build/test x86_64 using YA (relwithdebinfo) (dispatch)

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -74,4 +74,3 @@ jobs:
       cache_update_tests: true
       sleep_after_tests: 1
       number_of_retries: 1
- 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -74,4 +74,4 @@ jobs:
       cache_update_tests: true
       sleep_after_tests: 1
       number_of_retries: 1
-  
+ 

--- a/.github/workflows/on_demand_build_and_test.yaml
+++ b/.github/workflows/on_demand_build_and_test.yaml
@@ -172,6 +172,12 @@ on:
         default: ""
         description: "Nebius image id to use for VM"
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -116,6 +116,12 @@ on:
         description: "sleep_after_tests"
         value: ${{ jobs.build-and-test.outputs.sleep_after_tests }}
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_hybrid_build_and_test.yaml
+++ b/.github/workflows/on_hybrid_build_and_test.yaml
@@ -164,6 +164,12 @@ on:
         default: ""
         description: "Per ya make test attempt timeout in minutes"
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -116,6 +116,12 @@ on:
         description: "sleep_after_tests"
         value: ${{ jobs.build-and-test.outputs.sleep_after_tests }}
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_pooled_build_and_test.yaml
+++ b/.github/workflows/on_pooled_build_and_test.yaml
@@ -158,6 +158,12 @@ on:
 
 
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   build-and-test:
     name: Build and test NBS [build_preset=${{ inputs.build_preset }} component=${{ inputs.component == '' && 'all' || inputs.component }} target_platform=${{ inputs.target_platform == '' && 'native' || inputs.target_platform }}]

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -96,6 +96,12 @@ on:
         default: ""
         description: "Per ya make test attempt timeout in minutes"
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/orchestrator-heavy.yaml
+++ b/.github/workflows/orchestrator-heavy.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: orchestrator-heavy
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/orchestrator-heavy.yaml
+++ b/.github/workflows/orchestrator-heavy.yaml
@@ -28,7 +28,7 @@ jobs:
       loop: 'yes'
       run_light: 'no'
       run_heavy: 'yes'
-  
+
   restart:
     name: Run gh cli to run orchestrator-proxy with the same arguments, which will start orchestrator.yaml if not cancelled and looped
     if: ${{ !cancelled() }}
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/gh_cli
       - name: Run gh cli to start this workflow with the same arguments
         if: ${{ always() }}
-        shell: bash --noprofile --norc -eo pipefail -x {0} 
+        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           gh workflow run orchestrator-proxy.yaml -R "${GITHUB_REPO}" \
               --field workflow_name="${WORKFLOW_NAME}" \

--- a/.github/workflows/orchestrator-light.yaml
+++ b/.github/workflows/orchestrator-light.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: orchestrator-light
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/orchestrator-light.yaml
+++ b/.github/workflows/orchestrator-light.yaml
@@ -28,7 +28,7 @@ jobs:
       loop: 'yes'
       run_light: 'yes'
       run_heavy: 'no'
-  
+
   restart:
     name: Run gh cli to run orchestrator-proxy with the same arguments, which will start orchestrator.yaml if not cancelled and looped
     if: ${{ !cancelled() }}
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/gh_cli
       - name: Run gh cli to start this workflow with the same arguments
         if: ${{ always() }}
-        shell: bash --noprofile --norc -eo pipefail -x {0} 
+        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           gh workflow run orchestrator-proxy.yaml -R "${GITHUB_REPO}" \
               --field workflow_name="${WORKFLOW_NAME}" \

--- a/.github/workflows/orchestrator-proxy.yaml
+++ b/.github/workflows/orchestrator-proxy.yaml
@@ -46,6 +46,9 @@ on:
 concurrency:
   group: orchestrator-proxy
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/orchestrator-proxy.yaml
+++ b/.github/workflows/orchestrator-proxy.yaml
@@ -55,7 +55,6 @@ env:
   GIT_CONFIG_VALUE_0: HTTP/1.1
 
 jobs:
-  
   restart:
     name: Run ${{ inputs.workflow_name }}
     if: ${{ !cancelled() }}
@@ -76,7 +75,7 @@ jobs:
         run: sleep 15
       - name: Run gh cli to start this workflow with the same arguments
         if: ${{ always() }}
-        shell: bash --noprofile --norc -eo pipefail -x {0} 
+        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           gh workflow run "${WORKFLOW_NAME}" -R "${GITHUB_REPO}"
         env:

--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -67,6 +67,9 @@ on:
         required: true
         default: 'orchestrator-light.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   light:
     name: Populate light VMs
@@ -95,4 +98,3 @@ jobs:
       flavor: heavy
       provision_mode: ${{ inputs.provision_mode || 'regular' }}
       loop: ${{ inputs.provision_mode == 'initial' && 'no' || (inputs.loop == 'yes' && 'yes' || 'no') }}
-

--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -1,6 +1,6 @@
 name: Orchestrator
 run-name: ${{ format('Orchestrator ({0} {1} {2})', github.event_name, inputs.run_light, inputs.run_heavy)  }}
-      
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -97,6 +97,9 @@ concurrency:
   group: packer-build-vm-image
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -31,12 +31,6 @@ on:
           - "yes"
           - "no"
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 defaults:
   run:
     shell: bash
@@ -53,6 +47,12 @@ concurrency:
       ) && 'tests' || 'ignored'
     }}
   cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
 
 env:
   GIT_CONFIG_COUNT: "1"

--- a/.github/workflows/pr-vscode-yatool-extension.yaml
+++ b/.github/workflows/pr-vscode-yatool-extension.yaml
@@ -14,14 +14,14 @@ on:
       - "reopened"
       - "labeled"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: read
   pull-requests: write
   issues: write
-
-defaults:
-  run:
-    shell: bash
 
 env:
   GIT_CONFIG_COUNT: "1"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,12 +18,6 @@ on:
       - 'reopened'
       - 'labeled'
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{
@@ -36,6 +30,12 @@ concurrency:
       ) && 'tests' || 'ignored'
     }}
   cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
 
 env:
   GIT_CONFIG_COUNT: "1"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,9 +18,6 @@ on:
       - 'reopened'
       - 'labeled'
 
-permissions:
-  contents: read
-
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{
@@ -33,6 +30,9 @@ concurrency:
       ) && 'pre-commit' || 'ignored'
     }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   GIT_CONFIG_COUNT: "1"

--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -91,6 +91,9 @@ concurrency:
   cancel-in-progress: false
   
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -89,7 +89,6 @@ on:
 concurrency:
   group: 'populate-vms-${{ inputs.flavor }}'
   cancel-in-progress: false
-  
 
 permissions:
   contents: read

--- a/.github/workflows/vscode-yatool-extension.yaml
+++ b/.github/workflows/vscode-yatool-extension.yaml
@@ -3,12 +3,12 @@ name: Build VS Code yatool extension
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 defaults:
   run:
     shell: bash
+
+permissions:
+  contents: read
 
 env:
   GIT_CONFIG_COUNT: "1"


### PR DESCRIPTION
With this I want to address few issues:
0. Now it is practically [required](https://github.com/orgs/community/discussions/206581#discussioncomment-18269083) to have auth during checkout
1. [actions/checkout](https://github.com/actions/checkout#recommended-permissions) recommends setting `contents: read`
2. We have globally set write permissions for all workflows in repo settings. I want to change it to read-only by default. 

"By default" means "if permission dict is not set it will be read-only". And by setting `permissions` I will also be able to revoke permissions from default. And if downstream workflow needs tighter permissions we can add new `permissions` dict with tighter scope. And it is important that scope can't be extended this way.

And important to note: it only affects env variable `GITHUB_TOKEN` and `${{ github.token }}` workflow context variable.

So most of workflows have these four:

* `actions: read` - to read workflow/job metadata
* `contents: read` - read repo
* `pull-requests: write` - write to pull requests (e.g. plaque comments)
* `issues: write` - write to issues (distinction between issues and pull requests in Github API is blurry and _some_ api calls require it)

Some have `{}`, which means: nothing is allowed for `GITHUB_TOKEN`. But for, for example, `approvals.yaml` we use PAT, which has access to org data, which is not possible to get from `permissions` framework.

We also can set per-job permissions, but it looks clunky.

I would also like to have per-event-type permissions, but it is not possible. For example if event is `workflow_dispatch` there is no PR to write to, so write permissions are not required. It may be done by splitting workflows and using pure `workflow_call` workflows, but it will add clutter in workflows dir.