### PR TITLE
issue-1559: [Disk Manager, Filestore] Add UsedNodesCount  to TGetFileSystemTopologyResponse

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nfs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/client.go
@@ -487,6 +487,7 @@ func (c *client) GetFileSystemTopology(
 		FileShardFileSystemIDs:                 response.FileShardFileSystemIds,
 		CompressNodeRef:                        response.CompressNodeRef,
 		MainFileSystemID:                       response.MainFileSystemId,
+		UsedNodesCount:                         response.UsedNodesCount,
 	}, nil
 }
 

--- a/cloud/disk_manager/internal/pkg/clients/nfs/interface.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/interface.go
@@ -43,6 +43,7 @@ type FilesystemTopology struct {
 	FileShardFileSystemIDs                 []string
 	CompressNodeRef                        bool
 	MainFileSystemID                       string
+	UsedNodesCount                         uint64
 }
 
 type ConfigureAsShardParams struct {

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_metrics_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_metrics_test.go
@@ -303,6 +303,7 @@ func TestClientGetFileSystemTopologySuccess(t *testing.T) {
 				FileShardFileSystemIds:                 []string{"fs-1_file_s1"},
 				CompressNodeRef:                        true,
 				MainFileSystemId:                       "fs-1",
+				UsedNodesCount:                         42,
 			},
 		),
 		nil,
@@ -321,6 +322,7 @@ func TestClientGetFileSystemTopologySuccess(t *testing.T) {
 		FileShardFileSystemIDs:                 []string{"fs-1_file_s1"},
 		CompressNodeRef:                        true,
 		MainFileSystemID:                       "fs-1",
+		UsedNodesCount:                         42,
 	}, topology)
 
 	nfsMock.AssertExpectations(t)

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
@@ -61,17 +61,32 @@ func TestGetFileSystemTopology(t *testing.T) {
 		filesystemID + "_s2",
 	}
 
+	session, err := client.CreateSession(ctx, filesystemID, "", false)
+	require.NoError(t, err)
+	defer session.Close(ctx)
+
+	_, err = session.CreateNode(ctx, nfs.Node{
+		ParentNodeID: nfs.RootNodeID,
+		Name:         "testfile",
+		Mode:         0644,
+		Type:         nfs.NODE_KIND_FILE,
+	})
+	require.NoError(t, err)
+
 	topology, err := client.GetFileSystemTopology(ctx, filesystemID)
 	require.NoError(t, err)
 	require.Equal(t, expectedShardIDs, topology.ShardFileSystemIDs)
 	require.Equal(t, filesystemID, topology.MainFileSystemID)
+	require.Zero(t, topology.UsedNodesCount)
 
-	shardTopology, err := client.GetFileSystemTopology(
-		ctx,
-		expectedShardIDs[0],
-	)
-	require.NoError(t, err)
-	require.Equal(t, filesystemID, shardTopology.MainFileSystemID)
+	var usedNodesCount uint64
+	for _, shardID := range expectedShardIDs {
+		shardTopology, err := client.GetFileSystemTopology(ctx, shardID)
+		require.NoError(t, err)
+		require.Equal(t, filesystemID, shardTopology.MainFileSystemID)
+		usedNodesCount += shardTopology.UsedNodesCount
+	}
+	require.Equal(t, uint64(1), usedNodesCount)
 }
 
 func TestDeleteFilesystem(t *testing.T) {

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -3032,7 +3032,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         auto testFileSystemTopology =
             [&] (const ui32 shardNo,
                  const TString& shardId,
-                 const TString& mainFileSystemId)
+                 const TString& mainFileSystemId,
+                 const ui64 usedNodesCount)
         {
             const auto response = GetFileSystemTopology(service, shardId);
             const auto& shardIds = response.GetShardFileSystemIds();
@@ -3040,15 +3041,18 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             UNIT_ASSERT_EQUAL(
                 mainFileSystemId,
                 response.GetMainFileSystemId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                usedNodesCount,
+                response.GetUsedNodesCount());
             UNIT_ASSERT_EQUAL(2, shardIds.size());
             UNIT_ASSERT_EQUAL(fsConfig.Shard1Id, shardIds[0]);
             UNIT_ASSERT_EQUAL(fsConfig.Shard2Id, shardIds[1]);
             UNIT_ASSERT(response.GetStrictFileSystemSizeEnforcementEnabled());
         };
 
-        testFileSystemTopology(0, fsConfig.FsId, fsConfig.FsId);
-        testFileSystemTopology(1, fsConfig.Shard1Id, fsConfig.FsId);
-        testFileSystemTopology(2, fsConfig.Shard2Id, fsConfig.FsId);
+        testFileSystemTopology(0, fsConfig.FsId, fsConfig.FsId, 0);
+        testFileSystemTopology(1, fsConfig.Shard1Id, fsConfig.FsId, 1);
+        testFileSystemTopology(2, fsConfig.Shard2Id, fsConfig.FsId, 1);
     }
 
     SERVICE_TEST(ShouldGetStorageStatsInDifferentModes)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1186,6 +1186,7 @@ void TIndexTabletActor::HandleGetFileSystemTopology(
     response->Record.SetMaxShardCount(Config->GetMaxShardCount());
     response->Record.SetCompressNodeRef(GetCompressNodeRef());
     response->Record.SetMainFileSystemId(GetMainFileSystemId());
+    response->Record.SetUsedNodesCount(GetUsedNodesCount());
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET,

--- a/cloud/filestore/private/api/unsafe_protos/unsafe.proto
+++ b/cloud/filestore/private/api/unsafe_protos/unsafe.proto
@@ -99,6 +99,9 @@ message TGetFileSystemTopologyResponse
 
     // Main FileSystem identifier.
     string MainFileSystemId = 10;
+
+    // Number of nodes used by this FileSystem tablet, excluding its shards.
+    uint64 UsedNodesCount = 11;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
We need UsedNodesCount to track the progress of filesystem snapshot.

### Issue
#1559