### PR TITLE
[Filestore] vfs_fuse: introduce TPersistentStateManager which encapsulates per-session state files for write-back cache, handle ops queue and persistent directory handles storage

### DIFF
--- a/cloud/filestore/apps/client/lib/mount.cpp
+++ b/cloud/filestore/apps/client/lib/mount.cpp
@@ -9,6 +9,7 @@
 #include <cloud/filestore/libs/vfs/config.h>
 #include <cloud/filestore/libs/vfs/loop.h>
 #include <cloud/filestore/libs/vfs_fuse/loop.h>
+#include <cloud/filestore/libs/vfs_fuse/persistent_state_manager.h>
 
 #include <cloud/storage/core/libs/file_backed_containers/file_map_memory_limiter.h>
 
@@ -80,7 +81,8 @@ public:
             Timer,
             CreateProfileLogStub(),
             session,
-            CreateFileMapMemoryLimiterStub());
+            CreateFileMapMemoryLimiterStub(),
+            NFuse::CreatePersistentStateManagerStub());
     }
 
     void Start() override

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -36,6 +36,7 @@
 #include <cloud/filestore/libs/storage/fastshard/bootstrap/core.h>
 #include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
 #include <cloud/filestore/libs/vfs/probes.h>
+#include <cloud/filestore/libs/vfs_fuse/persistent_state_manager.h>
 #include <cloud/filestore/libs/vhost/server.h>
 
 #include <cloud/storage/core/libs/aio/service.h>
@@ -610,6 +611,12 @@ void TBootstrapVhost::InitEndpoints()
             .FileMapMemoryLimit =
                 Configs->VhostServiceConfig->GetFileMapMemoryLimit()});
 
+    // Shared by all the filesystem loops
+    auto persistentState = std::make_shared<NFuse::TPersistentStateManager>(
+        Configs->VhostServiceConfig->GetHandleOpsQueuePath(),
+        Configs->VhostServiceConfig->GetWriteBackCachePath(),
+        Configs->VhostServiceConfig->GetDirectoryHandlesStoragePath());
+
     EndpointListener = NVhost::CreateEndpointListener(
         Logging,
         Timer,
@@ -622,7 +629,8 @@ void TBootstrapVhost::InitEndpoints()
             StatsRegistry,
             ModuleStatsRegistry,
             FsCountersProvider,
-            ProfileLog),
+            ProfileLog,
+            std::move(persistentState)),
         THandleOpsQueueConfig{
             .PathPrefix = Configs->VhostServiceConfig->GetHandleOpsQueuePath(),
             .MaxQueueSize =

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -612,7 +612,7 @@ void TBootstrapVhost::InitEndpoints()
                 Configs->VhostServiceConfig->GetFileMapMemoryLimit()});
 
     // Shared by all the filesystem loops
-    auto persistentState = std::make_shared<NFuse::TPersistentStateManager>(
+    auto persistentState = NFuse::CreatePersistentStateManager(
         Configs->VhostServiceConfig->GetHandleOpsQueuePath(),
         Configs->VhostServiceConfig->GetWriteBackCachePath(),
         Configs->VhostServiceConfig->GetDirectoryHandlesStoragePath());

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.h
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.h
@@ -9,6 +9,7 @@
 #include <cloud/filestore/libs/server/public.h>
 #include <cloud/filestore/libs/service/public.h>
 #include <cloud/filestore/libs/vfs/public.h>
+#include <cloud/filestore/libs/vfs_fuse/public.h>
 
 #include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
@@ -32,7 +33,8 @@ struct TVhostModuleFactories
         IRequestStatsRegistryPtr requestStats,
         IModuleStatsRegistryPtr moduleStats,
         IFsCountersProviderPtr fsCountersProvider,
-        IProfileLogPtr profileLog)> LoopFactory;
+        IProfileLogPtr profileLog,
+        NFuse::TPersistentStateManagerPtr persistentState)> LoopFactory;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.h
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.h
@@ -34,7 +34,7 @@ struct TVhostModuleFactories
         IModuleStatsRegistryPtr moduleStats,
         IFsCountersProviderPtr fsCountersProvider,
         IProfileLogPtr profileLog,
-        NFuse::TPersistentStateManagerPtr persistentState)> LoopFactory;
+        NFuse::IPersistentStateManagerPtr persistentState)> LoopFactory;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -45,7 +45,7 @@ namespace NCloud::NFileStore{
     xxx(WriteBackCacheInitializationError)                                     \
     xxx(WriteBackCacheWritingNotAllowedInDrainingMode)                         \
     xxx(ErrorWasSentToTheGuest)                                                \
-    xxx(DirectoryHandlesStorageError)                                          \
+    xxx(DirectoryHandleStorageError)                                           \
     xxx(CalculateChecksumsBufferOverflow)                                      \
     xxx(UnexpectedFakeDescribeDataResponse)                                    \
     xxx(CreateLinkRequestWithShardNodeNameAndNoShardId)                        \

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -71,6 +71,7 @@ namespace NCloud::NFileStore{
     xxx(IncompatibleFeatures)                                                  \
     xxx(AvailabilityCountersUnavailableInterval)                               \
     xxx(AvailabilityCountersMissingIntervals)                                  \
+    xxx(PersistentStateSessionDirNotEmpty)                                     \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_CRITICAL_EVENTS_WITHOUT_LOGGING(xxx)                         \

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
@@ -45,7 +45,7 @@ void TDirectoryHandleStorage::StoreHandle(
     TGuard guard(TableLock);
 
     if (HandleIdToIndices.contains(handleId)) {
-        ReportDirectoryHandlesStorageError(
+        ReportDirectoryHandleStorageError(
             "Failed to store record with existing handle id");
         RemoveRecords(handleId);
         HandlesExcludedFromStorage.insert(handleId);

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -4,6 +4,7 @@
 #include "log.h"
 #include "loop.h"
 #include "node_cache.h"
+#include "persistent_state_manager.h"
 
 #include <cloud/filestore/libs/client/config.h>
 #include <cloud/filestore/libs/client/session.h>
@@ -299,7 +300,11 @@ struct TBootstrap
             Timer,
             CreateProfileLogStub(),
             Session,
-            std::move(fileMapMemoryLimiter));
+            std::move(fileMapMemoryLimiter),
+            std::make_shared<TPersistentStateManager>(
+                config->GetHandleOpsQueuePath(),
+                config->GetWriteBackCachePath(),
+                config->GetDirectoryHandlesStoragePath()));
     }
 
     NMonitoring::TDynamicCountersPtr GetFileSystemStatsCounters() const

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -5318,12 +5318,11 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
     Y_UNIT_TEST(ShouldStartAfterPreviousLoopWasDestroyedWithoutStop)
     {
-        // A single manager is shared by all the loops, as in production
+        // A single manager is shared by all the loops and all the components
+        // share one base path, as in production
+        const TString statePath = TempDir.Path() / "SharedState";
         auto persistentStateManager =
-            CreatePersistentStateManager(
-                TempDir.Path() / "HandleOpsQueue",
-                TempDir.Path() / "WriteBackCache",
-                TempDir.Path() / "DirectoryHandles");
+            CreatePersistentStateManager(statePath, statePath, statePath);
 
         NProto::TFileStoreFeatures features;
         features.SetServerWriteBackCacheEnabled(true);
@@ -5333,9 +5332,9 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         // the start fails after the write back cache state file has already
         // been acquired, like it happens when e.g. the FUSE loop fails to
         // start.
-        const auto directoryHandleStoragePath =
-            TFsPath(TempDir.Path() / "DirectoryHandles") / FileSystemId /
-            SessionId / "directory_handles_storage";
+        const auto directoryHandleStoragePath = TFsPath(statePath) /
+                                                FileSystemId / SessionId /
+                                                "directory_handles_storage";
         directoryHandleStoragePath.Parent().MkDirs();
         directoryHandleStoragePath.Touch();
         auto externalLock = MakeHolder<TFileLock>(directoryHandleStoragePath);

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -42,6 +42,7 @@
 #include <util/datetime/base.h>
 #include <util/folder/dirut.h>
 #include <util/folder/path.h>
+#include <util/system/file_lock.h>
 #include <util/folder/tempdir.h>
 #include <util/generic/guid.h>
 #include <util/generic/string.h>
@@ -192,7 +193,8 @@ struct TBootstrap
             ui64 directoryHandlesInitialDataSize = 0,
             ui64 directoryHandlesMaxDataAreaStepSize = 0,
             IFileMapMemoryLimiterPtr fileMapMemoryLimiter =
-                CreateFileMapMemoryLimiterStub())
+                CreateFileMapMemoryLimiterStub(),
+            TPersistentStateManagerPtr persistentStateManager = nullptr)
         : Logging(CreateLoggingService("console", { TLOG_RESOURCES }))
         , Scheduler{std::move(scheduler)}
         , Timer{std::move(timer)}
@@ -290,6 +292,13 @@ struct TBootstrap
             writeBackCacheAutomaticFlushPeriodMs);
 
         auto config = std::make_shared<TVFSConfig>(std::move(proto));
+        if (!persistentStateManager) {
+            persistentStateManager = std::make_shared<TPersistentStateManager>(
+                config->GetHandleOpsQueuePath(),
+                config->GetWriteBackCachePath(),
+                config->GetDirectoryHandlesStoragePath());
+        }
+
         Loop = NFuse::CreateFuseLoop(
             config,
             Logging,
@@ -301,10 +310,7 @@ struct TBootstrap
             CreateProfileLogStub(),
             Session,
             std::move(fileMapMemoryLimiter),
-            std::make_shared<TPersistentStateManager>(
-                config->GetHandleOpsQueuePath(),
-                config->GetWriteBackCachePath(),
-                config->GetDirectoryHandlesStoragePath()));
+            std::move(persistentStateManager));
     }
 
     NMonitoring::TDynamicCountersPtr GetFileSystemStatsCounters() const
@@ -5310,6 +5316,70 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT_VALUES_EQUAL(1, static_cast<int>(*writeBackCacheError));
     }
 
+    Y_UNIT_TEST(ShouldStartAfterPreviousLoopWasDestroyedWithoutStop)
+    {
+        // A single manager is shared by all the loops, as in production
+        auto persistentStateManager =
+            std::make_shared<TPersistentStateManager>(
+                TempDir.Path() / "HandleOpsQueue",
+                TempDir.Path() / "WriteBackCache",
+                TempDir.Path() / "DirectoryHandles");
+
+        NProto::TFileStoreFeatures features;
+        features.SetServerWriteBackCacheEnabled(true);
+        features.SetDirectoryHandlesStorageEnabled(true);
+
+        // Hold the directory handle storage state file from outside so that
+        // the start fails after the write back cache state file has already
+        // been acquired, like it happens when e.g. the FUSE loop fails to
+        // start.
+        const auto directoryHandleStoragePath =
+            TFsPath(TempDir.Path() / "DirectoryHandles") / FileSystemId /
+            SessionId / "directory_handles_storage";
+        directoryHandleStoragePath.Parent().MkDirs();
+        directoryHandleStoragePath.Touch();
+        auto externalLock = MakeHolder<TFileLock>(directoryHandleStoragePath);
+        UNIT_ASSERT(externalLock->TryAcquire());
+
+        {
+            TBootstrap bootstrap(
+                CreateWallClockTimer(),
+                CreateScheduler(),
+                features,
+                1000,
+                1000,
+                WriteBackCacheCapacity,
+                0,
+                0,
+                CreateFileMapMemoryLimiterStub(),
+                persistentStateManager);
+            auto error = bootstrap.Start();
+            UNIT_ASSERT(HasError(error));
+
+            // The loop goes away without being stopped, as it happens to an
+            // endpoint whose start has failed.
+        }
+
+        externalLock.Reset();
+
+        // A new loop for the same session must be able to acquire the state
+        // files left by the previous one.
+        TBootstrap bootstrap(
+            CreateWallClockTimer(),
+            CreateScheduler(),
+            features,
+            1000,
+            1000,
+            WriteBackCacheCapacity,
+            0,
+            0,
+            CreateFileMapMemoryLimiterStub(),
+            persistentStateManager);
+        auto error = bootstrap.Start();
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+        bootstrap.Stop();
+    }
+
     Y_UNIT_TEST(ShouldNotCrashWhileStoppingWhenForgetRequestIsInFlight)
     {
         TBootstrap bootstrap;
@@ -5856,6 +5926,113 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             bootstrap.Fuse->SendRequest<TFlushRequest>(nodeId, handleId);
         UNIT_ASSERT(reqFlush.Wait(WaitTimeout));
         UNIT_ASSERT_VALUES_EQUAL(1, writeDataCalled.load());
+    }
+
+    Y_UNIT_TEST(ShouldKeepPersistentStateUnderFileSystemIdReturnedBySession)
+    {
+        // The requested filesystem id may be an alias which the server
+        // resolves upon session creation. The state files have to be kept
+        // under the resolved id, otherwise the state of a previous session
+        // is not found and e.g. pending writes are lost.
+        const TString resolvedFileSystemId = FileSystemId + "-resolved";
+        const TString sessionId = CreateGuidAsString();
+
+        std::atomic<int> writeDataCalled = 0;
+        std::atomic<int> writeDataCalled2 = 0;
+
+        const ui64 nodeId = 123;
+        const ui64 handleId = 456;
+
+        auto createBootstrap = [&](bool serverWriteBackCacheEnabled,
+                                   std::atomic<int>& counter)
+        {
+            NProto::TFileStoreFeatures features;
+            features.SetServerWriteBackCacheEnabled(
+                serverWriteBackCacheEnabled);
+
+            TBootstrap bootstrap(
+                CreateWallClockTimer(),
+                CreateScheduler(),
+                features);
+
+            bootstrap.Service->CreateSessionHandler =
+                [features, &sessionId, &resolvedFileSystemId](auto, auto)
+            {
+                NProto::TCreateSessionResponse result;
+                result.MutableSession()->SetSessionId(sessionId);
+                result.MutableFileStore()->SetBlockSize(4096);
+                result.MutableFileStore()->MutableFeatures()->CopyFrom(
+                    features);
+                result.MutableFileStore()->SetFileSystemId(
+                    resolvedFileSystemId);
+                return MakeFuture(result);
+            };
+
+            bootstrap.Service->WriteDataHandler = [&counter](auto, const auto&)
+            {
+                counter++;
+                NProto::TWriteDataResponse result;
+                return MakeFuture(result);
+            };
+
+            return bootstrap;
+        };
+
+        const auto resolvedPath = TempDir.Path() / "WriteBackCache" /
+                                  resolvedFileSystemId / sessionId /
+                                  "write_back_cache";
+        const auto requestedPath = TempDir.Path() / "WriteBackCache" /
+                                   FileSystemId / sessionId /
+                                   "write_back_cache";
+
+        {
+            auto bootstrap = createBootstrap(true, writeDataCalled);
+
+            bootstrap.Start();
+            Y_DEFER
+            {
+                bootstrap.Stop();
+            };
+
+            UNIT_ASSERT(resolvedPath.Exists());
+            UNIT_ASSERT(!requestedPath.Exists());
+
+            auto reqWrite = std::make_shared<TWriteRequest>(
+                nodeId,
+                handleId,
+                0,
+                CreateBuffer(4096, 'a'));
+            reqWrite->In->Body.flags |= O_WRONLY;
+            auto write = bootstrap.Fuse->SendRequest<TWriteRequest>(reqWrite);
+            UNIT_ASSERT_NO_EXCEPTION(write.GetValue(WaitTimeout));
+
+            auto suspend = bootstrap.Loop->SuspendAsync();
+            UNIT_ASSERT(suspend.Wait(WaitTimeout));
+        }
+
+        // Since write-back cache was enabled, the actual write didn't happen
+        // and the request is stored in the persistent queue
+        UNIT_ASSERT_VALUES_EQUAL(0, writeDataCalled.load());
+        UNIT_ASSERT(resolvedPath.Exists());
+        UNIT_ASSERT(!requestedPath.Exists());
+
+        {
+            auto bootstrap = createBootstrap(false, writeDataCalled2);
+
+            bootstrap.Start();
+
+            // The state of the previous session is found under the resolved
+            // id although the feature is disabled now: drain triggers flush
+            // immediately
+            UNIT_ASSERT_VALUES_EQUAL(1, writeDataCalled2.load());
+
+            bootstrap.Stop();
+        }
+
+        // Stopping destroys the session, so its state is deleted, again
+        // under the resolved id
+        UNIT_ASSERT(!resolvedPath.Exists());
+        UNIT_ASSERT(!requestedPath.Exists());
     }
 
     Y_UNIT_TEST(ShouldRestoreAndDrainCacheAfterSessionRestart)

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -194,7 +194,7 @@ struct TBootstrap
             ui64 directoryHandlesMaxDataAreaStepSize = 0,
             IFileMapMemoryLimiterPtr fileMapMemoryLimiter =
                 CreateFileMapMemoryLimiterStub(),
-            TPersistentStateManagerPtr persistentStateManager = nullptr)
+            IPersistentStateManagerPtr persistentStateManager = nullptr)
         : Logging(CreateLoggingService("console", { TLOG_RESOURCES }))
         , Scheduler{std::move(scheduler)}
         , Timer{std::move(timer)}
@@ -293,7 +293,7 @@ struct TBootstrap
 
         auto config = std::make_shared<TVFSConfig>(std::move(proto));
         if (!persistentStateManager) {
-            persistentStateManager = std::make_shared<TPersistentStateManager>(
+            persistentStateManager = CreatePersistentStateManager(
                 config->GetHandleOpsQueuePath(),
                 config->GetWriteBackCachePath(),
                 config->GetDirectoryHandlesStoragePath());
@@ -5320,7 +5320,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         // A single manager is shared by all the loops, as in production
         auto persistentStateManager =
-            std::make_shared<TPersistentStateManager>(
+            CreatePersistentStateManager(
                 TempDir.Path() / "HandleOpsQueue",
                 TempDir.Path() / "WriteBackCache",
                 TempDir.Path() / "DirectoryHandles");

--- a/cloud/filestore/libs/vfs_fuse/fuzz/starter.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fuzz/starter.cpp
@@ -13,6 +13,7 @@
 #include <cloud/filestore/libs/vfs/config.h>
 #include <cloud/filestore/libs/vfs/loop.h>
 #include <cloud/filestore/libs/vfs_fuse/loop.h>
+#include <cloud/filestore/libs/vfs_fuse/persistent_state_manager.h>
 #include <cloud/filestore/libs/vhost/server.h>
 
 #include <cloud/storage/core/libs/common/error.h>
@@ -113,6 +114,10 @@ TStarter::TStarter()
     proto.SetSocketPath(SocketPath.c_str());
 
     auto config = std::make_shared<TVFSConfig>(std::move(proto));
+    auto persistentState = std::make_shared<TPersistentStateManager>(
+        config->GetHandleOpsQueuePath(),
+        config->GetWriteBackCachePath(),
+        config->GetDirectoryHandlesStoragePath());
 
     Loop = NFuse::CreateFuseLoop(
         std::move(config),
@@ -124,7 +129,8 @@ TStarter::TStarter()
         Timer,
         CreateProfileLogStub(),
         std::move(session),
-        CreateFileMapMemoryLimiterStub());
+        CreateFileMapMemoryLimiterStub(),
+        std::move(persistentState));
 }
 
 

--- a/cloud/filestore/libs/vfs_fuse/fuzz/starter.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fuzz/starter.cpp
@@ -114,7 +114,7 @@ TStarter::TStarter()
     proto.SetSocketPath(SocketPath.c_str());
 
     auto config = std::make_shared<TVFSConfig>(std::move(proto));
-    auto persistentState = std::make_shared<TPersistentStateManager>(
+    auto persistentState = CreatePersistentStateManager(
         config->GetHandleOpsQueuePath(),
         config->GetWriteBackCachePath(),
         config->GetDirectoryHandlesStoragePath());

--- a/cloud/filestore/libs/vfs_fuse/fuzz/starter.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fuzz/starter.cpp
@@ -114,10 +114,6 @@ TStarter::TStarter()
     proto.SetSocketPath(SocketPath.c_str());
 
     auto config = std::make_shared<TVFSConfig>(std::move(proto));
-    auto persistentState = CreatePersistentStateManager(
-        config->GetHandleOpsQueuePath(),
-        config->GetWriteBackCachePath(),
-        config->GetDirectoryHandlesStoragePath());
 
     Loop = NFuse::CreateFuseLoop(
         std::move(config),
@@ -130,7 +126,7 @@ TStarter::TStarter()
         CreateProfileLogStub(),
         std::move(session),
         CreateFileMapMemoryLimiterStub(),
-        std::move(persistentState));
+        CreatePersistentStateManagerStub());
 }
 
 

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -6,6 +6,7 @@
 #include "fuse.h"
 #include "handle_ops_queue.h"
 #include "log.h"
+#include "persistent_state_manager.h"
 
 #include <cloud/filestore/libs/client/session.h>
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
@@ -29,13 +30,10 @@
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <util/datetime/base.h>
-#include <util/folder/path.h>
 #include <util/generic/bitops.h>
 #include <util/generic/string.h>
 #include <util/generic/yexception.h>
 #include <util/system/event.h>
-#include "util/system/file_lock.h"
-#include <util/system/fs.h>
 #include <util/system/info.h>
 #include <util/system/rwlock.h>
 #include <util/system/spinlock.h>
@@ -59,49 +57,6 @@ using namespace NCloud::NFileStore::NVFS;
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
-
-static constexpr TStringBuf HandleOpsQueueFileName = "handle_ops_queue";
-static constexpr TStringBuf WriteBackCacheFileName = "write_back_cache";
-static constexpr TStringBuf DirectoryHandleStorageFileName = "directory_handles_storage";
-
-NProto::TError CreateAndLockFile(
-    const TString& dir,
-    const TStringBuf& fileName,
-    THolder<TFileLock>& fileLock)
-{
-    if (!NFs::MakeDirectoryRecursive(dir)) {
-        return MakeError(
-            E_FAIL,
-            TStringBuilder() << "Failed to create directories, path: " << dir);
-    }
-
-    auto filePath = TFsPath(dir) / fileName;
-    filePath.Touch();
-    fileLock = MakeHolder<TFileLock>(filePath);
-    if (!fileLock->TryAcquire()) {
-        return MakeError(
-            E_FAIL,
-            TStringBuilder() << "Failed to lock file, path: %s " << filePath);
-    }
-    return {};
-}
-
-NProto::TError UnlockAndDeleteFile(
-    const TString& dir,
-    THolder<TFileLock>& fileLock)
-{
-    fileLock->Release();
-
-    try {
-        NFs::RemoveRecursive(dir);
-    } catch (const TSystemError& err) {
-        return MakeError(
-            E_FAIL,
-            TStringBuilder() << "Failed to remove dir"
-                             << ", reason: " << err.AsStrBuf());
-    }
-    return {};
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -711,6 +666,7 @@ private:
     const IProfileLogPtr ProfileLog;
     const ISessionPtr Session;
     const IFileMapMemoryLimiterPtr FileMapMemoryLimiter;
+    const TPersistentStateManagerPtr PersistentState;
 
     TLog Log;
 
@@ -725,14 +681,7 @@ private:
     TDirectoryHandleModuleStatsPtr DirectoryHandleStats;
     TFileSystemConfigPtr FileSystemConfig;
 
-    THolder<TFileLock> HandleOpsQueueFileLock;
-    THolder<TFileLock> WriteBackCacheFileLock;
-    THolder<TFileLock> DirectoryHandleStorageFileLock;
-
     TWriteBackCache WriteBackCache;
-
-    bool HandleOpsQueueInitialized = false;
-    bool DirectoryHandleStorageInitialized = false;
 
 public:
     TFileSystemLoop(
@@ -745,7 +694,8 @@ public:
             ITimerPtr timer,
             IProfileLogPtr profileLog,
             ISessionPtr session,
-            IFileMapMemoryLimiterPtr fileMapMemoryLimiter)
+            IFileMapMemoryLimiterPtr fileMapMemoryLimiter,
+            TPersistentStateManagerPtr persistentState)
         : Config(std::move(config))
         , Logging(std::move(logging))
         , StatsRegistry(std::move(statsRegistry))
@@ -756,6 +706,7 @@ public:
         , ProfileLog(std::move(profileLog))
         , Session(std::move(session))
         , FileMapMemoryLimiter(std::move(fileMapMemoryLimiter))
+        , PersistentState(std::move(persistentState))
     {
         Log = Logging->CreateLog("NFS_FUSE");
     }
@@ -997,29 +948,29 @@ private:
 
             THandleOpsQueuePtr handleOpsQueue;
             if (Config->GetHandleOpsQueuePath()) {
-                const auto path = TFsPath(Config->GetHandleOpsQueuePath()) /
-                                  FileSystemConfig->GetFileSystemId() /
-                                  SessionId;
-                if (path.Exists() || ShouldCreateHandleOpsQueue(*FileSystemConfig)) {
-                    auto error = CreateAndLockFile(
-                        path,
-                        HandleOpsQueueFileName,
-                        HandleOpsQueueFileLock);
+                if (PersistentState->HasHandleOpsQueueState(
+                        Config->GetFileSystemId(),
+                        SessionId) ||
+                    ShouldCreateHandleOpsQueue(*FileSystemConfig))
+                {
+                    auto result =
+                        PersistentState->AcquireHandleOpsQueueStateFile(
+                            Config->GetFileSystemId(),
+                            SessionId);
 
-                    if (HasError(error)) {
+                    if (HasError(result.Error)) {
                         ReportHandleOpsQueueCreatingOrDeletingError(Sprintf(
-                            "[f:%s][c:%s] CreateAndLockFile error: %s (%s)",
+                            "[f:%s][c:%s] AcquireHandleOpsQueueStateFile "
+                            "error: %s",
                             Config->GetFileSystemId().Quote().c_str(),
                             Config->GetClientId().Quote().c_str(),
-                            error.GetMessage().c_str(),
-                            path.c_str()));
-                        return error;
+                            result.Error.GetMessage().c_str()));
+                        return result.Error;
                     }
 
                     handleOpsQueue = CreateHandleOpsQueue(
-                        path / HandleOpsQueueFileName,
+                        result.FilePath,
                         Config->GetHandleOpsQueueSize());
-                    HandleOpsQueueInitialized = true;
                 }
             } else if (ShouldCreateHandleOpsQueue(*FileSystemConfig)) {
                 ReportHandleOpsQueueCreatingOrDeletingError(Sprintf(
@@ -1030,25 +981,24 @@ private:
             }
 
             if (Config->GetWriteBackCachePath()) {
-                auto path = TFsPath(Config->GetWriteBackCachePath()) /
-                            FileSystemConfig->GetFileSystemId() / SessionId;
-
-                if (path.Exists() ||
+                if (PersistentState->HasWriteBackCacheState(
+                        Config->GetFileSystemId(),
+                        SessionId) ||
                     FileSystemConfig->GetServerWriteBackCacheEnabled())
                 {
-                    auto error = CreateAndLockFile(
-                        path,
-                        WriteBackCacheFileName,
-                        WriteBackCacheFileLock);
+                    auto result =
+                        PersistentState->AcquireWriteBackCacheStateFile(
+                            Config->GetFileSystemId(),
+                            SessionId);
 
-                    if (HasError(error)) {
+                    if (HasError(result.Error)) {
                         ReportWriteBackCacheCreatingOrDeletingError(Sprintf(
-                            "[f:%s][c:%s] CreateAndLockFile error: %s (%s)",
+                            "[f:%s][c:%s] AcquireWriteBackCacheStateFile "
+                            "error: %s",
                             Config->GetFileSystemId().Quote().c_str(),
                             Config->GetClientId().Quote().c_str(),
-                            error.GetMessage().c_str(),
-                            path.c_str()));
-                        return error;
+                            result.Error.GetMessage().c_str()));
+                        return result.Error;
                     }
 
                     WriteBackCache = TWriteBackCache(
@@ -1059,7 +1009,7 @@ private:
                          .Log = Log,
                          .FileSystemId = Config->GetFileSystemId(),
                          .ClientId = Config->GetClientId(),
-                         .FilePath = path / WriteBackCacheFileName,
+                         .FilePath = result.FilePath,
                          .CapacityBytes = Config->GetWriteBackCacheCapacity(),
                          .AutomaticFlushPeriod =
                              Config->GetWriteBackCacheAutomaticFlushPeriod(),
@@ -1109,19 +1059,16 @@ private:
             IDirectoryHandleStorageStatsPtr directoryHandleStorageStats;
             TDirectoryHandleStoragePtr directoryHandleStorage;
             if (Config->GetDirectoryHandlesStoragePath()) {
-                auto path = TFsPath(Config->GetDirectoryHandlesStoragePath()) /
-                            FileSystemConfig->GetFileSystemId() / SessionId;
-                auto filePath = path / DirectoryHandleStorageFileName;
-
                 if (FileSystemConfig->GetDirectoryHandlesStorageEnabled()) {
-                    auto error = CreateAndLockFile(
-                        path,
-                        DirectoryHandleStorageFileName,
-                        DirectoryHandleStorageFileLock);
+                    auto result =
+                        PersistentState->AcquireDirectoryHandleStorageStateFile(
+                            Config->GetFileSystemId(),
+                            SessionId);
 
-                    if (HasError(error)) {
-                        ReportDirectoryHandlesStorageError(error.GetMessage());
-                        return error;
+                    if (HasError(result.Error)) {
+                        ReportDirectoryHandleStorageError(
+                            result.Error.GetMessage());
+                        return result.Error;
                     }
 
                     directoryHandleStorageStats =
@@ -1131,7 +1078,7 @@ private:
                         {.Log = Log,
                          .FileMapMemoryLimiter = FileMapMemoryLimiter,
                          .Stats = directoryHandleStorageStats,
-                         .FilePath = filePath,
+                         .FilePath = result.FilePath,
                          .MaxRecords =
                              FileSystemConfig->GetDirectoryHandlesTableSize(),
                          .InitialDataAreaSize =
@@ -1143,20 +1090,17 @@ private:
                          .PersistentHandleMaxSize =
                              FileSystemConfig
                                  ->GetDirectoryHandlesPersistentHandleMaxSize()});
-
-                    DirectoryHandleStorageInitialized = true;
-                } else if (filePath.Exists()) {
+                } else {
                     // The feature is disabled but a file from a previous
-                    // session with it enabled is still on disk. The file
-                    // holds only a derived view of the directory listing,
-                    // so it can be removed without any drain.
-                    try {
-                        NFs::Remove(filePath);
-                    } catch (const TSystemError& err) {
-                        ReportDirectoryHandlesStorageError(
-                            TStringBuilder()
-                            << "Failed to remove orphan directory handles "
-                            << filePath << ": " << err.AsStrBuf());
+                    // session with it enabled may still be on disk. The file
+                    // holds only a derived view of the directory listing, so
+                    // it can be removed without any drain.
+                    auto error =
+                        PersistentState->DeleteDirectoryHandleStorageStateFile(
+                            Config->GetFileSystemId(),
+                            SessionId);
+                    if (HasError(error)) {
+                        ReportDirectoryHandleStorageError(error.GetMessage());
                     }
                 }
             } else if (FileSystemConfig->GetDirectoryHandlesStorageEnabled()) {
@@ -1540,38 +1484,33 @@ private:
 
         ModuleStatsRegistry->Unregister(SessionId);
 
+        const auto& fileSystemId = Config->GetFileSystemId();
+
         // We need to cleanup HandleOpsQueue file and directories
-        if (HandleOpsQueueInitialized) {
-            auto error = UnlockAndDeleteFile(
-                TFsPath(Config->GetHandleOpsQueuePath()) /
-                    Config->GetFileSystemId() / SessionId,
-                HandleOpsQueueFileLock);
-            if (HasError(error)) {
-                ReportHandleOpsQueueCreatingOrDeletingError(error.GetMessage());
-            }
+        auto error = PersistentState->DeleteHandleOpsQueueStateFile(
+            fileSystemId,
+            SessionId);
+        if (HasError(error)) {
+            ReportHandleOpsQueueCreatingOrDeletingError(error.GetMessage());
         }
 
-        // We need to cleanup WriteBackCache file and directories
-        if (WriteBackCache) {
-            WriteBackCache = {};
+        // We need to cleanup WriteBackCache file and directories:
+        // destroy the cache before releasing the lock and removing
+        // its backing file
+        WriteBackCache = {};
 
-            auto error = UnlockAndDeleteFile(
-                TFsPath(Config->GetWriteBackCachePath()) /
-                    Config->GetFileSystemId() / SessionId,
-                WriteBackCacheFileLock);
-            if (HasError(error)) {
-                ReportWriteBackCacheCreatingOrDeletingError(error.GetMessage());
-            }
+        error = PersistentState->DeleteWriteBackCacheStateFile(
+            fileSystemId,
+            SessionId);
+        if (HasError(error)) {
+            ReportWriteBackCacheCreatingOrDeletingError(error.GetMessage());
         }
 
-        if (DirectoryHandleStorageInitialized) {
-            auto error = UnlockAndDeleteFile(
-                TFsPath(Config->GetDirectoryHandlesStoragePath()) /
-                    Config->GetFileSystemId() / SessionId,
-                DirectoryHandleStorageFileLock);
-            if (HasError(error)) {
-                ReportDirectoryHandlesStorageError(error.GetMessage());
-            }
+        error = PersistentState->DeleteDirectoryHandleStorageStateFile(
+            fileSystemId,
+            SessionId);
+        if (HasError(error)) {
+            ReportDirectoryHandleStorageError(error.GetMessage());
         }
 
         stopCompleted.SetValue();
@@ -1890,6 +1829,8 @@ struct TFileSystemLoopFactory
     const IModuleStatsRegistryPtr ModuleStats;
     const IFsCountersProviderPtr FsCountersProvider;
     const IProfileLogPtr ProfileLog;
+    // Shared by all the loops created by this factory
+    const TPersistentStateManagerPtr PersistentState;
 
     TFileSystemLoopFactory(
             ILoggingServicePtr logging,
@@ -1898,7 +1839,8 @@ struct TFileSystemLoopFactory
             IRequestStatsRegistryPtr requestStats,
             IModuleStatsRegistryPtr moduleStats,
             IFsCountersProviderPtr fsCountersProvider,
-            IProfileLogPtr profileLog)
+            IProfileLogPtr profileLog,
+            TPersistentStateManagerPtr persistentState)
         : Logging(std::move(logging))
         , Timer(std::move(timer))
         , Scheduler(std::move(scheduler))
@@ -1906,6 +1848,7 @@ struct TFileSystemLoopFactory
         , ModuleStats(std::move(moduleStats))
         , FsCountersProvider(std::move(fsCountersProvider))
         , ProfileLog(std::move(profileLog))
+        , PersistentState(std::move(persistentState))
     {}
 
     IFileSystemLoopPtr Create(
@@ -1923,7 +1866,8 @@ struct TFileSystemLoopFactory
             Timer,
             ProfileLog,
             std::move(session),
-            std::move(fileMapMemoryLimiter));
+            std::move(fileMapMemoryLimiter),
+            PersistentState);
     }
 };
 
@@ -1941,7 +1885,8 @@ IFileSystemLoopPtr CreateFuseLoop(
     ITimerPtr timer,
     IProfileLogPtr profileLog,
     ISessionPtr session,
-    IFileMapMemoryLimiterPtr fileMapMemoryLimiter)
+    IFileMapMemoryLimiterPtr fileMapMemoryLimiter,
+    TPersistentStateManagerPtr persistentState)
 {
     return std::make_shared<TFileSystemLoop>(
         std::move(config),
@@ -1953,7 +1898,8 @@ IFileSystemLoopPtr CreateFuseLoop(
         std::move(timer),
         std::move(profileLog),
         std::move(session),
-        std::move(fileMapMemoryLimiter));
+        std::move(fileMapMemoryLimiter),
+        std::move(persistentState));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1965,7 +1911,8 @@ IFileSystemLoopFactoryPtr CreateFuseLoopFactory(
     IRequestStatsRegistryPtr requestStats,
     IModuleStatsRegistryPtr moduleStats,
     IFsCountersProviderPtr fsCountersProvider,
-    IProfileLogPtr profileLog)
+    IProfileLogPtr profileLog,
+    TPersistentStateManagerPtr persistentState)
 {
     struct TInitializer {
         TInitializer(const ILoggingServicePtr& logging)
@@ -1983,7 +1930,8 @@ IFileSystemLoopFactoryPtr CreateFuseLoopFactory(
         std::move(requestStats),
         std::move(moduleStats),
         std::move(fsCountersProvider),
-        std::move(profileLog));
+        std::move(profileLog),
+        std::move(persistentState));
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -666,7 +666,7 @@ private:
     const IProfileLogPtr ProfileLog;
     const ISessionPtr Session;
     const IFileMapMemoryLimiterPtr FileMapMemoryLimiter;
-    const TPersistentStateManagerPtr PersistentState;
+    const IPersistentStateManagerPtr PersistentState;
 
     TLog Log;
 
@@ -695,7 +695,7 @@ public:
             IProfileLogPtr profileLog,
             ISessionPtr session,
             IFileMapMemoryLimiterPtr fileMapMemoryLimiter,
-            TPersistentStateManagerPtr persistentState)
+            IPersistentStateManagerPtr persistentState)
         : Config(std::move(config))
         , Logging(std::move(logging))
         , StatsRegistry(std::move(statsRegistry))
@@ -1846,7 +1846,7 @@ struct TFileSystemLoopFactory
     const IFsCountersProviderPtr FsCountersProvider;
     const IProfileLogPtr ProfileLog;
     // Shared by all the loops created by this factory
-    const TPersistentStateManagerPtr PersistentState;
+    const IPersistentStateManagerPtr PersistentState;
 
     TFileSystemLoopFactory(
             ILoggingServicePtr logging,
@@ -1856,7 +1856,7 @@ struct TFileSystemLoopFactory
             IModuleStatsRegistryPtr moduleStats,
             IFsCountersProviderPtr fsCountersProvider,
             IProfileLogPtr profileLog,
-            TPersistentStateManagerPtr persistentState)
+            IPersistentStateManagerPtr persistentState)
         : Logging(std::move(logging))
         , Timer(std::move(timer))
         , Scheduler(std::move(scheduler))
@@ -1902,7 +1902,7 @@ IFileSystemLoopPtr CreateFuseLoop(
     IProfileLogPtr profileLog,
     ISessionPtr session,
     IFileMapMemoryLimiterPtr fileMapMemoryLimiter,
-    TPersistentStateManagerPtr persistentState)
+    IPersistentStateManagerPtr persistentState)
 {
     return std::make_shared<TFileSystemLoop>(
         std::move(config),
@@ -1928,7 +1928,7 @@ IFileSystemLoopFactoryPtr CreateFuseLoopFactory(
     IModuleStatsRegistryPtr moduleStats,
     IFsCountersProviderPtr fsCountersProvider,
     IProfileLogPtr profileLog,
-    TPersistentStateManagerPtr persistentState)
+    IPersistentStateManagerPtr persistentState)
 {
     struct TInitializer {
         TInitializer(const ILoggingServicePtr& logging)

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -681,6 +681,13 @@ private:
     TDirectoryHandleModuleStatsPtr DirectoryHandleStats;
     TFileSystemConfigPtr FileSystemConfig;
 
+    // Hold the locks on the state files for as long as the loop lives: if the
+    // loop goes away without being stopped (e.g. its start has failed and the
+    // endpoint is dropped), the files stay on disk for a future session.
+    TAcquireStateFileGuard HandleOpsQueueStateFileGuard;
+    TAcquireStateFileGuard WriteBackCacheStateFileGuard;
+    TAcquireStateFileGuard DirectoryHandleStorageStateFileGuard;
+
     TWriteBackCache WriteBackCache;
 
 public:
@@ -709,19 +716,6 @@ public:
         , PersistentState(std::move(persistentState))
     {
         Log = Logging->CreateLog("NFS_FUSE");
-    }
-
-    ~TFileSystemLoop() override
-    {
-        // The loop may be destroyed without being stopped, e.g. when its
-        // start has failed and the endpoint is dropped. Release the locks on
-        // the state files (keeping the files) so that a new loop for the
-        // same session is able to acquire them.
-        if (FileSystemConfig && SessionId) {
-            PersistentState->ReleaseStateFiles(
-                FileSystemConfig->GetFileSystemId(),
-                SessionId);
-        }
     }
 
     TFuture<NProto::TError> StartAsync() override
@@ -974,18 +968,19 @@ private:
                             FileSystemConfig->GetFileSystemId(),
                             SessionId);
 
-                    if (HasError(result.Error)) {
+                    if (HasError(result)) {
                         ReportHandleOpsQueueCreatingOrDeletingError(Sprintf(
                             "[f:%s][c:%s] AcquireHandleOpsQueueStateFile "
                             "error: %s",
                             Config->GetFileSystemId().Quote().c_str(),
                             Config->GetClientId().Quote().c_str(),
-                            result.Error.GetMessage().c_str()));
-                        return result.Error;
+                            result.GetError().GetMessage().c_str()));
+                        return result.GetError();
                     }
 
+                    HandleOpsQueueStateFileGuard = result.ExtractResult();
                     handleOpsQueue = CreateHandleOpsQueue(
-                        result.FilePath,
+                        HandleOpsQueueStateFileGuard.GetFilePath(),
                         Config->GetHandleOpsQueueSize());
                 }
             } else if (ShouldCreateHandleOpsQueue(*FileSystemConfig)) {
@@ -1007,16 +1002,17 @@ private:
                             FileSystemConfig->GetFileSystemId(),
                             SessionId);
 
-                    if (HasError(result.Error)) {
+                    if (HasError(result)) {
                         ReportWriteBackCacheCreatingOrDeletingError(Sprintf(
                             "[f:%s][c:%s] AcquireWriteBackCacheStateFile "
                             "error: %s",
                             Config->GetFileSystemId().Quote().c_str(),
                             Config->GetClientId().Quote().c_str(),
-                            result.Error.GetMessage().c_str()));
-                        return result.Error;
+                            result.GetError().GetMessage().c_str()));
+                        return result.GetError();
                     }
 
+                    WriteBackCacheStateFileGuard = result.ExtractResult();
                     WriteBackCache = TWriteBackCache(
                         {.Session = Session,
                          .Scheduler = Scheduler,
@@ -1025,7 +1021,7 @@ private:
                          .Log = Log,
                          .FileSystemId = Config->GetFileSystemId(),
                          .ClientId = Config->GetClientId(),
-                         .FilePath = result.FilePath,
+                         .FilePath = WriteBackCacheStateFileGuard.GetFilePath(),
                          .CapacityBytes = Config->GetWriteBackCacheCapacity(),
                          .AutomaticFlushPeriod =
                              Config->GetWriteBackCacheAutomaticFlushPeriod(),
@@ -1081,11 +1077,14 @@ private:
                             FileSystemConfig->GetFileSystemId(),
                             SessionId);
 
-                    if (HasError(result.Error)) {
+                    if (HasError(result)) {
                         ReportDirectoryHandleStorageError(
-                            result.Error.GetMessage());
-                        return result.Error;
+                            result.GetError().GetMessage());
+                        return result.GetError();
                     }
+
+                    DirectoryHandleStorageStateFileGuard =
+                        result.ExtractResult();
 
                     directoryHandleStorageStats =
                         CreateDirectoryHandleStorageStats(Timer);
@@ -1094,7 +1093,8 @@ private:
                         {.Log = Log,
                          .FileMapMemoryLimiter = FileMapMemoryLimiter,
                          .Stats = directoryHandleStorageStats,
-                         .FilePath = result.FilePath,
+                         .FilePath =
+                             DirectoryHandleStorageStateFileGuard.GetFilePath(),
                          .MaxRecords =
                              FileSystemConfig->GetDirectoryHandlesTableSize(),
                          .InitialDataAreaSize =
@@ -1106,15 +1106,23 @@ private:
                          .PersistentHandleMaxSize =
                              FileSystemConfig
                                  ->GetDirectoryHandlesPersistentHandleMaxSize()});
-                } else {
+                } else if (PersistentState->HasDirectoryHandleStorageState(
+                               FileSystemConfig->GetFileSystemId(),
+                               SessionId))
+                {
                     // The feature is disabled but a file from a previous
-                    // session with it enabled may still be on disk. The file
+                    // session with it enabled is still on disk. The file
                     // holds only a derived view of the directory listing, so
                     // it can be removed without any drain.
-                    auto error =
-                        PersistentState->DeleteDirectoryHandleStorageStateFile(
+                    auto result =
+                        PersistentState->AcquireDirectoryHandleStorageStateFile(
                             FileSystemConfig->GetFileSystemId(),
                             SessionId);
+
+                    NProto::TError error = result.GetError();
+                    if (!HasError(error)) {
+                        error = result.ExtractResult().DeleteStateFile();
+                    }
                     if (HasError(error)) {
                         ReportDirectoryHandleStorageError(error.GetMessage());
                     }
@@ -1500,12 +1508,8 @@ private:
 
         ModuleStatsRegistry->Unregister(SessionId);
 
-        const auto& fileSystemId = FileSystemConfig->GetFileSystemId();
-
         // We need to cleanup HandleOpsQueue file and directories
-        auto error = PersistentState->DeleteHandleOpsQueueStateFile(
-            fileSystemId,
-            SessionId);
+        auto error = HandleOpsQueueStateFileGuard.DeleteStateFile();
         if (HasError(error)) {
             ReportHandleOpsQueueCreatingOrDeletingError(error.GetMessage());
         }
@@ -1515,16 +1519,12 @@ private:
         // its backing file
         WriteBackCache = {};
 
-        error = PersistentState->DeleteWriteBackCacheStateFile(
-            fileSystemId,
-            SessionId);
+        error = WriteBackCacheStateFileGuard.DeleteStateFile();
         if (HasError(error)) {
             ReportWriteBackCacheCreatingOrDeletingError(error.GetMessage());
         }
 
-        error = PersistentState->DeleteDirectoryHandleStorageStateFile(
-            fileSystemId,
-            SessionId);
+        error = DirectoryHandleStorageStateFileGuard.DeleteStateFile();
         if (HasError(error)) {
             ReportDirectoryHandleStorageError(error.GetMessage());
         }

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -711,6 +711,19 @@ public:
         Log = Logging->CreateLog("NFS_FUSE");
     }
 
+    ~TFileSystemLoop() override
+    {
+        // The loop may be destroyed without being stopped, e.g. when its
+        // start has failed and the endpoint is dropped. Release the locks on
+        // the state files (keeping the files) so that a new loop for the
+        // same session is able to acquire them.
+        if (FileSystemConfig && SessionId) {
+            PersistentState->ReleaseStateFiles(
+                FileSystemConfig->GetFileSystemId(),
+                SessionId);
+        }
+    }
+
     TFuture<NProto::TError> StartAsync() override
     {
         RequestStats = StatsRegistry->GetFileSystemStats(
@@ -946,16 +959,19 @@ private:
 
             SessionId = response.GetSession().GetSessionId();
 
+            // The state files are kept under the filesystem id returned by
+            // the server rather than the requested one: the latter may be an
+            // alias, which the server resolves upon session creation.
             THandleOpsQueuePtr handleOpsQueue;
             if (Config->GetHandleOpsQueuePath()) {
                 if (PersistentState->HasHandleOpsQueueState(
-                        Config->GetFileSystemId(),
+                        FileSystemConfig->GetFileSystemId(),
                         SessionId) ||
                     ShouldCreateHandleOpsQueue(*FileSystemConfig))
                 {
                     auto result =
                         PersistentState->AcquireHandleOpsQueueStateFile(
-                            Config->GetFileSystemId(),
+                            FileSystemConfig->GetFileSystemId(),
                             SessionId);
 
                     if (HasError(result.Error)) {
@@ -982,13 +998,13 @@ private:
 
             if (Config->GetWriteBackCachePath()) {
                 if (PersistentState->HasWriteBackCacheState(
-                        Config->GetFileSystemId(),
+                        FileSystemConfig->GetFileSystemId(),
                         SessionId) ||
                     FileSystemConfig->GetServerWriteBackCacheEnabled())
                 {
                     auto result =
                         PersistentState->AcquireWriteBackCacheStateFile(
-                            Config->GetFileSystemId(),
+                            FileSystemConfig->GetFileSystemId(),
                             SessionId);
 
                     if (HasError(result.Error)) {
@@ -1062,7 +1078,7 @@ private:
                 if (FileSystemConfig->GetDirectoryHandlesStorageEnabled()) {
                     auto result =
                         PersistentState->AcquireDirectoryHandleStorageStateFile(
-                            Config->GetFileSystemId(),
+                            FileSystemConfig->GetFileSystemId(),
                             SessionId);
 
                     if (HasError(result.Error)) {
@@ -1097,7 +1113,7 @@ private:
                     // it can be removed without any drain.
                     auto error =
                         PersistentState->DeleteDirectoryHandleStorageStateFile(
-                            Config->GetFileSystemId(),
+                            FileSystemConfig->GetFileSystemId(),
                             SessionId);
                     if (HasError(error)) {
                         ReportDirectoryHandleStorageError(error.GetMessage());
@@ -1484,7 +1500,7 @@ private:
 
         ModuleStatsRegistry->Unregister(SessionId);
 
-        const auto& fileSystemId = Config->GetFileSystemId();
+        const auto& fileSystemId = FileSystemConfig->GetFileSystemId();
 
         // We need to cleanup HandleOpsQueue file and directories
         auto error = PersistentState->DeleteHandleOpsQueueStateFile(

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -668,6 +668,16 @@ private:
     const IFileMapMemoryLimiterPtr FileMapMemoryLimiter;
     const IPersistentStateManagerPtr PersistentState;
 
+    // Hold the locks on the state files for as long as the loop lives: if the
+    // loop goes away without being stopped (e.g. its start has failed and the
+    // endpoint is dropped), the files stay on disk for a future session.
+    // Declared before everything that uses the files (the write-back cache,
+    // the file system with its handle ops queue and directory handle storage)
+    // so that the locks are released after those are gone.
+    TAcquireStateFileGuard HandleOpsQueueStateFileGuard;
+    TAcquireStateFileGuard WriteBackCacheStateFileGuard;
+    TAcquireStateFileGuard DirectoryHandleStorageStateFileGuard;
+
     TLog Log;
 
     TString SessionState;
@@ -680,13 +690,6 @@ private:
     IFileSystemPtr FileSystem;
     TDirectoryHandleModuleStatsPtr DirectoryHandleStats;
     TFileSystemConfigPtr FileSystemConfig;
-
-    // Hold the locks on the state files for as long as the loop lives: if the
-    // loop goes away without being stopped (e.g. its start has failed and the
-    // endpoint is dropped), the files stay on disk for a future session.
-    TAcquireStateFileGuard HandleOpsQueueStateFileGuard;
-    TAcquireStateFileGuard WriteBackCacheStateFileGuard;
-    TAcquireStateFileGuard DirectoryHandleStorageStateFileGuard;
 
     TWriteBackCache WriteBackCache;
 

--- a/cloud/filestore/libs/vfs_fuse/loop.h
+++ b/cloud/filestore/libs/vfs_fuse/loop.h
@@ -24,7 +24,8 @@ NVFS::IFileSystemLoopPtr CreateFuseLoop(
     ITimerPtr timer,
     IProfileLogPtr profileLog,
     NClient::ISessionPtr session,
-    IFileMapMemoryLimiterPtr fileMapMemoryLimiter);
+    IFileMapMemoryLimiterPtr fileMapMemoryLimiter,
+    TPersistentStateManagerPtr persistentState);
 
 NVFS::IFileSystemLoopFactoryPtr CreateFuseLoopFactory(
     ILoggingServicePtr logging,
@@ -33,6 +34,7 @@ NVFS::IFileSystemLoopFactoryPtr CreateFuseLoopFactory(
     IRequestStatsRegistryPtr requestStats,
     IModuleStatsRegistryPtr moduleStats,
     IFsCountersProviderPtr fsCountersProvider,
-    IProfileLogPtr profileLog);
+    IProfileLogPtr profileLog,
+    TPersistentStateManagerPtr persistentState);
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/loop.h
+++ b/cloud/filestore/libs/vfs_fuse/loop.h
@@ -25,7 +25,7 @@ NVFS::IFileSystemLoopPtr CreateFuseLoop(
     IProfileLogPtr profileLog,
     NClient::ISessionPtr session,
     IFileMapMemoryLimiterPtr fileMapMemoryLimiter,
-    TPersistentStateManagerPtr persistentState);
+    IPersistentStateManagerPtr persistentState);
 
 NVFS::IFileSystemLoopFactoryPtr CreateFuseLoopFactory(
     ILoggingServicePtr logging,
@@ -35,6 +35,6 @@ NVFS::IFileSystemLoopFactoryPtr CreateFuseLoopFactory(
     IModuleStatsRegistryPtr moduleStats,
     IFsCountersProviderPtr fsCountersProvider,
     IProfileLogPtr profileLog,
-    TPersistentStateManagerPtr persistentState);
+    IPersistentStateManagerPtr persistentState);
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
@@ -1,0 +1,281 @@
+#include "persistent_state_manager.h"
+
+#include <util/generic/yexception.h>
+#include <util/string/builder.h>
+#include <util/system/error.h>
+#include <util/system/fs.h>
+
+namespace NCloud::NFileStore::NFuse {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr TStringBuf HandleOpsQueueFileName = "handle_ops_queue";
+constexpr TStringBuf WriteBackCacheFileName = "write_back_cache";
+constexpr TStringBuf DirectoryHandleStorageFileName = "directory_handles_storage";
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TPersistentStateManager::TPersistentStateManager(
+        TString handleOpsQueueBasePath,
+        TString writeBackCacheBasePath,
+        TString directoryHandlesStorageBasePath)
+    : HandleOpsQueue(
+          std::move(handleOpsQueueBasePath),
+          HandleOpsQueueFileName)
+    , WriteBackCache(
+          std::move(writeBackCacheBasePath),
+          WriteBackCacheFileName)
+    , DirectoryHandleStorage(
+          std::move(directoryHandlesStorageBasePath),
+          DirectoryHandleStorageFileName)
+{}
+
+////////////////////////////////////////////////////////////////////////////////
+// Generic implementation
+
+TFsPath TPersistentStateManager::GetSessionDir(
+    const TComponentConfig& component,
+    const TString& fileSystemId,
+    const TString& sessionId) const
+{
+    Y_DEBUG_ABORT_UNLESS(component.BasePath);
+    return TFsPath(component.BasePath) / fileSystemId / sessionId;
+}
+
+bool TPersistentStateManager::HasState(
+    const TComponentConfig& component,
+    const TString& fileSystemId,
+    const TString& sessionId) const
+{
+    if (!component.BasePath) {
+        return false;
+    }
+
+    const auto filePath =
+        GetSessionDir(component, fileSystemId, sessionId) / component.FileName;
+
+    TGuard guard(Mutex);
+    return filePath.Exists();
+}
+
+TPersistentStateManager::TAcquireStateFileResult
+TPersistentStateManager::AcquireStateFile(
+    const TComponentConfig& component,
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    if (!component.BasePath) {
+        return {
+            .Error = MakeError(
+                E_INVALID_STATE,
+                TStringBuilder() << "Base path for " << component.FileName
+                                 << " is not set"),
+            .FilePath = {}};
+    }
+
+    const auto dir = GetSessionDir(component, fileSystemId, sessionId);
+    const TString fileName(component.FileName);
+    auto filePath = dir / fileName;
+
+    TGuard guard(Mutex);
+
+    const auto* locks = SessionDirs.FindPtr(dir.GetPath());
+    if (locks && locks->contains(fileName)) {
+        return {
+            .Error = MakeError(
+                E_INVALID_STATE,
+                TStringBuilder() << "State file " << filePath
+                                 << " is already acquired"),
+            .FilePath = {}};
+    }
+
+    if (!NFs::MakeDirectoryRecursive(dir)) {
+        return {
+            .Error = MakeError(
+                E_FAIL,
+                TStringBuilder() << "Failed to create directories, path: "
+                                 << dir),
+            .FilePath = {}};
+    }
+
+    // Touch(), the TFileLock constructor (which opens the file) and
+    // TryAcquire() all report failures by throwing.
+    THolder<TFileLock> lock;
+    try {
+        filePath.Touch();
+
+        lock = MakeHolder<TFileLock>(filePath);
+        if (!lock->TryAcquire()) {
+            return {
+                .Error = MakeError(
+                    E_INVALID_STATE,
+                    TStringBuilder() << "State file " << filePath
+                                     << " is locked by another owner"),
+                .FilePath = {}};
+        }
+    } catch (const yexception& e) {
+        return {
+            .Error = MakeError(
+                E_FAIL,
+                TStringBuilder() << "Failed to lock file, path: " << filePath
+                                 << ", reason: " << e.what()),
+            .FilePath = {}};
+    }
+
+    SessionDirs[dir.GetPath()].emplace(fileName, std::move(lock));
+    return {.Error = {}, .FilePath = std::move(filePath)};
+}
+
+NProto::TError TPersistentStateManager::DeleteStateFile(
+    const TComponentConfig& component,
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    if (!component.BasePath) {
+        return {};
+    }
+
+    const auto dir = GetSessionDir(component, fileSystemId, sessionId);
+    const TString fileName(component.FileName);
+    const auto filePath = dir / fileName;
+
+    TGuard guard(Mutex);
+
+    // Release the lock if the state file is held. Stop referencing the
+    // session directory when it holds no more state files, no matter whether
+    // the removal below succeeds.
+    NProto::TError releaseError;
+    bool dirHoldsStateFiles = false;
+    if (auto dirIt = SessionDirs.find(dir.GetPath());
+        dirIt != SessionDirs.end())
+    {
+        auto& locks = dirIt->second;
+        if (auto lockIt = locks.find(fileName); lockIt != locks.end()) {
+            auto lock = std::move(lockIt->second);
+            locks.erase(lockIt);
+
+            // Release() reports failures by throwing. The lock is dropped
+            // either way once |lock| goes out of scope, since closing the
+            // file releases it.
+            try {
+                lock->Release();
+            } catch (const yexception& e) {
+                releaseError = MakeError(
+                    E_FAIL,
+                    TStringBuilder() << "Failed to unlock file " << filePath
+                                     << ", reason: " << e.what());
+            }
+        }
+
+        dirHoldsStateFiles = !locks.empty();
+        if (!dirHoldsStateFiles) {
+            SessionDirs.erase(dirIt);
+        }
+    }
+
+    // The state file may be present without being held, e.g. when it was
+    // left behind by a previous session and the component is now disabled.
+    if (filePath.Exists() && !NFs::Remove(filePath)) {
+        return MakeError(
+            E_FAIL,
+            TStringBuilder() << "Failed to remove file " << filePath
+                             << ", reason: " << LastSystemErrorText());
+    }
+
+    if (!dirHoldsStateFiles && dir.Exists()) {
+        try {
+            NFs::RemoveRecursive(dir);
+        } catch (const yexception& e) {
+            return MakeError(
+                E_FAIL,
+                TStringBuilder() << "Failed to remove dir " << dir
+                                 << ", reason: " << e.what());
+        }
+    }
+
+    return releaseError;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// HandleOpsQueue
+
+bool TPersistentStateManager::HasHandleOpsQueueState(
+    const TString& fileSystemId,
+    const TString& sessionId) const
+{
+    return HasState(HandleOpsQueue, fileSystemId, sessionId);
+}
+
+TPersistentStateManager::TAcquireStateFileResult
+TPersistentStateManager::AcquireHandleOpsQueueStateFile(
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    return AcquireStateFile(HandleOpsQueue, fileSystemId, sessionId);
+}
+
+NProto::TError TPersistentStateManager::DeleteHandleOpsQueueStateFile(
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    return DeleteStateFile(HandleOpsQueue, fileSystemId, sessionId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// WriteBackCache
+
+bool TPersistentStateManager::HasWriteBackCacheState(
+    const TString& fileSystemId,
+    const TString& sessionId) const
+{
+    return HasState(WriteBackCache, fileSystemId, sessionId);
+}
+
+TPersistentStateManager::TAcquireStateFileResult
+TPersistentStateManager::AcquireWriteBackCacheStateFile(
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    return AcquireStateFile(WriteBackCache, fileSystemId, sessionId);
+}
+
+NProto::TError TPersistentStateManager::DeleteWriteBackCacheStateFile(
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    return DeleteStateFile(WriteBackCache, fileSystemId, sessionId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DirectoryHandleStorage
+
+TPersistentStateManager::TAcquireStateFileResult
+TPersistentStateManager::AcquireDirectoryHandleStorageStateFile(
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    return AcquireStateFile(DirectoryHandleStorage, fileSystemId, sessionId);
+}
+
+NProto::TError TPersistentStateManager::DeleteDirectoryHandleStorageStateFile(
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    return DeleteStateFile(DirectoryHandleStorage, fileSystemId, sessionId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TPersistentStateManagerPtr CreatePersistentStateManagerStub()
+{
+    return std::make_shared<TPersistentStateManager>(
+        TString{},   // handleOpsQueueBasePath
+        TString{},   // writeBackCacheBasePath
+        TString{});  // directoryHandlesStorageBasePath
+}
+
+}   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
@@ -2,10 +2,16 @@
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 
+#include <util/generic/hash.h>
+#include <util/generic/ptr.h>
+#include <util/generic/strbuf.h>
 #include <util/generic/yexception.h>
 #include <util/string/builder.h>
 #include <util/system/error.h>
+#include <util/system/file_lock.h>
 #include <util/system/fs.h>
+#include <util/system/guard.h>
+#include <util/system/mutex.h>
 
 namespace NCloud::NFileStore::NFuse {
 
@@ -17,7 +23,117 @@ constexpr TStringBuf HandleOpsQueueFileName = "handle_ops_queue";
 constexpr TStringBuf WriteBackCacheFileName = "write_back_cache";
 constexpr TStringBuf DirectoryHandleStorageFileName = "directory_handles_storage";
 
-}   // namespace
+////////////////////////////////////////////////////////////////////////////////
+
+// Keeps the state files on disk under the configured base paths, following
+// the layout <basePath>/<fileSystemId>/<sessionId>/<fileName>, and holds the
+// advisory locks on the acquired ones.
+class TPersistentStateManager final
+    : public IPersistentStateManager
+{
+private:
+    struct TComponentConfig
+    {
+        const TString BasePath;
+        // Points to a static string.
+        const TStringBuf FileName;
+
+        TComponentConfig(TString basePath, TStringBuf fileName)
+            : BasePath(std::move(basePath))
+            , FileName(fileName)
+        {}
+    };
+
+    // Locked state files held in one session directory, keyed by file name.
+    using TSessionDirLocks = THashMap<TString, THolder<TFileLock>>;
+
+    // Guards SessionDirs and the filesystem operations on the state files.
+    mutable TMutex Mutex;
+
+    // Session directories that hold at least one locked state file, keyed by
+    // path. A directory may be shared by several components, so only the
+    // requested files are ever removed from it, and the directory itself is
+    // removed once it is empty. A directory found not empty after the last
+    // state file held in it has been deleted contains state nobody tracks
+    // (e.g. of a component which is not configured anymore), which is
+    // reported as a critical event.
+    THashMap<TString, TSessionDirLocks> SessionDirs;
+
+    const TComponentConfig HandleOpsQueue;
+    const TComponentConfig WriteBackCache;
+    const TComponentConfig DirectoryHandleStorage;
+
+public:
+    TPersistentStateManager(
+        TString handleOpsQueueBasePath,
+        TString writeBackCacheBasePath,
+        TString directoryHandlesStorageBasePath);
+
+    // HandleOpsQueue
+
+    bool HasHandleOpsQueueState(
+        const TString& fileSystemId,
+        const TString& sessionId) const override;
+    TAcquireStateFileResult AcquireHandleOpsQueueStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override;
+    NProto::TError DeleteHandleOpsQueueStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override;
+
+    // WriteBackCache
+
+    bool HasWriteBackCacheState(
+        const TString& fileSystemId,
+        const TString& sessionId) const override;
+    TAcquireStateFileResult AcquireWriteBackCacheStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override;
+    NProto::TError DeleteWriteBackCacheStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override;
+
+    // DirectoryHandleStorage
+
+    TAcquireStateFileResult AcquireDirectoryHandleStorageStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override;
+    NProto::TError DeleteDirectoryHandleStorageStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override;
+
+    // All components
+
+    void ReleaseStateFiles(
+        const TString& fileSystemId,
+        const TString& sessionId) override;
+
+private:
+    TFsPath GetSessionDir(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId) const;
+
+    bool HasState(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId) const;
+
+    TAcquireStateFileResult AcquireStateFile(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId);
+
+    NProto::TError DeleteStateFile(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId);
+
+    void ReleaseStateFile(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId);
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -324,12 +440,119 @@ void TPersistentStateManager::ReleaseStateFiles(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TPersistentStateManagerPtr CreatePersistentStateManagerStub()
+class TPersistentStateManagerStub final
+    : public IPersistentStateManager
+{
+public:
+    // HandleOpsQueue
+
+    bool HasHandleOpsQueueState(
+        const TString& fileSystemId,
+        const TString& sessionId) const override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return false;
+    }
+
+    TAcquireStateFileResult AcquireHandleOpsQueueStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return NotImplemented(HandleOpsQueueFileName);
+    }
+
+    NProto::TError DeleteHandleOpsQueueStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return {};
+    }
+
+    // WriteBackCache
+
+    bool HasWriteBackCacheState(
+        const TString& fileSystemId,
+        const TString& sessionId) const override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return false;
+    }
+
+    TAcquireStateFileResult AcquireWriteBackCacheStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return NotImplemented(WriteBackCacheFileName);
+    }
+
+    NProto::TError DeleteWriteBackCacheStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return {};
+    }
+
+    // DirectoryHandleStorage
+
+    TAcquireStateFileResult AcquireDirectoryHandleStorageStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return NotImplemented(DirectoryHandleStorageFileName);
+    }
+
+    NProto::TError DeleteDirectoryHandleStorageStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId) override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return {};
+    }
+
+    // All components
+
+    void ReleaseStateFiles(
+        const TString& fileSystemId,
+        const TString& sessionId) override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+    }
+
+private:
+    static TAcquireStateFileResult NotImplemented(TStringBuf fileName)
+    {
+        return {
+            .Error = MakeError(
+                E_NOT_IMPLEMENTED,
+                TStringBuilder() << "State file " << fileName
+                                 << " is not supported by the stub"),
+            .FilePath = {}};
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IPersistentStateManagerPtr CreatePersistentStateManager(
+    TString handleOpsQueueBasePath,
+    TString writeBackCacheBasePath,
+    TString directoryHandlesStorageBasePath)
 {
     return std::make_shared<TPersistentStateManager>(
-        TString{},   // handleOpsQueueBasePath
-        TString{},   // writeBackCacheBasePath
-        TString{});  // directoryHandlesStorageBasePath
+        std::move(handleOpsQueueBasePath),
+        std::move(writeBackCacheBasePath),
+        std::move(directoryHandlesStorageBasePath));
+}
+
+IPersistentStateManagerPtr CreatePersistentStateManagerStub()
+{
+    return std::make_shared<TPersistentStateManagerStub>();
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
@@ -86,23 +86,37 @@ TAcquireStateFileGuard::TAcquireStateFileGuard(
     TAcquireStateFileGuard&& other) noexcept = default;
 
 TAcquireStateFileGuard& TAcquireStateFileGuard::operator=(
-    TAcquireStateFileGuard&& other) noexcept = default;
+    TAcquireStateFileGuard&& other) noexcept
+{
+    if (this != &other) {
+        Reset();
+        Impl = std::move(other.Impl);
+    }
+    return *this;
+}
 
 TAcquireStateFileGuard::~TAcquireStateFileGuard()
+{
+    Reset();
+}
+
+void TAcquireStateFileGuard::Reset() noexcept
 {
     if (!Impl) {
         return;
     }
 
-    TGuard guard(Impl->Registry->Mutex);
-    Impl->UnregisterLocked();
+    auto impl = std::move(Impl);
+
+    TGuard guard(impl->Registry->Mutex);
+    impl->UnregisterLocked();
 
     // Destroying the lock closes the file, which releases the lock without
     // any chance of failure, unlike an explicit Release(). It has to happen
     // while the registry is still locked: otherwise an acquisition racing
     // with us finds the file unregistered but still locked. The file itself
     // is kept together with its session directory.
-    Impl->Lock.Reset();
+    impl->Lock.Reset();
 }
 
 TAcquireStateFileGuard::operator bool() const
@@ -331,7 +345,8 @@ TPersistentStateManager::AcquireStateFile(
     if (!NFs::MakeDirectoryRecursive(dir)) {
         return MakeError(
             E_FAIL,
-            TStringBuilder() << "Failed to create directories, path: " << dir);
+            TStringBuilder() << "Failed to create session dir: " << dir
+                             << ", reason: " << LastSystemErrorText());
     }
 
     // Touch(), the TFileLock constructor (which opens the file) and

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
@@ -57,8 +57,6 @@ struct TAcquireStateFileGuard::TImpl
     THolder<TFileLock> Lock;
 
     // Returns whether this is the last state file held in the directory.
-    // Must be called with the registry locked.
-    //
     // Should be guarded by TStateFileRegistry::Mutex.
     bool UnregisterLocked()
     {
@@ -100,8 +98,11 @@ TAcquireStateFileGuard::~TAcquireStateFileGuard()
     Impl->UnregisterLocked();
 
     // Destroying the lock closes the file, which releases the lock without
-    // any chance of failure, unlike an explicit Release(). The file itself
+    // any chance of failure, unlike an explicit Release(). It has to happen
+    // while the registry is still locked: otherwise an acquisition racing
+    // with us finds the file unregistered but still locked. The file itself
     // is kept together with its session directory.
+    Impl->Lock.Reset();
 }
 
 TAcquireStateFileGuard::operator bool() const
@@ -157,7 +158,9 @@ NProto::TError TAcquireStateFileGuard::DeleteStateFile()
     // (e.g. of a component which is not configured anymore).
     if (lastStateFile && !NFs::Remove(impl->Dir)) {
         const int err = LastSystemError();
-        if (err == ENOTEMPTY || err == EEXIST) {
+        if (err == ENOENT) {
+            // Already gone, e.g. removed together with the file by hand.
+        } else if (err == ENOTEMPTY || err == EEXIST) {
             ReportPersistentStateSessionDirNotEmpty(
                 TStringBuilder() << "Session dir " << impl->Dir
                                  << " is not empty after the state file "

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
@@ -200,6 +200,37 @@ NProto::TError TPersistentStateManager::DeleteStateFile(
     return releaseError;
 }
 
+void TPersistentStateManager::ReleaseStateFile(
+    const TComponentConfig& component,
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    if (!component.BasePath) {
+        return;
+    }
+
+    const auto dir = GetSessionDir(component, fileSystemId, sessionId);
+    const TString fileName(component.FileName);
+
+    TGuard guard(Mutex);
+
+    auto dirIt = SessionDirs.find(dir.GetPath());
+    if (dirIt == SessionDirs.end()) {
+        return;
+    }
+
+    // Destroying the lock closes the file, which releases the lock without
+    // any chance of failure, unlike an explicit Release().
+    auto& locks = dirIt->second;
+    locks.erase(fileName);
+
+    // The session directory is kept together with the state files, only the
+    // reference to it is dropped once nothing is held in it anymore.
+    if (locks.empty()) {
+        SessionDirs.erase(dirIt);
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // HandleOpsQueue
 
@@ -266,6 +297,18 @@ NProto::TError TPersistentStateManager::DeleteDirectoryHandleStorageStateFile(
     const TString& sessionId)
 {
     return DeleteStateFile(DirectoryHandleStorage, fileSystemId, sessionId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// All components
+
+void TPersistentStateManager::ReleaseStateFiles(
+    const TString& fileSystemId,
+    const TString& sessionId)
+{
+    ReleaseStateFile(HandleOpsQueue, fileSystemId, sessionId);
+    ReleaseStateFile(WriteBackCache, fileSystemId, sessionId);
+    ReleaseStateFile(DirectoryHandleStorage, fileSystemId, sessionId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
@@ -1,5 +1,7 @@
 #include "persistent_state_manager.h"
 
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
+
 #include <util/generic/yexception.h>
 #include <util/string/builder.h>
 #include <util/system/error.h>
@@ -146,10 +148,10 @@ NProto::TError TPersistentStateManager::DeleteStateFile(
     TGuard guard(Mutex);
 
     // Release the lock if the state file is held. Stop referencing the
-    // session directory when it holds no more state files, no matter whether
-    // the removal below succeeds.
+    // session directory when this manager holds no more state files in it,
+    // no matter whether the removal below succeeds.
     NProto::TError releaseError;
-    bool dirHoldsStateFiles = false;
+    bool dirHoldsNoLocks = true;
     if (auto dirIt = SessionDirs.find(dir.GetPath());
         dirIt != SessionDirs.end())
     {
@@ -171,14 +173,16 @@ NProto::TError TPersistentStateManager::DeleteStateFile(
             }
         }
 
-        dirHoldsStateFiles = !locks.empty();
-        if (!dirHoldsStateFiles) {
+        dirHoldsNoLocks = locks.empty();
+        if (dirHoldsNoLocks) {
             SessionDirs.erase(dirIt);
         }
     }
 
     // The state file may be present without being held, e.g. when it was
     // left behind by a previous session and the component is now disabled.
+    // Only this very file is removed: the directory may hold state files of
+    // other components, whether held by this manager or not.
     if (filePath.Exists() && !NFs::Remove(filePath)) {
         return MakeError(
             E_FAIL,
@@ -186,14 +190,21 @@ NProto::TError TPersistentStateManager::DeleteStateFile(
                              << ", reason: " << LastSystemErrorText());
     }
 
-    if (!dirHoldsStateFiles && dir.Exists()) {
-        try {
-            NFs::RemoveRecursive(dir);
-        } catch (const yexception& e) {
+    // If other state files are still held in the directory it is obviously
+    // not empty, so there is nothing to try. Otherwise remove it if empty: a
+    // directory found not empty at this point contains state nobody tracks.
+    if (dirHoldsNoLocks && dir.Exists() && !NFs::Remove(dir)) {
+        const int err = LastSystemError();
+        if (err == ENOTEMPTY || err == EEXIST) {
+            ReportPersistentStateSessionDirNotEmpty(
+                TStringBuilder() << "Session dir " << dir
+                                 << " is not empty after the state file "
+                                 << fileName << " has been deleted");
+        } else {
             return MakeError(
                 E_FAIL,
                 TStringBuilder() << "Failed to remove dir " << dir
-                                 << ", reason: " << e.what());
+                                 << ", reason: " << LastSystemErrorText(err));
         }
     }
 

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.cpp
@@ -3,7 +3,7 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 
 #include <util/generic/hash.h>
-#include <util/generic/ptr.h>
+#include <util/generic/hash_set.h>
 #include <util/generic/strbuf.h>
 #include <util/generic/yexception.h>
 #include <util/string/builder.h>
@@ -12,6 +12,7 @@
 #include <util/system/fs.h>
 #include <util/system/guard.h>
 #include <util/system/mutex.h>
+#include <util/system/yassert.h>
 
 namespace NCloud::NFileStore::NFuse {
 
@@ -25,9 +26,159 @@ constexpr TStringBuf DirectoryHandleStorageFileName = "directory_handles_storage
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Keeps track of the state files held by the guards, per session directory.
+// Shared by the manager and all the guards it has handed out, since the
+// guards are owned by the loops and may outlive the manager.
+struct TStateFileRegistry
+{
+    // Guards the registry and the filesystem operations on the state files.
+    TMutex Mutex;
+
+    // Session directories that hold at least one acquired state file, keyed
+    // by path, with the names of the files held. A directory may be shared
+    // by several components.
+    THashMap<TString, THashSet<TString>> HeldStateFiles;
+};
+
+using TStateFileRegistryPtr = std::shared_ptr<TStateFileRegistry>;
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TAcquireStateFileGuard::TImpl
+{
+    TStateFileRegistryPtr Registry;
+
+    TFsPath Dir;
+    TString FileName;
+    TFsPath FilePath;
+
+    THolder<TFileLock> Lock;
+
+    // Returns whether this is the last state file held in the directory.
+    // Must be called with the registry locked.
+    //
+    // Should be guarded by TStateFileRegistry::Mutex.
+    bool UnregisterLocked()
+    {
+        auto dirIt = Registry->HeldStateFiles.find(Dir.GetPath());
+        if (dirIt == Registry->HeldStateFiles.end()) {
+            return true;
+        }
+
+        auto& fileNames = dirIt->second;
+        fileNames.erase(FileName);
+        if (!fileNames.empty()) {
+            return false;
+        }
+
+        Registry->HeldStateFiles.erase(dirIt);
+        return true;
+    }
+};
+
+TAcquireStateFileGuard::TAcquireStateFileGuard() = default;
+
+TAcquireStateFileGuard::TAcquireStateFileGuard(THolder<TImpl> impl)
+    : Impl(std::move(impl))
+{}
+
+TAcquireStateFileGuard::TAcquireStateFileGuard(
+    TAcquireStateFileGuard&& other) noexcept = default;
+
+TAcquireStateFileGuard& TAcquireStateFileGuard::operator=(
+    TAcquireStateFileGuard&& other) noexcept = default;
+
+TAcquireStateFileGuard::~TAcquireStateFileGuard()
+{
+    if (!Impl) {
+        return;
+    }
+
+    TGuard guard(Impl->Registry->Mutex);
+    Impl->UnregisterLocked();
+
+    // Destroying the lock closes the file, which releases the lock without
+    // any chance of failure, unlike an explicit Release(). The file itself
+    // is kept together with its session directory.
+}
+
+TAcquireStateFileGuard::operator bool() const
+{
+    return !!Impl;
+}
+
+const TFsPath& TAcquireStateFileGuard::GetFilePath() const
+{
+    Y_ABORT_UNLESS(Impl, "The guard holds no state file");
+    return Impl->FilePath;
+}
+
+NProto::TError TAcquireStateFileGuard::DeleteStateFile()
+{
+    if (!Impl) {
+        return {};
+    }
+
+    // Leave nothing behind whatever happens below, so that a repeated call
+    // is a no-op and the destructor has nothing to do.
+    auto impl = std::move(Impl);
+
+    TGuard guard(impl->Registry->Mutex);
+
+    const bool lastStateFile = impl->UnregisterLocked();
+
+    // Release() reports failures by throwing. The lock is dropped either way
+    // once |impl| goes out of scope, since closing the file releases it.
+    NProto::TError releaseError;
+    try {
+        impl->Lock->Release();
+    } catch (const yexception& e) {
+        releaseError = MakeError(
+            E_FAIL,
+            TStringBuilder() << "Failed to unlock file " << impl->FilePath
+                             << ", reason: " << e.what());
+    }
+    impl->Lock.Reset();
+
+    // Only this very file is removed: the directory may hold state files of
+    // other components, whether held by other guards or not.
+    if (impl->FilePath.Exists() && !NFs::Remove(impl->FilePath)) {
+        return MakeError(
+            E_FAIL,
+            TStringBuilder() << "Failed to remove file " << impl->FilePath
+                             << ", reason: " << LastSystemErrorText());
+    }
+
+    // If other state files are still held in the directory it is obviously
+    // not empty, so there is nothing to try. Otherwise remove it if empty: a
+    // directory found not empty at this point contains state nobody tracks
+    // (e.g. of a component which is not configured anymore).
+    if (lastStateFile && !NFs::Remove(impl->Dir)) {
+        const int err = LastSystemError();
+        if (err == ENOTEMPTY || err == EEXIST) {
+            ReportPersistentStateSessionDirNotEmpty(
+                TStringBuilder() << "Session dir " << impl->Dir
+                                 << " is not empty after the state file "
+                                 << impl->FileName << " has been deleted");
+        } else {
+            return MakeError(
+                E_FAIL,
+                TStringBuilder() << "Failed to remove dir " << impl->Dir
+                                 << ", reason: " << LastSystemErrorText(err));
+        }
+    }
+
+    return releaseError;
+}
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
 // Keeps the state files on disk under the configured base paths, following
-// the layout <basePath>/<fileSystemId>/<sessionId>/<fileName>, and holds the
-// advisory locks on the acquired ones.
+// the layout <basePath>/<fileSystemId>/<sessionId>/<fileName>.
 class TPersistentStateManager final
     : public IPersistentStateManager
 {
@@ -44,20 +195,8 @@ private:
         {}
     };
 
-    // Locked state files held in one session directory, keyed by file name.
-    using TSessionDirLocks = THashMap<TString, THolder<TFileLock>>;
-
-    // Guards SessionDirs and the filesystem operations on the state files.
-    mutable TMutex Mutex;
-
-    // Session directories that hold at least one locked state file, keyed by
-    // path. A directory may be shared by several components, so only the
-    // requested files are ever removed from it, and the directory itself is
-    // removed once it is empty. A directory found not empty after the last
-    // state file held in it has been deleted contains state nobody tracks
-    // (e.g. of a component which is not configured anymore), which is
-    // reported as a critical event.
-    THashMap<TString, TSessionDirLocks> SessionDirs;
+    const TStateFileRegistryPtr Registry =
+        std::make_shared<TStateFileRegistry>();
 
     const TComponentConfig HandleOpsQueue;
     const TComponentConfig WriteBackCache;
@@ -74,10 +213,7 @@ public:
     bool HasHandleOpsQueueState(
         const TString& fileSystemId,
         const TString& sessionId) const override;
-    TAcquireStateFileResult AcquireHandleOpsQueueStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) override;
-    NProto::TError DeleteHandleOpsQueueStateFile(
+    TResultOrError<TAcquireStateFileGuard> AcquireHandleOpsQueueStateFile(
         const TString& fileSystemId,
         const TString& sessionId) override;
 
@@ -86,25 +222,17 @@ public:
     bool HasWriteBackCacheState(
         const TString& fileSystemId,
         const TString& sessionId) const override;
-    TAcquireStateFileResult AcquireWriteBackCacheStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) override;
-    NProto::TError DeleteWriteBackCacheStateFile(
+    TResultOrError<TAcquireStateFileGuard> AcquireWriteBackCacheStateFile(
         const TString& fileSystemId,
         const TString& sessionId) override;
 
     // DirectoryHandleStorage
 
-    TAcquireStateFileResult AcquireDirectoryHandleStorageStateFile(
+    bool HasDirectoryHandleStorageState(
         const TString& fileSystemId,
-        const TString& sessionId) override;
-    NProto::TError DeleteDirectoryHandleStorageStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) override;
-
-    // All components
-
-    void ReleaseStateFiles(
+        const TString& sessionId) const override;
+    TResultOrError<TAcquireStateFileGuard>
+    AcquireDirectoryHandleStorageStateFile(
         const TString& fileSystemId,
         const TString& sessionId) override;
 
@@ -119,17 +247,7 @@ private:
         const TString& fileSystemId,
         const TString& sessionId) const;
 
-    TAcquireStateFileResult AcquireStateFile(
-        const TComponentConfig& component,
-        const TString& fileSystemId,
-        const TString& sessionId);
-
-    NProto::TError DeleteStateFile(
-        const TComponentConfig& component,
-        const TString& fileSystemId,
-        const TString& sessionId);
-
-    void ReleaseStateFile(
+    TResultOrError<TAcquireStateFileGuard> AcquireStateFile(
         const TComponentConfig& component,
         const TString& fileSystemId,
         const TString& sessionId);
@@ -176,48 +294,41 @@ bool TPersistentStateManager::HasState(
     const auto filePath =
         GetSessionDir(component, fileSystemId, sessionId) / component.FileName;
 
-    TGuard guard(Mutex);
+    TGuard guard(Registry->Mutex);
     return filePath.Exists();
 }
 
-TPersistentStateManager::TAcquireStateFileResult
+TResultOrError<TAcquireStateFileGuard>
 TPersistentStateManager::AcquireStateFile(
     const TComponentConfig& component,
     const TString& fileSystemId,
     const TString& sessionId)
 {
     if (!component.BasePath) {
-        return {
-            .Error = MakeError(
-                E_INVALID_STATE,
-                TStringBuilder() << "Base path for " << component.FileName
-                                 << " is not set"),
-            .FilePath = {}};
+        return MakeError(
+            E_INVALID_STATE,
+            TStringBuilder() << "Base path for " << component.FileName
+                             << " is not set");
     }
 
-    const auto dir = GetSessionDir(component, fileSystemId, sessionId);
-    const TString fileName(component.FileName);
+    auto dir = GetSessionDir(component, fileSystemId, sessionId);
+    TString fileName(component.FileName);
     auto filePath = dir / fileName;
 
-    TGuard guard(Mutex);
+    TGuard guard(Registry->Mutex);
 
-    const auto* locks = SessionDirs.FindPtr(dir.GetPath());
-    if (locks && locks->contains(fileName)) {
-        return {
-            .Error = MakeError(
-                E_INVALID_STATE,
-                TStringBuilder() << "State file " << filePath
-                                 << " is already acquired"),
-            .FilePath = {}};
+    const auto* fileNames = Registry->HeldStateFiles.FindPtr(dir.GetPath());
+    if (fileNames && fileNames->contains(fileName)) {
+        return MakeError(
+            E_INVALID_STATE,
+            TStringBuilder() << "State file " << filePath
+                             << " is already acquired");
     }
 
     if (!NFs::MakeDirectoryRecursive(dir)) {
-        return {
-            .Error = MakeError(
-                E_FAIL,
-                TStringBuilder() << "Failed to create directories, path: "
-                                 << dir),
-            .FilePath = {}};
+        return MakeError(
+            E_FAIL,
+            TStringBuilder() << "Failed to create directories, path: " << dir);
     }
 
     // Touch(), the TFileLock constructor (which opens the file) and
@@ -228,134 +339,27 @@ TPersistentStateManager::AcquireStateFile(
 
         lock = MakeHolder<TFileLock>(filePath);
         if (!lock->TryAcquire()) {
-            return {
-                .Error = MakeError(
-                    E_INVALID_STATE,
-                    TStringBuilder() << "State file " << filePath
-                                     << " is locked by another owner"),
-                .FilePath = {}};
+            return MakeError(
+                E_INVALID_STATE,
+                TStringBuilder() << "State file " << filePath
+                                 << " is locked by another owner");
         }
     } catch (const yexception& e) {
-        return {
-            .Error = MakeError(
-                E_FAIL,
-                TStringBuilder() << "Failed to lock file, path: " << filePath
-                                 << ", reason: " << e.what()),
-            .FilePath = {}};
-    }
-
-    SessionDirs[dir.GetPath()].emplace(fileName, std::move(lock));
-    return {.Error = {}, .FilePath = std::move(filePath)};
-}
-
-NProto::TError TPersistentStateManager::DeleteStateFile(
-    const TComponentConfig& component,
-    const TString& fileSystemId,
-    const TString& sessionId)
-{
-    if (!component.BasePath) {
-        return {};
-    }
-
-    const auto dir = GetSessionDir(component, fileSystemId, sessionId);
-    const TString fileName(component.FileName);
-    const auto filePath = dir / fileName;
-
-    TGuard guard(Mutex);
-
-    // Release the lock if the state file is held. Stop referencing the
-    // session directory when this manager holds no more state files in it,
-    // no matter whether the removal below succeeds.
-    NProto::TError releaseError;
-    bool dirHoldsNoLocks = true;
-    if (auto dirIt = SessionDirs.find(dir.GetPath());
-        dirIt != SessionDirs.end())
-    {
-        auto& locks = dirIt->second;
-        if (auto lockIt = locks.find(fileName); lockIt != locks.end()) {
-            auto lock = std::move(lockIt->second);
-            locks.erase(lockIt);
-
-            // Release() reports failures by throwing. The lock is dropped
-            // either way once |lock| goes out of scope, since closing the
-            // file releases it.
-            try {
-                lock->Release();
-            } catch (const yexception& e) {
-                releaseError = MakeError(
-                    E_FAIL,
-                    TStringBuilder() << "Failed to unlock file " << filePath
-                                     << ", reason: " << e.what());
-            }
-        }
-
-        dirHoldsNoLocks = locks.empty();
-        if (dirHoldsNoLocks) {
-            SessionDirs.erase(dirIt);
-        }
-    }
-
-    // The state file may be present without being held, e.g. when it was
-    // left behind by a previous session and the component is now disabled.
-    // Only this very file is removed: the directory may hold state files of
-    // other components, whether held by this manager or not.
-    if (filePath.Exists() && !NFs::Remove(filePath)) {
         return MakeError(
             E_FAIL,
-            TStringBuilder() << "Failed to remove file " << filePath
-                             << ", reason: " << LastSystemErrorText());
+            TStringBuilder() << "Failed to lock file, path: " << filePath
+                             << ", reason: " << e.what());
     }
 
-    // If other state files are still held in the directory it is obviously
-    // not empty, so there is nothing to try. Otherwise remove it if empty: a
-    // directory found not empty at this point contains state nobody tracks.
-    if (dirHoldsNoLocks && dir.Exists() && !NFs::Remove(dir)) {
-        const int err = LastSystemError();
-        if (err == ENOTEMPTY || err == EEXIST) {
-            ReportPersistentStateSessionDirNotEmpty(
-                TStringBuilder() << "Session dir " << dir
-                                 << " is not empty after the state file "
-                                 << fileName << " has been deleted");
-        } else {
-            return MakeError(
-                E_FAIL,
-                TStringBuilder() << "Failed to remove dir " << dir
-                                 << ", reason: " << LastSystemErrorText(err));
-        }
-    }
+    Registry->HeldStateFiles[dir.GetPath()].insert(fileName);
 
-    return releaseError;
-}
-
-void TPersistentStateManager::ReleaseStateFile(
-    const TComponentConfig& component,
-    const TString& fileSystemId,
-    const TString& sessionId)
-{
-    if (!component.BasePath) {
-        return;
-    }
-
-    const auto dir = GetSessionDir(component, fileSystemId, sessionId);
-    const TString fileName(component.FileName);
-
-    TGuard guard(Mutex);
-
-    auto dirIt = SessionDirs.find(dir.GetPath());
-    if (dirIt == SessionDirs.end()) {
-        return;
-    }
-
-    // Destroying the lock closes the file, which releases the lock without
-    // any chance of failure, unlike an explicit Release().
-    auto& locks = dirIt->second;
-    locks.erase(fileName);
-
-    // The session directory is kept together with the state files, only the
-    // reference to it is dropped once nothing is held in it anymore.
-    if (locks.empty()) {
-        SessionDirs.erase(dirIt);
-    }
+    return TAcquireStateFileGuard(MakeHolder<TAcquireStateFileGuard::TImpl>(
+        TAcquireStateFileGuard::TImpl{
+            .Registry = Registry,
+            .Dir = std::move(dir),
+            .FileName = std::move(fileName),
+            .FilePath = std::move(filePath),
+            .Lock = std::move(lock)}));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -368,19 +372,12 @@ bool TPersistentStateManager::HasHandleOpsQueueState(
     return HasState(HandleOpsQueue, fileSystemId, sessionId);
 }
 
-TPersistentStateManager::TAcquireStateFileResult
+TResultOrError<TAcquireStateFileGuard>
 TPersistentStateManager::AcquireHandleOpsQueueStateFile(
     const TString& fileSystemId,
     const TString& sessionId)
 {
     return AcquireStateFile(HandleOpsQueue, fileSystemId, sessionId);
-}
-
-NProto::TError TPersistentStateManager::DeleteHandleOpsQueueStateFile(
-    const TString& fileSystemId,
-    const TString& sessionId)
-{
-    return DeleteStateFile(HandleOpsQueue, fileSystemId, sessionId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -393,7 +390,7 @@ bool TPersistentStateManager::HasWriteBackCacheState(
     return HasState(WriteBackCache, fileSystemId, sessionId);
 }
 
-TPersistentStateManager::TAcquireStateFileResult
+TResultOrError<TAcquireStateFileGuard>
 TPersistentStateManager::AcquireWriteBackCacheStateFile(
     const TString& fileSystemId,
     const TString& sessionId)
@@ -401,41 +398,22 @@ TPersistentStateManager::AcquireWriteBackCacheStateFile(
     return AcquireStateFile(WriteBackCache, fileSystemId, sessionId);
 }
 
-NProto::TError TPersistentStateManager::DeleteWriteBackCacheStateFile(
-    const TString& fileSystemId,
-    const TString& sessionId)
-{
-    return DeleteStateFile(WriteBackCache, fileSystemId, sessionId);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // DirectoryHandleStorage
 
-TPersistentStateManager::TAcquireStateFileResult
+bool TPersistentStateManager::HasDirectoryHandleStorageState(
+    const TString& fileSystemId,
+    const TString& sessionId) const
+{
+    return HasState(DirectoryHandleStorage, fileSystemId, sessionId);
+}
+
+TResultOrError<TAcquireStateFileGuard>
 TPersistentStateManager::AcquireDirectoryHandleStorageStateFile(
     const TString& fileSystemId,
     const TString& sessionId)
 {
     return AcquireStateFile(DirectoryHandleStorage, fileSystemId, sessionId);
-}
-
-NProto::TError TPersistentStateManager::DeleteDirectoryHandleStorageStateFile(
-    const TString& fileSystemId,
-    const TString& sessionId)
-{
-    return DeleteStateFile(DirectoryHandleStorage, fileSystemId, sessionId);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// All components
-
-void TPersistentStateManager::ReleaseStateFiles(
-    const TString& fileSystemId,
-    const TString& sessionId)
-{
-    ReleaseStateFile(HandleOpsQueue, fileSystemId, sessionId);
-    ReleaseStateFile(WriteBackCache, fileSystemId, sessionId);
-    ReleaseStateFile(DirectoryHandleStorage, fileSystemId, sessionId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -454,20 +432,12 @@ public:
         return false;
     }
 
-    TAcquireStateFileResult AcquireHandleOpsQueueStateFile(
+    TResultOrError<TAcquireStateFileGuard> AcquireHandleOpsQueueStateFile(
         const TString& fileSystemId,
         const TString& sessionId) override
     {
         Y_UNUSED(fileSystemId, sessionId);
         return NotImplemented(HandleOpsQueueFileName);
-    }
-
-    NProto::TError DeleteHandleOpsQueueStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) override
-    {
-        Y_UNUSED(fileSystemId, sessionId);
-        return {};
     }
 
     // WriteBackCache
@@ -480,7 +450,7 @@ public:
         return false;
     }
 
-    TAcquireStateFileResult AcquireWriteBackCacheStateFile(
+    TResultOrError<TAcquireStateFileGuard> AcquireWriteBackCacheStateFile(
         const TString& fileSystemId,
         const TString& sessionId) override
     {
@@ -488,17 +458,18 @@ public:
         return NotImplemented(WriteBackCacheFileName);
     }
 
-    NProto::TError DeleteWriteBackCacheStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) override
-    {
-        Y_UNUSED(fileSystemId, sessionId);
-        return {};
-    }
-
     // DirectoryHandleStorage
 
-    TAcquireStateFileResult AcquireDirectoryHandleStorageStateFile(
+    bool HasDirectoryHandleStorageState(
+        const TString& fileSystemId,
+        const TString& sessionId) const override
+    {
+        Y_UNUSED(fileSystemId, sessionId);
+        return false;
+    }
+
+    TResultOrError<TAcquireStateFileGuard>
+    AcquireDirectoryHandleStorageStateFile(
         const TString& fileSystemId,
         const TString& sessionId) override
     {
@@ -506,32 +477,13 @@ public:
         return NotImplemented(DirectoryHandleStorageFileName);
     }
 
-    NProto::TError DeleteDirectoryHandleStorageStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) override
-    {
-        Y_UNUSED(fileSystemId, sessionId);
-        return {};
-    }
-
-    // All components
-
-    void ReleaseStateFiles(
-        const TString& fileSystemId,
-        const TString& sessionId) override
-    {
-        Y_UNUSED(fileSystemId, sessionId);
-    }
-
 private:
-    static TAcquireStateFileResult NotImplemented(TStringBuf fileName)
+    static NProto::TError NotImplemented(TStringBuf fileName)
     {
-        return {
-            .Error = MakeError(
-                E_NOT_IMPLEMENTED,
-                TStringBuilder() << "State file " << fileName
-                                 << " is not supported by the stub"),
-            .FilePath = {}};
+        return MakeError(
+            E_NOT_IMPLEMENTED,
+            TStringBuilder() << "State file " << fileName
+                             << " is not supported by the stub");
     }
 };
 

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/folder/path.h>
+#include <util/generic/hash.h>
+#include <util/generic/ptr.h>
+#include <util/generic/strbuf.h>
+#include <util/generic/string.h>
+#include <util/system/file_lock.h>
+#include <util/system/guard.h>
+#include <util/system/mutex.h>
+
+namespace NCloud::NFileStore::NFuse {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Encapsulates the local per-session state files of the FUSE driver
+// components (HandleOpsQueue, WriteBackCache and DirectoryHandleStorage):
+// the on-disk layout (<basePath>/<fileSystemId>/<sessionId>/<fileName>),
+// file creation, advisory locking and cleanup.
+//
+// A single instance is shared by all filesystem loops, so it holds state files
+// of any number of filesystems and sessions at the same time.
+class TPersistentStateManager
+{
+public:
+    struct TAcquireStateFileResult
+    {
+        NProto::TError Error;
+        // Path to the locked state file. Valid iff there is no error.
+        TFsPath FilePath;
+    };
+
+    TPersistentStateManager(
+        TString handleOpsQueueBasePath,
+        TString writeBackCacheBasePath,
+        TString directoryHandlesStorageBasePath);
+
+    // HandleOpsQueue
+
+    // Returns true iff the component is configured (base path is set) and
+    // the state file of the given session is present on disk.
+    bool HasHandleOpsQueueState(
+        const TString& fileSystemId,
+        const TString& sessionId) const;
+    // If the corresponding state file exists, acquires the advisory lock and
+    // returns the file, otherwise creates the file first.
+    TAcquireStateFileResult AcquireHandleOpsQueueStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId);
+    NProto::TError DeleteHandleOpsQueueStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId);
+
+    // WriteBackCache
+
+    bool HasWriteBackCacheState(
+        const TString& fileSystemId,
+        const TString& sessionId) const;
+    // If the corresponding state file exists, acquires the advisory lock and
+    // returns the file, otherwise creates the file first.
+    TAcquireStateFileResult AcquireWriteBackCacheStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId);
+    NProto::TError DeleteWriteBackCacheStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId);
+
+    // DirectoryHandleStorage
+
+    // If the corresponding state file exists, acquires the advisory lock and
+    // returns the file, otherwise creates the file first.
+    TAcquireStateFileResult AcquireDirectoryHandleStorageStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId);
+    NProto::TError DeleteDirectoryHandleStorageStateFile(
+        const TString& fileSystemId,
+        const TString& sessionId);
+
+private:
+    struct TComponentConfig
+    {
+        const TString BasePath;
+        // Points to a static string.
+        const TStringBuf FileName;
+
+        TComponentConfig(TString basePath, TStringBuf fileName)
+            : BasePath(std::move(basePath))
+            , FileName(fileName)
+        {}
+    };
+
+    // Locked state files held in one session directory, keyed by file name.
+    using TSessionDirLocks = THashMap<TString, THolder<TFileLock>>;
+
+    TFsPath GetSessionDir(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId) const;
+
+    bool HasState(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId) const;
+
+    TAcquireStateFileResult AcquireStateFile(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId);
+
+    NProto::TError DeleteStateFile(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId);
+
+private:
+    // Guards SessionDirs and the filesystem operations on the state files.
+    mutable TMutex Mutex;
+
+    // Session directories that hold at least one locked state file, keyed by
+    // path. A directory may be shared by several components, it is removed
+    // once it holds no more state files.
+    THashMap<TString, TSessionDirLocks> SessionDirs;
+
+    const TComponentConfig HandleOpsQueue;
+    const TComponentConfig WriteBackCache;
+    const TComponentConfig DirectoryHandleStorage;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Creates a persistent state with no components configured: Has*State()
+// returns false, Acquire*StateFile() fails and Delete*StateFile() is a no-op.
+// Suitable for the cases where no state files are used at all.
+TPersistentStateManagerPtr CreatePersistentStateManagerStub();
+
+}   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
@@ -5,27 +5,59 @@
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/folder/path.h>
+#include <util/generic/ptr.h>
 #include <util/generic/string.h>
 
 namespace NCloud::NFileStore::NFuse {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Holds the advisory lock on an acquired state file. The guard is owned by
+// the loop that has acquired the file, so the lock lives as long as the loop
+// does: destroying the guard releases the lock keeping the file on disk, so
+// that a future session can restore the state, e.g. when the loop is
+// suspended or dropped because its start has failed. DeleteStateFile() is
+// for the case when the state is not needed anymore, i.e. when the session
+// is destroyed.
+class TAcquireStateFileGuard
+{
+public:
+    // Implementation detail of the persistent state manager.
+    struct TImpl;
+
+private:
+    THolder<TImpl> Impl;
+
+public:
+    TAcquireStateFileGuard();
+    explicit TAcquireStateFileGuard(THolder<TImpl> impl);
+    TAcquireStateFileGuard(TAcquireStateFileGuard&& other) noexcept;
+    TAcquireStateFileGuard& operator=(TAcquireStateFileGuard&& other) noexcept;
+    ~TAcquireStateFileGuard();
+
+    // Whether a state file is held.
+    explicit operator bool() const;
+
+    // Path to the held state file. Valid iff the guard holds one.
+    const TFsPath& GetFilePath() const;
+
+    // Releases the lock and removes the state file, and the session directory
+    // too once it is empty. Leaves the guard holding nothing; no-op if it
+    // holds nothing already.
+    NProto::TError DeleteStateFile();
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 // Manages the local per-session state files of the FUSE driver components
 // (HandleOpsQueue, WriteBackCache and DirectoryHandleStorage): their
-// creation, advisory locking and cleanup.
+// creation and advisory locking. The acquired files are handed out as guards
+// which take care of the locks and of the cleanup.
 //
-// A single instance is shared by all filesystem loops, so it holds state files
-// of any number of filesystems and sessions at the same time.
+// A single instance is shared by all filesystem loops, so it serves any
+// number of filesystems and sessions at the same time.
 struct IPersistentStateManager
 {
-    struct TAcquireStateFileResult
-    {
-        NProto::TError Error;
-        // Path to the locked state file. Valid iff there is no error.
-        TFsPath FilePath;
-    };
-
     virtual ~IPersistentStateManager() = default;
 
     // HandleOpsQueue
@@ -37,10 +69,8 @@ struct IPersistentStateManager
         const TString& sessionId) const = 0;
     // If the corresponding state file exists, acquires the advisory lock and
     // returns the file, otherwise creates the file first.
-    virtual TAcquireStateFileResult AcquireHandleOpsQueueStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) = 0;
-    virtual NProto::TError DeleteHandleOpsQueueStateFile(
+    virtual TResultOrError<TAcquireStateFileGuard>
+    AcquireHandleOpsQueueStateFile(
         const TString& fileSystemId,
         const TString& sessionId) = 0;
 
@@ -51,30 +81,20 @@ struct IPersistentStateManager
         const TString& sessionId) const = 0;
     // If the corresponding state file exists, acquires the advisory lock and
     // returns the file, otherwise creates the file first.
-    virtual TAcquireStateFileResult AcquireWriteBackCacheStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) = 0;
-    virtual NProto::TError DeleteWriteBackCacheStateFile(
+    virtual TResultOrError<TAcquireStateFileGuard>
+    AcquireWriteBackCacheStateFile(
         const TString& fileSystemId,
         const TString& sessionId) = 0;
 
     // DirectoryHandleStorage
 
+    virtual bool HasDirectoryHandleStorageState(
+        const TString& fileSystemId,
+        const TString& sessionId) const = 0;
     // If the corresponding state file exists, acquires the advisory lock and
     // returns the file, otherwise creates the file first.
-    virtual TAcquireStateFileResult AcquireDirectoryHandleStorageStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) = 0;
-    virtual NProto::TError DeleteDirectoryHandleStorageStateFile(
-        const TString& fileSystemId,
-        const TString& sessionId) = 0;
-
-    // All components
-
-    // Releases the locks of all the state files of the session held by this
-    // manager, keeping the files on disk so that a future session can
-    // restore them.
-    virtual void ReleaseStateFiles(
+    virtual TResultOrError<TAcquireStateFileGuard>
+    AcquireDirectoryHandleStorageStateFile(
         const TString& fileSystemId,
         const TString& sessionId) = 0;
 };
@@ -93,9 +113,8 @@ IPersistentStateManagerPtr CreatePersistentStateManager(
     TString directoryHandlesStorageBasePath);
 
 // Creates a manager which manages no state files at all: Has*State() returns
-// false, Acquire*StateFile() fails and Delete*StateFile() as well as
-// ReleaseStateFiles() are no-ops. Suitable for the cases where no state files
-// are used at all.
+// false and Acquire*StateFile() fails. Suitable for the cases where no state
+// files are used at all.
 IPersistentStateManagerPtr CreatePersistentStateManagerStub();
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
@@ -5,28 +5,20 @@
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/folder/path.h>
-#include <util/generic/hash.h>
-#include <util/generic/ptr.h>
-#include <util/generic/strbuf.h>
 #include <util/generic/string.h>
-#include <util/system/file_lock.h>
-#include <util/system/guard.h>
-#include <util/system/mutex.h>
 
 namespace NCloud::NFileStore::NFuse {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Encapsulates the local per-session state files of the FUSE driver
-// components (HandleOpsQueue, WriteBackCache and DirectoryHandleStorage):
-// the on-disk layout (<basePath>/<fileSystemId>/<sessionId>/<fileName>),
-// file creation, advisory locking and cleanup.
+// Manages the local per-session state files of the FUSE driver components
+// (HandleOpsQueue, WriteBackCache and DirectoryHandleStorage): their
+// creation, advisory locking and cleanup.
 //
 // A single instance is shared by all filesystem loops, so it holds state files
 // of any number of filesystems and sessions at the same time.
-class TPersistentStateManager
+struct IPersistentStateManager
 {
-public:
     struct TAcquireStateFileResult
     {
         NProto::TError Error;
@@ -34,125 +26,76 @@ public:
         TFsPath FilePath;
     };
 
-    TPersistentStateManager(
-        TString handleOpsQueueBasePath,
-        TString writeBackCacheBasePath,
-        TString directoryHandlesStorageBasePath);
+    virtual ~IPersistentStateManager() = default;
 
     // HandleOpsQueue
 
-    // Returns true iff the component is configured (base path is set) and
-    // the state file of the given session is present on disk.
-    bool HasHandleOpsQueueState(
+    // Returns true iff the component is configured and the state file of the
+    // given session is present on disk.
+    virtual bool HasHandleOpsQueueState(
         const TString& fileSystemId,
-        const TString& sessionId) const;
+        const TString& sessionId) const = 0;
     // If the corresponding state file exists, acquires the advisory lock and
     // returns the file, otherwise creates the file first.
-    TAcquireStateFileResult AcquireHandleOpsQueueStateFile(
+    virtual TAcquireStateFileResult AcquireHandleOpsQueueStateFile(
         const TString& fileSystemId,
-        const TString& sessionId);
-    NProto::TError DeleteHandleOpsQueueStateFile(
+        const TString& sessionId) = 0;
+    virtual NProto::TError DeleteHandleOpsQueueStateFile(
         const TString& fileSystemId,
-        const TString& sessionId);
+        const TString& sessionId) = 0;
 
     // WriteBackCache
 
-    bool HasWriteBackCacheState(
+    virtual bool HasWriteBackCacheState(
         const TString& fileSystemId,
-        const TString& sessionId) const;
+        const TString& sessionId) const = 0;
     // If the corresponding state file exists, acquires the advisory lock and
     // returns the file, otherwise creates the file first.
-    TAcquireStateFileResult AcquireWriteBackCacheStateFile(
+    virtual TAcquireStateFileResult AcquireWriteBackCacheStateFile(
         const TString& fileSystemId,
-        const TString& sessionId);
-    NProto::TError DeleteWriteBackCacheStateFile(
+        const TString& sessionId) = 0;
+    virtual NProto::TError DeleteWriteBackCacheStateFile(
         const TString& fileSystemId,
-        const TString& sessionId);
+        const TString& sessionId) = 0;
 
     // DirectoryHandleStorage
 
     // If the corresponding state file exists, acquires the advisory lock and
     // returns the file, otherwise creates the file first.
-    TAcquireStateFileResult AcquireDirectoryHandleStorageStateFile(
+    virtual TAcquireStateFileResult AcquireDirectoryHandleStorageStateFile(
         const TString& fileSystemId,
-        const TString& sessionId);
-    NProto::TError DeleteDirectoryHandleStorageStateFile(
+        const TString& sessionId) = 0;
+    virtual NProto::TError DeleteDirectoryHandleStorageStateFile(
         const TString& fileSystemId,
-        const TString& sessionId);
+        const TString& sessionId) = 0;
 
     // All components
 
     // Releases the locks of all the state files of the session held by this
     // manager, keeping the files on disk so that a future session can
     // restore them.
-    void ReleaseStateFiles(
+    virtual void ReleaseStateFiles(
         const TString& fileSystemId,
-        const TString& sessionId);
-
-private:
-    struct TComponentConfig
-    {
-        const TString BasePath;
-        // Points to a static string.
-        const TStringBuf FileName;
-
-        TComponentConfig(TString basePath, TStringBuf fileName)
-            : BasePath(std::move(basePath))
-            , FileName(fileName)
-        {}
-    };
-
-    // Locked state files held in one session directory, keyed by file name.
-    using TSessionDirLocks = THashMap<TString, THolder<TFileLock>>;
-
-    TFsPath GetSessionDir(
-        const TComponentConfig& component,
-        const TString& fileSystemId,
-        const TString& sessionId) const;
-
-    bool HasState(
-        const TComponentConfig& component,
-        const TString& fileSystemId,
-        const TString& sessionId) const;
-
-    TAcquireStateFileResult AcquireStateFile(
-        const TComponentConfig& component,
-        const TString& fileSystemId,
-        const TString& sessionId);
-
-    NProto::TError DeleteStateFile(
-        const TComponentConfig& component,
-        const TString& fileSystemId,
-        const TString& sessionId);
-
-    void ReleaseStateFile(
-        const TComponentConfig& component,
-        const TString& fileSystemId,
-        const TString& sessionId);
-
-private:
-    // Guards SessionDirs and the filesystem operations on the state files.
-    mutable TMutex Mutex;
-
-    // Session directories that hold at least one locked state file, keyed by
-    // path. A directory may be shared by several components, so only the
-    // requested files are ever removed from it, and the directory itself is
-    // removed once it is empty. A directory found not empty after the last
-    // state file held in it has been deleted contains state nobody tracks
-    // (e.g. of a component which is not configured anymore), which is
-    // reported as a critical event.
-    THashMap<TString, TSessionDirLocks> SessionDirs;
-
-    const TComponentConfig HandleOpsQueue;
-    const TComponentConfig WriteBackCache;
-    const TComponentConfig DirectoryHandleStorage;
+        const TString& sessionId) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Creates a persistent state with no components configured: Has*State()
-// returns false, Acquire*StateFile() fails and Delete*StateFile() is a no-op.
-// Suitable for the cases where no state files are used at all.
-TPersistentStateManagerPtr CreatePersistentStateManagerStub();
+// Creates the manager which keeps the state files on disk under the given
+// base paths, following the layout <basePath>/<fileSystemId>/<sessionId>/
+// <fileName>. A component whose base path is empty is not configured:
+// acquiring its state file fails with an error and Has*State() returns
+// false for it. Different components may be configured with the same base
+// path and thus share a session directory.
+IPersistentStateManagerPtr CreatePersistentStateManager(
+    TString handleOpsQueueBasePath,
+    TString writeBackCacheBasePath,
+    TString directoryHandlesStorageBasePath);
+
+// Creates a manager which manages no state files at all: Has*State() returns
+// false, Acquire*StateFile() fails and Delete*StateFile() as well as
+// ReleaseStateFiles() are no-ops. Suitable for the cases where no state files
+// are used at all.
+IPersistentStateManagerPtr CreatePersistentStateManagerStub();
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
@@ -80,6 +80,15 @@ public:
         const TString& fileSystemId,
         const TString& sessionId);
 
+    // All components
+
+    // Releases the locks of all the state files of the session held by this
+    // manager, keeping the files on disk so that a future session can
+    // restore them.
+    void ReleaseStateFiles(
+        const TString& fileSystemId,
+        const TString& sessionId);
+
 private:
     struct TComponentConfig
     {
@@ -112,6 +121,11 @@ private:
         const TString& sessionId);
 
     NProto::TError DeleteStateFile(
+        const TComponentConfig& component,
+        const TString& fileSystemId,
+        const TString& sessionId);
+
+    void ReleaseStateFile(
         const TComponentConfig& component,
         const TString& fileSystemId,
         const TString& sessionId);

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
@@ -45,6 +45,9 @@ public:
     // too once it is empty. Leaves the guard holding nothing; no-op if it
     // holds nothing already.
     NProto::TError DeleteStateFile();
+
+private:
+    void Reset() noexcept;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
@@ -38,7 +38,7 @@ public:
     // Whether a state file is held.
     explicit operator bool() const;
 
-    // Path to the held state file. Valid iff the guard holds one.
+    // Path to the held state file. Aborts if the guard holds none.
     const TFsPath& GetFilePath() const;
 
     // Releases the lock and removes the state file, and the session directory

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager.h
@@ -135,8 +135,12 @@ private:
     mutable TMutex Mutex;
 
     // Session directories that hold at least one locked state file, keyed by
-    // path. A directory may be shared by several components, it is removed
-    // once it holds no more state files.
+    // path. A directory may be shared by several components, so only the
+    // requested files are ever removed from it, and the directory itself is
+    // removed once it is empty. A directory found not empty after the last
+    // state file held in it has been deleted contains state nobody tracks
+    // (e.g. of a component which is not configured anymore), which is
+    // reported as a critical event.
     THashMap<TString, TSessionDirLocks> SessionDirs;
 
     const TComponentConfig HandleOpsQueue;

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
@@ -1,0 +1,401 @@
+#include "persistent_state_manager.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/folder/path.h>
+#include <util/folder/tempdir.h>
+#include <util/system/file_lock.h>
+#include <util/system/fs.h>
+
+namespace NCloud::NFileStore::NFuse {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const TString FileSystemId = "fs";
+const TString SessionId = "session";
+
+// In production all the components are configured with the same base path,
+// so their state files of one session live in one directory. The fixture
+// mirrors that: every manager it creates shares StatePath between the
+// components.
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    TTempDir TempDir;
+    TString StatePath = TempDir.Path() / "state";
+
+    TPersistentStateManager CreateManager()
+    {
+        return TPersistentStateManager(StatePath, StatePath, StatePath);
+    }
+
+    TFsPath SessionDir(
+        const TString& fileSystemId,
+        const TString& sessionId) const
+    {
+        return TFsPath(StatePath) / fileSystemId / sessionId;
+    }
+};
+
+bool IsLocked(const TFsPath& path)
+{
+    TFileLock lock(path);
+    if (lock.TryAcquire()) {
+        lock.Release();
+        return false;
+    }
+    return true;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
+{
+    Y_UNIT_TEST_F(ShouldAcquireCreateAndLockStateFile, TFixture)
+    {
+        auto manager = CreateManager();
+
+        UNIT_ASSERT(!manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+
+        auto result =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+
+        const auto expected =
+            SessionDir(FileSystemId, SessionId) / "handle_ops_queue";
+        UNIT_ASSERT_VALUES_EQUAL(
+            expected.GetPath(),
+            result.FilePath.GetPath());
+        UNIT_ASSERT(result.FilePath.Exists());
+        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+        UNIT_ASSERT(IsLocked(result.FilePath));
+    }
+
+    Y_UNIT_TEST_F(ShouldFailToAcquireSameStateFileTwice, TFixture)
+    {
+        auto manager = CreateManager();
+
+        auto first =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
+
+        auto second =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT(HasError(second.Error));
+        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, second.Error.GetCode());
+
+        // Other components are not affected by the failed attempt.
+        auto other =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(other.Error), other.Error.GetMessage());
+    }
+
+    Y_UNIT_TEST_F(ShouldDeleteStateFileAndSessionDir, TFixture)
+    {
+        auto manager = CreateManager();
+
+        auto result =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+
+        auto error =
+            manager.DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        UNIT_ASSERT(!result.FilePath.Exists());
+        UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT(!manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+    }
+
+    Y_UNIT_TEST_F(ShouldTreatDeleteOfMissingStateFileAsNoop, TFixture)
+    {
+        auto manager = CreateManager();
+
+        auto error =
+            manager.DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+    }
+
+    Y_UNIT_TEST_F(ShouldKeepStateFileOnDestruction, TFixture)
+    {
+        TFsPath filePath;
+        {
+            auto manager = CreateManager();
+            auto result = manager.AcquireHandleOpsQueueStateFile(
+                FileSystemId,
+                SessionId);
+            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+            filePath = result.FilePath;
+        }
+
+        // The state file survives so that a future session can restore it,
+        // and the lock is released so it can be re-acquired.
+        UNIT_ASSERT(filePath.Exists());
+        UNIT_ASSERT(!IsLocked(filePath));
+
+        auto manager = CreateManager();
+        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+
+        auto result =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+    }
+
+    Y_UNIT_TEST_F(ShouldKeepSessionDirUntilLastStateFileDeleted, TFixture)
+    {
+        auto manager = CreateManager();
+
+        auto hoq =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        auto wbc =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        auto dhs = manager.AcquireDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId);
+        UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(wbc.Error), wbc.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(dhs.Error), dhs.Error.GetMessage());
+
+        // Deleting one state file keeps the shared directory and the other
+        // state files held in it, whatever the order of deletion.
+        auto error =
+            manager.DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+        UNIT_ASSERT(!wbc.FilePath.Exists());
+        UNIT_ASSERT(hoq.FilePath.Exists());
+        UNIT_ASSERT(dhs.FilePath.Exists());
+        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+
+        error = manager.DeleteDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+        UNIT_ASSERT(!dhs.FilePath.Exists());
+        UNIT_ASSERT(hoq.FilePath.Exists());
+        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+
+        // Deleting the last one removes the directory.
+        error = manager.DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+        UNIT_ASSERT(!hoq.FilePath.Exists());
+        UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
+    }
+
+    Y_UNIT_TEST_F(ShouldNotDisturbHeldSiblingWhenDeletingUnheldFile, TFixture)
+    {
+        // Emulate a session start with the directory handle storage disabled
+        // after it had been enabled: its file is left on disk unheld, while
+        // the other components' files in the same directory are held.
+        TFsPath orphan;
+        {
+            auto previous = CreateManager();
+            auto result = previous.AcquireDirectoryHandleStorageStateFile(
+                FileSystemId,
+                SessionId);
+            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+            orphan = result.FilePath;
+        }
+
+        auto manager = CreateManager();
+        auto hoq =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        auto wbc =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(wbc.Error), wbc.Error.GetMessage());
+        UNIT_ASSERT(orphan.Exists());
+
+        // Cleaning up the unheld file must remove only that file.
+        auto error = manager.DeleteDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+        UNIT_ASSERT(!orphan.Exists());
+        UNIT_ASSERT(hoq.FilePath.Exists());
+        UNIT_ASSERT(wbc.FilePath.Exists());
+        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT(IsLocked(hoq.FilePath));
+        UNIT_ASSERT(IsLocked(wbc.FilePath));
+    }
+
+    Y_UNIT_TEST_F(ShouldManageSessionsIndependently, TFixture)
+    {
+        auto manager = CreateManager();
+
+        auto first =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, "session-1");
+        auto second =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, "session-2");
+        UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(second.Error), second.Error.GetMessage());
+        UNIT_ASSERT_UNEQUAL(
+            first.FilePath.Parent().GetPath(),
+            second.FilePath.Parent().GetPath());
+
+        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, "session-1"));
+        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, "session-2"));
+
+        auto error = manager.DeleteHandleOpsQueueStateFile(
+            FileSystemId,
+            "session-1");
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        UNIT_ASSERT(!manager.HasHandleOpsQueueState(FileSystemId, "session-1"));
+        UNIT_ASSERT(!SessionDir(FileSystemId, "session-1").Exists());
+        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, "session-2"));
+        UNIT_ASSERT(second.FilePath.Exists());
+    }
+
+    Y_UNIT_TEST_F(ShouldDeleteStateFileLeftByPreviousSession, TFixture)
+    {
+        // Emulate an orphan file: acquire it and let the manager go away, so
+        // the file stays on disk without being held.
+        TFsPath orphan;
+        {
+            auto manager = CreateManager();
+            auto result = manager.AcquireDirectoryHandleStorageStateFile(
+                FileSystemId,
+                SessionId);
+            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+            orphan = result.FilePath;
+        }
+        UNIT_ASSERT(orphan.Exists());
+
+        auto manager = CreateManager();
+        auto error = manager.DeleteDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        UNIT_ASSERT(!orphan.Exists());
+        UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
+    }
+
+    Y_UNIT_TEST_F(ShouldReacquireStateFileAfterDelete, TFixture)
+    {
+        auto manager = CreateManager();
+
+        auto first =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
+
+        auto error =
+            manager.DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        auto second =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(second.Error), second.Error.GetMessage());
+        UNIT_ASSERT(second.FilePath.Exists());
+    }
+
+    Y_UNIT_TEST_F(ShouldFailToAcquireUnconfiguredComponent, TFixture)
+    {
+        TPersistentStateManager manager(
+            StatePath,
+            {},   // writeBackCacheBasePath
+            StatePath);
+
+        UNIT_ASSERT(!manager.HasWriteBackCacheState(FileSystemId, SessionId));
+
+        auto result =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT(HasError(result.Error));
+        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, result.Error.GetCode());
+
+        auto error =
+            manager.DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        // The configured components of the same manager still work.
+        auto ok =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(ok.Error), ok.Error.GetMessage());
+    }
+
+    Y_UNIT_TEST_F(ShouldFailToAcquireStateFileLockedByAnotherOwner, TFixture)
+    {
+        auto owner = CreateManager();
+        auto result =
+            owner.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+
+        // A different manager (e.g. another process sharing the base path)
+        // must not be able to take the same state file while it is held.
+        auto other = CreateManager();
+        auto contended =
+            other.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT(HasError(contended.Error));
+        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, contended.Error.GetCode());
+
+        // Once released it becomes acquirable again.
+        auto error =
+            owner.DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        auto retried =
+            other.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(retried.Error), retried.Error.GetMessage());
+    }
+
+    Y_UNIT_TEST_F(ShouldReportErrorInsteadOfThrowingOnAcquireFailure, TFixture)
+    {
+        auto manager = CreateManager();
+
+        // Put a directory where the state file has to be created: touching
+        // and opening it then fail (EISDIR), which the underlying util calls
+        // report by throwing. The manager must turn that into an error.
+        const auto filePath =
+            SessionDir(FileSystemId, SessionId) / "handle_ops_queue";
+        UNIT_ASSERT(NFs::MakeDirectoryRecursive(filePath));
+
+        TPersistentStateManager::TAcquireStateFileResult result;
+        UNIT_ASSERT_NO_EXCEPTION(
+            result = manager.AcquireHandleOpsQueueStateFile(
+                FileSystemId,
+                SessionId));
+        UNIT_ASSERT(HasError(result.Error));
+        UNIT_ASSERT_VALUES_EQUAL(E_FAIL, result.Error.GetCode());
+
+        // Nothing was registered as held, so a later delete is a clean no-op
+        // for the manager (the stray directory is removed as the session
+        // directory is not referenced).
+        NProto::TError error;
+        UNIT_ASSERT_NO_EXCEPTION(
+            error = manager.DeleteHandleOpsQueueStateFile(
+                FileSystemId,
+                SessionId));
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+    }
+
+    Y_UNIT_TEST(ShouldTreatStubAsUnconfigured)
+    {
+        auto manager = CreatePersistentStateManagerStub();
+
+        UNIT_ASSERT(!manager->HasHandleOpsQueueState(FileSystemId, SessionId));
+        UNIT_ASSERT(!manager->HasWriteBackCacheState(FileSystemId, SessionId));
+
+        UNIT_ASSERT(HasError(
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId)
+                .Error));
+        UNIT_ASSERT(HasError(
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId)
+                .Error));
+        UNIT_ASSERT(HasError(
+            manager
+                ->AcquireDirectoryHandleStorageStateFile(
+                    FileSystemId,
+                    SessionId)
+                .Error));
+
+        UNIT_ASSERT(!HasError(
+            manager->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId)));
+    }
+}
+
+}   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
@@ -42,9 +42,9 @@ struct TFixture: public NUnitTest::TBaseFixture
             true);
     }
 
-    TPersistentStateManager CreateManager()
+    IPersistentStateManagerPtr CreateManager()
     {
-        return TPersistentStateManager(StatePath, StatePath, StatePath);
+        return CreatePersistentStateManager(StatePath, StatePath, StatePath);
     }
 
     TFsPath SessionDir(
@@ -75,10 +75,10 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
     {
         auto manager = CreateManager();
 
-        UNIT_ASSERT(!manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+        UNIT_ASSERT(!manager->HasHandleOpsQueueState(FileSystemId, SessionId));
 
         auto result =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
 
         const auto expected =
@@ -87,7 +87,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
             expected.GetPath(),
             result.FilePath.GetPath());
         UNIT_ASSERT(result.FilePath.Exists());
-        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+        UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, SessionId));
         UNIT_ASSERT(IsLocked(result.FilePath));
     }
 
@@ -96,17 +96,17 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         auto manager = CreateManager();
 
         auto first =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
 
         auto second =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT(HasError(second.Error));
         UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, second.Error.GetCode());
 
         // Other components are not affected by the failed attempt.
         auto other =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(other.Error), other.Error.GetMessage());
     }
 
@@ -115,16 +115,16 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         auto manager = CreateManager();
 
         auto result =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
 
         auto error =
-            manager.DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
         UNIT_ASSERT(!result.FilePath.Exists());
         UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
-        UNIT_ASSERT(!manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+        UNIT_ASSERT(!manager->HasHandleOpsQueueState(FileSystemId, SessionId));
     }
 
     Y_UNIT_TEST_F(ShouldTreatDeleteOfMissingStateFileAsNoop, TFixture)
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         auto manager = CreateManager();
 
         auto error =
-            manager.DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
     }
 
@@ -141,7 +141,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         TFsPath filePath;
         {
             auto manager = CreateManager();
-            auto result = manager.AcquireHandleOpsQueueStateFile(
+            auto result = manager->AcquireHandleOpsQueueStateFile(
                 FileSystemId,
                 SessionId);
             UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
@@ -154,10 +154,10 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT(!IsLocked(filePath));
 
         auto manager = CreateManager();
-        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+        UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, SessionId));
 
         auto result =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
     }
 
@@ -166,10 +166,10 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         auto manager = CreateManager();
 
         auto hoq =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         auto wbc =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        auto dhs = manager.AcquireDirectoryHandleStorageStateFile(
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        auto dhs = manager->AcquireDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
         UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
@@ -179,14 +179,14 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         // Deleting one state file keeps the shared directory and the other
         // state files held in it, whatever the order of deletion.
         auto error =
-            manager.DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
         UNIT_ASSERT(!wbc.FilePath.Exists());
         UNIT_ASSERT(hoq.FilePath.Exists());
         UNIT_ASSERT(dhs.FilePath.Exists());
         UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
 
-        error = manager.DeleteDirectoryHandleStorageStateFile(
+        error = manager->DeleteDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
@@ -195,7 +195,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
 
         // Deleting the last one removes the directory.
-        error = manager.DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        error = manager->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
         UNIT_ASSERT(!hoq.FilePath.Exists());
         UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
@@ -209,7 +209,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         TFsPath orphan;
         {
             auto previous = CreateManager();
-            auto result = previous.AcquireDirectoryHandleStorageStateFile(
+            auto result = previous->AcquireDirectoryHandleStorageStateFile(
                 FileSystemId,
                 SessionId);
             UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
@@ -218,15 +218,15 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
 
         auto manager = CreateManager();
         auto hoq =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         auto wbc =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
         UNIT_ASSERT_C(!HasError(wbc.Error), wbc.Error.GetMessage());
         UNIT_ASSERT(orphan.Exists());
 
         // Cleaning up the unheld file must remove only that file.
-        auto error = manager.DeleteDirectoryHandleStorageStateFile(
+        auto error = manager->DeleteDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
@@ -243,13 +243,13 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         auto manager = CreateManager();
 
         auto hoq =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         auto wbc =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
         UNIT_ASSERT_C(!HasError(wbc.Error), wbc.Error.GetMessage());
 
-        manager.ReleaseStateFiles(FileSystemId, SessionId);
+        manager->ReleaseStateFiles(FileSystemId, SessionId);
 
         // The locks are gone but the state stays, so that it can be restored
         // by the next loop of the same session.
@@ -258,16 +258,16 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
         UNIT_ASSERT(!IsLocked(hoq.FilePath));
         UNIT_ASSERT(!IsLocked(wbc.FilePath));
-        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+        UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, SessionId));
 
         // ... and the same manager is able to acquire them again.
         auto again =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(again.Error), again.Error.GetMessage());
         UNIT_ASSERT(IsLocked(again.FilePath));
 
         // Releasing what is not held is a no-op.
-        manager.ReleaseStateFiles(FileSystemId, "unknown-session");
+        manager->ReleaseStateFiles(FileSystemId, "unknown-session");
     }
 
     Y_UNIT_TEST_F(ShouldManageSessionsIndependently, TFixture)
@@ -275,26 +275,27 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         auto manager = CreateManager();
 
         auto first =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, "session-1");
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, "session-1");
         auto second =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, "session-2");
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, "session-2");
         UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
         UNIT_ASSERT_C(!HasError(second.Error), second.Error.GetMessage());
         UNIT_ASSERT_UNEQUAL(
             first.FilePath.Parent().GetPath(),
             second.FilePath.Parent().GetPath());
 
-        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, "session-1"));
-        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, "session-2"));
+        UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, "session-1"));
+        UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, "session-2"));
 
-        auto error = manager.DeleteHandleOpsQueueStateFile(
+        auto error = manager->DeleteHandleOpsQueueStateFile(
             FileSystemId,
             "session-1");
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
-        UNIT_ASSERT(!manager.HasHandleOpsQueueState(FileSystemId, "session-1"));
+        UNIT_ASSERT(
+            !manager->HasHandleOpsQueueState(FileSystemId, "session-1"));
         UNIT_ASSERT(!SessionDir(FileSystemId, "session-1").Exists());
-        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, "session-2"));
+        UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, "session-2"));
         UNIT_ASSERT(second.FilePath.Exists());
     }
 
@@ -306,7 +307,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         TFsPath unheld;
         {
             auto previous = CreateManager();
-            auto result = previous.AcquireWriteBackCacheStateFile(
+            auto result = previous->AcquireWriteBackCacheStateFile(
                 FileSystemId,
                 SessionId);
             UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
@@ -315,12 +316,12 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT(unheld.Exists());
 
         auto manager = CreateManager();
-        auto dhs = manager.AcquireDirectoryHandleStorageStateFile(
+        auto dhs = manager->AcquireDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
         UNIT_ASSERT_C(!HasError(dhs.Error), dhs.Error.GetMessage());
 
-        auto error = manager.DeleteDirectoryHandleStorageStateFile(
+        auto error = manager->DeleteDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
@@ -341,7 +342,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         TFsPath unheld;
         {
             auto previous = CreateManager();
-            auto result = previous.AcquireWriteBackCacheStateFile(
+            auto result = previous->AcquireWriteBackCacheStateFile(
                 FileSystemId,
                 SessionId);
             UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
@@ -349,7 +350,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         }
 
         auto manager = CreateManager();
-        auto error = manager.DeleteDirectoryHandleStorageStateFile(
+        auto error = manager->DeleteDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
@@ -366,7 +367,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         TFsPath orphan;
         {
             auto manager = CreateManager();
-            auto result = manager.AcquireDirectoryHandleStorageStateFile(
+            auto result = manager->AcquireDirectoryHandleStorageStateFile(
                 FileSystemId,
                 SessionId);
             UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
@@ -375,7 +376,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT(orphan.Exists());
 
         auto manager = CreateManager();
-        auto error = manager.DeleteDirectoryHandleStorageStateFile(
+        auto error = manager->DeleteDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
@@ -389,40 +390,40 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         auto manager = CreateManager();
 
         auto first =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
 
         auto error =
-            manager.DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
         auto second =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(second.Error), second.Error.GetMessage());
         UNIT_ASSERT(second.FilePath.Exists());
     }
 
     Y_UNIT_TEST_F(ShouldFailToAcquireUnconfiguredComponent, TFixture)
     {
-        TPersistentStateManager manager(
+        auto manager = CreatePersistentStateManager(
             StatePath,
             {},   // writeBackCacheBasePath
             StatePath);
 
-        UNIT_ASSERT(!manager.HasWriteBackCacheState(FileSystemId, SessionId));
+        UNIT_ASSERT(!manager->HasWriteBackCacheState(FileSystemId, SessionId));
 
         auto result =
-            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT(HasError(result.Error));
         UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, result.Error.GetCode());
 
         auto error =
-            manager.DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
+            manager->DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
         // The configured components of the same manager still work.
         auto ok =
-            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(ok.Error), ok.Error.GetMessage());
     }
 
@@ -430,24 +431,24 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
     {
         auto owner = CreateManager();
         auto result =
-            owner.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            owner->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
 
         // A different manager (e.g. another process sharing the base path)
         // must not be able to take the same state file while it is held.
         auto other = CreateManager();
         auto contended =
-            other.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            other->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT(HasError(contended.Error));
         UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, contended.Error.GetCode());
 
         // Once released it becomes acquirable again.
         auto error =
-            owner.DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+            owner->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
         auto retried =
-            other.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+            other->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
         UNIT_ASSERT_C(!HasError(retried.Error), retried.Error.GetMessage());
     }
 
@@ -462,9 +463,9 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
             SessionDir(FileSystemId, SessionId) / "handle_ops_queue";
         UNIT_ASSERT(NFs::MakeDirectoryRecursive(filePath));
 
-        TPersistentStateManager::TAcquireStateFileResult result;
+        IPersistentStateManager::TAcquireStateFileResult result;
         UNIT_ASSERT_NO_EXCEPTION(
-            result = manager.AcquireHandleOpsQueueStateFile(
+            result = manager->AcquireHandleOpsQueueStateFile(
                 FileSystemId,
                 SessionId));
         UNIT_ASSERT(HasError(result.Error));
@@ -475,7 +476,7 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         // directory is not referenced).
         NProto::TError error;
         UNIT_ASSERT_NO_EXCEPTION(
-            error = manager.DeleteHandleOpsQueueStateFile(
+            error = manager->DeleteHandleOpsQueueStateFile(
                 FileSystemId,
                 SessionId));
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
@@ -1,7 +1,10 @@
 #include "persistent_state_manager.h"
 
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/folder/path.h>
@@ -26,6 +29,18 @@ struct TFixture: public NUnitTest::TBaseFixture
 {
     TTempDir TempDir;
     TString StatePath = TempDir.Path() / "state";
+
+    NMonitoring::TDynamicCountersPtr Counters =
+        MakeIntrusive<NMonitoring::TDynamicCounters>();
+    NMonitoring::TDynamicCounters::TCounterPtr SessionDirNotEmptyCounter;
+
+    TFixture()
+    {
+        InitCriticalEventsCounter(Counters);
+        SessionDirNotEmptyCounter = Counters->GetCounter(
+            GetCriticalEventForPersistentStateSessionDirNotEmpty(),
+            true);
+    }
 
     TPersistentStateManager CreateManager()
     {
@@ -281,6 +296,67 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT(!SessionDir(FileSystemId, "session-1").Exists());
         UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, "session-2"));
         UNIT_ASSERT(second.FilePath.Exists());
+    }
+
+    Y_UNIT_TEST_F(ShouldNotDeleteUnheldSiblingStateFiles, TFixture)
+    {
+        // A state file of a component which is not configured anymore (or
+        // just not acquired) is left in the session directory. Deleting the
+        // state file of another component must not take it away.
+        TFsPath unheld;
+        {
+            auto previous = CreateManager();
+            auto result = previous.AcquireWriteBackCacheStateFile(
+                FileSystemId,
+                SessionId);
+            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+            unheld = result.FilePath;
+        }
+        UNIT_ASSERT(unheld.Exists());
+
+        auto manager = CreateManager();
+        auto dhs = manager.AcquireDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId);
+        UNIT_ASSERT_C(!HasError(dhs.Error), dhs.Error.GetMessage());
+
+        auto error = manager.DeleteDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        UNIT_ASSERT(!dhs.FilePath.Exists());
+        UNIT_ASSERT(unheld.Exists());
+        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+
+        // ... but the untracked leftover is reported, since nobody is going
+        // to clean it up.
+        UNIT_ASSERT_VALUES_EQUAL(1, SessionDirNotEmptyCounter->Val());
+    }
+
+    Y_UNIT_TEST_F(ShouldNotDeleteUnheldSiblingEvenIfOwnFileIsMissing, TFixture)
+    {
+        // Nothing of the requested component is on disk at all, only an unheld
+        // file of another one.
+        TFsPath unheld;
+        {
+            auto previous = CreateManager();
+            auto result = previous.AcquireWriteBackCacheStateFile(
+                FileSystemId,
+                SessionId);
+            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+            unheld = result.FilePath;
+        }
+
+        auto manager = CreateManager();
+        auto error = manager.DeleteDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId);
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        UNIT_ASSERT(unheld.Exists());
+        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT_VALUES_EQUAL(1, SessionDirNotEmptyCounter->Val());
     }
 
     Y_UNIT_TEST_F(ShouldDeleteStateFileLeftByPreviousSession, TFixture)

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
@@ -79,16 +79,19 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
 
         auto result =
             manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+
+        auto guard = result.ExtractResult();
+        UNIT_ASSERT(guard);
 
         const auto expected =
             SessionDir(FileSystemId, SessionId) / "handle_ops_queue";
         UNIT_ASSERT_VALUES_EQUAL(
             expected.GetPath(),
-            result.FilePath.GetPath());
-        UNIT_ASSERT(result.FilePath.Exists());
+            guard.GetFilePath().GetPath());
+        UNIT_ASSERT(guard.GetFilePath().Exists());
         UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, SessionId));
-        UNIT_ASSERT(IsLocked(result.FilePath));
+        UNIT_ASSERT(IsLocked(guard.GetFilePath()));
     }
 
     Y_UNIT_TEST_F(ShouldFailToAcquireSameStateFileTwice, TFixture)
@@ -97,17 +100,18 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
 
         auto first =
             manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(first), first.GetError().GetMessage());
+        auto guard = first.ExtractResult();
 
         auto second =
             manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT(HasError(second.Error));
-        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, second.Error.GetCode());
+        UNIT_ASSERT(HasError(second));
+        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, second.GetError().GetCode());
 
         // Other components are not affected by the failed attempt.
         auto other =
             manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(other.Error), other.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(other), other.GetError().GetMessage());
     }
 
     Y_UNIT_TEST_F(ShouldDeleteStateFileAndSessionDir, TFixture)
@@ -116,187 +120,204 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
 
         auto result =
             manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+        auto guard = result.ExtractResult();
+        const auto filePath = guard.GetFilePath();
 
-        auto error =
-            manager->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        auto error = guard.DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
-        UNIT_ASSERT(!result.FilePath.Exists());
+        UNIT_ASSERT(!guard);
+        UNIT_ASSERT(!filePath.Exists());
         UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
         UNIT_ASSERT(!manager->HasHandleOpsQueueState(FileSystemId, SessionId));
     }
 
-    Y_UNIT_TEST_F(ShouldTreatDeleteOfMissingStateFileAsNoop, TFixture)
+    Y_UNIT_TEST_F(ShouldTreatRepeatedDeleteAsNoop, TFixture)
     {
         auto manager = CreateManager();
 
-        auto error =
-            manager->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        auto result =
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+        auto guard = result.ExtractResult();
+
+        auto error = guard.DeleteStateFile();
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        // Delete should be idempotent.
+        error = guard.DeleteStateFile();
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        // An empty guard has nothing to delete either.
+        TAcquireStateFileGuard empty;
+        UNIT_ASSERT(!empty);
+        error = empty.DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
     }
 
-    Y_UNIT_TEST_F(ShouldKeepStateFileOnDestruction, TFixture)
+    Y_UNIT_TEST_F(ShouldKeepStateFileOnGuardDestruction, TFixture)
     {
+        auto manager = CreateManager();
+
         TFsPath filePath;
         {
-            auto manager = CreateManager();
             auto result = manager->AcquireHandleOpsQueueStateFile(
                 FileSystemId,
                 SessionId);
-            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
-            filePath = result.FilePath;
+            UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+            auto guard = result.ExtractResult();
+            filePath = guard.GetFilePath();
+            UNIT_ASSERT(IsLocked(filePath));
         }
 
         // The state file survives so that a future session can restore it,
-        // and the lock is released so it can be re-acquired.
+        // and the lock is released so it can be re-acquired, even by the
+        // same manager.
         UNIT_ASSERT(filePath.Exists());
         UNIT_ASSERT(!IsLocked(filePath));
-
-        auto manager = CreateManager();
         UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, SessionId));
 
         auto result =
             manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+    }
+
+    Y_UNIT_TEST_F(ShouldKeepStateFileOnManagerDestruction, TFixture)
+    {
+        // A guard may outlive the manager which has handed it out.
+        TFsPath filePath;
+        {
+            TAcquireStateFileGuard guard;
+            {
+                auto manager = CreateManager();
+                auto result = manager->AcquireHandleOpsQueueStateFile(
+                    FileSystemId,
+                    SessionId);
+                UNIT_ASSERT_C(
+                    !HasError(result),
+                    result.GetError().GetMessage());
+                guard = result.ExtractResult();
+            }
+            filePath = guard.GetFilePath();
+            UNIT_ASSERT(IsLocked(filePath));
+        }
+
+        UNIT_ASSERT(filePath.Exists());
+        UNIT_ASSERT(!IsLocked(filePath));
     }
 
     Y_UNIT_TEST_F(ShouldKeepSessionDirUntilLastStateFileDeleted, TFixture)
     {
         auto manager = CreateManager();
 
-        auto hoq =
+        auto hoqResult =
             manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        auto wbc =
+        auto wbcResult =
             manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        auto dhs = manager->AcquireDirectoryHandleStorageStateFile(
+        auto dhsResult = manager->AcquireDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
-        UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
-        UNIT_ASSERT_C(!HasError(wbc.Error), wbc.Error.GetMessage());
-        UNIT_ASSERT_C(!HasError(dhs.Error), dhs.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(hoqResult), hoqResult.GetError().GetMessage());
+        UNIT_ASSERT_C(!HasError(wbcResult), wbcResult.GetError().GetMessage());
+        UNIT_ASSERT_C(!HasError(dhsResult), dhsResult.GetError().GetMessage());
+        auto hoq = hoqResult.ExtractResult();
+        auto wbc = wbcResult.ExtractResult();
+        auto dhs = dhsResult.ExtractResult();
+        const auto hoqPath = hoq.GetFilePath();
+        const auto wbcPath = wbc.GetFilePath();
+        const auto dhsPath = dhs.GetFilePath();
 
         // Deleting one state file keeps the shared directory and the other
         // state files held in it, whatever the order of deletion.
-        auto error =
-            manager->DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
+        auto error = wbc.DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
-        UNIT_ASSERT(!wbc.FilePath.Exists());
-        UNIT_ASSERT(hoq.FilePath.Exists());
-        UNIT_ASSERT(dhs.FilePath.Exists());
+        UNIT_ASSERT(!wbcPath.Exists());
+        UNIT_ASSERT(hoqPath.Exists());
+        UNIT_ASSERT(dhsPath.Exists());
         UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT_VALUES_EQUAL(0, SessionDirNotEmptyCounter->Val());
 
-        error = manager->DeleteDirectoryHandleStorageStateFile(
-            FileSystemId,
-            SessionId);
+        error = dhs.DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
-        UNIT_ASSERT(!dhs.FilePath.Exists());
-        UNIT_ASSERT(hoq.FilePath.Exists());
+        UNIT_ASSERT(!dhsPath.Exists());
+        UNIT_ASSERT(hoqPath.Exists());
         UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT_VALUES_EQUAL(0, SessionDirNotEmptyCounter->Val());
 
         // Deleting the last one removes the directory.
-        error = manager->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        error = hoq.DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
-        UNIT_ASSERT(!hoq.FilePath.Exists());
+        UNIT_ASSERT(!hoqPath.Exists());
         UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
-    }
-
-    Y_UNIT_TEST_F(ShouldNotDisturbHeldSiblingWhenDeletingUnheldFile, TFixture)
-    {
-        // Emulate a session start with the directory handle storage disabled
-        // after it had been enabled: its file is left on disk unheld, while
-        // the other components' files in the same directory are held.
-        TFsPath orphan;
-        {
-            auto previous = CreateManager();
-            auto result = previous->AcquireDirectoryHandleStorageStateFile(
-                FileSystemId,
-                SessionId);
-            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
-            orphan = result.FilePath;
-        }
-
-        auto manager = CreateManager();
-        auto hoq =
-            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        auto wbc =
-            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
-        UNIT_ASSERT_C(!HasError(wbc.Error), wbc.Error.GetMessage());
-        UNIT_ASSERT(orphan.Exists());
-
-        // Cleaning up the unheld file must remove only that file.
-        auto error = manager->DeleteDirectoryHandleStorageStateFile(
-            FileSystemId,
-            SessionId);
-        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
-        UNIT_ASSERT(!orphan.Exists());
-        UNIT_ASSERT(hoq.FilePath.Exists());
-        UNIT_ASSERT(wbc.FilePath.Exists());
-        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
-        UNIT_ASSERT(IsLocked(hoq.FilePath));
-        UNIT_ASSERT(IsLocked(wbc.FilePath));
-    }
-
-    Y_UNIT_TEST_F(ShouldReleaseStateFilesKeepingThemOnDisk, TFixture)
-    {
-        auto manager = CreateManager();
-
-        auto hoq =
-            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        auto wbc =
-            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
-        UNIT_ASSERT_C(!HasError(wbc.Error), wbc.Error.GetMessage());
-
-        manager->ReleaseStateFiles(FileSystemId, SessionId);
-
-        // The locks are gone but the state stays, so that it can be restored
-        // by the next loop of the same session.
-        UNIT_ASSERT(hoq.FilePath.Exists());
-        UNIT_ASSERT(wbc.FilePath.Exists());
-        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
-        UNIT_ASSERT(!IsLocked(hoq.FilePath));
-        UNIT_ASSERT(!IsLocked(wbc.FilePath));
-        UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, SessionId));
-
-        // ... and the same manager is able to acquire them again.
-        auto again =
-            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(again.Error), again.Error.GetMessage());
-        UNIT_ASSERT(IsLocked(again.FilePath));
-
-        // Releasing what is not held is a no-op.
-        manager->ReleaseStateFiles(FileSystemId, "unknown-session");
+        UNIT_ASSERT_VALUES_EQUAL(0, SessionDirNotEmptyCounter->Val());
     }
 
     Y_UNIT_TEST_F(ShouldManageSessionsIndependently, TFixture)
     {
         auto manager = CreateManager();
 
-        auto first =
+        auto firstResult =
             manager->AcquireHandleOpsQueueStateFile(FileSystemId, "session-1");
-        auto second =
+        auto secondResult =
             manager->AcquireHandleOpsQueueStateFile(FileSystemId, "session-2");
-        UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
-        UNIT_ASSERT_C(!HasError(second.Error), second.Error.GetMessage());
+        UNIT_ASSERT_C(
+            !HasError(firstResult),
+            firstResult.GetError().GetMessage());
+        UNIT_ASSERT_C(
+            !HasError(secondResult),
+            secondResult.GetError().GetMessage());
+        auto first = firstResult.ExtractResult();
+        auto second = secondResult.ExtractResult();
         UNIT_ASSERT_UNEQUAL(
-            first.FilePath.Parent().GetPath(),
-            second.FilePath.Parent().GetPath());
+            first.GetFilePath().Parent().GetPath(),
+            second.GetFilePath().Parent().GetPath());
 
         UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, "session-1"));
         UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, "session-2"));
 
-        auto error = manager->DeleteHandleOpsQueueStateFile(
-            FileSystemId,
-            "session-1");
+        auto error = first.DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
         UNIT_ASSERT(
             !manager->HasHandleOpsQueueState(FileSystemId, "session-1"));
         UNIT_ASSERT(!SessionDir(FileSystemId, "session-1").Exists());
         UNIT_ASSERT(manager->HasHandleOpsQueueState(FileSystemId, "session-2"));
-        UNIT_ASSERT(second.FilePath.Exists());
+        UNIT_ASSERT(second.GetFilePath().Exists());
+    }
+
+    Y_UNIT_TEST_F(ShouldDeleteStateFileLeftByPreviousSession, TFixture)
+    {
+        // Emulate an orphan file: acquire it and let the guard go away, so
+        // the file stays on disk without being held. Then, as the loop does
+        // for a disabled component, acquire it again just to delete it.
+        TFsPath orphan;
+        {
+            auto manager = CreateManager();
+            auto result = manager->AcquireDirectoryHandleStorageStateFile(
+                FileSystemId,
+                SessionId);
+            UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+            orphan = result.ExtractResult().GetFilePath();
+        }
+        UNIT_ASSERT(orphan.Exists());
+
+        auto manager = CreateManager();
+        UNIT_ASSERT(
+            manager->HasDirectoryHandleStorageState(FileSystemId, SessionId));
+
+        auto result = manager->AcquireDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId);
+        UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+
+        auto error = result.ExtractResult().DeleteStateFile();
+        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+
+        UNIT_ASSERT(!orphan.Exists());
+        UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT(
+            !manager->HasDirectoryHandleStorageState(FileSystemId, SessionId));
     }
 
     Y_UNIT_TEST_F(ShouldNotDeleteUnheldSiblingStateFiles, TFixture)
@@ -310,23 +331,23 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
             auto result = previous->AcquireWriteBackCacheStateFile(
                 FileSystemId,
                 SessionId);
-            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
-            unheld = result.FilePath;
+            UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+            unheld = result.ExtractResult().GetFilePath();
         }
         UNIT_ASSERT(unheld.Exists());
 
         auto manager = CreateManager();
-        auto dhs = manager->AcquireDirectoryHandleStorageStateFile(
+        auto result = manager->AcquireDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
-        UNIT_ASSERT_C(!HasError(dhs.Error), dhs.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+        auto dhs = result.ExtractResult();
+        const auto dhsPath = dhs.GetFilePath();
 
-        auto error = manager->DeleteDirectoryHandleStorageStateFile(
-            FileSystemId,
-            SessionId);
+        auto error = dhs.DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
-        UNIT_ASSERT(!dhs.FilePath.Exists());
+        UNIT_ASSERT(!dhsPath.Exists());
         UNIT_ASSERT(unheld.Exists());
         UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
 
@@ -335,54 +356,47 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT_VALUES_EQUAL(1, SessionDirNotEmptyCounter->Val());
     }
 
-    Y_UNIT_TEST_F(ShouldNotDeleteUnheldSiblingEvenIfOwnFileIsMissing, TFixture)
+    Y_UNIT_TEST_F(ShouldNotDisturbHeldSiblingWhenDeletingOrphan, TFixture)
     {
-        // Nothing of the requested component is on disk at all, only an unheld
-        // file of another one.
-        TFsPath unheld;
-        {
-            auto previous = CreateManager();
-            auto result = previous->AcquireWriteBackCacheStateFile(
-                FileSystemId,
-                SessionId);
-            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
-            unheld = result.FilePath;
-        }
-
-        auto manager = CreateManager();
-        auto error = manager->DeleteDirectoryHandleStorageStateFile(
-            FileSystemId,
-            SessionId);
-        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
-
-        UNIT_ASSERT(unheld.Exists());
-        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
-        UNIT_ASSERT_VALUES_EQUAL(1, SessionDirNotEmptyCounter->Val());
-    }
-
-    Y_UNIT_TEST_F(ShouldDeleteStateFileLeftByPreviousSession, TFixture)
-    {
-        // Emulate an orphan file: acquire it and let the manager go away, so
-        // the file stays on disk without being held.
+        // Emulate a session start with the directory handle storage disabled
+        // after it had been enabled: its file is left on disk unheld, while
+        // the other components' files in the same directory are held.
         TFsPath orphan;
         {
-            auto manager = CreateManager();
-            auto result = manager->AcquireDirectoryHandleStorageStateFile(
+            auto previous = CreateManager();
+            auto result = previous->AcquireDirectoryHandleStorageStateFile(
                 FileSystemId,
                 SessionId);
-            UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
-            orphan = result.FilePath;
+            UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+            orphan = result.ExtractResult().GetFilePath();
         }
-        UNIT_ASSERT(orphan.Exists());
 
         auto manager = CreateManager();
-        auto error = manager->DeleteDirectoryHandleStorageStateFile(
+        auto hoqResult =
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        auto wbcResult =
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(hoqResult), hoqResult.GetError().GetMessage());
+        UNIT_ASSERT_C(!HasError(wbcResult), wbcResult.GetError().GetMessage());
+        auto hoq = hoqResult.ExtractResult();
+        auto wbc = wbcResult.ExtractResult();
+        UNIT_ASSERT(orphan.Exists());
+
+        // Cleaning up the orphan must remove only that file.
+        auto dhsResult = manager->AcquireDirectoryHandleStorageStateFile(
             FileSystemId,
             SessionId);
+        UNIT_ASSERT_C(!HasError(dhsResult), dhsResult.GetError().GetMessage());
+        auto error = dhsResult.ExtractResult().DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
         UNIT_ASSERT(!orphan.Exists());
-        UNIT_ASSERT(!SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT(hoq.GetFilePath().Exists());
+        UNIT_ASSERT(wbc.GetFilePath().Exists());
+        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT(IsLocked(hoq.GetFilePath()));
+        UNIT_ASSERT(IsLocked(wbc.GetFilePath()));
+        UNIT_ASSERT_VALUES_EQUAL(0, SessionDirNotEmptyCounter->Val());
     }
 
     Y_UNIT_TEST_F(ShouldReacquireStateFileAfterDelete, TFixture)
@@ -391,16 +405,15 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
 
         auto first =
             manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(first.Error), first.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(first), first.GetError().GetMessage());
 
-        auto error =
-            manager->DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
+        auto error = first.ExtractResult().DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
         auto second =
             manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(second.Error), second.Error.GetMessage());
-        UNIT_ASSERT(second.FilePath.Exists());
+        UNIT_ASSERT_C(!HasError(second), second.GetError().GetMessage());
+        UNIT_ASSERT(second.GetResult().GetFilePath().Exists());
     }
 
     Y_UNIT_TEST_F(ShouldFailToAcquireUnconfiguredComponent, TFixture)
@@ -414,17 +427,13 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
 
         auto result =
             manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT(HasError(result.Error));
-        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, result.Error.GetCode());
-
-        auto error =
-            manager->DeleteWriteBackCacheStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+        UNIT_ASSERT(HasError(result));
+        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, result.GetError().GetCode());
 
         // The configured components of the same manager still work.
         auto ok =
             manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(ok.Error), ok.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(ok), ok.GetError().GetMessage());
     }
 
     Y_UNIT_TEST_F(ShouldFailToAcquireStateFileLockedByAnotherOwner, TFixture)
@@ -432,24 +441,26 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         auto owner = CreateManager();
         auto result =
             owner->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(result.Error), result.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(result), result.GetError().GetMessage());
+        auto guard = result.ExtractResult();
 
         // A different manager (e.g. another process sharing the base path)
         // must not be able to take the same state file while it is held.
         auto other = CreateManager();
         auto contended =
             other->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT(HasError(contended.Error));
-        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, contended.Error.GetCode());
+        UNIT_ASSERT(HasError(contended));
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            contended.GetError().GetCode());
 
         // Once released it becomes acquirable again.
-        auto error =
-            owner->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId);
+        auto error = guard.DeleteStateFile();
         UNIT_ASSERT_C(!HasError(error), error.GetMessage());
 
         auto retried =
             other->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
-        UNIT_ASSERT_C(!HasError(retried.Error), retried.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(retried), retried.GetError().GetMessage());
     }
 
     Y_UNIT_TEST_F(ShouldReportErrorInsteadOfThrowingOnAcquireFailure, TFixture)
@@ -463,23 +474,15 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
             SessionDir(FileSystemId, SessionId) / "handle_ops_queue";
         UNIT_ASSERT(NFs::MakeDirectoryRecursive(filePath));
 
-        IPersistentStateManager::TAcquireStateFileResult result;
-        UNIT_ASSERT_NO_EXCEPTION(
-            result = manager->AcquireHandleOpsQueueStateFile(
-                FileSystemId,
-                SessionId));
-        UNIT_ASSERT(HasError(result.Error));
-        UNIT_ASSERT_VALUES_EQUAL(E_FAIL, result.Error.GetCode());
-
-        // Nothing was registered as held, so a later delete is a clean no-op
-        // for the manager (the stray directory is removed as the session
-        // directory is not referenced).
         NProto::TError error;
         UNIT_ASSERT_NO_EXCEPTION(
-            error = manager->DeleteHandleOpsQueueStateFile(
-                FileSystemId,
-                SessionId));
-        UNIT_ASSERT_C(!HasError(error), error.GetMessage());
+            error = manager
+                        ->AcquireHandleOpsQueueStateFile(
+                            FileSystemId,
+                            SessionId)
+                        .GetError());
+        UNIT_ASSERT(HasError(error));
+        UNIT_ASSERT_VALUES_EQUAL(E_FAIL, error.GetCode());
     }
 
     Y_UNIT_TEST(ShouldTreatStubAsUnconfigured)
@@ -488,22 +491,16 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
 
         UNIT_ASSERT(!manager->HasHandleOpsQueueState(FileSystemId, SessionId));
         UNIT_ASSERT(!manager->HasWriteBackCacheState(FileSystemId, SessionId));
+        UNIT_ASSERT(
+            !manager->HasDirectoryHandleStorageState(FileSystemId, SessionId));
 
         UNIT_ASSERT(HasError(
-            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId)
-                .Error));
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId)));
         UNIT_ASSERT(HasError(
-            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId)
-                .Error));
-        UNIT_ASSERT(HasError(
-            manager
-                ->AcquireDirectoryHandleStorageStateFile(
-                    FileSystemId,
-                    SessionId)
-                .Error));
-
-        UNIT_ASSERT(!HasError(
-            manager->DeleteHandleOpsQueueStateFile(FileSystemId, SessionId)));
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId)));
+        UNIT_ASSERT(HasError(manager->AcquireDirectoryHandleStorageStateFile(
+            FileSystemId,
+            SessionId)));
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
@@ -207,6 +207,41 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT(!IsLocked(filePath));
     }
 
+    Y_UNIT_TEST_F(ShouldReleaseHeldStateFileOnMoveAssignment, TFixture)
+    {
+        auto manager = CreateManager();
+
+        auto hoqResult =
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        auto wbcResult =
+            manager->AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(hoqResult), hoqResult.GetError().GetMessage());
+        UNIT_ASSERT_C(!HasError(wbcResult), wbcResult.GetError().GetMessage());
+        auto guard = hoqResult.ExtractResult();
+        auto other = wbcResult.ExtractResult();
+        const auto hoqPath = guard.GetFilePath();
+        const auto wbcPath = other.GetFilePath();
+
+        // Assigning onto a guard which holds a file releases that file just
+        // like destroying the guard would: the lock is dropped, the file is
+        // kept, and it becomes acquirable again.
+        guard = std::move(other);
+
+        UNIT_ASSERT(guard);
+        UNIT_ASSERT_VALUES_EQUAL(
+            wbcPath.GetPath(),
+            guard.GetFilePath().GetPath());
+        UNIT_ASSERT(!other);
+
+        UNIT_ASSERT(hoqPath.Exists());
+        UNIT_ASSERT(!IsLocked(hoqPath));
+        UNIT_ASSERT(IsLocked(wbcPath));
+
+        auto again =
+            manager->AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(again), again.GetError().GetMessage());
+    }
+
     Y_UNIT_TEST_F(ShouldKeepSessionDirUntilLastStateFileDeleted, TFixture)
     {
         auto manager = CreateManager();

--- a/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/persistent_state_manager_ut.cpp
@@ -223,6 +223,38 @@ Y_UNIT_TEST_SUITE(TPersistentStateManagerTest)
         UNIT_ASSERT(IsLocked(wbc.FilePath));
     }
 
+    Y_UNIT_TEST_F(ShouldReleaseStateFilesKeepingThemOnDisk, TFixture)
+    {
+        auto manager = CreateManager();
+
+        auto hoq =
+            manager.AcquireHandleOpsQueueStateFile(FileSystemId, SessionId);
+        auto wbc =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(hoq.Error), hoq.Error.GetMessage());
+        UNIT_ASSERT_C(!HasError(wbc.Error), wbc.Error.GetMessage());
+
+        manager.ReleaseStateFiles(FileSystemId, SessionId);
+
+        // The locks are gone but the state stays, so that it can be restored
+        // by the next loop of the same session.
+        UNIT_ASSERT(hoq.FilePath.Exists());
+        UNIT_ASSERT(wbc.FilePath.Exists());
+        UNIT_ASSERT(SessionDir(FileSystemId, SessionId).Exists());
+        UNIT_ASSERT(!IsLocked(hoq.FilePath));
+        UNIT_ASSERT(!IsLocked(wbc.FilePath));
+        UNIT_ASSERT(manager.HasHandleOpsQueueState(FileSystemId, SessionId));
+
+        // ... and the same manager is able to acquire them again.
+        auto again =
+            manager.AcquireWriteBackCacheStateFile(FileSystemId, SessionId);
+        UNIT_ASSERT_C(!HasError(again.Error), again.Error.GetMessage());
+        UNIT_ASSERT(IsLocked(again.FilePath));
+
+        // Releasing what is not held is a no-op.
+        manager.ReleaseStateFiles(FileSystemId, "unknown-session");
+    }
+
     Y_UNIT_TEST_F(ShouldManageSessionsIndependently, TFixture)
     {
         auto manager = CreateManager();

--- a/cloud/filestore/libs/vfs_fuse/public.h
+++ b/cloud/filestore/libs/vfs_fuse/public.h
@@ -30,4 +30,8 @@ class TDirectoryEntryVersionCache;
 using TDirectoryEntryVersionCachePtr =
     std::shared_ptr<TDirectoryEntryVersionCache>;
 
+class TPersistentStateManager;
+using TPersistentStateManagerPtr =
+    std::shared_ptr<TPersistentStateManager>;
+
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/public.h
+++ b/cloud/filestore/libs/vfs_fuse/public.h
@@ -30,8 +30,7 @@ class TDirectoryEntryVersionCache;
 using TDirectoryEntryVersionCachePtr =
     std::shared_ptr<TDirectoryEntryVersionCache>;
 
-class TPersistentStateManager;
-using TPersistentStateManagerPtr =
-    std::shared_ptr<TPersistentStateManager>;
+struct IPersistentStateManager;
+using IPersistentStateManagerPtr = std::shared_ptr<IPersistentStateManager>;
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/ut/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/ut/ya.make
@@ -11,6 +11,7 @@ SRCS(
     fs_directory_handle_ut.cpp
     fs_impl_data_ut.cpp
     fs_ut.cpp
+    persistent_state_manager_ut.cpp
 )
 
 PEERDIR(

--- a/cloud/filestore/libs/vfs_fuse/ya.make.inc
+++ b/cloud/filestore/libs/vfs_fuse/ya.make.inc
@@ -20,6 +20,7 @@ SRCS(
     log.cpp
     loop.cpp
     node_cache.cpp
+    persistent_state_manager.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
### Notes

`TFileSystemLoop` manages local per-session state files for three components - `HandleOpsQueue`, `WriteBackCache` and `DirectoryHandleStorage`. Each of them repeated the same routine by hand: build the `<basePath>/<fileSystemId>/<sessionId>/` path, call `CreateAndLockFile`, keep a `THolder<TFileLock>` plus an `*Initialized` flag as members, and call `UnlockAndDeleteFile` with a re-derived path on session destruction. 

This PR moves all of that into a new `TPeristentStateManager` class (`fs_persistent_state.h/.cpp`), owned by `TFileSystemLoop` and constructed from the VFS config.

Small behavior differences:
- Deleting the first component no longer wipes the others' state. The old cleanup did RemoveRecursive(<base>/<fs>/<session>) per component. With a shared directory, the first component's cleanup removed the session directory together with the state files of the other two components, from under them, while they were still held. Now only the requested file is ever removed, and the directory is removed with a non-recursive rmdir once it is empty, i.e. after the last component's file is gone. Unheld sibling files (e.g. of a component that has since been unconfigured) are never touched.
- Acquiring the same component for the same session twice now returns an `E_INVALID_STATE` error instead of silently dropping the previous lock.
- Acquiring an unconfigured component returns an error instead of hitting a debug assert.

### Issue

#7048 
