### PR TITLE
issue-7053: make TryHandleControlNamespaceXXX accept session as the third argument

### DIFF
--- a/cloud/filestore/libs/storage/core/model.h
+++ b/cloud/filestore/libs/storage/core/model.h
@@ -42,7 +42,9 @@ constexpr TStringBuf ShardNumPrefix = "_s";
 
 // It is not possible to have more than MaxShardCount shards,
 // as we reserve two bytes to store it in handles and node IDs.
-constexpr ui64 MaxShardCount = Max<ui16>();
+//
+// Max<ui16>() is reserved for the synthetic filestore controls namespace
+constexpr ui64 MaxShardCount = Max<ui16>() - 1;
 
 // Range of possible ShardId encoding versions.
 constexpr char MinShardIdEncodingVersion = 1;

--- a/cloud/filestore/libs/storage/model/utils.h
+++ b/cloud/filestore/libs/storage/model/utils.h
@@ -26,7 +26,7 @@ constexpr ui32 IdBitsCount = 48;
 constexpr ui64 IdMask = Max<ui64>() >> (64 - IdBitsCount);
 
 // It is assumed that two most significant bytes are equal to zero
-inline ui32 SwapTwoLeastSignificantBytes(ui32 shardNo)
+constexpr ui32 SwapTwoLeastSignificantBytes(ui32 shardNo)
 {
     ui32 leastSignificantByte = (shardNo & 0xff);
     shardNo >>= CHAR_BIT;
@@ -35,7 +35,7 @@ inline ui32 SwapTwoLeastSignificantBytes(ui32 shardNo)
 
 }   // namespace
 
-inline ui64 ShardedId(ui64 id, ui32 shardNo)
+constexpr ui64 ShardedId(ui64 id, ui32 shardNo)
 {
     // Historically, shardNo occupied only the 8th byte.
     // To place the second byte of shardNo into the 7th byte of the
@@ -45,7 +45,7 @@ inline ui64 ShardedId(ui64 id, ui32 shardNo)
     return (static_cast<ui64>(shardNo) << IdBitsCount) | (IdMask & id);
 }
 
-inline ui32 ExtractShardNo(ui64 id)
+constexpr ui32 ExtractShardNo(ui64 id)
 {
     ui32 shardNo = static_cast<ui32>(id >> IdBitsCount);
     shardNo = SwapTwoLeastSignificantBytes(shardNo);

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -148,25 +148,32 @@ private:
     // answered here and the caller should return
     bool TryHandleControlNamespaceGetNodeAttr(
         const NActors::TActorContext& ctx,
-        const TEvService::TEvGetNodeAttrRequest::TPtr& ev);
+        const TEvService::TEvGetNodeAttrRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceCreateHandle(
         const NActors::TActorContext& ctx,
-        const TEvService::TEvCreateHandleRequest::TPtr& ev);
+        const TEvService::TEvCreateHandleRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceCreateNode(
         const NActors::TActorContext& ctx,
-        const TEvService::TEvCreateNodeRequest::TPtr& ev);
+        const TEvService::TEvCreateNodeRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceReadData(
         const NActors::TActorContext& ctx,
-        const TEvService::TEvReadDataRequest::TPtr& ev);
+        const TEvService::TEvReadDataRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceWriteData(
         const NActors::TActorContext& ctx,
-        const TEvService::TEvWriteDataRequest::TPtr& ev);
+        const TEvService::TEvWriteDataRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceListNodes(
         const NActors::TActorContext& ctx,
-        const TEvService::TEvListNodesRequest::TPtr& ev);
+        const TEvService::TEvListNodesRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceRenameNode(
         const NActors::TActorContext& ctx,
-        const TEvService::TEvRenameNodeRequest::TPtr& ev);
+        const TEvService::TEvRenameNodeRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceGetNodeXAttr(
         const NActors::TActorContext& ctx,
         const TEvService::TEvGetNodeXAttrRequest::TPtr& ev,

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -121,6 +121,15 @@ private:
         bool forceBehaveAsShard,
         ui64 entityId);
 
+    // Overload for a caller that already validated the session
+    template <typename TMethod>
+    void ForwardRequestToShard(
+        const NActors::TActorContext& ctx,
+        const typename TMethod::TRequest::TPtr& ev,
+        bool forceBehaveAsShard,
+        ui64 entityId,
+        TSessionInfo* session);
+
     template <typename TMethod>
     TSessionInfo* GetAndValidateSession(
         const NActors::TActorContext& ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
@@ -9,57 +9,64 @@ using namespace NActors;
 
 bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
     const TActorContext& ctx,
-    const TEvService::TEvGetNodeAttrRequest::TPtr& ev)
+    const TEvService::TEvGetNodeAttrRequest::TPtr& ev,
+    const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev);
+    Y_UNUSED(ctx, ev, session);
     return false;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
     const TActorContext& ctx,
-    const TEvService::TEvCreateHandleRequest::TPtr& ev)
+    const TEvService::TEvCreateHandleRequest::TPtr& ev,
+    const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev);
+    Y_UNUSED(ctx, ev, session);
     return false;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceCreateNode(
     const TActorContext& ctx,
-    const TEvService::TEvCreateNodeRequest::TPtr& ev)
+    const TEvService::TEvCreateNodeRequest::TPtr& ev,
+    const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev);
+    Y_UNUSED(ctx, ev, session);
     return false;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceReadData(
     const TActorContext& ctx,
-    const TEvService::TEvReadDataRequest::TPtr& ev)
+    const TEvService::TEvReadDataRequest::TPtr& ev,
+    const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev);
+    Y_UNUSED(ctx, ev, session);
     return false;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceWriteData(
     const TActorContext& ctx,
-    const TEvService::TEvWriteDataRequest::TPtr& ev)
+    const TEvService::TEvWriteDataRequest::TPtr& ev,
+    const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev);
+    Y_UNUSED(ctx, ev, session);
     return false;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceListNodes(
     const TActorContext& ctx,
-    const TEvService::TEvListNodesRequest::TPtr& ev)
+    const TEvService::TEvListNodesRequest::TPtr& ev,
+    const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev);
+    Y_UNUSED(ctx, ev, session);
     return false;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceRenameNode(
     const TActorContext& ctx,
-    const TEvService::TEvRenameNodeRequest::TPtr& ev)
+    const TEvService::TEvRenameNodeRequest::TPtr& ev,
+    const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev);
+    Y_UNUSED(ctx, ev, session);
     return false;
 }
 

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -259,10 +259,6 @@ void TStorageServiceActor::HandleCreateHandle(
 {
     auto* msg = ev->Get();
 
-    if (TryHandleControlNamespaceCreateHandle(ctx, ev)) {
-        return;
-    }
-
     if (msg->Record.GetName().empty()) {
         // handle creation by NodeId can be handled directly by the shard
         ForwardRequestToShard<TEvService::TCreateHandleMethod>(
@@ -273,18 +269,18 @@ void TStorageServiceActor::HandleCreateHandle(
         return;
     }
 
-    const auto& clientId = GetClientId(msg->Record);
+    auto* session =
+        GetAndValidateSession<TEvService::TCreateHandleMethod>(ctx, ev);
+    if (!session) {
+        return;
+    }
+
+    if (TryHandleControlNamespaceCreateHandle(ctx, ev, session)) {
+        return;
+    }
+
     const auto& sessionId = GetSessionId(msg->Record);
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
-
-    auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<TEvService::TEvCreateHandleResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        return NCloud::Reply(ctx, *ev, std::move(response));
-    }
     const NProto::TFileStore& filestore = session->FileStore;
 
     auto& headers = *msg->Record.MutableHeaders();

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -258,17 +258,6 @@ void TStorageServiceActor::HandleCreateHandle(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-
-    if (msg->Record.GetName().empty()) {
-        // handle creation by NodeId can be handled directly by the shard
-        ForwardRequestToShard<TEvService::TCreateHandleMethod>(
-            ctx,
-            ev,
-            true /* forceBehaveAsShard */,
-            msg->Record.GetNodeId());
-        return;
-    }
-
     auto* session =
         GetAndValidateSession<TEvService::TCreateHandleMethod>(ctx, ev);
     if (!session) {
@@ -276,6 +265,17 @@ void TStorageServiceActor::HandleCreateHandle(
     }
 
     if (TryHandleControlNamespaceCreateHandle(ctx, ev, session)) {
+        return;
+    }
+
+    if (msg->Record.GetName().empty()) {
+        // handle creation by NodeId can be handled directly by the shard
+        ForwardRequestToShard<TEvService::TCreateHandleMethod>(
+            ctx,
+            ev,
+            true /* forceBehaveAsShard */,
+            msg->Record.GetNodeId(),
+            session);
         return;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -285,22 +285,18 @@ void TStorageServiceActor::HandleCreateNode(
 {
     auto* msg = ev->Get();
 
-    if (TryHandleControlNamespaceCreateNode(ctx, ev)) {
+    auto* session =
+        GetAndValidateSession<TEvService::TCreateNodeMethod>(ctx, ev);
+    if (!session) {
         return;
     }
 
-    const auto& clientId = GetClientId(msg->Record);
+    if (TryHandleControlNamespaceCreateNode(ctx, ev, session)) {
+        return;
+    }
+
     const auto& sessionId = GetSessionId(msg->Record);
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
-
-    auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        return NCloud::Reply(ctx, *ev, std::move(response));
-    }
 
     const NProto::TFileStore& filestore = session->FileStore;
 

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -135,6 +135,43 @@ TResultOrError<TString> TStorageServiceActor::SelectShard(
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>
+TSessionInfo* TStorageServiceActor::GetAndValidateSession(
+    const TActorContext& ctx,
+    const typename TMethod::TRequest::TPtr& ev)
+{
+    auto* msg = ev->Get();
+
+    const auto& clientId = GetClientId(msg->Record);
+    const auto& sessionId = GetSessionId(msg->Record);
+    const ui64 seqNo = GetSessionSeqNo(msg->Record);
+
+    TSessionInfo* session = State->FindSession(sessionId, seqNo);
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
+        auto response = std::make_unique<typename TMethod::TResponse>(
+            ErrorInvalidSession(clientId, sessionId, seqNo));
+        NCloud::Reply(ctx, *ev, std::move(response));
+        return nullptr;
+    }
+
+    return session;
+}
+
+#define FILESTORE_DEFINE_HANDLE_GET_AND_VALIDATE_SESSION(name, ns)             \
+template TSessionInfo*                                                         \
+TStorageServiceActor::GetAndValidateSession<ns::T##name##Method>(              \
+    const TActorContext&, const ns::TEv##name##Request::TPtr&);                \
+
+    FILESTORE_SERVICE_REQUESTS_HANDLE(
+        FILESTORE_DEFINE_HANDLE_GET_AND_VALIDATE_SESSION,
+        TEvService)
+
+#undef FILESTORE_DEFINE_HANDLE_GET_AND_VALIDATE_SESSION
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TMethod>
 void TStorageServiceActor::ForwardRequest(
     const TActorContext& ctx,
     const typename TMethod::TRequest::TPtr& ev)

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -178,7 +178,6 @@ void TStorageServiceActor::ForwardRequest(
 {
     auto* msg = ev->Get();
 
-    const auto& clientId = GetClientId(msg->Record);
     const auto& sessionId = GetSessionId(msg->Record);
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
@@ -189,13 +188,9 @@ void TStorageServiceActor::ForwardRequest(
         TMethod::Name,
         msg->CallContext->RequestId);
 
-    auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<typename TMethod::TResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        return NCloud::Reply(ctx, *ev, std::move(response));
+    auto* session = GetAndValidateSession<TMethod>(ctx, ev);
+    if (!session) {
+        return;
     }
     const NProto::TFileStore& filestore = session->FileStore;
 
@@ -241,9 +236,23 @@ void TStorageServiceActor::ForwardRequestToShard(
     bool forceBehaveAsShard,
     ui64 entityId)
 {
+    auto* session = GetAndValidateSession<TMethod>(ctx, ev);
+    if (!session) {
+        return;
+    }
+    ForwardRequestToShard<TMethod>(ctx, ev, forceBehaveAsShard, entityId, session);
+}
+
+template <typename TMethod>
+void TStorageServiceActor::ForwardRequestToShard(
+    const TActorContext& ctx,
+    const typename TMethod::TRequest::TPtr& ev,
+    bool forceBehaveAsShard,
+    ui64 entityId,
+    TSessionInfo* session)
+{
     auto* msg = ev->Get();
 
-    const auto& clientId = GetClientId(msg->Record);
     const auto& sessionId = GetSessionId(msg->Record);
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
@@ -254,14 +263,6 @@ void TStorageServiceActor::ForwardRequestToShard(
         TMethod::Name,
         msg->CallContext->RequestId);
 
-    auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<typename TMethod::TResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        return NCloud::Reply(ctx, *ev, std::move(response));
-    }
     const NProto::TFileStore& filestore = session->FileStore;
 
     if (!forceBehaveAsShard) {
@@ -377,20 +378,23 @@ TStorageServiceActor::ForwardRequestToShard<TEvService::TCreateHandleMethod>(
     const TActorContext& ctx,
     const TEvService::TCreateHandleMethod::TRequest::TPtr& ev,
     bool forceBehaveAsShard,
-    ui64 entityId);
+    ui64 entityId,
+    TSessionInfo* session);
 
 template void
 TStorageServiceActor::ForwardRequestToShard<TEvService::TGetNodeAttrMethod>(
     const TActorContext& ctx,
     const TEvService::TGetNodeAttrMethod::TRequest::TPtr& ev,
     bool forceBehaveAsShard,
-    ui64 entityId);
+    ui64 entityId,
+    TSessionInfo* session);
 
 template void
 TStorageServiceActor::ForwardRequestToShard<TEvService::TRenameNodeMethod>(
     const TActorContext& ctx,
     const TEvService::TRenameNodeMethod::TRequest::TPtr& ev,
     bool forceBehaveAsShard,
-    ui64 entityId);
+    ui64 entityId,
+    TSessionInfo* session);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -271,10 +271,6 @@ void TStorageServiceActor::HandleGetNodeAttr(
 {
     auto* msg = ev->Get();
 
-    if (TryHandleControlNamespaceGetNodeAttr(ctx, ev)) {
-        return;
-    }
-
     if (msg->Record.GetName().empty()) {
         // GetNodeAttr by NodeId can be handled directly by the shard
         ForwardRequestToShard<TEvService::TGetNodeAttrMethod>(
@@ -285,18 +281,18 @@ void TStorageServiceActor::HandleGetNodeAttr(
         return;
     }
 
-    const auto& clientId = GetClientId(msg->Record);
+    auto* session =
+        GetAndValidateSession<TEvService::TGetNodeAttrMethod>(ctx, ev);
+    if (!session) {
+        return;
+    }
+
+    if (TryHandleControlNamespaceGetNodeAttr(ctx, ev, session)) {
+        return;
+    }
+
     const auto& sessionId = GetSessionId(msg->Record);
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
-
-    auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        return NCloud::Reply(ctx, *ev, std::move(response));
-    }
 
     const NProto::TFileStore& filestore = session->FileStore;
 

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -270,17 +270,6 @@ void TStorageServiceActor::HandleGetNodeAttr(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-
-    if (msg->Record.GetName().empty()) {
-        // GetNodeAttr by NodeId can be handled directly by the shard
-        ForwardRequestToShard<TEvService::TGetNodeAttrMethod>(
-            ctx,
-            ev,
-            false /* forceBehaveAsShard */,
-            msg->Record.GetNodeId());
-        return;
-    }
-
     auto* session =
         GetAndValidateSession<TEvService::TGetNodeAttrMethod>(ctx, ev);
     if (!session) {
@@ -288,6 +277,17 @@ void TStorageServiceActor::HandleGetNodeAttr(
     }
 
     if (TryHandleControlNamespaceGetNodeAttr(ctx, ev, session)) {
+        return;
+    }
+
+    if (msg->Record.GetName().empty()) {
+        // GetNodeAttr by NodeId can be handled directly by the shard
+        ForwardRequestToShard<TEvService::TGetNodeAttrMethod>(
+            ctx,
+            ev,
+            false /* forceBehaveAsShard */,
+            msg->Record.GetNodeId(),
+            session);
         return;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -667,23 +667,18 @@ void TStorageServiceActor::HandleListNodes(
 {
     auto* msg = ev->Get();
 
-    if (TryHandleControlNamespaceListNodes(ctx, ev)) {
+    auto* session =
+        GetAndValidateSession<TEvService::TListNodesMethod>(ctx, ev);
+    if (!session) {
         return;
     }
 
-    const auto& clientId = GetClientId(msg->Record);
-    const auto& sessionId = GetSessionId(msg->Record);
-    const ui64 seqNo = GetSessionSeqNo(msg->Record);
-
-    auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<TEvService::TEvListNodesResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        return NCloud::Reply(ctx, *ev, std::move(response));
+    if (TryHandleControlNamespaceListNodes(ctx, ev, session)) {
+        return;
     }
 
+    const auto& sessionId = GetSessionId(msg->Record);
+    const ui64 seqNo = GetSessionSeqNo(msg->Record);
     const NProto::TFileStore& filestore = session->FileStore;
 
     auto& headers = *msg->Record.MutableHeaders();

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -1045,22 +1045,18 @@ void TStorageServiceActor::HandleReadData(
 
     FILESTORE_TRACK(RequestReceived_Service, msg->CallContext, "ReadData");
 
-    if (TryHandleControlNamespaceReadData(ctx, ev)) {
+    auto* session =
+        GetAndValidateSession<TEvService::TReadDataMethod>(ctx, ev);
+    if (!session) {
         return;
     }
 
-    const auto& clientId = GetClientId(msg->Record);
+    if (TryHandleControlNamespaceReadData(ctx, ev, session)) {
+        return;
+    }
+
     const auto& sessionId = GetSessionId(msg->Record);
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
-
-    auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<TEvService::TEvReadDataResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        return NCloud::Reply(ctx, *ev, std::move(response));
-    }
     const NProto::TFileStore& filestore = session->FileStore;
 
     // In handleless IO mode, if the handle is not set, we use the nodeId to

--- a/cloud/filestore/libs/storage/service/service_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_renamenode.cpp
@@ -10,7 +10,13 @@ void TStorageServiceActor::HandleRenameNode(
     const TEvService::TEvRenameNodeRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    if (TryHandleControlNamespaceRenameNode(ctx, ev)) {
+    auto* session =
+        GetAndValidateSession<TEvService::TRenameNodeMethod>(ctx, ev);
+    if (!session) {
+        return;
+    }
+
+    if (TryHandleControlNamespaceRenameNode(ctx, ev, session)) {
         return;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_renamenode.cpp
@@ -24,7 +24,8 @@ void TStorageServiceActor::HandleRenameNode(
         ctx,
         ev,
         false /* forceBehaveAsShard */,
-        ev->Get()->Record.GetNodeId());
+        ev->Get()->Record.GetNodeId(),
+        session);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -1000,22 +1000,18 @@ void TStorageServiceActor::HandleWriteData(
 
     FILESTORE_TRACK(RequestReceived_Service, msg->CallContext, "WriteData");
 
-    if (TryHandleControlNamespaceWriteData(ctx, ev)) {
+    auto* session =
+        GetAndValidateSession<TEvService::TWriteDataMethod>(ctx, ev);
+    if (!session) {
         return;
     }
 
-    const auto& clientId = GetClientId(msg->Record);
+    if (TryHandleControlNamespaceWriteData(ctx, ev, session)) {
+        return;
+    }
+
     const auto& sessionId = GetSessionId(msg->Record);
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
-
-    auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<TEvService::TEvWriteDataResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        return NCloud::Reply(ctx, *ev, std::move(response));
-    }
     const NProto::TFileStore& filestore = session->FileStore;
 
     // In handleless IO mode, if the handle is not set, we use the nodeId to

--- a/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
@@ -111,33 +111,6 @@ STFUNC(TSetHasXAttrsActor::StateWork)
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>
-TSessionInfo* TStorageServiceActor::GetAndValidateSession(
-    const NActors::TActorContext& ctx,
-    const typename TMethod::TRequest::TPtr& ev)
-{
-    auto* msg = ev->Get();
-
-    const auto& clientId = GetClientId(msg->Record);
-    const auto& sessionId = GetSessionId(msg->Record);
-    const ui64 seqNo = GetSessionSeqNo(msg->Record);
-
-    TSessionInfo* session = State->FindSession(sessionId, seqNo);
-    if (!session ||
-        session->ClientId != clientId ||
-        !session->GetSessionActor(seqNo))
-    {
-        auto response = std::make_unique<typename TMethod::TResponse>(
-            ErrorInvalidSession(clientId, sessionId, seqNo));
-        NCloud::Reply(ctx, *ev, std::move(response));
-        return nullptr;
-    }
-
-    return session;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-template <typename TMethod>
 void TStorageServiceActor::ForwardXAttrRequest(
     const TActorContext& ctx,
     const typename TMethod::TRequest::TPtr& ev,


### PR DESCRIPTION
### Notes
Some preparatory work for control namespace implementation: move session extraction and validation to the common section from each service actor, and make sure TryHandleControlNamespaceXXX methods accept the session, since this session will be needed in the future

MaxShardsCount is also decremented by one. I'm gonna use highest shard count as a control namespace marker

### Issue
#6608
#7053
