### PR TITLE
issue-6958: fastshard - extracted TFiberShard template from naive_mirrored to reuse it in production shard implementation

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/fiber_shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/fiber_shard.cpp
@@ -1,0 +1,1 @@
+#include "fiber_shard.h"

--- a/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/fiber_shard.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/fiber_shard.h
@@ -6,11 +6,19 @@
 
 #include <silk/fibers/fiber.h>
 
+#include <library/cpp/threading/future/future.h>
+
 #include <util/string/builder.h>
+
+#include <cstring>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
+// TODO(#6958):
+// * strerror -> strerror_r (it's thread-safe)
+// * deal with SetValue being called from fiber context (it triggers arbitrary
+//  callback invocation)
 
 template <typename TFiberShardImpl>
 class TFiberShard: public IFileSystemShard
@@ -24,7 +32,7 @@ public:
     {}
 
 private:
-#define FAST_SHARD_DEFINE_METHOD(name, ns, ...)                                \
+#define FAST_SHARD_FB_DEFINE_METHOD(name, ns, ...)                             \
     struct TFiberShard##name##Params                                           \
     {                                                                          \
         std::shared_ptr<TFiberShardImpl> Impl;                                 \
@@ -38,12 +46,12 @@ private:
         params->Promise.SetValue(std::move(response));                         \
         return 0;                                                              \
     }                                                                          \
-    // FAST_SHARD_DEFINE_METHOD
+    // FAST_SHARD_FB_DEFINE_METHOD
 
-    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_DEFINE_METHOD, NProtoPrivate)
-    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
+    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_FB_DEFINE_METHOD, NProtoPrivate)
+    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_FB_DEFINE_METHOD, NProto)
 
-#undef FAST_SHARD_DEFINE_METHOD
+#undef FAST_SHARD_FB_DEFINE_METHOD
 
     struct TFiberShardCollectStatsParams
     {
@@ -61,7 +69,7 @@ private:
     }
 
 public:
-#define FAST_SHARD_DEFINE_METHOD(name, ns, ...)                                \
+#define FAST_SHARD_FB_DEFINE_METHOD(name, ns, ...)                             \
     NThreading::TFuture<ns::T##name##Response> name(                           \
         ns::T##name##Request request) override                                 \
     {                                                                          \
@@ -88,12 +96,12 @@ public:
                                                                                \
         return future;                                                         \
     }                                                                          \
-    // FAST_SHARD_DEFINE_METHOD
+    // FAST_SHARD_FB_DEFINE_METHOD
 
-    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_DEFINE_METHOD, NProtoPrivate)
-    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
+    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_FB_DEFINE_METHOD, NProtoPrivate)
+    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_FB_DEFINE_METHOD, NProto)
 
-#undef FAST_SHARD_DEFINE_METHOD
+#undef FAST_SHARD_FB_DEFINE_METHOD
 
     [[nodiscard]] NThreading::TFuture<NProto::TError> CollectStats(
         TFileSystemShardStats* stats) const override

--- a/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/fiber_shard.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/fiber_shard.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <silk/fibers/fiber.h>
+
+#include <util/string/builder.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TFiberShardImpl>
+class TFiberShard: public IFileSystemShard
+{
+private:
+    std::shared_ptr<TFiberShardImpl> Impl;
+
+public:
+    explicit TFiberShard(std::shared_ptr<TFiberShardImpl> impl)
+        : Impl(std::move(impl))
+    {}
+
+private:
+#define FAST_SHARD_DEFINE_METHOD(name, ns, ...)                                \
+    struct TFiberShard##name##Params                                           \
+    {                                                                          \
+        std::shared_ptr<TFiberShardImpl> Impl;                                 \
+        std::shared_ptr<ns::T##name##Request> Request;                         \
+        NThreading::TPromise<ns::T##name##Response> Promise;                   \
+    };                                                                         \
+                                                                               \
+    static int name##FiberMain(TFiberShard##name##Params* params) noexcept     \
+    {                                                                          \
+        auto response = params->Impl->name(std::move(*params->Request));       \
+        params->Promise.SetValue(std::move(response));                         \
+        return 0;                                                              \
+    }                                                                          \
+    // FAST_SHARD_DEFINE_METHOD
+
+    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_DEFINE_METHOD, NProtoPrivate)
+    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
+
+#undef FAST_SHARD_DEFINE_METHOD
+
+    struct TFiberShardCollectStatsParams
+    {
+        std::shared_ptr<TFiberShardImpl> Impl;
+        TFileSystemShardStats* Stats;
+        NThreading::TPromise<NProto::TError> Promise;
+    };
+
+    static int CollectStatsFiberMain(TFiberShardCollectStatsParams* params)
+        noexcept
+    {
+        auto e = params->Impl->CollectStats(params->Stats);
+        params->Promise.SetValue(std::move(e));
+        return 0;
+    }
+
+public:
+#define FAST_SHARD_DEFINE_METHOD(name, ns, ...)                                \
+    NThreading::TFuture<ns::T##name##Response> name(                           \
+        ns::T##name##Request request) override                                 \
+    {                                                                          \
+        auto promise = NThreading::NewPromise<ns::T##name##Response>();        \
+        auto future = promise.GetFuture();                                     \
+                                                                               \
+        int r = silk::FiberScheduler::run(                                     \
+            name##FiberMain,                                                   \
+            TFiberShard##name##Params{                                         \
+                .Impl = Impl,                                                  \
+                .Request = std::make_shared<ns::T##name##Request>(             \
+                    std::move(request)),                                       \
+                .Promise = promise,                                            \
+            },                                                                 \
+            nullptr /* future */);                                             \
+        if (r) {                                                               \
+            ns::T##name##Response response;                                    \
+            *response.MutableError() = MakeError(                              \
+                E_FAIL,                                                        \
+                TStringBuilder()                                               \
+                    << "failed to spawn fiber: " << ::strerror(r));            \
+            promise.SetValue(std::move(response));                             \
+        }                                                                      \
+                                                                               \
+        return future;                                                         \
+    }                                                                          \
+    // FAST_SHARD_DEFINE_METHOD
+
+    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_DEFINE_METHOD, NProtoPrivate)
+    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
+
+#undef FAST_SHARD_DEFINE_METHOD
+
+    [[nodiscard]] NThreading::TFuture<NProto::TError> CollectStats(
+        TFileSystemShardStats* stats) const override
+    {
+        auto promise = NThreading::NewPromise<NProto::TError>();
+        auto future = promise.GetFuture();
+
+        int r = silk::FiberScheduler::run(
+            CollectStatsFiberMain,
+            TFiberShardCollectStatsParams{
+                .Impl = Impl,
+                .Stats = stats,
+                .Promise = promise,
+            },
+            nullptr /* future */);
+        if (r) {
+            promise.SetValue(MakeError(
+                E_FAIL,
+                TStringBuilder()
+                    << "failed to spawn fiber: " << ::strerror(r)));
+        }
+
+        return future;
+    }
+
+    //
+    // The layout is immutable after construction and its dump does no
+    // page IO, so no fiber is needed here.
+    //
+
+    void DumpLayoutHtml(IOutputStream& out) const override
+    {
+        Impl->DumpLayoutHtml(out);
+    }
+
+    void DumpLayoutJson(IOutputStream& out) const override
+    {
+        Impl->DumpLayoutJson(out);
+    }
+};
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/ya.make
@@ -1,0 +1,17 @@
+LIBRARY()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/deny_ydb_dependency.inc)
+
+SRCS(
+    fiber_shard.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/iface
+
+    cloud/storage/core/libs/common
+
+    contrib/libs/silk/src/fibers
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/ya.make
@@ -11,6 +11,8 @@ PEERDIR(
 
     cloud/storage/core/libs/common
 
+    library/cpp/threading/future
+
     contrib/libs/silk/src/fibers
 )
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/libs/service/error.h>
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/fiber_bridge/fiber_shard.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/model/handle_table.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/model/helpers.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/model/name_table.h>
@@ -20,7 +21,6 @@
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/simple_template.h>
 
-#include <silk/fibers/fiber.h>
 #include <silk/fibers/mutex.h>
 
 #include <library/cpp/json/writer/json.h>
@@ -2037,45 +2037,6 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-using namespace NThreading;
-
-#define FAST_SHARD_DEFINE_METHOD(name, ns, ...)                                \
-    struct TFiberShard##name##Params                                           \
-    {                                                                          \
-        std::shared_ptr<TFiberShardImpl> FiberShard;                           \
-        std::shared_ptr<ns::T##name##Request> Request;                         \
-        TPromise<ns::T##name##Response> Promise;                               \
-    };                                                                         \
-                                                                               \
-    int name##FiberMain(TFiberShard##name##Params* params) noexcept            \
-    {                                                                          \
-        auto response = params->FiberShard->name(std::move(*params->Request)); \
-        params->Promise.SetValue(std::move(response));                         \
-        return 0;                                                              \
-    }                                                                          \
-    // FAST_SHARD_DEFINE_METHOD
-
-FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_DEFINE_METHOD, NProtoPrivate)
-FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
-
-#undef FAST_SHARD_DEFINE_METHOD
-
-struct TFiberShardCollectStatsParams
-{
-    std::shared_ptr<TFiberShardImpl> FiberShard;
-    TFileSystemShardStats* Stats;
-    TPromise<NProto::TError> Promise;
-};
-
-int CollectStatsFiberMain(TFiberShardCollectStatsParams* params) noexcept
-{
-    auto e = params->FiberShard->CollectStats(params->Stats);
-    params->Promise.SetValue(std::move(e));
-    return 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct TStorageGroupFactory: IStorageGroupFactory
 {
     IStorageGroupPtr MakeStorageGroup(
@@ -2125,97 +2086,21 @@ IStorageGroupFactoryPtr CreateStorageGroupFactory()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TNaiveMirroredFileSystemShard: public IFileSystemShard
+class TNaiveMirroredFileSystemShard: public TFiberShard<TFiberShardImpl>
 {
-private:
-    std::shared_ptr<TFiberShardImpl> FiberShard;
-
 public:
     TNaiveMirroredFileSystemShard(
         TString fileSystemId,
         ui32 shardNo,
         IStorageGroupFactoryPtr storageGroupFactory,
         NProtoPrivate::TPersistentFastShardConfig config)
-        : FiberShard(
+        : TFiberShard<TFiberShardImpl>(
               std::make_shared<TFiberShardImpl>(
                   std::move(fileSystemId),
                   shardNo,
                   std::move(storageGroupFactory),
                   std::move(config)))
     {}
-
-public:
-#define FAST_SHARD_DEFINE_METHOD(name, ns, ...)                                \
-    TFuture<ns::T##name##Response> name(ns::T##name##Request request) override \
-    {                                                                          \
-        auto promise = NewPromise<ns::T##name##Response>();                    \
-        auto future = promise.GetFuture();                                     \
-                                                                               \
-        int r = silk::FiberScheduler::run(                                     \
-            name##FiberMain,                                                   \
-            TFiberShard##name##Params{                                         \
-                .FiberShard = FiberShard,                                      \
-                .Request = std::make_shared<ns::T##name##Request>(             \
-                    std::move(request)),                                       \
-                .Promise = promise,                                            \
-            },                                                                 \
-            nullptr /* future */);                                             \
-        if (r) {                                                               \
-            ns::T##name##Response response;                                    \
-            *response.MutableError() = MakeError(                              \
-                E_FAIL,                                                        \
-                TStringBuilder()                                               \
-                    << "failed to spawn fiber: " << ::strerror(r));            \
-            promise.SetValue(std::move(response));                             \
-        }                                                                      \
-                                                                               \
-        return future;                                                         \
-    }                                                                          \
-    // FAST_SHARD_DEFINE_METHOD
-
-    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_DEFINE_METHOD, NProtoPrivate)
-    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
-
-#undef FAST_SHARD_DEFINE_METHOD
-
-    [[nodiscard]] TFuture<NProto::TError> CollectStats(
-        TFileSystemShardStats* stats) const override
-    {
-        auto promise = NewPromise<NProto::TError>();
-        auto future = promise.GetFuture();
-
-        int r = silk::FiberScheduler::run(
-            CollectStatsFiberMain,
-            TFiberShardCollectStatsParams{
-                .FiberShard = FiberShard,
-                .Stats = stats,
-                .Promise = promise,
-            },
-            nullptr /* future */);
-        if (r) {
-            promise.SetValue(MakeError(
-                E_FAIL,
-                TStringBuilder()
-                    << "failed to spawn fiber: " << ::strerror(r)));
-        }
-
-        return future;
-    }
-
-    //
-    // The layout is immutable after construction and its dump does no
-    // page IO, so no fiber is needed here.
-    //
-
-    void DumpLayoutHtml(IOutputStream& out) const override
-    {
-        FiberShard->DumpLayoutHtml(out);
-    }
-
-    void DumpLayoutJson(IOutputStream& out) const override
-    {
-        FiberShard->DumpLayoutJson(out);
-    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ya.make
@@ -8,6 +8,7 @@ IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     )
 
     PEERDIR(
+        cloud/filestore/libs/storage/fastshard/impl/fiber_bridge
         cloud/filestore/libs/storage/fastshard/impl/model
         cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/resources
         cloud/filestore/libs/storage/fastshard/ipc

--- a/cloud/filestore/libs/storage/fastshard/impl/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/ya.make
@@ -6,6 +6,7 @@ RECURSE(
 IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     RECURSE(
         model
+        fiber_bridge
     )
 
     RECURSE_FOR_TESTS(


### PR DESCRIPTION
### Notes
Extracted `TFiberShard<TFiberShardImpl>` template which adapts a synchronous shard implementation which is supposed to work in fiber context to the `TFuture`-based `IFileSystemShard` interface.

No changes in functionality.

### Issue
https://github.com/ydb-platform/nbs/issues/6958
