### PR TITLE
issue-7054: fix `E_FS_INVALID_SESSION` errors from shards upon file creations in case of a concurrent filestore resize

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -42,9 +42,10 @@ namespace {
 // non-zero, we cap number of in-flight requests.
 // 7. Create shards if needed. If MaxShardManagementRequestsInFlight is
 // non-zero, we cap number of in-flight requests.
-// 8. Configure shards if we created some new ones.
+// 8. Configure shards if we created some new ones. Done in two phases: the
+// newly created shards first, the pre-existing shards next.
 // If MaxShardManagementRequestsInFlight is non-zero, we cap number of in-flight
-// requests.
+// requests within each phase.
 // 9. Configure main filestore if new shards were created.
 // The end!
 
@@ -72,12 +73,23 @@ private:
     TVector<TString> ExistingShardIds;
     ui32 NextShardToCreate = 0;
     ui32 ShardsToCreate = 0;
+
     ui32 NextShardToConfigure = 0;
     ui32 ShardsToConfigure = 0;
+    ui32 EndShardToConfigure = 0;
+
+    enum class EShardConfigPhase {
+        NewShards,
+        OldShards,
+    };
+    EShardConfigPhase ShardConfigPhase = EShardConfigPhase::NewShards;
+
     ui32 NextShardToAlter = 0;
     ui32 ShardsToAlter = 0;
+
     ui32 NextShardToDescribe = 0;
     ui32 ShardsToDescribe = 0;
+
     ui32 MaxShardCount = 0;
     ui64 SevenBytesHandlesCount = 0;
 
@@ -117,6 +129,11 @@ private:
     void CreateShards(const TActorContext& ctx);
     void CreateShard(const TActorContext& ctx, const ui32 shardIndex);
     void ConfigureShards(const TActorContext& ctx);
+    void ConfigureShardRange(
+        const TActorContext& ctx,
+        ui32 beginShardIndex,
+        ui32 endShardIndex,
+        EShardConfigPhase phase);
     void ConfigureShard(const TActorContext& ctx, const ui32 shardIndex);
     void ConfigureMainFileStore(const TActorContext& ctx);
 
@@ -819,14 +836,44 @@ void TAlterFileStoreActor::ConfigureShards(const TActorContext& ctx)
         return;
     }
 
-    NextShardToConfigure = 0;
+    const ui32 existingShardCount = ExistingShardIds.size();
+    const ui32 totalShardCount = FileStoreConfig.ShardConfigs.size();
+
+    if (existingShardCount < totalShardCount) {
+        ConfigureShardRange(
+            ctx,
+            existingShardCount,
+            totalShardCount,
+            EShardConfigPhase::NewShards);
+    } else {
+        // No new shards (e.g. a resize that only toggles strict-size /
+        // directory-creation-in-shards) - configure the existing shards now.
+        ConfigureShardRange(
+            ctx,
+            0,
+            existingShardCount,
+            EShardConfigPhase::OldShards);
+    }
+}
+
+void TAlterFileStoreActor::ConfigureShardRange(
+    const TActorContext& ctx,
+    const ui32 beginShardIndex,
+    const ui32 endShardIndex,
+    const EShardConfigPhase phase)
+{
+    ShardConfigPhase = phase;
+    EndShardToConfigure = endShardIndex;
+    NextShardToConfigure = beginShardIndex;
+    ShardsToConfigure = endShardIndex - beginShardIndex;
+
     const ui32 limit = StorageConfig->GetMaxShardManagementRequestsInFlight();
-    const ui32 endShardIndex = (limit == 0)
-                                   ? FileStoreConfig.ShardConfigs.size()
-                                   : std::min<ui32>(
-                                         NextShardToConfigure + limit,
-                                         FileStoreConfig.ShardConfigs.size());
-    for (ui32 i = NextShardToConfigure; i < endShardIndex; ++i) {
+    const ui32 cappedEndIndex =
+        (limit == 0)
+            ? endShardIndex
+            : std::min<ui32>(beginShardIndex + limit, endShardIndex);
+
+    for (ui32 i = beginShardIndex; i < cappedEndIndex; ++i) {
         ConfigureShard(ctx, i);
         NextShardToConfigure = i + 1;
     }
@@ -906,9 +953,21 @@ void TAlterFileStoreActor::HandleConfigureShardResponse(
 
     Y_DEBUG_ABORT_UNLESS(ShardsToConfigure);
     if (--ShardsToConfigure == 0) {
-        ConfigureMainFileStore(ctx);
+        if (ShardConfigPhase == EShardConfigPhase::NewShards
+                && !ExistingShardIds.empty())
+        {
+            // The newly created shards are all configured now - configure the
+            // pre-existing shards so that they pick up the new shard list.
+            ConfigureShardRange(
+                ctx,
+                0,
+                ExistingShardIds.size(),
+                EShardConfigPhase::OldShards);
+        } else {
+            ConfigureMainFileStore(ctx);
+        }
     } else if (StorageConfig->GetMaxShardManagementRequestsInFlight()) {
-        if (NextShardToConfigure < FileStoreConfig.ShardConfigs.size()) {
+        if (NextShardToConfigure < EndShardToConfigure) {
             ConfigureShard(ctx, NextShardToConfigure);
             ++NextShardToConfigure;
         }

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -7496,6 +7496,140 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
+    SERVICE_TEST(
+        ShouldNotRouteCreateNodeToNotYetConfiguredShardDuringExpansion)
+    {
+        // See https://github.com/ydb-platform/nbs/issues/7054
+        config.SetDirectoryCreationInShardsEnabled(true);
+        // the test relies on round-robin shard selection (the default)
+        config.SetShardBalancerPolicy(NProto::SBP_ROUND_ROBIN);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        const TString shard3Id = fsConfig.FsId + "_s3";
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        // a directory owned by an existing shard - CreateNode under it is
+        // handled by that shard, which picks the target shard for the new node
+        const ui64 dirId = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, "dir"))
+            ->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_UNEQUAL(0, ExtractShardNo(dirId));
+
+        // hold back ConfigureAsShard for the new shard s3 (it stays at
+        // ShardNo == 0); count how many times s1/s2 get reconfigured
+        TVector<TAutoPtr<IEventHandle>> delayedShard3Config;
+        bool delayShard3Config = true;
+        ui32 existingShardConfigureCount = 0;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+                if (ev->GetTypeRewrite()
+                        == TEvIndexTablet::EvConfigureAsShardRequest)
+                {
+                    const auto* msg =
+                        ev->Get<TEvIndexTablet::TEvConfigureAsShardRequest>();
+                    const auto& fsId = msg->Record.GetFileSystemId();
+                    if (delayShard3Config && fsId == shard3Id) {
+                        delayedShard3Config.emplace_back(ev.Release());
+                        return true;
+                    }
+                    if (fsId == fsConfig.Shard1Id || fsId == fsConfig.Shard2Id) {
+                        ++existingShardConfigureCount;
+                    }
+                }
+                return false;
+            });
+
+        // 2 -> 3 shard expansion
+        service.SendResizeFileStoreRequest(
+            fsConfig.FsId,
+            fsConfig.MainFsBlockCount,
+            false /* force */,
+            3 /* shardCount */);
+
+        // wait until s3 is created and its ConfigureAsShard is intercepted
+        for (ui32 i = 0; i < 200 && delayedShard3Config.empty(); ++i) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(!delayedShard3Config.empty());
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        // s1/s2 must not be reconfigured (learn about s3) while s3 is held back
+        UNIT_ASSERT_VALUES_EQUAL(0, existingShardConfigureCount);
+
+        const auto critCounter =
+            env.GetCounters()
+                ->FindSubgroup("component", "service")
+                ->GetCounter("AppCriticalEvents/ReceivedNodeOpErrorFromShard");
+        UNIT_ASSERT_VALUES_EQUAL(0, critCounter->GetAtomic());
+
+        // files created under the directory while the expansion is stuck must
+        // all succeed and none may be routed to the unconfigured shard s3
+        for (ui32 i = 0; i < 6; ++i) {
+            auto response = service.SendAndRecvCreateNode(
+                headers,
+                TCreateNodeArgs::File(
+                    dirId,
+                    TStringBuilder() << "file" << i));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetError().GetCode(),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_VALUES_UNEQUAL(
+                3,
+                ExtractShardNo(response->Record.GetNode().GetId()));
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(0, critCounter->GetAtomic());
+
+        // release the held config and let the expansion finish
+        delayShard3Config = false;
+        for (auto& ev: delayedShard3Config) {
+            env.GetRuntime().Send(ev.Release(), nodeIdx);
+        }
+        delayedShard3Config.clear();
+
+        {
+            auto response = service.RecvResizeFileStoreResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetError().GetCode(),
+                FormatError(response->GetError()));
+        }
+
+        // now s1/s2 get reconfigured with the 3-shard list
+        UNIT_ASSERT_VALUES_UNEQUAL(0, existingShardConfigureCount);
+
+        // main tablet suicides after ConfigureShards
+        WaitForTabletStart(service);
+        headers = service.InitSession(fsConfig.FsId, "client");
+
+        // s3 is a normal shard now and gets used without errors
+        bool sawShard3 = false;
+        for (ui32 i = 0; i < 12; ++i) {
+            auto response = service.SendAndRecvCreateNode(
+                headers,
+                TCreateNodeArgs::File(
+                    dirId,
+                    TStringBuilder() << "file_after_" << i));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetError().GetCode(),
+                FormatError(response->GetError()));
+            if (ExtractShardNo(response->Record.GetNode().GetId()) == 3) {
+                sawShard3 = true;
+            }
+        }
+
+        UNIT_ASSERT(sawShard3);
+        UNIT_ASSERT_VALUES_EQUAL(0, critCounter->GetAtomic());
+    }
+
     SERVICE_TEST(ShouldHandleRenameNodeInDestinationError)
     {
         config.SetDirectoryCreationInShardsEnabled(true);


### PR DESCRIPTION
### Notes
how this test failed without the fix:

```
------- [TM] {debug, default-linux-x86_64} cloud/filestore/libs/storage/service/ut/unittest >> TStorageServiceSharding
Test command err:
2026-09-06T10:57:23.213823Z node 1 :BS_PROXY_DISCOVER WARN: [d3a1fc113ba9dc9e] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.214567Z node 1 :BS_PROXY_DISCOVER WARN: [0ba3dc80ac2e664d] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.217333Z node 1 :BS_PROXY_DISCOVER WARN: [1ff8c6bd1c773d5b] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.218043Z node 1 :BS_PROXY_DISCOVER WARN: [b6845e37898c7df3] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.335093Z node 1 :BS_PROXY_DISCOVER WARN: [74f3fe3eccc1e6e3] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.341566Z node 1 :BS_PROXY_DISCOVER WARN: [045be497128c87f5] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.349814Z node 1 :BS_PROXY_DISCOVER WARN: [b9ab9fa4de4b03bf] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.351651Z node 1 :BS_PROXY_DISCOVER WARN: [228f3240d1677545] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.353405Z node 1 :BS_PROXY_DISCOVER WARN: [a68d86426db8d7c3] Die. Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD05
2026-09-06T10:57:23.386068Z node 1 :BS_PROXY_DISCOVER WARN: [bdacece49e31ae42] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.388027Z node 1 :BS_PROXY_DISCOVER WARN: [6f8059a6d378e0eb] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.396928Z node 1 :BS_PROXY_DISCOVER WARN: [65862f973780eb64] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 1 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:23.511416Z node 1 :FLAT_TX_SCHEMESHARD WARN: Cannot subscribe to console configs
2026-09-06T10:57:23.511452Z node 1 :IMPORT WARN: Table profiles were not loaded
tablet_helpers.cpp: SetPath # /home/debnatkh/.ya/build/build_root/kbqj/00000a/r3tmp/tmpWdMIit/pdisk_1.dat
2026-09-06T10:57:24.024442Z node 1 :FLAT_TX_SCHEMESHARD WARN: Operation part proposed ok, but propose itself is undo unsafe, suboperation type: ESchemeOpAlterSubDomain, opId: 1:0, at schemeshard:  72075186232688896
2026-09-06T10:57:24.046561Z node 1 :FLAT_TX_SCHEMESHARD WARN: NotifyTxCompletion, unknown transaction, txId: 1, at schemeshard: 72075186232688896
2026-09-06T10:57:24.080915Z node 1 :FLAT_TX_SCHEMESHARD WARN: Operation part proposed ok, but propose itself is undo unsafe, suboperation type: ESchemeOpCreateSubDomain, opId: 281474976720656:0, at schemeshard:  72075186232688896
2026-09-06T10:57:24.137110Z node 2 :NFS_SERVICE INFO: [test] Will create filesystem with 2 shards
2026-09-06T10:57:24.137259Z node 2 :NFS_SS_PROXY DEBUG: FileStore "test": send create request (dir: "local/nfs/_12E", name: "test")
2026-09-06T10:57:24.145072Z node 1 :HIVE WARN: HIVE#72075186224013313 Node(2, (0,0,0,0)) VolatileState: Unknown -> Disconnected
2026-09-06T10:57:24.145123Z node 1 :HIVE WARN: HIVE#72075186224013313 Node(2, (0,0,0,0)) VolatileState: Disconnected -> Connecting
2026-09-06T10:57:24.147376Z node 1 :FLAT_TX_SCHEMESHARD WARN: Operation part proposed ok, but propose itself is undo unsafe, suboperation type: ESchemeOpCreateFileStore, opId: 281474976720658:1, at schemeshard:  72075186232688896
2026-09-06T10:57:24.149149Z node 2 :NFS_SS_PROXY DEBUG: Request ESchemeOpCreateFileStore with TxId# 281474976720658 in progress, waiting for completion
2026-09-06T10:57:24.149236Z node 2 :NFS_SS_PROXY DEBUG: Creating reply proxy actor for schemeshard 72075186232688896
2026-09-06T10:57:24.149263Z node 2 :NFS_SS_PROXY DEBUG: Sending NotifyTxCompletion to 72075186232688896 for txId# 281474976720658
2026-09-06T10:57:24.159191Z node 2 :NFS_SS_PROXY DEBUG: Received NotifyTxCompletionRegistered from 72075186232688896 for txId# 281474976720658
2026-09-06T10:57:24.615738Z node 1 :FLAT_TX_SCHEMESHARD WARN: Cannot get console configs
2026-09-06T10:57:24.615776Z node 1 :IMPORT WARN: Table profiles were not loaded
2026-09-06T10:57:25.225965Z node 1 :HIVE WARN: HIVE#72075186224013313 Handle TEvInterconnect::TEvNodeConnected, NodeId 2 Cookie 2
2026-09-06T10:57:25.227189Z node 1 :HIVE WARN: HIVE#72075186224013313 Node(2, (0,0,0,0)) VolatileState: Connecting -> Connected
2026-09-06T10:57:25.262314Z node 2 :BS_PROXY_DISCOVER WARN: [bb98e5cbdda02686] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:25.272823Z node 2 :BS_PROXY_DISCOVER WARN: [db38e40e5c321908] Result# TEvDiscoverResult {Status# NODATA BlockedGeneration# 0 Id# [0:0:0:0:0:0:0] Size# 0 MinGeneration# 0} Marker# BSD01
2026-09-06T10:57:25.276090Z node 2 :NFS_TABLET DEBUG: [t:72075186224037888] Switched to state Init (system: [2:801:2124], user: [2:817:2135], executor: [2:839:2135])
2026-09-06T10:57:25.277765Z node 2 :NFS_TABLET TRACE: [72075186224037888] PrepareTx InitSchema (gen: 1, step: 2)
2026-09-06T10:57:25.277787Z node 2 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx InitSchema (gen: 1, step: 2)
2026-09-06T10:57:25.357615Z node 2 :NFS_TABLET TRACE: [72075186224037888] CompleteTx InitSchema (gen: 1, step: 2)
2026-09-06T10:57:25.357761Z node 2 :NFS_TABLET TRACE: [72075186224037888] PrepareTx LoadState (gen: 1, step: 3)
2026-09-06T10:57:25.357777Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet state data
2026-09-06T10:57:25.358100Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet state data finished
2026-09-06T10:57:25.358115Z node 2 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx LoadState (gen: 1, step: 3)
2026-09-06T10:57:25.358124Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Preparing tablet state
2026-09-06T10:57:25.358190Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Initializing tablet storage info
2026-09-06T10:57:25.360101Z node 2 :NFS_TABLET TRACE: [72075186224037888] CompleteTx LoadState (gen: 1, step: 3)
2026-09-06T10:57:25.360134Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Setting CloudId=, FolderId=, EntityId= for the storage config features overrides
2026-09-06T10:57:25.382204Z node 2 :NFS_TABLET DEBUG: [t:72075186224037888] Switched to state Work (system: [2:801:2124], user: [2:817:2135], executor: [2:839:2135])
2026-09-06T10:57:25.382244Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Activating tablet
2026-09-06T10:57:25.382263Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Initializing tablet state
2026-09-06T10:57:25.382369Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet sessions
2026-09-06T10:57:25.382392Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Enqueueing truncate operations: 0
2026-09-06T10:57:25.382402Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet checkpoints: 0
2026-09-06T10:57:25.382412Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet quotas: 0
2026-09-06T10:57:25.382422Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading tablet quota usages: 0
2026-09-06T10:57:25.382431Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading fresh bytes: 0
2026-09-06T10:57:25.382441Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading fresh blocks: 0
2026-09-06T10:57:25.382451Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading garbage blobs: 0
2026-09-06T10:57:25.382461Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading unconfirmed data entries: 0
2026-09-06T10:57:25.382477Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Scheduling startup events
2026-09-06T10:57:25.382502Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Scheduling OpLog ops
2026-09-06T10:57:25.382520Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Load state completed
2026-09-06T10:57:25.382643Z node 2 :NFS_TABLET INFO: [t:72075186224037888] LoadCompactionMapChunk started (first range: #0, count: 10485760)
2026-09-06T10:57:25.382675Z node 2 :NFS_TABLET TRACE: [72075186224037888] PrepareTx LoadCompactionMapChunk (gen: 1, step: 4)
2026-09-06T10:57:25.382687Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading compaction map chunk 0, 10485760
2026-09-06T10:57:25.382736Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Loading compaction map chunk finished
2026-09-06T10:57:25.382748Z node 2 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx LoadCompactionMapChunk (gen: 1, step: 4)
2026-09-06T10:57:25.382771Z node 2 :NFS_TABLET TRACE: [72075186224037888] CompleteTx LoadCompactionMapChunk (gen: 1, step: 4)
2026-09-06T10:57:25.382847Z node 2 :NFS_TABLET INFO: [t:72075186224037888] LoadCompactionMapChunk completed (S_OK)
2026-09-06T10:57:25.382858Z node 2 :NFS_TABLET INFO: [t:72075186224037888] ConfirmBlobs: recovery confirmation completed
2026-09-06T10:57:25.382878Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Compaction state loaded, MaxLoadedInOrderRangeId: 0, RangesWithEmptyScore: 0
2026-09-06T10:57:25.436550Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Starting tablet config initialization [txId: 10002], autosharding [1, 4096000]
2026-09-06T10:57:25.436615Z node 2 :NFS_TABLET TRACE: [72075186224037888] PrepareTx UpdateConfig (gen: 1, step: 4)
2026-09-06T10:57:25.436627Z node 2 :NFS_TABLET TRACE: [72075186224037888] ExecuteTx UpdateConfig (gen: 1, step: 4)
2026-09-06T10:57:25.436651Z node 2 :NFS_TABLET INFO: [t:72075186224037888] Setting CloudId=test_cloud, FolderId=test_folder, EntityId=test for the storage config features overrides
2026-09-06T10:57:25.438304Z node 2 :NFS_TABLET TRACE: [72075186224037888] CompleteTx UpdateConfig (gen: 1, step: 4)
2026-09-06T10:57:25.463056Z node 2 :NFS_TABLET DEBUG: [f:test][t:72075186224037888] Sending OK response for UpdateConfig with version=1
2026-09-06T10:57:25.477001Z node 2 :NFS_SS_PROXY DEBUG: Received NotifyTxCompletionResult from 72075186232688896 for txId# 281474976720658
2026-09-06T10:57:25.477036Z node 2 :NFS_SS_PROXY DEBUG: TModifySchemeActor received TEvWaitSchemeTxResponse
2026-09-06T10:57:25.477077Z node 2 :NFS_SS_PROXY INFO: FileStore "test": created successfully
2026-09-06T10:57:25.477126Z node 2 :NFS_SERVICE INFO: [test] Created main filesystem
2026-09-06T10:57:25.477145Z node 2 :NFS_SERVICE INFO: [test] Creating shard test_s1
2026-09-06T10:57:25.477161Z node 2 :NFS_SERVICE INFO: [test] Creating shard test_s2
2026-09-06T10:57:25.477274Z node 2 :NFS_SS_PROXY DEBUG: FileStore "test_s1": send create request (dir: "local/nfs/_2BE", name: "test_s1")
2026-09-06T10:57:25.477313Z node 2 :NFS_SS_PROXY DEBUG: FileStore "test_s2": send create request (dir: "local/nfs/_3E6", name: "test_s2")
2026-09-06T10:57:25.482572Z node 1 :FLAT_TX_SCHEMESHARD WARN: Operation part proposed ok, but propose itself is undo unsafe, suboperation type: ESchemeOpCreateFileStore, opId: 281474976720659:1, at schemeshard:  72075186232688896
2026-09-06T10:57:25.484954Z node 2 :NFS_SS_PROXY DEBUG: Request ESchemeOpCreateFileStore with TxId# 281474976720659 in progress, waiting for completion
2026-09-06T10:57:25.485247Z node 2 :NFS_SS_PROXY DEBUG: Sending NotifyTxCompletion to 72075186232688896 for txId# 281474976720659
2026-09-06T10:57:25.489331Z node 1 :FLAT_TX_SCHEMESHARD WARN: Operation part proposed ok, but propose itself is undo unsafe, suboperation type: ESchemeOpCreateFileStore, opId: 281474976720660:1, at schemeshard:  72075186232688896
2026-09-06T10:57:25.494875Z node 2 :NFS_SS_PR
...
-06T10:57:26.344674Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CreateNode: #0 completed (S_OK), trace-info: 0
2026-09-06T10:57:26.344790Z node 2 :NFS_TABLET_WORKER DEBUG: [f:test_s1][t:72075186224037889] Shard node created for test_s1, b7c2823b-926e2a0d-81896c37-1cf8d9d6, 72057594037927939
2026-09-06T10:57:26.344855Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CreateNode: #0 completed (S_OK), trace-info: 0
2026-09-06T10:57:26.344881Z node 2 :NFS_TABLET TRACE: [72075186224037889] PrepareTx CommitNodeCreationInShard (gen: 1, step: 11)
2026-09-06T10:57:26.344891Z node 2 :NFS_TABLET TRACE: [72075186224037889] ExecuteTx CommitNodeCreationInShard (gen: 1, step: 11)
2026-09-06T10:57:26.345010Z node 2 :NFS_SERVICE DEBUG: #0 completed CreateNode (S_OK)
2026-09-06T10:57:26.346308Z node 2 :NFS_TABLET TRACE: [72075186224037889] CompleteTx CommitNodeCreationInShard (gen: 1, step: 11)
2026-09-06T10:57:26.346330Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CommitNodeCreationInShard completed (4294967299): 3c0386e7-de27adc3-5fdb8787-ff01ca3c, 0
2026-09-06T10:57:26.346541Z node 2 :NFS_SERVICE DEBUG: ["3c0386e7-de27adc3-5fdb8787-ff01ca3c"][0] forward CreateNode #0 to shard test_s1
2026-09-06T10:57:26.346560Z node 2 :NFS_SERVICE DEBUG: ["3c0386e7-de27adc3-5fdb8787-ff01ca3c"][0] forward CreateNode #0
2026-09-06T10:57:26.346597Z node 2 :NFS_TABLET_PROXY TRACE: Forward request 0 as 16 to file store: 72075186224037889 (remote: [2:1113:2239])
2026-09-06T10:57:26.346736Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CreateNode: Headers { ClientId: "client" SessionId: "3c0386e7-de27adc3-5fdb8787-ff01ca3c" Internal { Trace { } } BehaveAsDirectoryTablet: true } FileSystemId: "test_s1" NodeId: 72057594037927938 Name: "file1" File { }
2026-09-06T10:57:26.346773Z node 2 :NFS_TABLET TRACE: [72075186224037889] PrepareTx CreateNode (gen: 1, step: 12)
2026-09-06T10:57:26.346791Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] Selected shard test_s2, name af60f4b8-66b55168-3a1c2b34-dafb1337 upon CreateNode: 72057594037927938, file1
2026-09-06T10:57:26.346859Z node 2 :NFS_TABLET TRACE: [72075186224037889] ExecuteTx CreateNode (gen: 1, step: 12)
2026-09-06T10:57:26.348225Z node 2 :NFS_TABLET TRACE: [72075186224037889] CompleteTx CreateNode (gen: 1, step: 12)
2026-09-06T10:57:26.348246Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] Creating node in shard upon CreateNode: test_s2, af60f4b8-66b55168-3a1c2b34-dafb1337
2026-09-06T10:57:26.348319Z node 2 :NFS_TABLET_WORKER DEBUG: [f:test_s1][t:72075186224037889] Sending CreateNodeRequest to shard test_s2, af60f4b8-66b55168-3a1c2b34-dafb1337
2026-09-06T10:57:26.348366Z node 2 :NFS_TABLET_PROXY TRACE: Forward request 0 as 17 to file store: 72075186224037890 (remote: [2:1114:2240])
2026-09-06T10:57:26.348491Z node 2 :NFS_TABLET DEBUG: [f:test_s2][t:72075186224037890] CreateNode: Headers { ClientId: "client" SessionId: "3c0386e7-de27adc3-5fdb8787-ff01ca3c" Internal { Trace { } } } FileSystemId: "test_s2" NodeId: 1 Name: "af60f4b8-66b55168-3a1c2b34-dafb1337" File { } OriginalNodeId: 72057594037927938 OriginalName: "file1"
2026-09-06T10:57:26.348549Z node 2 :NFS_TABLET TRACE: [72075186224037890] PrepareTx CreateNode (gen: 1, step: 8)
2026-09-06T10:57:26.348624Z node 2 :NFS_TABLET TRACE: [72075186224037890] ExecuteTx CreateNode (gen: 1, step: 8)
2026-09-06T10:57:26.350068Z node 2 :NFS_TABLET TRACE: [72075186224037890] CompleteTx CreateNode (gen: 1, step: 8)
2026-09-06T10:57:26.350102Z node 2 :NFS_TABLET DEBUG: [f:test_s2][t:72075186224037890] CreateNode: #0 completed (S_OK), trace-info: 0
2026-09-06T10:57:26.350207Z node 2 :NFS_TABLET_WORKER DEBUG: [f:test_s1][t:72075186224037889] Shard node created for test_s2, af60f4b8-66b55168-3a1c2b34-dafb1337, 144115188075855874
2026-09-06T10:57:26.350266Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CreateNode: #0 completed (S_OK), trace-info: 0
2026-09-06T10:57:26.350291Z node 2 :NFS_TABLET TRACE: [72075186224037889] PrepareTx CommitNodeCreationInShard (gen: 1, step: 13)
2026-09-06T10:57:26.350301Z node 2 :NFS_TABLET TRACE: [72075186224037889] ExecuteTx CommitNodeCreationInShard (gen: 1, step: 13)
2026-09-06T10:57:26.350493Z node 2 :NFS_SERVICE DEBUG: #0 completed CreateNode (S_OK)
2026-09-06T10:57:26.351735Z node 2 :NFS_TABLET TRACE: [72075186224037889] CompleteTx CommitNodeCreationInShard (gen: 1, step: 13)
2026-09-06T10:57:26.351755Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CommitNodeCreationInShard completed (4294967301): 3c0386e7-de27adc3-5fdb8787-ff01ca3c, 0
2026-09-06T10:57:26.351928Z node 2 :NFS_SERVICE DEBUG: ["3c0386e7-de27adc3-5fdb8787-ff01ca3c"][0] forward CreateNode #0 to shard test_s1
2026-09-06T10:57:26.351942Z node 2 :NFS_SERVICE DEBUG: ["3c0386e7-de27adc3-5fdb8787-ff01ca3c"][0] forward CreateNode #0
2026-09-06T10:57:26.351977Z node 2 :NFS_TABLET_PROXY TRACE: Forward request 0 as 18 to file store: 72075186224037889 (remote: [2:1113:2239])
2026-09-06T10:57:26.352112Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CreateNode: Headers { ClientId: "client" SessionId: "3c0386e7-de27adc3-5fdb8787-ff01ca3c" Internal { Trace { } } BehaveAsDirectoryTablet: true } FileSystemId: "test_s1" NodeId: 72057594037927938 Name: "file2" File { }
2026-09-06T10:57:26.352148Z node 2 :NFS_TABLET TRACE: [72075186224037889] PrepareTx CreateNode (gen: 1, step: 14)
2026-09-06T10:57:26.352166Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] Selected shard test_s3, name 84084da0-76b87403-a636a8e7-5e7cd18d upon CreateNode: 72057594037927938, file2
2026-09-06T10:57:26.352234Z node 2 :NFS_TABLET TRACE: [72075186224037889] ExecuteTx CreateNode (gen: 1, step: 14)
2026-09-06T10:57:26.353699Z node 2 :NFS_TABLET TRACE: [72075186224037889] CompleteTx CreateNode (gen: 1, step: 14)
2026-09-06T10:57:26.353720Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] Creating node in shard upon CreateNode: test_s3, 84084da0-76b87403-a636a8e7-5e7cd18d
2026-09-06T10:57:26.353811Z node 2 :NFS_TABLET_WORKER DEBUG: [f:test_s1][t:72075186224037889] Sending CreateNodeRequest to shard test_s3, 84084da0-76b87403-a636a8e7-5e7cd18d
2026-09-06T10:57:26.353841Z node 2 :NFS_TABLET_PROXY DEBUG: Describe file store test_s3
2026-09-06T10:57:26.356663Z node 2 :NFS_TABLET_PROXY DEBUG: File store test_s3 (path: "local/nfs/_1CB/test_s3") resolved: 72075186224037891
2026-09-06T10:57:26.356716Z node 2 :NFS_TABLET_PROXY TRACE: Forward request 0 as 19 to file store: 72075186224037891 (remote: [2:1419:2376])
2026-09-06T10:57:26.357528Z node 2 :NFS_TABLET DEBUG: [f:test_s3][t:72075186224037891] CreateNode: Headers { ClientId: "client" SessionId: "3c0386e7-de27adc3-5fdb8787-ff01ca3c" Internal { Trace { } } } FileSystemId: "test_s3" NodeId: 1 Name: "84084da0-76b87403-a636a8e7-5e7cd18d" File { } OriginalNodeId: 72057594037927938 OriginalName: "file2"
2026-09-06T10:57:26.357631Z node 2 :NFS_TABLET_WORKER ERROR: [f:test_s1][t:72075186224037889] Shard node creation failed for test_s3, 84084da0-76b87403-a636a8e7-5e7cd18d with error "E_FS_INVALID_SESSION invalid session (clientId: \"client\", sessionId: \"3c0386e7-de27adc3-5fdb8787-ff01ca3c\", sessionSeqNo: 0)", will not retry
CRITICAL_EVENT:AppCriticalEvents/ReceivedNodeOpErrorFromShard: Shard node creation failed for test_s3, 84084da0-76b87403-a636a8e7-5e7cd18d with error "E_FS_INVALID_SESSION invalid session (clientId: \"client\", sessionId: \"3c0386e7-de27adc3-5fdb8787-ff01ca3c\", sessionSeqNo: 0)", will not retry
2026-09-06T10:57:26.357702Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CreateNode: #0 completed (E_FS_INVALID_SESSION invalid session (clientId: "client", sessionId: "3c0386e7-de27adc3-5fdb8787-ff01ca3c", sessionSeqNo: 0), request-id: 0), trace-info: 0
2026-09-06T10:57:26.357728Z node 2 :NFS_TABLET TRACE: [72075186224037889] PrepareTx CommitNodeCreationInShard (gen: 1, step: 15)
2026-09-06T10:57:26.357738Z node 2 :NFS_TABLET TRACE: [72075186224037889] ExecuteTx CommitNodeCreationInShard (gen: 1, step: 15)
2026-09-06T10:57:26.357903Z node 2 :NFS_SERVICE DEBUG: #0 completed CreateNode (E_FS_INVALID_SESSION invalid session (clientId: "client", sessionId: "3c0386e7-de27adc3-5fdb8787-ff01ca3c", sessionSeqNo: 0), request-id: 0)
2026-09-06T10:57:26.359151Z node 2 :NFS_TABLET TRACE: [72075186224037889] CompleteTx CommitNodeCreationInShard (gen: 1, step: 15)
2026-09-06T10:57:26.359172Z node 2 :NFS_TABLET DEBUG: [f:test_s1][t:72075186224037889] CommitNodeCreationInShard completed (4294967302): 3c0386e7-de27adc3-5fdb8787-ff01ca3c, 0
assertion failed at cloud/filestore/libs/storage/service/service_ut_sharding.cpp:7584, void NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TestImplShouldNotRouteCreateNodeToNotYetConfiguredShardDuringExpansion(NProto::TStorageConfig): (S_OK == response->GetError().GetCode()) failed: (S_OK != 2147942500) E_FS_INVALID_SESSION invalid session (clientId: "client", sessionId: "3c0386e7-de27adc3-5fdb8787-ff01ca3c", sessionSeqNo: 0), request-id: 0, with diff:
(S_OK|2147942500)
BackTrace(void**, unsigned long)+29 (0x2C38DB3D)
TBackTrace::Capture()+30 (0x2C38E0AE)
NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char>> const&, bool)+560 (0x2C5878D0)
NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TestImplShouldNotRouteCreateNodeToNotYetConfiguredShardDuringExpansion(NCloud::NFileStore::NProto::TStorageConfig)+8035 (0x2C082943)
NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TTestCaseShouldNotRouteCreateNodeToNotYetConfiguredShardDuringExpansion::Execute_(NUnitTest::TTestContext&)+50 (0x2C080992)
NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'()::operator()() const+127 (0x2C0EBFBF)
decltype(std::declval<NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'()&>()()) std::__y1::__invoke[abi:fe190000]<NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'()&>(NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'()&)+21 (0x2C0EBF35)
void std::__y1::__invoke_void_return_wrapper<void, true>::__call[abi:fe190000]<NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'()&>(NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'()&)+21 (0x2C0EBEF5)
std::__y1::__function::__alloc_func<NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()[abi:fe190000]()+29 (0x2C0EBECD)
std::__y1::__function::__func<NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()()+25 (0x2C0EB2B9)
std::__y1::__function::__value_func<void ()>::operator()[abi:fe190000]() const+50 (0x2A54B472)
std::__y1::function<void ()>::operator()() const+21 (0x2A543045)
TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+149 (0x2C5B0555)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+144 (0x2C589EC0)
NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceShardingTest::TCurrentTest::Execute()+498 (0x2C0EA7D2)
NUnitTest::TTestFactory::Execute()+711 (0x2C58A787)
NUnitTest::RunMain(int, char**)+4240 (0x2C5AE1D0)
main+34 (0x2C5AD102)
??+0 (0x7FFA3F08DD90)
__libc_start_main+128 (0x7FFA3F08DE40)
_start+41 (0x2A337029)
```

### Issue
#7054
