### PR TITLE
[NBS] Account for data newer than the compaction snapshot

### DIFF
--- a/cloud/blockstore/libs/storage/partition/model/block.h
+++ b/cloud/blockstore/libs/storage/partition/model/block.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include "block_mask.h"
+
 #include <cloud/blockstore/libs/common/block_range.h>
 
 #include <cloud/storage/core/libs/common/sglist.h>
@@ -82,7 +84,7 @@ struct IBlobsVisitor
     virtual bool Visit(
         TBlockRange32 blockRange,
         const TPartialBlobId& blobId,
-        ui32 skippedBlocksCount) = 0;
+        const TBlockMask& skipMask) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -876,16 +876,9 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
             auto [blobIt, inserted] =
                 affectedBlobs.try_emplace(blobId, std::move(blob));
             if (!inserted) {
+                // In AddBlobs transaction we only looking at block masks, so we
+                // need to merge them.
                 auto& affectedBlob = blobIt->second;
-                affectedBlob.Offsets.insert(
-                    affectedBlob.Offsets.end(),
-                    blob.Offsets.begin(),
-                    blob.Offsets.end());
-                affectedBlob.AffectedBlocks.insert(
-                    affectedBlob.AffectedBlocks.end(),
-                    blob.AffectedBlocks.begin(),
-                    blob.AffectedBlocks.end());
-
                 affectedBlob.BlockMask.GetRef() |= blockMask;
             }
         }

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -184,10 +184,10 @@ struct TMergedBlobVisitor final
     bool Visit(
         TBlockRange32 blockRange,
         const TPartialBlobId& blobId,
-        ui32 skippedBlocksCount) override
+        const TBlockMask& skipMask) override
     {
         Y_UNUSED(blockRange);
-        Y_UNUSED(skippedBlocksCount);
+        Y_UNUSED(skipMask);
 
         if (blobId == BlobId) {
             Found = true;

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -230,7 +230,7 @@ public:
         for (ui32 i = 0; i < end - start + 1; ++i) {
             const ui32 blobOffset = start - blockRange.Start + i;
             if (!skipMask.Get(blobOffset)) {
-                ab.MergedBlobsSpecificInfo->BlocksInRange++;
+                ++ab.MergedBlobsSpecificInfo->BlocksInRange;
             }
         }
 
@@ -240,10 +240,9 @@ public:
 
     // Returns blobs that do not have any blocks in the compaction range with
     // an available commit ID.
-    THashMap<TPartialBlobId, TAffectedBlob, TPartialBlobIdHash> Finish()
+    TAffectedBlobs Finish()
     {
-        THashMap<TPartialBlobId, TAffectedBlob, TPartialBlobIdHash>
-            blobsToDelete;
+        TAffectedBlobs blobsToDelete;
 
         for (auto& [blobId, ab]: Args.AffectedBlobs) {
             if (ab.MinCommitIdInCompactionRange > MaxCommitId) {
@@ -671,7 +670,8 @@ void ApplyBlobsSkipping(
     const TStorageConfig& config,
     const ui32 maxSkippedBlobs,
     TPartitionState& state,
-    TTxPartition::TRangeCompaction& args)
+    TTxPartition::TRangeCompaction& args,
+    TAffectedBlobs& skippedBlobs)
 {
     THashMap<TPartialBlobId, ui32, TPartialBlobIdHash> blobsToSkip;
     for (const auto& m: args.BlockMarks) {
@@ -688,17 +688,6 @@ void ApplyBlobsSkipping(
 
     if (state.GetMixedBlocksFilter()) {
         ApplyMixedBlocksSkipping(blobsToSkip, args);
-    }
-
-    args.BlobsSkipped += blobsToSkip.size();
-    for (const auto& [blobId, skippedBlockCount]: blobsToSkip) {
-        args.BlocksSkipped += skippedBlockCount;
-
-        auto* ab = args.AffectedBlobs.FindPtr(blobId);
-        Y_ABORT_UNLESS(ab);
-        if (ab->IndexKind == EChannelDataKind::Mixed) {
-            args.MixedBlocksSkipped += skippedBlockCount;
-        }
     }
 
     TAffectedBlocks skippedBlocks;
@@ -719,6 +708,7 @@ void ApplyBlobsSkipping(
                     {affectedBlock.BlockIndex, affectedBlock.CommitId});
             }
         }
+        skippedBlobs.emplace(ab->first, std::move(ab->second));
         args.AffectedBlobs.erase(ab);
     }
 
@@ -745,7 +735,7 @@ void ApplyBlobsSkipping(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RecreateBlobMetas(TTxPartition::TRangeCompaction& args, ui64 commitId)
+void RecreateBlobMetas(TTxPartition::TRangeCompaction& args, ui64 commitId, ui64 tabletId)
 {
     for (auto& [blobId, ab]: args.AffectedBlobs) {
         if (ab.MergedBlobsSpecificInfo) {
@@ -766,7 +756,10 @@ void RecreateBlobMetas(TTxPartition::TRangeCompaction& args, ui64 commitId)
 
         auto& meta = ab.RecreatedBlobMeta.ConstructInPlace();
         auto* mixedBlocks = meta.MutableMixedBlocks();
-        Y_ABORT_UNLESS(ab.MixedBlobsSpecificInfo);
+        STORAGE_VERIFY(
+            ab.MixedBlobsSpecificInfo,
+            TWellKnownEntityTypes::TABLET,
+            tabletId);
         for (const auto& affectedBlock:
              ab.MixedBlobsSpecificInfo->AllVisitedBlocks)
         {
@@ -780,22 +773,21 @@ void AccountSkippedBlobsAndBlocks(
     const ui64 commitId,
     const ui64 tabletId,
     const TAffectedBlobs& affectedBlobs,
-    const TAffectedBlobs& blobsSkippedByCommitId,
+    const TAffectedBlobs& skippedBlobs,
     ui32& blobsSkipped,
     ui32& blocksSkipped,
     ui32& mixedBlocksSkipped)
 {
-    // Account for blobs and blocks whose commit ID is greater than the commit ID
-    // of the range compaction. So they are visible for compaction map.
-    blobsSkipped += blobsSkippedByCommitId.size();
-    for (const auto& [blobId, ab]: blobsSkippedByCommitId) {
+    // Fully skipped blobs retain all their blocks in the compaction range,
+    // including overwritten blocks and blocks newer than the compaction.
+    blobsSkipped += skippedBlobs.size();
+    for (const auto& [blobId, ab]: skippedBlobs) {
         if (IsDeletionMarker(blobId)) {
             continue;
         }
 
         switch (*ab.IndexKind) {
             case EChannelDataKind::Mixed:
-
                 STORAGE_VERIFY(
                     ab.MixedBlobsSpecificInfo,
                     TWellKnownEntityTypes::TABLET,
@@ -809,6 +801,11 @@ void AccountSkippedBlobsAndBlocks(
 
                 break;
             case EChannelDataKind::Merged:
+                STORAGE_VERIFY(
+                    ab.MergedBlobsSpecificInfo,
+                    TWellKnownEntityTypes::TABLET,
+                    tabletId);
+
                 blocksSkipped += ab.MergedBlobsSpecificInfo->BlocksInRange;
                 break;
             default:
@@ -873,14 +870,15 @@ void PrepareRangeCompaction(
         true,   // precharge
         state.GetMaxBlocksInBlob());
 
-    auto blobsSkippedByCommitId = visitor.Finish();
+    auto skippedBlobs = visitor.Finish();
 
     if (ready && maxSkippedBlobs > 0) {
         ApplyBlobsSkipping(
             config,
             maxSkippedBlobs,
             state,
-            args);
+            args,
+            skippedBlobs);
     }
 
     const ui32 checksumBoundary =
@@ -901,7 +899,7 @@ void PrepareRangeCompaction(
         commitId,
         tabletId,
         args.AffectedBlobs,
-        blobsSkippedByCommitId,
+        skippedBlobs,
         args.BlobsSkipped,
         args.BlocksSkipped,
         args.MixedBlocksSkipped);
@@ -961,7 +959,7 @@ void CompleteRangeCompaction(
     }
 
     if (shouldRecreateBlobMetas) {
-        RecreateBlobMetas(args, commitId);
+        RecreateBlobMetas(args, commitId, tabletId);
     }
 
     rangeCompactionInfos.emplace_back(

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -690,7 +690,7 @@ void ApplyBlobsSkipping(
         ApplyMixedBlocksSkipping(blobsToSkip, args);
     }
 
-    TAffectedBlocks skippedBlocks;
+    THashSet<ui32> skippedBlockIndices;
 
     for (const auto& x: blobsToSkip) {
         auto ab = args.AffectedBlobs.find(x.first);
@@ -703,23 +703,16 @@ void ApplyBlobsSkipping(
                 // but it does not cause data corruption - the important thing
                 // is to ensure that all skipped indices are added, not that
                 // all non-skipped are preserved
-
-                skippedBlocks.push_back(
-                    {affectedBlock.BlockIndex, affectedBlock.CommitId});
+                skippedBlockIndices.insert(affectedBlock.BlockIndex);
             }
         }
-        skippedBlobs.emplace(ab->first, std::move(ab->second));
         args.AffectedBlobs.erase(ab);
     }
-
-    Sort(skippedBlocks);
 
     if (blobsToSkip.size()) {
         TAffectedBlocks affectedBlocks;
         for (const auto& b: args.AffectedBlocks) {
-            const bool isSkipped =
-                BinarySearch(skippedBlocks.begin(), skippedBlocks.end(), b);
-            if (!isSkipped) {
+            if (!skippedBlockIndices.contains(b.BlockIndex)) {
                 affectedBlocks.push_back(b);
             }
         }

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -706,6 +706,7 @@ void ApplyBlobsSkipping(
                 skippedBlockIndices.insert(affectedBlock.BlockIndex);
             }
         }
+        skippedBlobs.emplace(ab->first, std::move(ab->second));
         args.AffectedBlobs.erase(ab);
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -174,10 +174,6 @@ public:
         ab.MinCommitIdInCompactionRange =
             std::min(commitId, ab.MinCommitIdInCompactionRange);
 
-        if (commitId > MaxCommitId) {
-            return true;
-        }
-
         STORAGE_VERIFY_C(
             ab.CompactionRangeCount == 0 ||
                 ab.CompactionRangeCount == compactionRangeCount,
@@ -191,6 +187,18 @@ public:
         ab.CompactionRangeCount = compactionRangeCount;
         ab.IndexKind = EChannelDataKind::Mixed;
 
+        // Track all visited blocks for mixed blobs to restore compaction map
+        // counters correctly
+        if (!ab.MixedBlobsSpecificInfo) {
+            ab.MixedBlobsSpecificInfo.ConstructInPlace();
+        }
+        ab.MixedBlobsSpecificInfo->AllVisitedBlocks.push_back(
+            {blockIndex, commitId});
+
+        if (commitId > MaxCommitId) {
+            return true;
+        }
+
         Args.MarkBlock(
             blockIndex,
             commitId,
@@ -203,7 +211,7 @@ public:
     bool Visit(
         TBlockRange32 blockRange,
         const TPartialBlobId& blobId,
-        ui32 skippedBlocksCount) override
+        const TBlockMask& skipMask) override
     {
         auto& ab = Args.AffectedBlobs[blobId];
         ab.MaxCommitIdInCompactionRange = blobId.CommitId();
@@ -214,25 +222,40 @@ public:
 
         ab.MergedBlobsSpecificInfo.ConstructInPlace();
         ab.MergedBlobsSpecificInfo->BlockRange = blockRange;
-        ab.MergedBlobsSpecificInfo->SkippedBlocksCount = skippedBlocksCount;
+        ab.MergedBlobsSpecificInfo->SkippedBlocksCount = skipMask.Count();
+
+        const ui32 start = Max(blockRange.Start, Args.BlockRange.Start);
+        const ui32 end = Min(blockRange.End, Args.BlockRange.End);
+
+        for (ui32 i = 0; i < end - start + 1; ++i) {
+            const ui32 blobOffset = start - blockRange.Start + i;
+            if (!skipMask.Get(blobOffset)) {
+                ab.MergedBlobsSpecificInfo->BlocksInRange++;
+            }
+        }
 
         ab.IndexKind = EChannelDataKind::Merged;
         return true;
     }
 
-    void Finish()
+    // Returns blobs that do not have any blocks in the compaction range with
+    // an available commit ID.
+    THashMap<TPartialBlobId, TAffectedBlob, TPartialBlobIdHash> Finish()
     {
-        TVector<TPartialBlobId> blobIdsToDelete;
+        THashMap<TPartialBlobId, TAffectedBlob, TPartialBlobIdHash>
+            blobsToDelete;
 
-        for (const auto& [blobId, ab]: Args.AffectedBlobs) {
+        for (auto& [blobId, ab]: Args.AffectedBlobs) {
             if (ab.MinCommitIdInCompactionRange > MaxCommitId) {
-                blobIdsToDelete.push_back(blobId);
+                blobsToDelete.emplace(blobId, std::move(ab));
             }
         }
 
-        for (const auto& blobId: blobIdsToDelete) {
+        for (const auto& [blobId, _]: blobsToDelete) {
             Args.AffectedBlobs.erase(blobId);
         }
+
+        return blobsToDelete;
     }
 };
 
@@ -667,7 +690,7 @@ void ApplyBlobsSkipping(
         ApplyMixedBlocksSkipping(blobsToSkip, args);
     }
 
-    args.BlobsSkipped = blobsToSkip.size();
+    args.BlobsSkipped += blobsToSkip.size();
     for (const auto& [blobId, skippedBlockCount]: blobsToSkip) {
         args.BlocksSkipped += skippedBlockCount;
 
@@ -678,25 +701,35 @@ void ApplyBlobsSkipping(
         }
     }
 
-    THashSet<ui32> skippedBlockIndices;
+    TAffectedBlocks skippedBlocks;
 
     for (const auto& x: blobsToSkip) {
         auto ab = args.AffectedBlobs.find(x.first);
         Y_ABORT_UNLESS(ab != args.AffectedBlobs.end());
-        for (const auto& affectedBlock: ab->second.AffectedBlocks) {
-            // we can actually add extra indices to skippedBlockIndices,
-            // but it does not cause data corruption - the important thing
-            // is to ensure that all skipped indices are added, not that
-            // all non-skipped are preserved
-            skippedBlockIndices.insert(affectedBlock.BlockIndex);
+        if (ab->second.MixedBlobsSpecificInfo) {
+            for (const auto& affectedBlock:
+                 ab->second.MixedBlobsSpecificInfo->AllVisitedBlocks)
+            {
+                // we can actually add extra indices to skippedBlockIndices,
+                // but it does not cause data corruption - the important thing
+                // is to ensure that all skipped indices are added, not that
+                // all non-skipped are preserved
+
+                skippedBlocks.push_back(
+                    {affectedBlock.BlockIndex, affectedBlock.CommitId});
+            }
         }
         args.AffectedBlobs.erase(ab);
     }
 
+    Sort(skippedBlocks);
+
     if (blobsToSkip.size()) {
         TAffectedBlocks affectedBlocks;
         for (const auto& b: args.AffectedBlocks) {
-            if (!skippedBlockIndices.contains(b.BlockIndex)) {
+            const bool isSkipped =
+                BinarySearch(skippedBlocks.begin(), skippedBlocks.end(), b);
+            if (!isSkipped) {
                 affectedBlocks.push_back(b);
             }
         }
@@ -733,10 +766,80 @@ void RecreateBlobMetas(TTxPartition::TRangeCompaction& args, ui64 commitId)
 
         auto& meta = ab.RecreatedBlobMeta.ConstructInPlace();
         auto* mixedBlocks = meta.MutableMixedBlocks();
-        for (const auto& affectedBlock: ab.AffectedBlocks) {
+        Y_ABORT_UNLESS(ab.MixedBlobsSpecificInfo);
+        for (const auto& affectedBlock:
+             ab.MixedBlobsSpecificInfo->AllVisitedBlocks)
+        {
             mixedBlocks->AddBlocks(affectedBlock.BlockIndex);
             mixedBlocks->AddCommitIds(affectedBlock.CommitId);
         }
+    }
+}
+
+void AccountSkippedBlobsAndBlocks(
+    const ui64 commitId,
+    const ui64 tabletId,
+    const TAffectedBlobs& affectedBlobs,
+    const TAffectedBlobs& blobsSkippedByCommitId,
+    ui32& blobsSkipped,
+    ui32& blocksSkipped,
+    ui32& mixedBlocksSkipped)
+{
+    // Account for blobs and blocks whose commit ID is greater than the commit ID
+    // of the range compaction. So they are visible for compaction map.
+    blobsSkipped += blobsSkippedByCommitId.size();
+    for (const auto& [blobId, ab]: blobsSkippedByCommitId) {
+        if (IsDeletionMarker(blobId)) {
+            continue;
+        }
+
+        switch (*ab.IndexKind) {
+            case EChannelDataKind::Mixed:
+
+                STORAGE_VERIFY(
+                    ab.MixedBlobsSpecificInfo,
+                    TWellKnownEntityTypes::TABLET,
+                    tabletId);
+
+                blocksSkipped +=
+                    ab.MixedBlobsSpecificInfo->AllVisitedBlocks.size();
+
+                mixedBlocksSkipped +=
+                    ab.MixedBlobsSpecificInfo->AllVisitedBlocks.size();
+
+                break;
+            case EChannelDataKind::Merged:
+                blocksSkipped += ab.MergedBlobsSpecificInfo->BlocksInRange;
+                break;
+            default:
+                STORAGE_VERIFY_C(
+                    false,
+                    TWellKnownEntityTypes::TABLET,
+                    tabletId,
+                    TStringBuilder() << "Unknown channel data kind: "
+                                     << static_cast<ui32>(*ab.IndexKind));
+        }
+    }
+
+    for (const auto& [blobId, ab]: affectedBlobs) {
+        // AllVisitedBlocks is filled only for mixed blobs. All blocks in a
+        // merged blob have the same commit ID, so blocks newer than the range
+        // compaction were already added to skipped blocks.
+        if (!ab.MixedBlobsSpecificInfo) {
+            continue;
+        }
+        for (const auto& affectedBlock:
+             ab.MixedBlobsSpecificInfo->AllVisitedBlocks)
+        {
+            if (affectedBlock.CommitId > commitId && !IsDeletionMarker(blobId))
+            {
+                ++blocksSkipped;
+                ++mixedBlocksSkipped;
+            }
+        }
+
+        blobsSkipped +=
+            static_cast<ui32>(ab.MaxCommitIdInCompactionRange > commitId);
     }
 }
 
@@ -768,10 +871,9 @@ void PrepareRangeCompaction(
         visitor,
         args.BlockRange,
         true,   // precharge
-        state.GetMaxBlocksInBlob(),
-        commitId);
+        state.GetMaxBlocksInBlob());
 
-    visitor.Finish();
+    auto blobsSkippedByCommitId = visitor.Finish();
 
     if (ready && maxSkippedBlobs > 0) {
         ApplyBlobsSkipping(
@@ -794,6 +896,15 @@ void PrepareRangeCompaction(
         state,
         blobsToReadBlockMasks,
         blobsToReadBlobMetas);
+
+    AccountSkippedBlobsAndBlocks(
+        commitId,
+        tabletId,
+        args.AffectedBlobs,
+        blobsSkippedByCommitId,
+        args.BlobsSkipped,
+        args.BlocksSkipped,
+        args.MixedBlocksSkipped);
 }
 
 void CompleteRangeCompaction(

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
@@ -114,16 +114,20 @@ void ApplyBlobsSkipping(
     const TStorageConfig& config,
     const ui32 maxSkippedBlobs,
     TPartitionState& state,
-    TTxPartition::TRangeCompaction& args);
+    TTxPartition::TRangeCompaction& args,
+    TAffectedBlobs& skippedBlobs);
 
-void RecreateBlobMetas(TTxPartition::TRangeCompaction& args, ui64 commitId);
+void RecreateBlobMetas(
+    TTxPartition::TRangeCompaction& args,
+    ui64 commitId,
+    ui64 tabletId);
 
-// Account for blobs and blocks skipped because of their commit ID.
+// Account for blobs and blocks skipped by incremental compaction or commit ID.
 void AccountSkippedBlobsAndBlocks(
     const ui64 commitId,
     const ui64 tabletId,
     const TAffectedBlobs& affectedBlobs,
-    const TAffectedBlobs& blobsSkippedByCommitId,
+    const TAffectedBlobs& skippedBlobs,
     ui32& blobsSkipped,
     ui32& blocksSkipped,
     ui32& mixedBlocksSkipped);

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
@@ -50,9 +50,9 @@ struct TRangeCompactionInfo
     const TBlockMask DataBlobSkipMask;
     const TPartialBlobId ZeroBlobId;
     const TBlockMask ZeroBlobSkipMask;
-    const ui32 BlobsSkippedByCompaction;
-    const ui32 BlocksSkippedByCompaction;
-    const ui32 MixedBlockCountSkippedByCompaction;
+    ui32 BlobsSkippedByCompaction;
+    ui32 BlocksSkippedByCompaction;
+    ui32 MixedBlockCountSkippedByCompaction;
     TVector<std::optional<ui32>> BlockChecksums;
     const EChannelDataKind ChannelDataKind;
 
@@ -116,9 +116,17 @@ void ApplyBlobsSkipping(
     TPartitionState& state,
     TTxPartition::TRangeCompaction& args);
 
-////////////////////////////////////////////////////////////////////////////////
-
 void RecreateBlobMetas(TTxPartition::TRangeCompaction& args, ui64 commitId);
+
+// Account for blobs and blocks skipped because of their commit ID.
+void AccountSkippedBlobsAndBlocks(
+    const ui64 commitId,
+    const ui64 tabletId,
+    const TAffectedBlobs& affectedBlobs,
+    const TAffectedBlobs& blobsSkippedByCommitId,
+    ui32& blobsSkipped,
+    ui32& blocksSkipped,
+    ui32& mixedBlocksSkipped);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -319,9 +319,6 @@ Y_UNIT_TEST_SUITE(TApplyBlobsSkippingTest)
         UNIT_ASSERT_VALUES_EQUAL(3, args.BlocksSkipped);
         UNIT_ASSERT(!args.AffectedBlobs.contains(skippedBlobId));
         UNIT_ASSERT(args.AffectedBlobs.contains(preservedBlobId));
-        UNIT_ASSERT_VALUES_EQUAL(1, args.AffectedBlocks.size());
-        UNIT_ASSERT_VALUES_EQUAL(0, args.AffectedBlocks[0].BlockIndex);
-        UNIT_ASSERT_VALUES_EQUAL(10, args.AffectedBlocks[0].CommitId);
         UNIT_ASSERT(!args.BlockMarks[0].CommitId);
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -124,13 +124,13 @@ TTxPartition::TRangeCompaction MakeArgs()
         TBlockRange32::MakeClosedInterval(0, 7));
 }
 
-TAffectedBlob MakeFullyAvailableMixedBlob(
-    TVector<TAffectedBlock> affectedBlocks)
+TAffectedBlob MakeFullyAvailableMixedBlob(TVector<TAffectedBlock> visitedBlocks)
 {
     TAffectedBlob ab;
     ab.CompactionRangeCount = 1;
     ab.MaxCommitIdInCompactionRange = CommitId;
-    ab.AffectedBlocks = std::move(affectedBlocks);
+    ab.MixedBlobsSpecificInfo.ConstructInPlace();
+    ab.MixedBlobsSpecificInfo->AllVisitedBlocks = std::move(visitedBlocks);
     return ab;
 }
 
@@ -238,7 +238,7 @@ Y_UNIT_TEST_SUITE(TApplyBlobsSkippingTest)
 
         args.MarkBlock(0, CommitId, mixedBlobId, 0, true);
         args.MarkBlock(1, CommitId, mixedBlobId, 1, true);
-        args.MarkBlock(2, CommitId, mergedBlobId, 0, true);
+        args.MarkBlock(2, CommitId, mergedBlobId, 0, false);
 
         args.AffectedBlobs[mixedBlobId].IndexKind =
             EChannelDataKind::Mixed;
@@ -264,6 +264,61 @@ Y_UNIT_TEST_SUITE(TApplyBlobsSkippingTest)
         UNIT_ASSERT_VALUES_EQUAL(mixedBlobId, args.BlockMarks[0].BlobId);
         UNIT_ASSERT_VALUES_EQUAL(mixedBlobId, args.BlockMarks[1].BlobId);
         UNIT_ASSERT(!args.BlockMarks[2].CommitId);
+    }
+
+    Y_UNIT_TEST(ShouldPreserveOtherVersionsOfSkippedMixedBlobBlocks)
+    {
+        auto state = MakeState();
+        auto config = MakeStorageConfig(
+            0,   // diskPrefixLength
+            0);  // targetCompactionBytesPerOp
+
+        const TPartialBlobId skippedBlobId(
+            1,
+            1,
+            3,
+            DefaultBlockSize,
+            1,
+            0);
+        const TPartialBlobId preservedBlobId(
+            1,
+            1,
+            3,
+            DefaultBlockSize,
+            2,
+            0);
+
+        auto args = MakeArgs();
+        args.MarkBlock(0, 20, skippedBlobId, 0, true);
+        args.MarkBlock(0, 10, preservedBlobId, 0, true);
+
+        auto& skippedBlob = args.AffectedBlobs.at(skippedBlobId);
+        skippedBlob.IndexKind = EChannelDataKind::Mixed;
+        skippedBlob.MixedBlobsSpecificInfo.ConstructInPlace();
+        skippedBlob.MixedBlobsSpecificInfo->AllVisitedBlocks.push_back(
+            {.BlockIndex = 0, .CommitId = 20});
+
+        auto& preservedBlob = args.AffectedBlobs.at(preservedBlobId);
+        preservedBlob.IndexKind = EChannelDataKind::Mixed;
+        preservedBlob.MixedBlobsSpecificInfo.ConstructInPlace();
+        preservedBlob.MixedBlobsSpecificInfo->AllVisitedBlocks.push_back(
+            {.BlockIndex = 0, .CommitId = 10});
+
+        // We fill these fileds with non zero values to be sure that skip
+        // function increments counters, not resets them.
+        args.BlobsSkipped = 2;
+        args.BlocksSkipped = 3;
+
+        ApplyBlobsSkipping(*config, 1, state, args);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, args.BlobsSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(4, args.BlocksSkipped);
+        UNIT_ASSERT(!args.AffectedBlobs.contains(skippedBlobId));
+        UNIT_ASSERT(args.AffectedBlobs.contains(preservedBlobId));
+        UNIT_ASSERT_VALUES_EQUAL(1, args.AffectedBlocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, args.AffectedBlocks[0].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(10, args.AffectedBlocks[0].CommitId);
+        UNIT_ASSERT(!args.BlockMarks[0].CommitId);
     }
 }
 
@@ -417,6 +472,58 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         UNIT_ASSERT(ready);
         UNIT_ASSERT_VALUES_EQUAL(1, blobsToReadBlockMasks.size());
         UNIT_ASSERT(blobsToReadBlockMasks.contains(blobId));
+    }
+
+    Y_UNIT_TEST(PrepareCountsUnskippedMergedBlocksInCompactionRange)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        const auto blobRange = TBlockRange32::MakeClosedInterval(100, 104);
+        TBlockMask skipMask;
+        skipMask.Set(1);
+        skipMask.Set(3);
+
+        TPartialBlobId blobId;
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(blobRange.Size());
+                db.WriteMergedBlocks(blobId, blobRange, skipMask);
+            });
+
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(101, 103));
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *MakeStorageConfig(),
+                    0,
+                    MakeCommitId(0, 100),
+                    TTestExecutor::TabletId,
+                    true,
+                    false,   // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT(args.AffectedBlobs.contains(blobId));
+        const auto& info =
+            args.AffectedBlobs.at(blobId).MergedBlobsSpecificInfo;
+        UNIT_ASSERT(info);
+        UNIT_ASSERT_VALUES_EQUAL(1, info->BlocksInRange);
     }
 
     // PrepareRangeCompaction: a blob already in the cleanup queue gets a full
@@ -893,6 +1000,119 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         UNIT_ASSERT_VALUES_EQUAL(1, ab.CompactionRangeCount);
         UNIT_ASSERT(ab.MaxCommitIdInCompactionRange > compactionCommitId);
         UNIT_ASSERT(!ab.RecreatedBlobMeta);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            result.RangeCompactionInfos[0].BlobsSkippedByCompaction);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            result.RangeCompactionInfos[0].BlocksSkippedByCompaction);
+    }
+
+    Y_UNIT_TEST(PrepareAccountsMixedBlobWithoutBlocksVisibleToCompaction)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        const auto compactionCommitId = MakeCommitId(0, 100);
+        TPartialBlobId blobId;
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(2);
+                state.WriteMixedBlock(
+                    db,
+                    TMixedBlock(blobId, MakeCommitId(0, 101), 0, 0, 1));
+                state.WriteMixedBlock(
+                    db,
+                    TMixedBlock(blobId, MakeCommitId(0, 102), 1, 1, 1));
+            });
+
+        auto args = MakeArgs();
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *MakeStorageConfig(),
+                    0,
+                    compactionCommitId,
+                    TTestExecutor::TabletId,
+                    true,
+                    false,   // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT(!args.AffectedBlobs.contains(blobId));
+        UNIT_ASSERT_VALUES_EQUAL(1, args.BlobsSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(2, args.BlocksSkipped);
+        UNIT_ASSERT(blobsToReadBlockMasks.empty());
+        UNIT_ASSERT(blobsToReadBlobMetas.empty());
+    }
+}
+
+Y_UNIT_TEST_SUITE(TAccountSkippedBlobsAndBlocksTest)
+{
+    Y_UNIT_TEST(ShouldAddMixedAndMergedCommitIdSkipsToExistingCounters)
+    {
+        const auto activeMixedBlobId = TPartialBlobId(1, 0, 3, 1024, 0, 0);
+        const auto skippedMixedBlobId = TPartialBlobId(2, 0, 3, 1024, 0, 0);
+        const auto skippedMergedBlobId = TPartialBlobId(3, 0, 3, 1024, 0, 0);
+
+        TAffectedBlobs affectedBlobs;
+        auto& activeMixedBlob = affectedBlobs[activeMixedBlobId];
+        activeMixedBlob.MinCommitIdInCompactionRange = CommitId - 1;
+        activeMixedBlob.MaxCommitIdInCompactionRange = CommitId + 2;
+        activeMixedBlob.MixedBlobsSpecificInfo.ConstructInPlace();
+        activeMixedBlob.MixedBlobsSpecificInfo->AllVisitedBlocks = {
+            {.BlockIndex = 1, .CommitId = CommitId - 1},
+            {.BlockIndex = 2, .CommitId = CommitId},
+            {.BlockIndex = 3, .CommitId = CommitId + 1},
+            {.BlockIndex = 4, .CommitId = CommitId + 2},
+        };
+
+        TAffectedBlobs blobsSkippedByCommitId;
+        auto& skippedMixedBlob =
+            blobsSkippedByCommitId[skippedMixedBlobId];
+        skippedMixedBlob.IndexKind = EChannelDataKind::Mixed;
+        skippedMixedBlob.MixedBlobsSpecificInfo.ConstructInPlace();
+        skippedMixedBlob.MixedBlobsSpecificInfo->AllVisitedBlocks = {
+            {.BlockIndex = 5, .CommitId = CommitId + 1},
+            {.BlockIndex = 6, .CommitId = CommitId + 1},
+            {.BlockIndex = 7, .CommitId = CommitId + 2},
+        };
+
+        auto& skippedMergedBlob =
+            blobsSkippedByCommitId[skippedMergedBlobId];
+        skippedMergedBlob.IndexKind = EChannelDataKind::Merged;
+        skippedMergedBlob.MergedBlobsSpecificInfo.ConstructInPlace();
+        skippedMergedBlob.MergedBlobsSpecificInfo->BlocksInRange = 4;
+
+        ui32 blobsSkipped = 0;
+        ui32 blocksSkipped = 0;
+        ui32 mixedBlocksSkipped = 0;
+
+        AccountSkippedBlobsAndBlocks(
+            CommitId,
+            TTestExecutor::TabletId,
+            affectedBlobs,
+            blobsSkippedByCommitId,
+            blobsSkipped,
+            blocksSkipped,
+            mixedBlocksSkipped);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, blobsSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(9, blocksSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(5, mixedBlocksSkipped);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -245,14 +245,16 @@ Y_UNIT_TEST_SUITE(TApplyBlobsSkippingTest)
         args.AffectedBlobs[mergedBlobId].IndexKind =
             EChannelDataKind::Merged;
 
+        TAffectedBlobs skippedBlobs;
         ApplyBlobsSkipping(
             *config,
             2,
             state,
-            args);
+            args,
+            skippedBlobs);
 
-        UNIT_ASSERT_VALUES_EQUAL(1, args.BlobsSkipped);
-        UNIT_ASSERT_VALUES_EQUAL(1, args.BlocksSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(1, skippedBlobs.size());
+        UNIT_ASSERT(skippedBlobs.contains(mergedBlobId));
 
         UNIT_ASSERT(args.AffectedBlobs.contains(mixedBlobId));
         UNIT_ASSERT(!args.AffectedBlobs.contains(mergedBlobId));
@@ -304,15 +306,17 @@ Y_UNIT_TEST_SUITE(TApplyBlobsSkippingTest)
         preservedBlob.MixedBlobsSpecificInfo->AllVisitedBlocks.push_back(
             {.BlockIndex = 0, .CommitId = 10});
 
-        // We fill these fileds with non zero values to be sure that skip
-        // function increments counters, not resets them.
+        // Skipping leaves counter accounting to AccountSkippedBlobsAndBlocks.
         args.BlobsSkipped = 2;
         args.BlocksSkipped = 3;
 
-        ApplyBlobsSkipping(*config, 1, state, args);
+        TAffectedBlobs skippedBlobs;
+        ApplyBlobsSkipping(*config, 1, state, args, skippedBlobs);
 
-        UNIT_ASSERT_VALUES_EQUAL(3, args.BlobsSkipped);
-        UNIT_ASSERT_VALUES_EQUAL(4, args.BlocksSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(1, skippedBlobs.size());
+        UNIT_ASSERT(skippedBlobs.contains(skippedBlobId));
+        UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(3, args.BlocksSkipped);
         UNIT_ASSERT(!args.AffectedBlobs.contains(skippedBlobId));
         UNIT_ASSERT(args.AffectedBlobs.contains(preservedBlobId));
         UNIT_ASSERT_VALUES_EQUAL(1, args.AffectedBlocks.size());
@@ -1008,6 +1012,86 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
             result.RangeCompactionInfos[0].BlocksSkippedByCompaction);
     }
 
+    Y_UNIT_TEST(PrepareAccountsAllBlocksInIncrementallySkippedBlobs)
+    {
+        for (bool mixed: {false, true}) {
+            auto state = MakeState();
+            TTestExecutor executor;
+            executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+            const TPartialBlobId skippedBlobId(
+                0, 50, 3, 4 * DefaultBlockSize, 0, 0);
+            const TPartialBlobId compactedBlobId(
+                0, 90, 3, DefaultBlockSize, 0, 0);
+            const TPartialBlobId newerBlobId(
+                0, 150, 3, DefaultBlockSize, 0, 0);
+
+            executor.WriteTx(
+                [&](TPartitionDatabase db)
+                {
+                    if (mixed) {
+                        for (ui32 i = 0; i < 4; ++i) {
+                            state.WriteMixedBlock(
+                                db,
+                                TMixedBlock(
+                                    skippedBlobId,
+                                    i == 3 ? 150 : 50,
+                                    i,
+                                    i,
+                                    1));
+                        }
+                    } else {
+                        TBlockMask skipMask;
+                        skipMask.Set(3);
+                        db.WriteMergedBlocks(
+                            skippedBlobId,
+                            TBlockRange32::MakeClosedInterval(0, 3),
+                            skipMask);
+                    }
+                    // Overwrite one block of the incrementally skipped blob.
+                    db.WriteMergedBlocks(
+                        compactedBlobId,
+                        TBlockRange32::WithLength(0, 1),
+                        TBlockMask{});
+                    db.WriteMergedBlocks(
+                        newerBlobId,
+                        TBlockRange32::WithLength(4, 1),
+                        TBlockMask{});
+                });
+
+            auto args = MakeArgs();
+            THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+            THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+            bool ready = true;
+
+            executor.ReadTx(
+                [&](TPartitionDatabase db)
+                {
+                    PrepareRangeCompaction(
+                        *MakeStorageConfig(0, 0),
+                        1,
+                        CommitId,
+                        TTestExecutor::TabletId,
+                        true,
+                        false,
+                        ready,
+                        db,
+                        state,
+                        args,
+                        blobsToReadBlockMasks,
+                        blobsToReadBlobMetas);
+                });
+
+            UNIT_ASSERT(ready);
+            UNIT_ASSERT_VALUES_EQUAL(1, args.AffectedBlobs.size());
+            UNIT_ASSERT(args.AffectedBlobs.contains(compactedBlobId));
+            UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsSkipped);
+            // Include overwritten blocks and, for mixed blobs, newer blocks.
+            UNIT_ASSERT_VALUES_EQUAL(mixed ? 5 : 4, args.BlocksSkipped);
+            UNIT_ASSERT_VALUES_EQUAL(mixed ? 4 : 0, args.MixedBlocksSkipped);
+        }
+    }
+
     Y_UNIT_TEST(PrepareAccountsMixedBlobWithoutBlocksVisibleToCompaction)
     {
         auto state = MakeState();
@@ -1130,7 +1214,7 @@ Y_UNIT_TEST_SUITE(TRecreateBlobMetasTest)
         ab.MergedBlobsSpecificInfo->SkippedBlocksCount = 11;
         args.AffectedBlobs.emplace(blobId, std::move(ab));
 
-        RecreateBlobMetas(args, CommitId);
+        RecreateBlobMetas(args, CommitId, TTestExecutor::TabletId);
 
         const auto& recreatedMeta =
             args.AffectedBlobs.at(blobId).RecreatedBlobMeta;
@@ -1156,7 +1240,7 @@ Y_UNIT_TEST_SUITE(TRecreateBlobMetasTest)
                 {.BlockIndex = 7, .CommitId = 80},
             }));
 
-        RecreateBlobMetas(args, CommitId);
+        RecreateBlobMetas(args, CommitId, TTestExecutor::TabletId);
 
         const auto& recreatedMeta =
             args.AffectedBlobs.at(blobId).RecreatedBlobMeta;
@@ -1184,7 +1268,7 @@ Y_UNIT_TEST_SUITE(TRecreateBlobMetasTest)
         ab.CompactionRangeCount = 2;
         args.AffectedBlobs.emplace(blobId, std::move(ab));
 
-        RecreateBlobMetas(args, CommitId);
+        RecreateBlobMetas(args, CommitId, TTestExecutor::TabletId);
 
         UNIT_ASSERT(!args.AffectedBlobs.at(blobId).RecreatedBlobMeta);
     }
@@ -1200,7 +1284,7 @@ Y_UNIT_TEST_SUITE(TRecreateBlobMetasTest)
         ab.MaxCommitIdInCompactionRange = CommitId + 1;
         args.AffectedBlobs.emplace(blobId, std::move(ab));
 
-        RecreateBlobMetas(args, CommitId);
+        RecreateBlobMetas(args, CommitId, TTestExecutor::TabletId);
 
         UNIT_ASSERT(!args.AffectedBlobs.at(blobId).RecreatedBlobMeta);
     }
@@ -1217,7 +1301,7 @@ Y_UNIT_TEST_SUITE(TRecreateBlobMetasTest)
                 {.BlockIndex = 3, .CommitId = CommitId},
             }));
 
-        RecreateBlobMetas(args, CommitId);
+        RecreateBlobMetas(args, CommitId, TTestExecutor::TabletId);
 
         const auto& recreatedMeta =
             args.AffectedBlobs.at(blobId).RecreatedBlobMeta;

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -534,7 +534,7 @@ bool TPartitionDatabaseImpl<TCounters>::FindMergedBlocks(
                 const auto skipMask = BlockMaskFromString(
                     it.template GetValueOrDefault<TTable::SkipMask>());
 
-                if (!blobsVisitor.Visit(range, blobId, skipMask.Count())) {
+                if (!blobsVisitor.Visit(range, blobId, skipMask)) {
                     return true;   // interrupted
                 }
 
@@ -592,11 +592,11 @@ bool TPartitionDatabaseImpl<TCounters>::FindMergedBlocks(
         bool Visit(
             TBlockRange32 blockRange,
             const TPartialBlobId& blobId,
-            ui32 skippedBlocksCount) override
+            const TBlockMask& skipMask) override
         {
             Y_UNUSED(blockRange);
             Y_UNUSED(blobId);
-            Y_UNUSED(skippedBlocksCount);
+            Y_UNUSED(skipMask);
             return true;
         }
     };

--- a/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
@@ -34,9 +34,9 @@ struct TTestBlockVisitor final
     bool Visit(
         TBlockRange32 blockRange,
         const TPartialBlobId& blobId,
-        ui32 skippedBlocksCount) override
+        const TBlockMask& skipMask) override
     {
-        Y_UNUSED(skippedBlocksCount);
+        Y_UNUSED(skipMask);
         BlobToRange[blobId] = blockRange;
 
         return true;

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -128,6 +128,8 @@ struct TAffectedBlock
 {
     ui32 BlockIndex = 0;
     ui64 CommitId = 0;
+
+    std::strong_ordering operator<=>(const TAffectedBlock&) const = default;
 };
 
 using TAffectedBlocks = TVector<TAffectedBlock>;
@@ -140,6 +142,12 @@ struct TAffectedBlob
     {
         TBlockRange32 BlockRange;
         ui32 SkippedBlocksCount = 0;
+        ui32 BlocksInRange = 0;
+    };
+
+    struct TMixedBlobsSpecificInfo
+    {
+        TAffectedBlocks AllVisitedBlocks;
     };
 
     ui8 CompactionRangeCount = 0;
@@ -148,6 +156,9 @@ struct TAffectedBlob
     // Filled only for merged blobs.
     TMaybe<TMergedBlobsSpecificInfo> MergedBlobsSpecificInfo;
 
+    // Filled only for mixed blobs.
+    TMaybe<TMixedBlobsSpecificInfo> MixedBlobsSpecificInfo;
+
     std::optional<EChannelDataKind> IndexKind;
 
     TVector<ui16> Offsets;
@@ -155,8 +166,6 @@ struct TAffectedBlob
     TMaybe<TBlockMask> BlockMask;
 
     bool BlobAlreadyInCleanupQueue = false;
-
-    TAffectedBlocks AffectedBlocks;
 
     // Filled only if a flag is set. BlobMeta is needed only to do some extra
     // consistency checks.

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -430,7 +430,6 @@ struct TTxPartition
             ab.Offsets.push_back(blobOffset);
 
             if (keepTrackOfAffectedBlocks) {
-                ab.AffectedBlocks.push_back({ blockIndex, commitId });
                 AffectedBlocks.push_back({ blockIndex, commitId });
             }
         }

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -16732,7 +16732,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 }
             });
 
-        // Intercepring write blob request to slow down compaction (as it should
+        // Intercepting write blob request to slow down compaction (as it should
         // wait for it before start executing).
         interceptWriteBlobRequest = true;
         partition.SendWriteBlocksRequest(1, '1');

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -6247,7 +6247,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         partition.ZeroBlocks(TBlockRange32::WithLength(20, 6));
 
-        runtime->Send(firstCompactionRequest.release());
+        runtime->SendAsync(firstCompactionRequest.release());
         runtime->DispatchEvents({}, TDuration::Seconds(1));
 
         UNIT_ASSERT(compactionResultObserved);
@@ -16697,6 +16697,83 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         partition.Drain();
     }
+
+    Y_UNIT_TEST(ShouldAccountForWritesNewerThanCompactionCommit)
+    {
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 'A');
+
+        partition.WriteBlocks(0, '0');
+
+        std::unique_ptr<IEventHandle> writeBlobRequest;
+
+        bool interceptWriteBlobRequest = true;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::EvWriteBlobRequest &&
+                    interceptWriteBlobRequest)
+                {
+                    writeBlobRequest.reset(event.Release());
+
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendWriteBlocksRequest(1, '1');
+
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(writeBlobRequest);
+        interceptWriteBlobRequest = false;
+
+        partition.SendCompactionRequest();
+
+        runtime->DispatchEvents({}, 10ms);
+
+        partition.WriteBlocks(2, '2');
+
+        partition.Flush();
+        partition.TrimFreshLog();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(511, 512), 'B');
+
+        runtime->SendAsync(writeBlobRequest.release());
+
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(response->GetStatus(), S_OK);
+
+        partition.Cleanup();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('0'),
+            GetBlockContent(partition.ReadBlocks(0)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('1'),
+            GetBlockContent(partition.ReadBlocks(1)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('2'),
+            GetBlockContent(partition.ReadBlocks(2)));
+
+        const auto counters = partition.GetCompactionCounters(0);
+        UNIT_ASSERT_VALUES_EQUAL(3, counters->Counters.BlobCount);
+        UNIT_ASSERT_VALUES_EQUAL(512 + 1 + 1024, counters->Counters.BlockCount);
+    }
+
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -6254,7 +6254,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         const auto counters = partition.GetCompactionCounters(0);
         UNIT_ASSERT_VALUES_EQUAL(3, counters->Counters.BlobCount);
-        UNIT_ASSERT_VALUES_EQUAL(1018, counters->Counters.BlockCount);
+        // All 1024 blocks remain in the skipped blob, plus 10 compacted blocks.
+        UNIT_ASSERT_VALUES_EQUAL(1034, counters->Counters.BlockCount);
     }
 
     Y_UNIT_TEST(ShouldPreserveSkippedCountersForMixedCompactionResults)
@@ -16698,6 +16699,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.Drain();
     }
 
+    // Test that writes with commit id newer than compaction commit id and can
+    // be observed in compaction tx should be accounted for skipped blobs and
+    // blocks.
     Y_UNIT_TEST(ShouldAccountForWritesNewerThanCompactionCommit)
     {
         auto config = DefaultConfig();
@@ -16709,15 +16713,15 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         TPartitionClient partition(*runtime);
         partition.WaitReady();
 
+        // Just some writes before compaction.
         partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 'A');
-
         partition.WriteBlocks(0, '0');
 
         std::unique_ptr<IEventHandle> writeBlobRequest;
 
-        bool interceptWriteBlobRequest = true;
+        bool interceptWriteBlobRequest = false;
 
-        runtime->SetObserverFunc(
+        auto observer = runtime->AddObserver(
             [&](TAutoPtr<IEventHandle>& event)
             {
                 if (event->GetTypeRewrite() ==
@@ -16725,17 +16729,14 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                     interceptWriteBlobRequest)
                 {
                     writeBlobRequest.reset(event.Release());
-
-                    return TTestActorRuntime::EEventAction::DROP;
                 }
-
-                return TTestActorRuntime::DefaultObserverFunc(event);
             });
 
+        // Intercepring write blob request to slow down compaction (as it should
+        // wait for it before start executing).
+        interceptWriteBlobRequest = true;
         partition.SendWriteBlocksRequest(1, '1');
-
         runtime->DispatchEvents({}, 10ms);
-
         UNIT_ASSERT(writeBlobRequest);
         interceptWriteBlobRequest = false;
 
@@ -16743,37 +16744,35 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         runtime->DispatchEvents({}, 10ms);
 
+        // Do fresh write with commit id higher than compaction commit id and
+        // then flush to create a mixed blob that has commit ids less and
+        // greater than compaction commit id.
         partition.WriteBlocks(2, '2');
-
         partition.Flush();
         partition.TrimFreshLog();
 
+        // Merged blob newer than compaction.
         partition.WriteBlocks(TBlockRange32::WithLength(511, 512), 'B');
 
+        // Unblock write blob request to continue compaction.
         runtime->SendAsync(writeBlobRequest.release());
 
         auto response = partition.RecvCompactionResponse();
         UNIT_ASSERT_VALUES_EQUAL(response->GetStatus(), S_OK);
-
         partition.Cleanup();
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            GetBlockContent('0'),
-            GetBlockContent(partition.ReadBlocks(0)));
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            GetBlockContent('1'),
-            GetBlockContent(partition.ReadBlocks(1)));
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            GetBlockContent('2'),
-            GetBlockContent(partition.ReadBlocks(2)));
-
         const auto counters = partition.GetCompactionCounters(0);
+
+        // Check that compaction accounted for blocks and blobs that was written
+        // with commit id higher than compaction commit id.
+
+        // 1 compaction blob + 1 flush blob + 1 merged blob
         UNIT_ASSERT_VALUES_EQUAL(3, counters->Counters.BlobCount);
+        // 512 blocks form merged blob + 1 block from
+        // flush blob newer than compaction + 1024
+        // blocks from compaction merged blob
         UNIT_ASSERT_VALUES_EQUAL(512 + 1 + 1024, counters->Counters.BlockCount);
     }
-
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition


### PR DESCRIPTION
### Notes
During compaction account blobs and blocks with commit id higher than compaction commit Id in skipped blobs and blocks counters.
### Issue
#7057