### PR TITLE
issue-6956: extract journalled device into cloud/storage/core/libs

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent.h
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/spdk/iface/public.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 
 #include <cloud/storage/core/libs/rdma/iface/public.h>
 

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.h
@@ -23,6 +23,7 @@
 #include <cloud/blockstore/libs/storage/disk_agent/recent_blocks_tracker.h>
 
 #include <cloud/storage/core/libs/coroutine/public.h>
+#include <cloud/storage/core/libs/journalled_device/journalled_device.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/events.h>
@@ -196,7 +197,7 @@ private:
 
     void StartJournalledDeviceTcpServer(
         const NActors::TActorContext& ctx,
-        THashMap<TString, IJournalledDevicePtr> devices);
+        THashMap<TString, NJournalled::IJournalledDevicePtr> devices);
 
 private:
     STFUNC(StateInit);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -3,12 +3,13 @@
 #include <cloud/blockstore/libs/diagnostics/request_stats.h>
 #include <cloud/blockstore/libs/storage/disk_agent/actors/io_request_parser.h>
 #include <cloud/blockstore/libs/storage/disk_agent/actors/multi_agent_write_handler.h>
-#include <cloud/blockstore/libs/storage/disk_agent/journalled_device.h>
+#include <cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.h>
 
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/future_helper.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
+#include <cloud/storage/core/libs/journalled_device/journalled_device.h>
 
 #include <contrib/ydb/core/base/appdata.h>
 
@@ -172,12 +173,13 @@ void TDiskAgentActor::HandleInitAgentCompleted(
     }
 
     if (State) {
-        THashMap<TString, IJournalledDevicePtr> devices;
+        THashMap<TString, NJournalled::IJournalledDevicePtr> devices;
 
         for (const auto& deviceId: State->GetDeviceIds()) {
             devices.emplace(
                 deviceId,
-                CreateJournalledDevice(deviceId, State->GetDeviceClient()));
+                NJournalled::CreateJournalledDevice(
+                    CreateDeviceAdapter(deviceId, State->GetDeviceClient())));
         }
 
         StartJournalledDeviceTcpServer(ctx, std::move(devices));

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_init.cpp
@@ -8,6 +8,7 @@
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/future_helper.h>
+#include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
 #include <cloud/storage/core/libs/journalled_device/journalled_device.h>
 
@@ -175,11 +176,15 @@ void TDiskAgentActor::HandleInitAgentCompleted(
     if (State) {
         THashMap<TString, NJournalled::IJournalledDevicePtr> devices;
 
+        auto timer = CreateWallClockTimer();
+
         for (const auto& deviceId: State->GetDeviceIds()) {
             devices.emplace(
                 deviceId,
-                NJournalled::CreateJournalledDevice(
-                    CreateDeviceAdapter(deviceId, State->GetDeviceClient())));
+                NJournalled::CreateJournalledDevice(CreateDeviceAdapter(
+                    timer,
+                    deviceId,
+                    State->GetDeviceClient())));
         }
 
         StartJournalledDeviceTcpServer(ctx, std::move(devices));

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
@@ -1,7 +1,5 @@
 #include "disk_agent_actor.h"
 
-#include "journalled_device.h"
-
 #include <cloud/storage/core/libs/coroutine/executor.h>
 #include <cloud/storage/core/libs/journalled_device_tcp_server/server.h>
 
@@ -45,13 +43,13 @@ class TJournalledDeviceHandler final: public IServerBackend
 private:
     TActorSystem* ActorSystem = nullptr;
     const TActorId DiskAgentActorId;
-    const THashMap<TString, IJournalledDevicePtr> Devices;
+    const THashMap<TString, NJournalled::IJournalledDevicePtr> Devices;
 
 public:
     TJournalledDeviceHandler(
         TActorSystem* actorSystem,
         const TActorId& diskAgentActorId,
-        THashMap<TString, IJournalledDevicePtr> devices)
+        THashMap<TString, NJournalled::IJournalledDevicePtr> devices)
         : ActorSystem(actorSystem)
         , DiskAgentActorId(diskAgentActorId)
         , Devices(std::move(devices))
@@ -60,12 +58,9 @@ public:
     // IServerBackend
 
     [[nodiscard]] auto AcquireDevices(
-        TInstant now,
         NCloud::NProto::TAcquireDevicesRequest request)
         -> TFuture<NCloud::NProto::TAcquireDevicesResponse> final
     {
-        Y_UNUSED(now);
-
         auto ev = std::make_unique<TEvDiskAgent::TEvAcquireDevicesRequest>();
 
         CopyHeaders(*ev->Record.MutableHeaders(), request.GetHeaders());
@@ -93,12 +88,9 @@ public:
     }
 
     [[nodiscard]] auto ReleaseDevices(
-        TInstant now,
         NCloud::NProto::TReleaseDevicesRequest request)
         -> TFuture<NCloud::NProto::TReleaseDevicesResponse> final
     {
-        Y_UNUSED(now);
-
         auto promise = NewPromise<NCloud::NProto::TReleaseDevicesResponse>();
 
         auto ev = std::make_unique<TEvDiskAgent::TEvReleaseDevicesRequest>();
@@ -124,7 +116,6 @@ public:
     }
 
     [[nodiscard]] auto ReadPages(
-        TInstant now,
         NCloud::NProto::TReadPagesRequest request)
         -> TFuture<NCloud::NProto::TReadPagesResponse> final
     {
@@ -134,11 +125,10 @@ public:
                 TErrorResponse(error));
         }
 
-        return device->ReadPages(now, std::move(request));
+        return device->ReadPages(std::move(request));
     }
 
     [[nodiscard]] auto WriteLogRecord(
-        TInstant now,
         NCloud::NProto::TWriteLogRecordRequest request)
         -> TFuture<NCloud::NProto::TWriteLogRecordResponse> final
     {
@@ -148,11 +138,10 @@ public:
                 TErrorResponse(error));
         }
 
-        return device->WriteLogRecord(now, std::move(request));
+        return device->WriteLogRecord(std::move(request));
     }
 
     [[nodiscard]] auto ReadJournalTail(
-        TInstant now,
         NCloud::NProto::TReadJournalTailRequest request)
         -> TFuture<NCloud::NProto::TReadJournalTailResponse> final
     {
@@ -162,11 +151,10 @@ public:
                 TErrorResponse(error));
         }
 
-        return device->ReadJournalTail(now, std::move(request));
+        return device->ReadJournalTail(std::move(request));
     }
 
     [[nodiscard]] auto AdvanceLsnLowWatermark(
-        TInstant now,
         NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
         -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> final
     {
@@ -176,11 +164,11 @@ public:
                 TErrorResponse(error));
         }
 
-        return device->AdvanceLsnLowWatermark(now, std::move(request));
+        return device->AdvanceLsnLowWatermark(std::move(request));
     }
 
 private:
-    TResultOrError<IJournalledDevicePtr> GetDevice(
+    TResultOrError<NJournalled::IJournalledDevicePtr> GetDevice(
         const TString& deviceUUID) const
     {
         if (deviceUUID.empty()) {
@@ -216,7 +204,7 @@ TNetworkAddress CreateNetworkAddress(TStringBuf s)
 
 void TDiskAgentActor::StartJournalledDeviceTcpServer(
     const NActors::TActorContext& ctx,
-    THashMap<TString, IJournalledDevicePtr> devices)
+    THashMap<TString, NJournalled::IJournalledDevicePtr> devices)
 {
     if (AgentConfig->GetJournalledDeviceTcpServerListenAddress().empty()) {
         return;

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.cpp
@@ -4,6 +4,7 @@
 #include <cloud/blockstore/libs/storage/disk_agent/model/device_client.h>
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/journalled_device/device.h>
 
 #include <util/generic/hash_set.h>
@@ -122,12 +123,17 @@ class TDeviceAdapter final
     : public NJournalled::IDevice
 {
 private:
+    const ITimerPtr Timer;
     const TString DeviceUUID;
     const TDeviceClientPtr DeviceClient;
 
 public:
-    TDeviceAdapter(TString deviceUUID, TDeviceClientPtr deviceClient)
-        : DeviceUUID(std::move(deviceUUID))
+    TDeviceAdapter(
+            ITimerPtr timer,
+            TString deviceUUID,
+            TDeviceClientPtr deviceClient)
+        : Timer(std::move(timer))
+        , DeviceUUID(std::move(deviceUUID))
         , DeviceClient(std::move(deviceClient))
     {}
 
@@ -155,7 +161,7 @@ public:
         TVector<TFuture<NProto::TReadBlocksResponse>> futures;
         futures.reserve(request.PageGroupRefsSize());
 
-        auto now = TInstant::Now();
+        auto now = Timer->Now();
         for (const auto& group: request.GetPageGroupRefs()) {
             futures.push_back(storageAdapter->ReadBlocks(
                 now,
@@ -226,7 +232,7 @@ public:
         TVector<TFuture<NProto::TWriteBlocksResponse>> futures;
         futures.reserve(request.PageGroupsSize());
 
-        auto now = TInstant::Now();
+        auto now = Timer->Now();
         for (auto& group: *request.MutablePageGroups()) {
             futures.push_back(storageAdapter->WriteBlocks(
                 now,
@@ -263,10 +269,12 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 NJournalled::IDevicePtr CreateDeviceAdapter(
+    ITimerPtr timer,
     TString deviceUUID,
     TDeviceClientPtr deviceClient)
 {
     return std::make_shared<TDeviceAdapter>(
+        std::move(timer),
         std::move(deviceUUID),
         std::move(deviceClient));
 }

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.cpp
@@ -1,14 +1,13 @@
-#include "journalled_device.h"
+#include "journalled_device_adapter.h"
 
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/storage/disk_agent/model/device_client.h>
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/journalled_device/device.h>
 
 #include <util/generic/hash_set.h>
 #include <util/string/builder.h>
-
-#include <atomic>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -61,13 +60,6 @@ TResultOrError<ui32> ValidateWriteLogRecordRequest(
 
     if (request.PageGroupsSize() == 0) {
         return MakeError(E_ARGUMENT, "nothing to write");
-    }
-
-    if (request.GetLogSequenceNumber() <= request.GetPrevLogSequenceNumber()) {
-        return MakeError(E_ARGUMENT, TStringBuilder()
-                << "invalid lsn: " << request.GetLogSequenceNumber()
-                << ", must be greater than the prev one: "
-                << request.GetPrevLogSequenceNumber());
     }
 
     for (const auto& group: request.GetPageGroups()) {
@@ -126,26 +118,22 @@ NProto::TError ValidateReadPagesRequest(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TJournalledDevice final
-    : public IJournalledDevice
-    , public std::enable_shared_from_this<TJournalledDevice>
+class TDeviceAdapter final
+    : public NJournalled::IDevice
 {
 private:
     const TString DeviceUUID;
     const TDeviceClientPtr DeviceClient;
 
-    std::atomic<ui64> LastLsn = 0;
-
 public:
-    TJournalledDevice(TString deviceUUID, TDeviceClientPtr deviceClient)
+    TDeviceAdapter(TString deviceUUID, TDeviceClientPtr deviceClient)
         : DeviceUUID(std::move(deviceUUID))
         , DeviceClient(std::move(deviceClient))
     {}
 
-    // IJournalledDevice
+    // NJournalled::IDevice
 
     [[nodiscard]] auto ReadPages(
-        TInstant now,
         NCloud::NProto::TReadPagesRequest request)
         -> TFuture<NCloud::NProto::TReadPagesResponse> final
     {
@@ -167,6 +155,7 @@ public:
         TVector<TFuture<NProto::TReadBlocksResponse>> futures;
         futures.reserve(request.PageGroupRefsSize());
 
+        auto now = TInstant::Now();
         for (const auto& group: request.GetPageGroupRefs()) {
             futures.push_back(storageAdapter->ReadBlocks(
                 now,
@@ -179,9 +168,8 @@ public:
 
         auto all = WaitAll(futures);
 
-        return all.Apply(
-            [futures,
-             request = std::move(request)](const TFuture<void>& future) mutable
+        return all.Apply([futures, request = std::move(request)]
+            (const TFuture<void>& future) mutable
                 -> NCloud::NProto::TReadPagesResponse
             {
                 if (future.HasException()) {
@@ -211,8 +199,7 @@ public:
             });
     }
 
-    [[nodiscard]] auto WriteLogRecord(
-        TInstant now,
+    [[nodiscard]] auto WritePages(
         NCloud::NProto::TWriteLogRecordRequest request)
         -> TFuture<NCloud::NProto::TWriteLogRecordResponse> final
     {
@@ -224,19 +211,6 @@ public:
                 TErrorResponse(error));
         } else {
             requestBlockSize = bs;
-        }
-
-        const ui64 lastLsn = LastLsn.load(std::memory_order_relaxed);
-        const ui64 lsn = request.GetLogSequenceNumber();
-        const ui64 prevLsn = request.GetPrevLogSequenceNumber();
-
-        // TODO(#6956): allow to handle request with wrong lsn order
-        if (lastLsn != 0 && prevLsn != lastLsn) {
-            const auto code = prevLsn > lastLsn ? E_REJECTED : E_INVALID_STATE;
-
-            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
-                TErrorResponse(code, TStringBuilder()
-                    << "Wrong lsn: " << prevLsn << ", expected " << lastLsn));
         }
 
         auto [storageAdapter, error] = DeviceClient->AccessDevice(
@@ -252,6 +226,7 @@ public:
         TVector<TFuture<NProto::TWriteBlocksResponse>> futures;
         futures.reserve(request.PageGroupsSize());
 
+        auto now = TInstant::Now();
         for (auto& group: *request.MutablePageGroups()) {
             futures.push_back(storageAdapter->WriteBlocks(
                 now,
@@ -264,10 +239,8 @@ public:
 
         auto all = WaitAll(futures);
 
-        return all.Apply(
-            [futures, self = shared_from_this(), lsn](
-                const TFuture<void>& future) mutable
-                -> NCloud::NProto::TWriteLogRecordResponse
+        return all.Apply([futures](const TFuture<void>& future) mutable
+            -> NCloud::NProto::TWriteLogRecordResponse
             {
                 if (future.HasException()) {
                     return TErrorResponse(ResultOrError(future).GetError());
@@ -280,34 +253,8 @@ public:
                     }
                 }
 
-                self->LastLsn.store(lsn, std::memory_order_relaxed);
-
                 return {};
             });
-    }
-
-    [[nodiscard]] auto ReadJournalTail(
-        TInstant now,
-        NCloud::NProto::TReadJournalTailRequest request)
-        -> TFuture<NCloud::NProto::TReadJournalTailResponse> final
-    {
-        // TODO(#6956): implement journal tail reading
-        Y_UNUSED(now, request);
-
-        return MakeFuture<NCloud::NProto::TReadJournalTailResponse>(
-            TErrorResponse(E_NOT_IMPLEMENTED, "ReadJournalTail"));
-    }
-
-    [[nodiscard]] auto AdvanceLsnLowWatermark(
-        TInstant now,
-        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
-        -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> final
-    {
-        // TODO(#6956): implement lsn low watermark advancing
-        Y_UNUSED(now, request);
-
-        return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
-            TErrorResponse(E_NOT_IMPLEMENTED, "AdvanceLsnLowWatermark"));
     }
 };
 
@@ -315,11 +262,11 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IJournalledDevicePtr CreateJournalledDevice(
+NJournalled::IDevicePtr CreateDeviceAdapter(
     TString deviceUUID,
     TDeviceClientPtr deviceClient)
 {
-    return std::make_shared<TJournalledDevice>(
+    return std::make_shared<TDeviceAdapter>(
         std::move(deviceUUID),
         std::move(deviceClient));
 }

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.h
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 
+#include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/journalled_device/public.h>
 
 #include <util/generic/string.h>
@@ -13,6 +14,7 @@ namespace NCloud::NBlockStore::NStorage {
 ////////////////////////////////////////////////////////////////////////////////
 
 NJournalled::IDevicePtr CreateDeviceAdapter(
+    ITimerPtr timer,
     TString deviceUUID,
     TDeviceClientPtr deviceClient);
 

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.h
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
+
+#include <cloud/storage/core/libs/journalled_device/public.h>
+
+#include <util/generic/string.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NJournalled::IDevicePtr CreateDeviceAdapter(
+    TString deviceUUID,
+    TDeviceClientPtr deviceClient);
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter_ut.cpp
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/storage/disk_agent/model/device_client.h>
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/timer_test.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/journalled_device/device.h>
 
@@ -38,6 +39,7 @@ struct TFixture: public NUnitTest::TBaseFixture
     const TInstant Now = TInstant::Seconds(1);
 
     ILoggingServicePtr Logging = CreateLoggingService("console");
+    std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
 
     std::shared_ptr<TMemoryTestStorage> Storage;
     TStorageAdapterPtr StorageAdapter;
@@ -66,7 +68,9 @@ struct TFixture: public NUnitTest::TBaseFixture
 
         // the device is not acquired here: some of the tests observe the
         // behaviour of an unacquired device
-        Device = CreateDeviceAdapter(DeviceUUID, DeviceClient);
+        Timer->AdvanceTime(Now - TInstant::Zero());
+
+        Device = CreateDeviceAdapter(Timer, DeviceUUID, DeviceClient);
     }
 
     void AcquireDevice()

--- a/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/journalled_device_adapter_ut.cpp
@@ -1,4 +1,4 @@
-#include "journalled_device.h"
+#include "journalled_device_adapter.h"
 
 #include <cloud/blockstore/libs/rdma_test/memory_test_storage.h>
 #include <cloud/blockstore/libs/service/context.h>
@@ -7,6 +7,7 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/journalled_device/device.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -41,7 +42,7 @@ struct TFixture: public NUnitTest::TBaseFixture
     std::shared_ptr<TMemoryTestStorage> Storage;
     TStorageAdapterPtr StorageAdapter;
     TDeviceClientPtr DeviceClient;
-    IJournalledDevicePtr Device;
+    NJournalled::IDevicePtr Device;
 
     void SetUp(NUnitTest::TTestContext& /*context*/) override
     {
@@ -65,7 +66,7 @@ struct TFixture: public NUnitTest::TBaseFixture
 
         // the device is not acquired here: some of the tests observe the
         // behaviour of an unacquired device
-        Device = CreateJournalledDevice(DeviceUUID, DeviceClient);
+        Device = CreateDeviceAdapter(DeviceUUID, DeviceClient);
     }
 
     void AcquireDevice()
@@ -112,32 +113,16 @@ struct TFixture: public NUnitTest::TBaseFixture
         UNIT_ASSERT_C(!HasError(response), FormatError(response.GetError()));
     }
 
-    NProto::TError WriteLogRecord(
-        NCloud::NProto::TWriteLogRecordRequest request)
+    NProto::TError WritePages(NCloud::NProto::TWriteLogRecordRequest request)
     {
-        return Device->WriteLogRecord(Now, std::move(request))
+        return Device->WritePages(std::move(request))
             .GetValueSync()
             .GetError();
     }
 
-    NProto::TError WriteLogRecord(ui64 lsn, ui64 prevLsn)
-    {
-        NCloud::NProto::TWriteLogRecordRequest request;
-        request.MutableHeaders()->SetClientId(ClientId);
-        request.SetDeviceUUID(DeviceUUID);
-        request.SetLogSequenceNumber(lsn);
-        request.SetPrevLogSequenceNumber(prevLsn);
-
-        auto& group = *request.MutablePageGroups()->Add();
-        group.SetFirstPageNo(0x10);
-        group.MutableContent()->Add()->resize(DefaultBlockSize, 'A');
-
-        return WriteLogRecord(std::move(request));
-    }
-
     auto ReadPages(NCloud::NProto::TReadPagesRequest request)
     {
-        return Device->ReadPages(Now, std::move(request)).GetValueSync();
+        return Device->ReadPages(std::move(request)).GetValueSync();
     }
 };
 
@@ -145,9 +130,9 @@ struct TFixture: public NUnitTest::TBaseFixture
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
+Y_UNIT_TEST_SUITE(TDeviceAdapterTest)
 {
-    Y_UNIT_TEST_F(ShouldValidateWriteLogRecordRequest, TFixture)
+    Y_UNIT_TEST_F(ShouldValidateWritePagesRequest, TFixture)
     {
         using TPrepareFunc =
             std::function<void(NCloud::NProto::TWriteLogRecordRequest&)>;
@@ -159,14 +144,12 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
             {[&](auto& proto)
              {
                  proto.SetDeviceUUID(DeviceUUID);
-                 proto.SetLogSequenceNumber(1);
                  proto.MutablePageGroups()->Add();
              },
              MakeError(E_ARGUMENT, "empty page group")},
             {[&](auto& proto)
              {
                  proto.SetDeviceUUID(DeviceUUID);
-                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -181,7 +164,6 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
             {[&](auto& proto)
              {
                  proto.SetDeviceUUID(DeviceUUID);
-                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -204,7 +186,6 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
             {[&](auto& proto)
              {
                  proto.SetDeviceUUID(DeviceUUID);
-                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -219,7 +200,6 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
              {
                  // the client id is checked after the device is found
                  proto.SetDeviceUUID(DeviceUUID);
-                 proto.SetLogSequenceNumber(1);
                  auto& groups = *proto.MutablePageGroups();
 
                  {
@@ -238,7 +218,6 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
              {
                  proto.MutableHeaders()->SetClientId(ClientId);
                  proto.SetDeviceUUID(DeviceUUID);
-                 proto.SetLogSequenceNumber(1);
 
                  auto& groups = *proto.MutablePageGroups();
 
@@ -254,43 +233,6 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
                  }
              },
              MakeError(E_BS_INVALID_SESSION, "not acquired by client")},
-            {[&](auto& proto)
-             {
-                 proto.MutableHeaders()->SetClientId(ClientId);
-                 proto.SetDeviceUUID(DeviceUUID);
-                 // LogSequenceNumber is not set
-
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'A');
-                 }
-             },
-             MakeError(E_ARGUMENT, "invalid lsn: 0")},
-            {[&](auto& proto)
-             {
-                 proto.MutableHeaders()->SetClientId(ClientId);
-                 proto.SetDeviceUUID(DeviceUUID);
-                 proto.SetLogSequenceNumber(10);
-                 proto.SetPrevLogSequenceNumber(10);
-
-                 auto& groups = *proto.MutablePageGroups();
-
-                 {
-                     auto& group = *groups.Add();
-                     group.SetFirstPageNo(0x10);
-                     group.MutableContent()->Add()->resize(
-                         DefaultBlockSize,
-                         'A');
-                 }
-             },
-             MakeError(
-                 E_ARGUMENT,
-                 "invalid lsn: 10, must be greater than the prev one: 10")},
         };
 
         for (size_t i = 0; i != std::size(testCases); ++i) {
@@ -299,7 +241,7 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
             NCloud::NProto::TWriteLogRecordRequest request;
             prepare(request);
 
-            const auto error = WriteLogRecord(std::move(request));
+            const auto error = WritePages(std::move(request));
 
             UNIT_ASSERT_VALUES_EQUAL_C(
                 expectedError.GetCode(),
@@ -440,7 +382,7 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
         }
     }
 
-    Y_UNIT_TEST_F(ShouldWriteLogRecord, TFixture)
+    Y_UNIT_TEST_F(ShouldWritePages, TFixture)
     {
         const auto makeRequest = [&]
         {
@@ -471,7 +413,7 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
         // the device has not been acquired yet
 
         {
-            const auto error = WriteLogRecord(makeRequest());
+            const auto error = WritePages(makeRequest());
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_BS_INVALID_SESSION,
                 error.GetCode(),
@@ -481,66 +423,7 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
         AcquireDevice();
 
         {
-            const auto error = WriteLogRecord(makeRequest());
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                S_OK,
-                error.GetCode(),
-                FormatError(error));
-        }
-    }
-
-    Y_UNIT_TEST_F(ShouldValidateLogSequenceNumber, TFixture)
-    {
-        AcquireDevice();
-
-        // the very first record is accepted with any prev lsn
-
-        {
-            const auto error = WriteLogRecord(10, 5);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                S_OK,
-                error.GetCode(),
-                FormatError(error));
-        }
-
-        {
-            const auto error = WriteLogRecord(11, 10);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                S_OK,
-                error.GetCode(),
-                FormatError(error));
-        }
-
-        // a gap in the log
-
-        {
-            const auto error = WriteLogRecord(20, 15);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                E_REJECTED,
-                error.GetCode(),
-                FormatError(error));
-            UNIT_ASSERT_STRING_CONTAINS(
-                error.GetMessage(),
-                "Wrong lsn: 15, expected 11");
-        }
-
-        // an outdated record
-
-        {
-            const auto error = WriteLogRecord(13, 5);
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                E_INVALID_STATE,
-                error.GetCode(),
-                FormatError(error));
-            UNIT_ASSERT_STRING_CONTAINS(
-                error.GetMessage(),
-                "Wrong lsn: 5, expected 11");
-        }
-
-        // the rejected records have not changed the state
-
-        {
-            const auto error = WriteLogRecord(12, 11);
+            const auto error = WritePages(makeRequest());
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),

--- a/cloud/blockstore/libs/storage/disk_agent/public.h
+++ b/cloud/blockstore/libs/storage/disk_agent/public.h
@@ -1,16 +1,1 @@
 #pragma once
-
-#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
-
-#include <util/generic/strbuf.h>
-
-#include <memory>
-
-namespace NCloud::NBlockStore::NStorage {
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct IJournalledDevice;
-using IJournalledDevicePtr = std::shared_ptr<IJournalledDevice>;
-
-}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_agent/spdk_initializer.h
+++ b/cloud/blockstore/libs/storage/disk_agent/spdk_initializer.h
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/common/public.h>
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/spdk/iface/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 
 #include <util/generic/vector.h>

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.h
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.h
@@ -8,9 +8,9 @@
 #include <cloud/blockstore/libs/nvme/public.h>
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
-#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
-
 #include <cloud/blockstore/libs/storage/disk_agent/model/device_guard.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
+#include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 
 #include <util/generic/vector.h>
 

--- a/cloud/blockstore/libs/storage/disk_agent/ut/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/ut/ya.make
@@ -8,7 +8,7 @@ ENDIF()
 
 SRCS(
     disk_agent_state_ut.cpp
-    journalled_device_ut.cpp
+    journalled_device_adapter_ut.cpp
     rdma_target_ut.cpp
     recent_blocks_tracker_ut.cpp
     spdk_initializer_ut.cpp

--- a/cloud/blockstore/libs/storage/disk_agent/ya.make
+++ b/cloud/blockstore/libs/storage/disk_agent/ya.make
@@ -24,7 +24,7 @@ SRCS(
     disk_agent_state.cpp
     disk_agent.cpp
     hash_table_storage.cpp
-    journalled_device.cpp
+    journalled_device_adapter.cpp
     rdma_target.cpp
     recent_blocks_tracker.cpp
     spdk_initializer.cpp
@@ -46,6 +46,7 @@ PEERDIR(
     cloud/blockstore/libs/storage/model
 
     cloud/storage/core/libs/common
+    cloud/storage/core/libs/journalled_device
     cloud/storage/core/libs/journalled_device_tcp_server
     cloud/storage/core/libs/rdma/iface
 

--- a/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.h
@@ -10,7 +10,7 @@
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/spdk/iface/public.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
-#include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 #include <cloud/blockstore/libs/storage/disk_registry_proxy/public.h>
 
 #include <cloud/storage/core/libs/diagnostics/stats_fetcher.h>

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.h
@@ -16,7 +16,7 @@
 #include <cloud/blockstore/libs/service/public.h>
 #include <cloud/blockstore/libs/spdk/iface/public.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
-#include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 #include <cloud/blockstore/libs/storage/disk_registry_proxy/public.h>
 #include <cloud/blockstore/libs/ydbstats/public.h>
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/checksum_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/checksum_range.cpp
@@ -1,7 +1,7 @@
 #include "checksum_range.h"
 
 #include <cloud/blockstore/libs/storage/core/probes.h>
-#include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 
 #include <contrib/ydb/library/actors/core/log.h>
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/copy_range.cpp
@@ -6,7 +6,7 @@
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
-#include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 #include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
 #include <cloud/storage/core/libs/common/sglist.h>
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/direct_copy_range.cpp
@@ -7,7 +7,7 @@
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/core/forward_helpers.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
-#include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/copy_range.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_common.h>
 #include <cloud/storage/core/libs/common/sglist.h>

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_fastpath_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_fastpath_actor.cpp
@@ -7,7 +7,7 @@
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
-#include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 
 #include <cloud/storage/core/libs/common/guarded_sglist.h>
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
@@ -6,7 +6,7 @@
 #include <cloud/blockstore/libs/kikimr/helpers.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
-#include <cloud/blockstore/libs/storage/disk_agent/public.h>
+#include <cloud/blockstore/libs/storage/disk_agent/model/public.h>
 #include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
 
 #include <cloud/storage/core/libs/common/sglist.h>

--- a/cloud/storage/core/libs/journalled_device/device.cpp
+++ b/cloud/storage/core/libs/journalled_device/device.cpp
@@ -1,0 +1,1 @@
+#include "device.h"

--- a/cloud/storage/core/libs/journalled_device/device.h
+++ b/cloud/storage/core/libs/journalled_device/device.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <library/cpp/threading/future/future.h>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IDevice
+{
+    virtual ~IDevice() = default;
+
+    [[nodiscard]] virtual auto ReadPages(
+        NCloud::NProto::TReadPagesRequest request)
+        -> NThreading::TFuture<NCloud::NProto::TReadPagesResponse> = 0;
+
+    [[nodiscard]] virtual auto WritePages(
+        NCloud::NProto::TWriteLogRecordRequest request)
+        -> NThreading::TFuture<NCloud::NProto::TWriteLogRecordResponse> = 0;
+};
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journalled_device.cpp
+++ b/cloud/storage/core/libs/journalled_device/journalled_device.cpp
@@ -1,0 +1,117 @@
+#include "journalled_device.h"
+
+#include "device.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/string/builder.h>
+
+#include <atomic>
+
+namespace NCloud::NJournalled {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TJournalledDevice final
+    : public IJournalledDevice
+    , public std::enable_shared_from_this<TJournalledDevice>
+{
+private:
+    const IDevicePtr DataStore;
+
+    std::atomic<ui64> LastLsn = 0;
+
+public:
+    TJournalledDevice(IDevicePtr dataStore)
+        : DataStore(std::move(dataStore))
+    {}
+
+    // IJournalledDevice
+
+    [[nodiscard]] auto ReadPages(
+        NCloud::NProto::TReadPagesRequest request)
+        -> TFuture<NCloud::NProto::TReadPagesResponse> final
+    {
+        return DataStore->ReadPages(std::move(request));
+    }
+
+    [[nodiscard]] auto WriteLogRecord(
+        NCloud::NProto::TWriteLogRecordRequest request)
+        -> TFuture<NCloud::NProto::TWriteLogRecordResponse> final
+    {
+        if (request.GetLogSequenceNumber() <= request.GetPrevLogSequenceNumber()) {
+            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(E_ARGUMENT, TStringBuilder()
+                    << "invalid lsn: " << request.GetLogSequenceNumber()
+                    << ", must be greater than the prev one: "
+                    << request.GetPrevLogSequenceNumber()));
+        }
+
+        const ui64 lastLsn = LastLsn.load(std::memory_order_relaxed);
+        const ui64 lsn = request.GetLogSequenceNumber();
+        const ui64 prevLsn = request.GetPrevLogSequenceNumber();
+
+        // TODO(#6956): allow to handle request with wrong lsn order
+        if (lastLsn != 0 && prevLsn != lastLsn) {
+            const auto code = prevLsn > lastLsn ? E_REJECTED : E_INVALID_STATE;
+
+            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(code, TStringBuilder()
+                    << "Wrong lsn: " << prevLsn << ", expected " << lastLsn));
+        }
+
+        return DataStore->WritePages(std::move(request)).Apply(
+            [self = shared_from_this(), lsn](const auto& future) mutable
+                -> NCloud::NProto::TWriteLogRecordResponse
+            {
+                if (future.HasException()) {
+                    return TErrorResponse(ResultOrError(future).GetError());
+                }
+
+                const auto& response = future.GetValue();
+                if (HasError(response)) {
+                    return response;
+                }
+
+                self->LastLsn.store(lsn, std::memory_order_relaxed);
+                return {};
+            });
+    }
+
+    [[nodiscard]] auto ReadJournalTail(
+        NCloud::NProto::TReadJournalTailRequest request)
+        -> TFuture<NCloud::NProto::TReadJournalTailResponse> final
+    {
+        // TODO(#6956): implement journal tail reading
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TReadJournalTailResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "ReadJournalTail"));
+    }
+
+    [[nodiscard]] auto AdvanceLsnLowWatermark(
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> final
+    {
+        // TODO(#6956): implement lsn low watermark advancing
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "AdvanceLsnLowWatermark"));
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IJournalledDevicePtr CreateJournalledDevice(IDevicePtr dataStore)
+{
+    return std::make_shared<TJournalledDevice>(std::move(dataStore));
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journalled_device.cpp
+++ b/cloud/storage/core/libs/journalled_device/journalled_device.cpp
@@ -26,7 +26,7 @@ private:
     std::atomic<ui64> LastLsn = 0;
 
 public:
-    TJournalledDevice(IDevicePtr dataStore)
+    explicit TJournalledDevice(IDevicePtr dataStore)
         : DataStore(std::move(dataStore))
     {}
 

--- a/cloud/storage/core/libs/journalled_device/journalled_device.h
+++ b/cloud/storage/core/libs/journalled_device/journalled_device.h
@@ -2,17 +2,11 @@
 
 #include "public.h"
 
-#include <cloud/storage/core/libs/common/error.h>
-
 #include <cloud/storage/core/protos/device.pb.h>
 
 #include <library/cpp/threading/future/future.h>
 
-#include <util/datetime/base.h>
-#include <util/generic/string.h>
-#include <util/generic/vector.h>
-
-namespace NCloud::NBlockStore::NStorage {
+namespace NCloud::NJournalled {
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -21,30 +15,24 @@ struct IJournalledDevice
     virtual ~IJournalledDevice() = default;
 
     [[nodiscard]] virtual auto ReadPages(
-        TInstant now,
         NCloud::NProto::TReadPagesRequest request)
         -> NThreading::TFuture<NCloud::NProto::TReadPagesResponse> = 0;
 
     [[nodiscard]] virtual auto WriteLogRecord(
-        TInstant now,
         NCloud::NProto::TWriteLogRecordRequest request)
         -> NThreading::TFuture<NCloud::NProto::TWriteLogRecordResponse> = 0;
 
     [[nodiscard]] virtual auto ReadJournalTail(
-        TInstant now,
         NCloud::NProto::TReadJournalTailRequest request)
         -> NThreading::TFuture<NCloud::NProto::TReadJournalTailResponse> = 0;
 
     [[nodiscard]] virtual auto AdvanceLsnLowWatermark(
-        TInstant now,
         NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
         -> NThreading::TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IJournalledDevicePtr CreateJournalledDevice(
-    TString deviceUUID,
-    TDeviceClientPtr deviceClient);
+IJournalledDevicePtr CreateJournalledDevice(IDevicePtr dataStore);
 
-}   // namespace NCloud::NBlockStore::NStorage
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journalled_device_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/journalled_device_ut.cpp
@@ -1,0 +1,185 @@
+#include "journalled_device.h"
+
+#include "device.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NJournalled {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestDevice final: public IDevice
+{
+    ui32 WritePagesCount = 0;
+
+    [[nodiscard]] auto ReadPages(
+        NCloud::NProto::TReadPagesRequest request)
+        -> TFuture<NCloud::NProto::TReadPagesResponse> final
+    {
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TReadPagesResponse>();
+    }
+
+    [[nodiscard]] auto WritePages(
+        NCloud::NProto::TWriteLogRecordRequest request)
+        -> TFuture<NCloud::NProto::TWriteLogRecordResponse> final
+    {
+        Y_UNUSED(request);
+
+        ++WritePagesCount;
+
+        return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    std::shared_ptr<TTestDevice> DataStore;
+    IJournalledDevicePtr Device;
+
+    void SetUp(NUnitTest::TTestContext& /*context*/) override
+    {
+        DataStore = std::make_shared<TTestDevice>();
+        Device = CreateJournalledDevice(DataStore);
+    }
+
+    NProto::TError WriteLogRecord(ui64 lsn, ui64 prevLsn)
+    {
+        NCloud::NProto::TWriteLogRecordRequest request;
+        request.SetLogSequenceNumber(lsn);
+        request.SetPrevLogSequenceNumber(prevLsn);
+
+        auto& group = *request.MutablePageGroups()->Add();
+        group.SetFirstPageNo(0x10);
+        group.MutableContent()->Add()->resize(4096, 'A');
+
+        return Device->WriteLogRecord(std::move(request))
+            .GetValueSync()
+            .GetError();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TJournalledDeviceTest)
+{
+    Y_UNIT_TEST_F(ShouldRejectNonIncreasingLogSequenceNumber, TFixture)
+    {
+        // an unset lsn
+
+        {
+            const auto error = WriteLogRecord(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "invalid lsn: 0");
+        }
+
+        // the lsn is equal to the prev one
+
+        {
+            const auto error = WriteLogRecord(10, 10);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "invalid lsn: 10, must be greater than the prev one: 10");
+        }
+
+        // the lsn is below the prev one
+
+        {
+            const auto error = WriteLogRecord(5, 10);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "invalid lsn: 5, must be greater than the prev one: 10");
+        }
+
+        // the rejected records have not reached the data store
+
+        UNIT_ASSERT_VALUES_EQUAL(0, DataStore->WritePagesCount);
+    }
+
+    Y_UNIT_TEST_F(ShouldValidateLogSequenceNumber, TFixture)
+    {
+        // the very first record is accepted with any prev lsn
+
+        {
+            const auto error = WriteLogRecord(10, 5);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            const auto error = WriteLogRecord(11, 10);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        // a gap in the log
+
+        {
+            const auto error = WriteLogRecord(20, 15);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "Wrong lsn: 15, expected 11");
+        }
+
+        // an outdated record
+
+        {
+            const auto error = WriteLogRecord(13, 5);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_INVALID_STATE,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS(
+                error.GetMessage(),
+                "Wrong lsn: 5, expected 11");
+        }
+
+        // the rejected records have not reached the data store
+
+        UNIT_ASSERT_VALUES_EQUAL(2, DataStore->WritePagesCount);
+
+        // the rejected records have not changed the state
+
+        {
+            const auto error = WriteLogRecord(12, 11);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+    }
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/public.h
+++ b/cloud/storage/core/libs/journalled_device/public.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IDevice;
+using IDevicePtr = std::shared_ptr<IDevice>;
+
+struct IJournalledDevice;
+using IJournalledDevicePtr = std::shared_ptr<IJournalledDevice>;
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/ut/ya.make
+++ b/cloud/storage/core/libs/journalled_device/ut/ya.make
@@ -1,0 +1,14 @@
+UNITTEST_FOR(cloud/storage/core/libs/journalled_device)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+SRCS(
+    journalled_device_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/testing/unittest
+    library/cpp/threading/future
+)
+
+END()

--- a/cloud/storage/core/libs/journalled_device/ya.make
+++ b/cloud/storage/core/libs/journalled_device/ya.make
@@ -1,0 +1,17 @@
+LIBRARY()
+
+SRCS(
+    device.cpp
+    journalled_device.cpp
+)
+
+PEERDIR(
+    cloud/storage/core/libs/common
+    cloud/storage/core/protos
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server.cpp
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server.cpp
@@ -34,7 +34,7 @@ namespace {
 template <
     typename TProtoRequest,
     typename TProtoResponse,
-    TFuture<TProtoResponse> (IServerBackend::*Method)(TInstant, TProtoRequest),
+    auto Method,
     TProtoRequest* (NProto::TDeviceProtocolRequest::*mutableRequest)(),
     TProtoResponse* (NProto::TDeviceProtocolResponse::*mutableResponse)()>
 struct TServerMethod
@@ -44,10 +44,9 @@ struct TServerMethod
 
     static auto Execute(
         IServerBackend& backend,
-        TInstant now,
         TRequest&& request) -> TFuture<TResponse>
     {
-        return (backend.*Method)(now, std::move(request));
+        return (backend.*Method)(std::move(request));
     }
 
     static auto MutableProto(NProto::TDeviceProtocolRequest& request)
@@ -194,7 +193,7 @@ private:
         try {
             auto& proto = TMethod::MutableProto(request);
 
-            future = TMethod::Execute(*Backend, Now(), std::move(proto));
+            future = TMethod::Execute(*Backend, std::move(proto));
         } catch (...) {
             STORAGE_ERROR(
                 TMethod::Name << " failed: " << CurrentExceptionMessage());

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server.h
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server.h
@@ -6,6 +6,7 @@
 #include <cloud/storage/core/libs/common/startable.h>
 #include <cloud/storage/core/libs/coroutine/public.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
+#include <cloud/storage/core/libs/journalled_device/journalled_device.h>
 #include <cloud/storage/core/protos/device.pb.h>
 
 #include <library/cpp/threading/future/future.h>
@@ -16,39 +17,17 @@ namespace NCloud::NJournalled {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IServerBackend
+struct IServerBackend : public IJournalledDevice
 {
     virtual ~IServerBackend() = default;
 
     [[nodiscard]] virtual auto AcquireDevices(
-        TInstant now,
         NProto::TAcquireDevicesRequest request)
         -> NThreading::TFuture<NProto::TAcquireDevicesResponse> = 0;
 
     [[nodiscard]] virtual auto ReleaseDevices(
-        TInstant now,
         NProto::TReleaseDevicesRequest request)
         -> NThreading::TFuture<NProto::TReleaseDevicesResponse> = 0;
-
-    [[nodiscard]] virtual auto ReadPages(
-        TInstant now,
-        NProto::TReadPagesRequest request)
-        -> NThreading::TFuture<NProto::TReadPagesResponse> = 0;
-
-    [[nodiscard]] virtual auto WriteLogRecord(
-        TInstant now,
-        NProto::TWriteLogRecordRequest request)
-        -> NThreading::TFuture<NProto::TWriteLogRecordResponse> = 0;
-
-    [[nodiscard]] virtual auto ReadJournalTail(
-        TInstant now,
-        NProto::TReadJournalTailRequest request)
-        -> NThreading::TFuture<NProto::TReadJournalTailResponse> = 0;
-
-    [[nodiscard]] virtual auto AdvanceLsnLowWatermark(
-        TInstant now,
-        NProto::TAdvanceLsnLowWatermarkRequest request)
-        -> NThreading::TFuture<NProto::TAdvanceLsnLowWatermarkResponse> = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server_ut.cpp
@@ -54,62 +54,44 @@ struct TTestBackend: public IServerBackend
     TAdvanceLsnLowWatermarkFunc AdvanceLsnLowWatermarkImpl;
 
     [[nodiscard]] auto AcquireDevices(
-        TInstant now,
         NProto::TAcquireDevicesRequest request)
         -> TFuture<NProto::TAcquireDevicesResponse> final
     {
-        Y_UNUSED(now);
-
         return AcquireDevicesImpl(std::move(request));
     }
 
     [[nodiscard]] auto ReleaseDevices(
-        TInstant now,
         NProto::TReleaseDevicesRequest request)
         -> TFuture<NProto::TReleaseDevicesResponse> final
     {
-        Y_UNUSED(now);
-
         return ReleaseDevicesImpl(std::move(request));
     }
 
     [[nodiscard]] auto ReadPages(
-        TInstant now,
         NProto::TReadPagesRequest request)
         -> TFuture<NProto::TReadPagesResponse> final
     {
-        Y_UNUSED(now);
-
         return ReadPagesImpl(std::move(request));
     }
 
     [[nodiscard]] auto WriteLogRecord(
-        TInstant now,
         NProto::TWriteLogRecordRequest request)
         -> TFuture<NProto::TWriteLogRecordResponse> final
     {
-        Y_UNUSED(now);
-
         return WriteLogRecordImpl(std::move(request));
     }
 
     [[nodiscard]] auto ReadJournalTail(
-        TInstant now,
         NProto::TReadJournalTailRequest request)
         -> TFuture<NProto::TReadJournalTailResponse> final
     {
-        Y_UNUSED(now);
-
         return ReadJournalTailImpl(std::move(request));
     }
 
     [[nodiscard]] auto AdvanceLsnLowWatermark(
-        TInstant now,
         NProto::TAdvanceLsnLowWatermarkRequest request)
         -> TFuture<NProto::TAdvanceLsnLowWatermarkResponse> final
     {
-        Y_UNUSED(now);
-
         return AdvanceLsnLowWatermarkImpl(std::move(request));
     }
 };

--- a/cloud/storage/core/libs/journalled_device_tcp_server/ya.make
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     cloud/storage/core/libs/common
     cloud/storage/core/libs/coroutine
     cloud/storage/core/libs/diagnostics
+    cloud/storage/core/libs/journalled_device
 
     library/cpp/coroutine/listener
 )

--- a/cloud/storage/core/libs/ya.make
+++ b/cloud/storage/core/libs/ya.make
@@ -14,6 +14,7 @@ RECURSE(
     hive_proxy
     http
     io_uring
+    journalled_device
     journalled_device_tcp_server
     kikimr
     netlink


### PR DESCRIPTION
### Notes
Split the journalled device into two layers:

* NJournalled::IJournalledDevice (cloud/storage/core/libs/journalled_device) owns the transport-agnostic part - the log sequence number validation and the not-yet-implemented journal tail / lsn low watermark handling;
* NJournalled::IDevice is the page IO backend it is built on top of.

The disk_agent-specific code becomes a thin TDeviceAdapter over TDeviceClient, and IServerBackend now derives from IJournalledDevice instead of redeclaring its methods.

The TInstant now argument is dropped from these interfaces: the adapter takes the timestamp itself when calling the storage adapter.

### Issue
https://github.com/ydb-platform/nbs/issues/6956
