### PR TITLE
Add op-based latency counters (LatencyTotalOps/LatencyGoodOps)

### DIFF
--- a/cloud/blockstore/config/diagnostics.proto
+++ b/cloud/blockstore/config/diagnostics.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/config";
 
 import "cloud/storage/core/config/opentelemetry_client.proto";
 import "cloud/storage/core/protos/diagnostics.proto";
+import "cloud/storage/core/protos/media.proto";
 import "cloud/storage/core/protos/trace.proto";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -117,6 +118,36 @@ message TMonitoringUrlData
     // - diskId
     optional string MonitoringUrlTemplate = 10;
 
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Operation latency thresholds (op-based latency metric, see
+// TDiagnosticsConfig.LatencyThresholdsEnabled/LatencyThresholds below).
+
+// A single operation-size bucket: the lower bound (inclusive) of the
+// operation size range together with the execution time thresholds for read
+// and write operations of that size. An operation is considered timely if
+// it completes within the threshold configured for its size class. The
+// upper bound of a bucket is the next bucket's MinRequestBytes (open-ended
+// for the last bucket of a media kind).
+message TLatencyThresholdBucket
+{
+    // Lower bound of the operation size range, in bytes, inclusive. The
+    // first bucket of every media kind must have MinRequestBytes == 0, so
+    // that no operation size falls outside of every bucket.
+    optional uint64 MinRequestBytes = 1;
+
+    // Execution time thresholds, in milliseconds. Must be > 0.
+    optional uint32 ReadThresholdMs = 2;
+    optional uint32 WriteThresholdMs = 3;
+};
+
+// Latency threshold ladder for a single storage media kind. Buckets must be
+// sorted strictly ascending by MinRequestBytes, with no duplicates.
+message TMediaKindLatencyThresholds
+{
+    optional NCloud.NProto.EStorageMediaKind MediaKind = 1;
+    repeated TLatencyThresholdBucket Buckets = 2;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -297,4 +328,16 @@ message TDiagnosticsConfig
     // Selects the critical event metrics to report.
     optional EVolumeCriticalEventsReportingMode
         VolumeCriticalEventsReportingMode = 60;
+
+    // Enables the operation latency threshold mechanism (LatencyTotalOps/
+    // LatencyGoodOps counters, see volume_stats.cpp). Disabled by default.
+    // When enabled with an empty or invalid LatencyThresholds table, the
+    // mechanism stays disabled (see the LatencyThresholdsConfigInvalid
+    // diagnostic gauge) instead of crashing on a config mistake.
+    optional bool LatencyThresholdsEnabled = 61;
+
+    // Per-media-kind operation size -> execution time threshold ladders.
+    // Empty by default. See TMediaKindLatencyThresholds/
+    // TLatencyThresholdBucket above for the validation rules.
+    repeated TMediaKindLatencyThresholds LatencyThresholds = 62;
 }

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -385,7 +385,8 @@ void TBootstrapBase::Init()
             Configs->DiagnosticsConfig,
             inactiveClientsTimeout,
             EVolumeStatsType::EServerStats,
-            Timer);
+            Timer,
+            Log);
     }
 
     ServerStats = CreateServerStats(

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -550,16 +550,18 @@ void TBootstrapBase::Init()
         if (Configs->ServerConfig->GetVhostServerPath()
                 && !Configs->Options->TemporaryServer)
         {
-            vhostEndpointListener = CreateExternalVhostEndpointListener(
-                Configs->ServerConfig,
-                Logging,
-                ServerStats,
-                Executor,
-                Configs->Options->SkipDeviceLocalityValidation
-                    ? TString {}
-                    : FQDNHostName(),
-                RdmaClient && RdmaClient->IsAlignedDataEnabled(),
-                std::move(vhostEndpointListener));
+            vhostEndpointListener =
+                CreateExternalVhostEndpointListenerWithDiagnostics(
+                    Configs->ServerConfig,
+                    Logging,
+                    ServerStats,
+                    Executor,
+                    Configs->Options->SkipDeviceLocalityValidation
+                        ? TString {}
+                        : FQDNHostName(),
+                    RdmaClient && RdmaClient->IsAlignedDataEnabled(),
+                    std::move(vhostEndpointListener),
+                    Configs->DiagnosticsConfig);
 
             STORAGE_INFO("VHOST External Vhost EndpointListener initialized");
         }

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -388,6 +388,10 @@ void TBootstrapBase::Init()
             Timer,
             Log);
     }
+    // Some server variants construct VolumeStats while their monitoring
+    // proxy is still deferred. At this point monitoring is ready, so publish
+    // server-level diagnostics before the first volume is mounted.
+    VolumeStats->InitializeMonitoringCounters();
 
     ServerStats = CreateServerStats(
         Configs->ServerConfig,

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -615,7 +615,8 @@ void TBootstrapYdb::InitKikimrService()
         Configs->DiagnosticsConfig,
         Configs->StorageConfig->GetInactiveClientsTimeout(),
         EVolumeStatsType::EServerStats,
-        Timer);
+        Timer,
+        Log);
 
     ClientPercentiles = CreateClientPercentileCalculator(logging);
 

--- a/cloud/blockstore/libs/diagnostics/config.cpp
+++ b/cloud/blockstore/libs/diagnostics/config.cpp
@@ -69,6 +69,11 @@ namespace {
     xxx(VolumeCriticalEventsReportingMode,                                                               \
                                         NProto::EVolumeCriticalEventsReportingMode,                      \
                                                                  NProto::EVolumeCriticalEventsReportingMode::APP_ONLY)\
+                                                                                                         \
+    xxx(LatencyThresholdsEnabled,       bool,                    false                                  )\
+    xxx(LatencyThresholds,                                                                               \
+        TVector<NProto::TMediaKindLatencyThresholds>,                                                    \
+                                        {}                                                                )\
 
 // BLOCKSTORE_DIAGNOSTICS_CONFIG
 // clang-format on
@@ -142,6 +147,18 @@ TVector<TSizeInterval> ConvertValue(
     return v;
 }
 
+template <>
+TVector<NProto::TMediaKindLatencyThresholds> ConvertValue(
+    const google::protobuf::RepeatedPtrField<
+        NProto::TMediaKindLatencyThresholds>& value)
+{
+    TVector<NProto::TMediaKindLatencyThresholds> v;
+    for (const auto& x : value) {
+        v.push_back(x);
+    }
+    return v;
+}
+
 template <typename T>
 void DumpImpl(const T& t, IOutputStream& os)
 {
@@ -167,6 +184,19 @@ void DumpImpl(const TVector<TSizeInterval>& value, IOutputStream& os)
             os << ",";
         }
         os << ToString(value[i]);
+    }
+}
+
+template <>
+void DumpImpl(
+    const TVector<NProto::TMediaKindLatencyThresholds>& value,
+    IOutputStream& os)
+{
+    for (size_t i = 0; i < value.size(); ++i) {
+        if (i) {
+            os << ",";
+        }
+        SerializeToTextFormat(value[i], os);
     }
 }
 

--- a/cloud/blockstore/libs/diagnostics/config.h
+++ b/cloud/blockstore/libs/diagnostics/config.h
@@ -196,6 +196,11 @@ public:
     [[nodiscard]] NProto::EVolumeCriticalEventsReportingMode
     GetVolumeCriticalEventsReportingMode() const;
 
+    [[nodiscard]] bool GetLatencyThresholdsEnabled() const;
+
+    [[nodiscard]] TVector<NProto::TMediaKindLatencyThresholds>
+    GetLatencyThresholds() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
@@ -241,6 +241,20 @@ TLatencyThresholdOutcome ClassifyLatencyOutcome(
         case EDiagnosticsErrorKind::ErrorFatal:
             // The service failed to execute the operation - bad, but there
             // is nothing to compare against a duration threshold.
+            //
+            // Known limitation, opposite in direction to the retriable case
+            // above: a request rejected by argument validation lands here as
+            // well, because the gRPC layer opens the stats lifecycle before
+            // it validates (RequestStarted in
+            // cloud/blockstore/libs/server/server.cpp precedes
+            // ValidateRequest a few lines below it). A client that sets the
+            // internal-only header, or talks on the wrong channel, is
+            // therefore counted as a bad operation of its volume without any
+            // I/O having run. The blast radius is that client's own mount,
+            // since the per-volume stats path resolves nothing without an
+            // active mount for the client/disk pair, and separating the two
+            // cases would mean carrying the request stage down from the
+            // server layer, which nothing on this path does today.
             return {.CountTotal = true};
 
         case EDiagnosticsErrorKind::Success:

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
@@ -89,6 +89,17 @@ TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
             return result;
         }
 
+        if (static_cast<size_t>(mediaKindThresholds.BucketsSize()) >
+            MaxLatencyThresholdBucketsPerMediaKind)
+        {
+            result.Error = TStringBuilder()
+                << "media kind " << mediaKindName << " has "
+                << mediaKindThresholds.BucketsSize()
+                << " buckets in LatencyThresholds; maximum is "
+                << MaxLatencyThresholdBucketsPerMediaKind;
+            return result;
+        }
+
         // Safe to index Ladders with mediaKind: bounds-checked above.
         TLatencyThresholdLadder ladder;
         ladder.reserve(mediaKindThresholds.BucketsSize());
@@ -197,7 +208,7 @@ const TLatencyThresholdBucket& FindLatencyThresholdBucket(
 
 TLatencyThresholdOutcome ClassifyLatencyOutcome(
     const TLatencyThresholdLadder* ladder,
-    EDiagnosticsErrorKind errorKind,
+    const NProto::TError& error,
     bool isWrite,
     ui64 requestBytes,
     TDuration execTime)
@@ -208,60 +219,47 @@ TLatencyThresholdOutcome ClassifyLatencyOutcome(
     // gate applies unconditionally, before looking at errorKind, so it also
     // covers ErrorFatal operations.
     if (!ladder) {
-        return {.MediaKindNotConfigured = true};
+        return {.CountSkipped = true};
+    }
+
+    const auto errorKind = GetDiagnosticsErrorKind(error);
+
+    // These outcomes do not describe a storage operation whose latency can
+    // fairly be judged: the service explicitly refused to start it, the
+    // request was invalid before execution, or its owner cancelled it.
+    if (errorKind == EDiagnosticsErrorKind::ErrorThrottling ||
+        errorKind == EDiagnosticsErrorKind::ErrorWriteRejectedByCheckpoint ||
+        error.GetCode() == E_ARGUMENT ||
+        error.GetCode() == E_CANCELLED)
+    {
+        return {.CountSkipped = true};
+    }
+
+    // At this API boundary the error is the final logical outcome. Retriable,
+    // session, aborted-transport and silent errors are therefore terminal for
+    // this operation (including retry exhaustion), rather than intermediate
+    // attempts to exclude.
+    if (HasError(error)) {
+        return {.CountTotal = true};
     }
 
     switch (errorKind) {
+        case EDiagnosticsErrorKind::Success:
+            break;
+
+        // A successful error code is the source of truth. The remaining
+        // diagnostic kinds are defensive fallbacks for inconsistent input;
+        // count such an operation as failed instead of allowing it into the
+        // numerator.
         case EDiagnosticsErrorKind::ErrorThrottling:
         case EDiagnosticsErrorKind::ErrorWriteRejectedByCheckpoint:
-            // Rejected by the client's own choice/fault - not judged.
-            return {};
-
         case EDiagnosticsErrorKind::ErrorRetriable:
         case EDiagnosticsErrorKind::ErrorSession:
         case EDiagnosticsErrorKind::ErrorAborted:
         case EDiagnosticsErrorKind::ErrorSilent:
-            // Treated as one attempt of a retry chain whose outcome is
-            // decided elsewhere, so this attempt is not judged.
-            //
-            // Known limitation: the successful retry these counters expect
-            // to see instead does not always arrive. The durable client
-            // decides to stop retrying after receiving the last server
-            // response and substitutes E_RETRY_TIMEOUT locally
-            // (cloud/blockstore/libs/client/durable.cpp:351-355) without
-            // issuing another request, so a chain that ends in failure
-            // contributes nothing at all here. Terminal errors that map to
-            // this group in the first place have the same effect: E_IO_SILENT
-            // is in NeverRetriableErrors (durable.cpp) yet arrives as
-            // ErrorSilent. Telling such an outcome apart from a genuinely
-            // intermediate one needs more than the collapsed errorKind this
-            // function receives, so both stay excluded here.
-            return {};
-
         case EDiagnosticsErrorKind::ErrorFatal:
-            // The service failed to execute the operation - bad, but there
-            // is nothing to compare against a duration threshold.
-            //
-            // Known limitation, opposite in direction to the retriable case
-            // above: a request rejected by argument validation lands here as
-            // well, because the gRPC layer opens the stats lifecycle before
-            // it validates (RequestStarted in
-            // cloud/blockstore/libs/server/server.cpp precedes
-            // ValidateRequest a few lines below it). A client that sets the
-            // internal-only header, or talks on the wrong channel, is
-            // therefore counted as a bad operation of its volume without any
-            // I/O having run. The blast radius is that client's own mount,
-            // since the per-volume stats path resolves nothing without an
-            // active mount for the client/disk pair, and separating the two
-            // cases would mean carrying the request stage down from the
-            // server layer, which nothing on this path does today.
-            return {.CountTotal = true};
-
-        case EDiagnosticsErrorKind::Success:
-            break;
-
         case EDiagnosticsErrorKind::Max:
-            return {};
+            return {.CountTotal = true};
     }
 
     const auto& bucket = FindLatencyThresholdBucket(*ladder, requestBytes);

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
@@ -211,7 +211,7 @@ TLatencyThresholdOutcome ClassifyLatencyOutcome(
     const NProto::TError& error,
     bool isWrite,
     ui64 requestBytes,
-    TDuration execTime)
+    TDuration latency)
 {
     // A media kind without a configured ladder is not judged at all: not
     // counting it (rather than counting it as bad) avoids showing a bogus
@@ -225,11 +225,14 @@ TLatencyThresholdOutcome ClassifyLatencyOutcome(
     const auto errorKind = GetDiagnosticsErrorKind(error);
 
     // These outcomes do not describe a storage operation whose latency can
-    // fairly be judged: the service explicitly refused to start it, the
-    // request was invalid before execution, or its owner cancelled it.
+    // fairly be judged: the service explicitly refused to start it or its
+    // owner cancelled it. E_ARGUMENT is deliberately not excluded here: the
+    // same code is also used for invalid service responses after a valid
+    // operation has executed, so a final E_ARGUMENT at this boundary is a
+    // service failure unless the endpoint recorded a known pre-execution
+    // rejection explicitly.
     if (errorKind == EDiagnosticsErrorKind::ErrorThrottling ||
         errorKind == EDiagnosticsErrorKind::ErrorWriteRejectedByCheckpoint ||
-        error.GetCode() == E_ARGUMENT ||
         error.GetCode() == E_CANCELLED)
     {
         return {.CountSkipped = true};
@@ -270,7 +273,7 @@ TLatencyThresholdOutcome ClassifyLatencyOutcome(
         .CountTotal = true,
         // Non-strict comparison: an operation exactly at the threshold is
         // good.
-        .CountGood = execTime <= threshold,
+        .CountGood = latency <= threshold,
     };
 }
 

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
@@ -29,9 +29,9 @@ TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
 {
     TLatencyThresholdsValidationResult result;
 
-    // Rule 1: an enabled mechanism with an empty table is a config mistake,
-    // not a way to disable the mechanism (the flag itself already does
-    // that). Left invalid so the caller keeps the mechanism off and logs it.
+    // An enabled mechanism with an empty table is a config mistake, not a
+    // way to disable the mechanism (the flag itself already does that).
+    // Left invalid so the caller keeps the mechanism off and logs it.
     if (config.empty()) {
         result.Error = "LatencyThresholds is empty";
         return result;
@@ -41,16 +41,27 @@ TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
     THashSet<int> seenMediaKinds;
 
     for (const auto& mediaKindThresholds: config) {
+        // MediaKind is an optional field, so an entry that omits it parses
+        // cleanly and reads back as STORAGE_MEDIA_DEFAULT. That would
+        // silently calibrate a media kind nobody asked for while leaving
+        // the intended one unjudged, with the config reported as valid. An
+        // entry that spells out STORAGE_MEDIA_DEFAULT is still accepted:
+        // volumes whose config leaves the media kind unset do exist.
+        if (!mediaKindThresholds.HasMediaKind()) {
+            result.Error = "missing MediaKind in a LatencyThresholds entry";
+            return result;
+        }
+
         const auto mediaKind = mediaKindThresholds.GetMediaKind();
 
-        // Rule 0: mediaKind indexes a fixed-size array of ladders below, so
-        // it is bounds-checked here rather than trusted. Today the field
-        // cannot hold an out-of-range value: diagnostics.proto is proto2,
-        // whose enum fields are closed, so an unrecognized number from a
-        // config or from the wire is kept in the unknown-field set and the
-        // getter returns the default instead. That guarantee comes from the
-        // file's syntax, not from anything visible at this call site, so the
-        // check keeps the indexing safe if the enum ever becomes open
+        // mediaKind indexes a fixed-size array of ladders below, so it is
+        // bounds-checked here rather than trusted. Today the field cannot
+        // hold an out-of-range value: diagnostics.proto is proto2, whose
+        // enum fields are closed, so an unrecognized number from a config
+        // or from the wire is kept in the unknown-field set and the getter
+        // returns the default instead. That guarantee comes from the file's
+        // syntax, not from anything visible at this call site, so the check
+        // keeps the indexing safe if the enum ever becomes open
         // (proto3/editions), where an out-of-range index would be UB.
         if (!NCloud::NProto::EStorageMediaKind_IsValid(mediaKind)) {
             result.Error = TStringBuilder()
@@ -62,7 +73,7 @@ TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
         const TString mediaKindName =
             NCloud::NProto::EStorageMediaKind_Name(mediaKind);
 
-        // Rule 6: a media kind must not repeat within the list.
+        // A media kind must not repeat within the list.
         if (!seenMediaKinds.insert(static_cast<int>(mediaKind)).second) {
             result.Error = TStringBuilder()
                 << "duplicate media kind " << mediaKindName
@@ -70,7 +81,7 @@ TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
             return result;
         }
 
-        // Rule 2: every media kind needs at least one bucket.
+        // Every media kind needs at least one bucket.
         if (mediaKindThresholds.BucketsSize() == 0) {
             result.Error = TStringBuilder()
                 << "media kind " << mediaKindName
@@ -88,7 +99,7 @@ TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
         for (const auto& bucket: mediaKindThresholds.GetBuckets()) {
             const bool first = ladder.empty();
 
-            // Rule 3: the first bucket must start at 0, so that no operation
+            // The first bucket must start at 0, so that no operation
             // size falls outside of every bucket (this is what makes the
             // ladder total, not just "the ranges we happened to calibrate").
             if (first && bucket.GetMinRequestBytes() != 0) {
@@ -99,7 +110,7 @@ TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
                 return result;
             }
 
-            // Rule 4: strictly increasing lower bounds, never silently
+            // Strictly increasing lower bounds, never silently
             // sorted - a disordered/duplicated config is a typo, not
             // something to paper over.
             if (!first &&
@@ -113,7 +124,7 @@ TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
                 return result;
             }
 
-            // Rule 5: a zero threshold would fail every operation of that
+            // A zero threshold would fail every operation of that
             // size class outright.
             if (bucket.GetReadThresholdMs() == 0 ||
                 bucket.GetWriteThresholdMs() == 0)
@@ -210,8 +221,21 @@ TLatencyThresholdOutcome ClassifyLatencyOutcome(
         case EDiagnosticsErrorKind::ErrorSession:
         case EDiagnosticsErrorKind::ErrorAborted:
         case EDiagnosticsErrorKind::ErrorSilent:
-            // Per-attempt; the final attempt of the retry chain will be
-            // visible on its own.
+            // Treated as one attempt of a retry chain whose outcome is
+            // decided elsewhere, so this attempt is not judged.
+            //
+            // Known limitation: the successful retry these counters expect
+            // to see instead does not always arrive. The durable client
+            // decides to stop retrying after receiving the last server
+            // response and substitutes E_RETRY_TIMEOUT locally
+            // (cloud/blockstore/libs/client/durable.cpp:351-355) without
+            // issuing another request, so a chain that ends in failure
+            // contributes nothing at all here. Terminal errors that map to
+            // this group in the first place have the same effect: E_IO_SILENT
+            // is in NeverRetriableErrors (durable.cpp) yet arrives as
+            // ErrorSilent. Telling such an outcome apart from a genuinely
+            // intermediate one needs more than the collapsed errorKind this
+            // function receives, so both stay excluded here.
             return {};
 
         case EDiagnosticsErrorKind::ErrorFatal:

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.cpp
@@ -1,0 +1,241 @@
+#include "latency_thresholds.h"
+
+#include <util/generic/algorithm.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/string.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const TLatencyThresholdLadder* TLatencyThresholdsTable::FindLadder(
+    NCloud::NProto::EStorageMediaKind mediaKind) const
+{
+    if (mediaKind < 0 ||
+        static_cast<size_t>(mediaKind) >= Ladders.size())
+    {
+        return nullptr;
+    }
+
+    const auto& ladder = Ladders[mediaKind];
+    return ladder.empty() ? nullptr : &ladder;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
+    const TVector<NProto::TMediaKindLatencyThresholds>& config)
+{
+    TLatencyThresholdsValidationResult result;
+
+    // Rule 1: an enabled mechanism with an empty table is a config mistake,
+    // not a way to disable the mechanism (the flag itself already does
+    // that). Left invalid so the caller keeps the mechanism off and logs it.
+    if (config.empty()) {
+        result.Error = "LatencyThresholds is empty";
+        return result;
+    }
+
+    auto table = MakeIntrusive<TLatencyThresholdsTable>();
+    THashSet<int> seenMediaKinds;
+
+    for (const auto& mediaKindThresholds: config) {
+        const auto mediaKind = mediaKindThresholds.GetMediaKind();
+
+        // Rule 0: mediaKind indexes a fixed-size array of ladders below, so
+        // it is bounds-checked here rather than trusted. Today the field
+        // cannot hold an out-of-range value: diagnostics.proto is proto2,
+        // whose enum fields are closed, so an unrecognized number from a
+        // config or from the wire is kept in the unknown-field set and the
+        // getter returns the default instead. That guarantee comes from the
+        // file's syntax, not from anything visible at this call site, so the
+        // check keeps the indexing safe if the enum ever becomes open
+        // (proto3/editions), where an out-of-range index would be UB.
+        if (!NCloud::NProto::EStorageMediaKind_IsValid(mediaKind)) {
+            result.Error = TStringBuilder()
+                << "invalid media kind " << static_cast<int>(mediaKind)
+                << " in LatencyThresholds";
+            return result;
+        }
+
+        const TString mediaKindName =
+            NCloud::NProto::EStorageMediaKind_Name(mediaKind);
+
+        // Rule 6: a media kind must not repeat within the list.
+        if (!seenMediaKinds.insert(static_cast<int>(mediaKind)).second) {
+            result.Error = TStringBuilder()
+                << "duplicate media kind " << mediaKindName
+                << " in LatencyThresholds";
+            return result;
+        }
+
+        // Rule 2: every media kind needs at least one bucket.
+        if (mediaKindThresholds.BucketsSize() == 0) {
+            result.Error = TStringBuilder()
+                << "media kind " << mediaKindName
+                << " has no buckets in LatencyThresholds";
+            return result;
+        }
+
+        // Safe to index Ladders with mediaKind: bounds-checked above.
+        TLatencyThresholdLadder ladder;
+        ladder.reserve(mediaKindThresholds.BucketsSize());
+
+        ui32 lastReadThresholdMs = 0;
+        ui32 lastWriteThresholdMs = 0;
+
+        for (const auto& bucket: mediaKindThresholds.GetBuckets()) {
+            const bool first = ladder.empty();
+
+            // Rule 3: the first bucket must start at 0, so that no operation
+            // size falls outside of every bucket (this is what makes the
+            // ladder total, not just "the ranges we happened to calibrate").
+            if (first && bucket.GetMinRequestBytes() != 0) {
+                result.Error = TStringBuilder()
+                    << "media kind " << mediaKindName
+                    << ": first bucket MinRequestBytes must be 0, got "
+                    << bucket.GetMinRequestBytes();
+                return result;
+            }
+
+            // Rule 4: strictly increasing lower bounds, never silently
+            // sorted - a disordered/duplicated config is a typo, not
+            // something to paper over.
+            if (!first &&
+                bucket.GetMinRequestBytes() <= ladder.back().MinRequestBytes)
+            {
+                result.Error = TStringBuilder()
+                    << "media kind " << mediaKindName
+                    << ": MinRequestBytes must be strictly increasing, "
+                    << bucket.GetMinRequestBytes() << " does not follow "
+                    << ladder.back().MinRequestBytes;
+                return result;
+            }
+
+            // Rule 5: a zero threshold would fail every operation of that
+            // size class outright.
+            if (bucket.GetReadThresholdMs() == 0 ||
+                bucket.GetWriteThresholdMs() == 0)
+            {
+                result.Error = TStringBuilder()
+                    << "media kind " << mediaKindName << ": bucket at "
+                    << bucket.GetMinRequestBytes()
+                    << " has a zero threshold";
+                return result;
+            }
+
+            // Running-max (monotonicity) contract: a violation is not
+            // mechanically dangerous and a hard failure here could block an
+            // urgent config fix, so this is a warning, not an error.
+            if (!first &&
+                (bucket.GetReadThresholdMs() < lastReadThresholdMs ||
+                 bucket.GetWriteThresholdMs() < lastWriteThresholdMs))
+            {
+                result.Warnings.push_back(TStringBuilder()
+                    << "media kind " << mediaKindName
+                    << ": thresholds are not non-decreasing at bucket "
+                    << bucket.GetMinRequestBytes()
+                    << " (running-max contract violated)");
+            }
+
+            ladder.push_back(TLatencyThresholdBucket{
+                .MinRequestBytes = bucket.GetMinRequestBytes(),
+                .ReadThreshold =
+                    TDuration::MilliSeconds(bucket.GetReadThresholdMs()),
+                .WriteThreshold =
+                    TDuration::MilliSeconds(bucket.GetWriteThresholdMs()),
+            });
+
+            lastReadThresholdMs =
+                Max(lastReadThresholdMs, bucket.GetReadThresholdMs());
+            lastWriteThresholdMs =
+                Max(lastWriteThresholdMs, bucket.GetWriteThresholdMs());
+        }
+
+        table->Ladders[mediaKind] = std::move(ladder);
+    }
+
+    result.Table = std::move(table);
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+const TLatencyThresholdBucket& FindLatencyThresholdBucket(
+    const TLatencyThresholdLadder& ladder,
+    ui64 requestBytes)
+{
+    Y_DEBUG_ABORT_UNLESS(!ladder.empty());
+    Y_DEBUG_ABORT_UNLESS(ladder.front().MinRequestBytes == 0);
+
+    // upper_bound(requestBytes) - 1 == "the last bucket whose
+    // MinRequestBytes <= requestBytes". See the header comment for why a
+    // plain lower_bound over the lower bounds is wrong here.
+    auto it = UpperBound(
+        ladder.begin(),
+        ladder.end(),
+        requestBytes,
+        [](ui64 bytes, const TLatencyThresholdBucket& bucket)
+        { return bytes < bucket.MinRequestBytes; });
+    --it;
+    return *it;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TLatencyThresholdOutcome ClassifyLatencyOutcome(
+    const TLatencyThresholdLadder* ladder,
+    EDiagnosticsErrorKind errorKind,
+    bool isWrite,
+    ui64 requestBytes,
+    TDuration execTime)
+{
+    // A media kind without a configured ladder is not judged at all: not
+    // counting it (rather than counting it as bad) avoids showing a bogus
+    // 0% good-operation rate for media kinds nobody has calibrated yet. This
+    // gate applies unconditionally, before looking at errorKind, so it also
+    // covers ErrorFatal operations.
+    if (!ladder) {
+        return {.MediaKindNotConfigured = true};
+    }
+
+    switch (errorKind) {
+        case EDiagnosticsErrorKind::ErrorThrottling:
+        case EDiagnosticsErrorKind::ErrorWriteRejectedByCheckpoint:
+            // Rejected by the client's own choice/fault - not judged.
+            return {};
+
+        case EDiagnosticsErrorKind::ErrorRetriable:
+        case EDiagnosticsErrorKind::ErrorSession:
+        case EDiagnosticsErrorKind::ErrorAborted:
+        case EDiagnosticsErrorKind::ErrorSilent:
+            // Per-attempt; the final attempt of the retry chain will be
+            // visible on its own.
+            return {};
+
+        case EDiagnosticsErrorKind::ErrorFatal:
+            // The service failed to execute the operation - bad, but there
+            // is nothing to compare against a duration threshold.
+            return {.CountTotal = true};
+
+        case EDiagnosticsErrorKind::Success:
+            break;
+
+        case EDiagnosticsErrorKind::Max:
+            return {};
+    }
+
+    const auto& bucket = FindLatencyThresholdBucket(*ladder, requestBytes);
+    const auto threshold =
+        isWrite ? bucket.WriteThreshold : bucket.ReadThreshold;
+
+    return {
+        .CountTotal = true,
+        // Non-strict comparison: an operation exactly at the threshold is
+        // good.
+        .CountGood = execTime <= threshold,
+    };
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.h
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.h
@@ -42,13 +42,23 @@ using TLatencyThresholdLadder = TVector<TLatencyThresholdBucket>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TLatencyThresholdsValidationResult;
+
 // Immutable, validated snapshot of the whole latency thresholds table. Built
 // once from config and stored behind a THotSwap (see TLatencyThresholdsHotSwap
 // below) so that a future dynamic config source can replace it without
 // touching the request-completion hot path.
-struct TLatencyThresholdsTable
+class TLatencyThresholdsTable
     : public TAtomicRefCount<TLatencyThresholdsTable>
 {
+public:
+    // Returns nullptr if the media kind has no configured ladder (including
+    // out-of-range values). Callers must treat "no ladder" as "do not judge
+    // this operation at all", not as "bad operation".
+    [[nodiscard]] const TLatencyThresholdLadder* FindLadder(
+        NCloud::NProto::EStorageMediaKind mediaKind) const;
+
+private:
     // Indexed by NCloud::NProto::EStorageMediaKind. A media kind with an
     // empty ladder has no configured thresholds: operations of that media
     // kind must be skipped entirely (neither total nor good), not treated as
@@ -57,11 +67,13 @@ struct TLatencyThresholdsTable
         TLatencyThresholdLadder,
         NCloud::NProto::EStorageMediaKind_ARRAYSIZE> Ladders;
 
-    // Returns nullptr if the media kind has no configured ladder (including
-    // out-of-range values). Callers must treat "no ladder" as "do not judge
-    // this operation at all", not as "bad operation".
-    [[nodiscard]] const TLatencyThresholdLadder* FindLadder(
-        NCloud::NProto::EStorageMediaKind mediaKind) const;
+    // Filling the table is the validating builder's job alone, so that a
+    // published snapshot really is immutable: THotSwap synchronizes
+    // replacing the pointer, not writes to the object it points at, and a
+    // holder able to write here would race with the request path once a
+    // dynamic config source starts replacing tables.
+    friend TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
+        const TVector<NProto::TMediaKindLatencyThresholds>& config);
 };
 
 // Shared, hot-swappable holder for the current table. A single instance is

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.h
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.h
@@ -94,15 +94,19 @@ struct TLatencyThresholdsValidationResult
 };
 
 // Validates the raw proto config and builds the runtime lookup table.
-// Rules:
-//   1. The list must not be empty (an enabled mechanism with an empty table
-//      is a config mistake, not "disable via empty table").
-//   2. Every media kind entry has at least one bucket.
-//   3. The first bucket of every media kind has MinRequestBytes == 0.
-//   4. MinRequestBytes strictly increases within a media kind (no
-//      duplicates, no reordering; never silently sorted).
-//   5. Both thresholds in every bucket are > 0.
-//   6. A media kind appears at most once in the list.
+// Rules, in the order they are checked:
+//   - the list is not empty (an enabled mechanism with an empty table is a
+//     config mistake, not "disable via empty table");
+//   - every entry sets MediaKind explicitly (the field is optional, so an
+//     entry that omits it would parse as STORAGE_MEDIA_DEFAULT);
+//   - MediaKind is within the declared enum range (it indexes a fixed-size
+//     array of ladders);
+//   - a media kind appears at most once in the list;
+//   - every media kind entry has at least one bucket;
+//   - the first bucket of every media kind has MinRequestBytes == 0;
+//   - MinRequestBytes strictly increases within a media kind (no
+//     duplicates, no reordering; never silently sorted);
+//   - both thresholds in every bucket are > 0.
 // Non-decreasing thresholds with size (the "running max" contract) is
 // checked too, but only produces a Warning, not an Error.
 TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
@@ -134,10 +138,12 @@ const TLatencyThresholdBucket& FindLatencyThresholdBucket(
 
 // Outcome of judging a single completed read/write operation against the
 // latency thresholds table. Fatal errors are always bad (nothing to compare
-// a duration against); throttling/checkpoint rejections and per-attempt
-// retry outcomes are excluded entirely (not judged, not counted as bad);
+// a duration against); throttling/checkpoint rejections and retriable
+// outcomes are excluded entirely (not judged, not counted as bad);
 // everything else is judged by comparing execution time against the
 // threshold for its media kind, direction (read/write), and size bucket.
+// See ClassifyLatencyOutcome for a known gap in the retriable case: an
+// operation whose retries are exhausted contributes to neither counter.
 struct TLatencyThresholdOutcome
 {
     // Operation counted in the total (denominator).

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.h
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.h
@@ -27,7 +27,7 @@ inline constexpr size_t MaxLatencyThresholdBucketsPerMediaKind = 1024;
 ////////////////////////////////////////////////////////////////////////////////
 
 // A single operation-size bucket: the lower bound (inclusive) of the
-// operation size range together with the execution time thresholds for read
+// operation size range together with the measured-latency thresholds for read
 // and write operations of that size. An operation is considered timely if it
 // completes within the threshold configured for its size class. The upper
 // bound of a bucket is the next bucket's MinRequestBytes (open-ended for the
@@ -144,8 +144,9 @@ const TLatencyThresholdBucket& FindLatencyThresholdBucket(
 // Outcome of judging one final logical read/write operation after all
 // splitting and retries have completed. Successful operations are compared
 // with the size-dependent threshold. A final service failure is bad. Explicit
-// load-shedding/checkpoint rejections, invalid input and cancellation are
-// excluded from latency accounting.
+// load-shedding/checkpoint rejections and cancellation are excluded from
+// latency accounting. A bare E_ARGUMENT is not enough to prove invalid guest
+// input because service-response validation also uses that code.
 struct TLatencyThresholdOutcome
 {
     // Operation counted in the total (denominator).
@@ -170,6 +171,6 @@ TLatencyThresholdOutcome ClassifyLatencyOutcome(
     const NProto::TError& error,
     bool isWrite,
     ui64 requestBytes,
-    TDuration execTime);
+    TDuration latency);
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.h
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.h
@@ -7,8 +7,6 @@
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/protos/media.pb.h>
 
-#include <library/cpp/threading/hot_swap/hot_swap.h>
-
 #include <util/datetime/base.h>
 #include <util/generic/ptr.h>
 #include <util/generic/string.h>
@@ -16,8 +14,15 @@
 #include <util/system/yassert.h>
 
 #include <array>
+#include <cstddef>
 
 namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Keeps the external-vhost v1 environment value well below Linux's per-string
+// exec limit even when every numeric field uses its maximum decimal width.
+inline constexpr size_t MaxLatencyThresholdBucketsPerMediaKind = 1024;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -44,10 +49,8 @@ using TLatencyThresholdLadder = TVector<TLatencyThresholdBucket>;
 
 struct TLatencyThresholdsValidationResult;
 
-// Immutable, validated snapshot of the whole latency thresholds table. Built
-// once from config and stored behind a THotSwap (see TLatencyThresholdsHotSwap
-// below) so that a future dynamic config source can replace it without
-// touching the request-completion hot path.
+// Immutable, validated snapshot of the whole latency thresholds table. It is
+// built once from startup config and then shared by all per-volume objects.
 class TLatencyThresholdsTable
     : public TAtomicRefCount<TLatencyThresholdsTable>
 {
@@ -68,22 +71,10 @@ private:
         NCloud::NProto::EStorageMediaKind_ARRAYSIZE> Ladders;
 
     // Filling the table is the validating builder's job alone, so that a
-    // published snapshot really is immutable: THotSwap synchronizes
-    // replacing the pointer, not writes to the object it points at, and a
-    // holder able to write here would race with the request path once a
-    // dynamic config source starts replacing tables.
+    // published snapshot really is immutable.
     friend TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
         const TVector<NProto::TMediaKindLatencyThresholds>& config);
 };
-
-// Shared, hot-swappable holder for the current table. A single instance is
-// owned by the volume stats component and referenced (via shared_ptr) by
-// every per-volume object, mirroring how THotSwap<TVolumePerfSettings> is
-// used for PerfSettings on the same request-completion path (see
-// volume_perf.h). Read access is a single AtomicLoad() per operation.
-using TLatencyThresholdsHotSwap = THotSwap<TLatencyThresholdsTable>;
-
-////////////////////////////////////////////////////////////////////////////////
 
 struct TLatencyThresholdsValidationResult
 {
@@ -115,6 +106,8 @@ struct TLatencyThresholdsValidationResult
 //     array of ladders);
 //   - a media kind appears at most once in the list;
 //   - every media kind entry has at least one bucket;
+//   - every media kind entry has at most
+//     MaxLatencyThresholdBucketsPerMediaKind buckets;
 //   - the first bucket of every media kind has MinRequestBytes == 0;
 //   - MinRequestBytes strictly increases within a media kind (no
 //     duplicates, no reordering; never silently sorted);
@@ -148,14 +141,11 @@ const TLatencyThresholdBucket& FindLatencyThresholdBucket(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Outcome of judging a single completed read/write operation against the
-// latency thresholds table. Fatal errors are always bad (nothing to compare
-// a duration against); throttling/checkpoint rejections and retriable
-// outcomes are excluded entirely (not judged, not counted as bad);
-// everything else is judged by comparing execution time against the
-// threshold for its media kind, direction (read/write), and size bucket.
-// See ClassifyLatencyOutcome for a known gap in the retriable case: an
-// operation whose retries are exhausted contributes to neither counter.
+// Outcome of judging one final logical read/write operation after all
+// splitting and retries have completed. Successful operations are compared
+// with the size-dependent threshold. A final service failure is bad. Explicit
+// load-shedding/checkpoint rejections, invalid input and cancellation are
+// excluded from latency accounting.
 struct TLatencyThresholdOutcome
 {
     // Operation counted in the total (denominator).
@@ -164,19 +154,20 @@ struct TLatencyThresholdOutcome
     // Operation counted as good (numerator); only meaningful if CountTotal.
     bool CountGood = false;
 
-    // The operation's media kind has no configured ladder at all: the
-    // operation was skipped entirely (neither total nor good). Callers
-    // should tally this separately (a diagnostic "skipped" counter), never
-    // as a bad operation - see TLatencyThresholdsTable::FindLadder.
-    bool MediaKindNotConfigured = false;
+    // The operation was deliberately excluded (neither total nor good).
+    // This covers both an unconfigured media kind and a final outcome that
+    // is outside the latency counter contract. Callers tally it in the diagnostic
+    // skipped counter.
+    bool CountSkipped = false;
 };
 
 // Pure classification function, no side effects (the caller performs the
 // actual counter increments). `ladder` is nullptr when the operation's media
-// kind has no configured thresholds at all.
+// kind has no configured thresholds at all. `error` is the final result
+// visible at the endpoint boundary, not an individual server attempt.
 TLatencyThresholdOutcome ClassifyLatencyOutcome(
     const TLatencyThresholdLadder* ladder,
-    EDiagnosticsErrorKind errorKind,
+    const NProto::TError& error,
     bool isWrite,
     ui64 requestBytes,
     TDuration execTime);

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds.h
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds.h
@@ -1,0 +1,166 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/config/diagnostics.pb.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/protos/media.pb.h>
+
+#include <library/cpp/threading/hot_swap/hot_swap.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/system/yassert.h>
+
+#include <array>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// A single operation-size bucket: the lower bound (inclusive) of the
+// operation size range together with the execution time thresholds for read
+// and write operations of that size. An operation is considered timely if it
+// completes within the threshold configured for its size class. The upper
+// bound of a bucket is the next bucket's MinRequestBytes (open-ended for the
+// last bucket of a media kind).
+struct TLatencyThresholdBucket
+{
+    ui64 MinRequestBytes = 0;
+    TDuration ReadThreshold;
+    TDuration WriteThreshold;
+};
+
+// Ascending-by-MinRequestBytes ladder of buckets for a single media kind.
+// Non-empty and ladder.front().MinRequestBytes == 0 are invariants guaranteed
+// by BuildLatencyThresholdsTable for every ladder it stores in a
+// TLatencyThresholdsTable.
+using TLatencyThresholdLadder = TVector<TLatencyThresholdBucket>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Immutable, validated snapshot of the whole latency thresholds table. Built
+// once from config and stored behind a THotSwap (see TLatencyThresholdsHotSwap
+// below) so that a future dynamic config source can replace it without
+// touching the request-completion hot path.
+struct TLatencyThresholdsTable
+    : public TAtomicRefCount<TLatencyThresholdsTable>
+{
+    // Indexed by NCloud::NProto::EStorageMediaKind. A media kind with an
+    // empty ladder has no configured thresholds: operations of that media
+    // kind must be skipped entirely (neither total nor good), not treated as
+    // bad - see FindLadder.
+    std::array<
+        TLatencyThresholdLadder,
+        NCloud::NProto::EStorageMediaKind_ARRAYSIZE> Ladders;
+
+    // Returns nullptr if the media kind has no configured ladder (including
+    // out-of-range values). Callers must treat "no ladder" as "do not judge
+    // this operation at all", not as "bad operation".
+    [[nodiscard]] const TLatencyThresholdLadder* FindLadder(
+        NCloud::NProto::EStorageMediaKind mediaKind) const;
+};
+
+// Shared, hot-swappable holder for the current table. A single instance is
+// owned by the volume stats component and referenced (via shared_ptr) by
+// every per-volume object, mirroring how THotSwap<TVolumePerfSettings> is
+// used for PerfSettings on the same request-completion path (see
+// volume_perf.h). Read access is a single AtomicLoad() per operation.
+using TLatencyThresholdsHotSwap = THotSwap<TLatencyThresholdsTable>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TLatencyThresholdsValidationResult
+{
+    // Non-null only if the table is structurally valid (Error is empty).
+    TIntrusivePtr<TLatencyThresholdsTable> Table;
+
+    // First rule violation found; empty if valid. Validation stops at the
+    // first violation, so only one error is ever reported per call.
+    TString Error;
+
+    // Non-fatal notices (currently: thresholds that are not non-decreasing
+    // with operation size within a media kind). The table is still usable
+    // when only warnings are present.
+    TVector<TString> Warnings;
+
+    [[nodiscard]] bool IsValid() const
+    {
+        return Error.empty();
+    }
+};
+
+// Validates the raw proto config and builds the runtime lookup table.
+// Rules:
+//   1. The list must not be empty (an enabled mechanism with an empty table
+//      is a config mistake, not "disable via empty table").
+//   2. Every media kind entry has at least one bucket.
+//   3. The first bucket of every media kind has MinRequestBytes == 0.
+//   4. MinRequestBytes strictly increases within a media kind (no
+//      duplicates, no reordering; never silently sorted).
+//   5. Both thresholds in every bucket are > 0.
+//   6. A media kind appears at most once in the list.
+// Non-decreasing thresholds with size (the "running max" contract) is
+// checked too, but only produces a Warning, not an Error.
+TLatencyThresholdsValidationResult BuildLatencyThresholdsTable(
+    const TVector<NProto::TMediaKindLatencyThresholds>& config);
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Finds the bucket for requestBytes using [MinRequestBytes[i],
+// MinRequestBytes[i+1)) semantics: the returned bucket is the one with the
+// largest MinRequestBytes <= requestBytes ("last lower bound not exceeding
+// the size"), and the last bucket is implicitly open-ended upward.
+//
+// A naive std::lower_bound over the lower bounds is *not* equivalent to this:
+// it returns the first bound >= requestBytes, which for a size strictly
+// between two boundaries names the *next* (bigger) bucket, and for a size
+// above the last boundary returns end() (out of bounds). Both failure modes
+// bias toward a bigger/softer threshold than intended, i.e. the reported
+// metric would look better than reality. The correct idiom is
+// upper_bound(...) - 1: "the last boundary <= requestBytes".
+//
+// ladder must be non-empty with ladder.front().MinRequestBytes == 0 (both
+// guaranteed by BuildLatencyThresholdsTable), so upper_bound never returns
+// begin() and the decrement below is always safe.
+const TLatencyThresholdBucket& FindLatencyThresholdBucket(
+    const TLatencyThresholdLadder& ladder,
+    ui64 requestBytes);
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Outcome of judging a single completed read/write operation against the
+// latency thresholds table. Fatal errors are always bad (nothing to compare
+// a duration against); throttling/checkpoint rejections and per-attempt
+// retry outcomes are excluded entirely (not judged, not counted as bad);
+// everything else is judged by comparing execution time against the
+// threshold for its media kind, direction (read/write), and size bucket.
+struct TLatencyThresholdOutcome
+{
+    // Operation counted in the total (denominator).
+    bool CountTotal = false;
+
+    // Operation counted as good (numerator); only meaningful if CountTotal.
+    bool CountGood = false;
+
+    // The operation's media kind has no configured ladder at all: the
+    // operation was skipped entirely (neither total nor good). Callers
+    // should tally this separately (a diagnostic "skipped" counter), never
+    // as a bad operation - see TLatencyThresholdsTable::FindLadder.
+    bool MediaKindNotConfigured = false;
+};
+
+// Pure classification function, no side effects (the caller performs the
+// actual counter increments). `ladder` is nullptr when the operation's media
+// kind has no configured thresholds at all.
+TLatencyThresholdOutcome ClassifyLatencyOutcome(
+    const TLatencyThresholdLadder* ladder,
+    EDiagnosticsErrorKind errorKind,
+    bool isWrite,
+    ui64 requestBytes,
+    TDuration execTime);
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds_config.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds_config.cpp
@@ -1,0 +1,96 @@
+#include "latency_thresholds_config.h"
+
+#include <util/generic/yexception.h>
+#include <util/string/builder.h>
+#include <util/string/cast.h>
+
+namespace NCloud::NBlockStore::NVHostServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TLatencyThresholdLadder ParseLatencyThresholdsConfigV1(TStringBuf value)
+{
+    if (value == "unconfigured") {
+        return {};
+    }
+
+    Y_ENSURE(value, "latency thresholds v1 config is empty");
+
+    TLatencyThresholdLadder result;
+    size_t offset = 0;
+    while (offset < value.size()) {
+        const size_t comma = value.find(',', offset);
+        const TStringBuf item = value.SubStr(
+            offset,
+            comma == TStringBuf::npos ? TStringBuf::npos : comma - offset);
+
+        const size_t firstColon = item.find(':');
+        const size_t secondColon = firstColon == TStringBuf::npos
+            ? TStringBuf::npos
+            : item.find(':', firstColon + 1);
+        Y_ENSURE(
+            item && firstColon != TStringBuf::npos &&
+                secondColon != TStringBuf::npos &&
+                item.find(':', secondColon + 1) == TStringBuf::npos,
+            "invalid latency thresholds v1 bucket: " << item);
+
+        const ui64 minRequestBytes =
+            FromString<ui64>(item.SubStr(0, firstColon));
+        const ui32 readThresholdMs = FromString<ui32>(
+            item.SubStr(firstColon + 1, secondColon - firstColon - 1));
+        const ui32 writeThresholdMs =
+            FromString<ui32>(item.SubStr(secondColon + 1));
+
+        Y_ENSURE(
+            readThresholdMs && writeThresholdMs,
+            "latency thresholds v1 values must be positive");
+        Y_ENSURE(
+            !result.empty() || minRequestBytes == 0,
+            "latency thresholds v1 first bucket must start at zero");
+        Y_ENSURE(
+            result.empty() ||
+                result.back().MinRequestBytes < minRequestBytes,
+            "latency thresholds v1 bucket bounds must be strictly increasing");
+        Y_ENSURE(
+            result.size() < MaxLatencyThresholdBucketsPerMediaKind,
+            "latency thresholds v1 config has too many buckets");
+
+        result.push_back(TLatencyThresholdBucket{
+            .MinRequestBytes = minRequestBytes,
+            .ReadThreshold = TDuration::MilliSeconds(readThresholdMs),
+            .WriteThreshold = TDuration::MilliSeconds(writeThresholdMs),
+        });
+
+        if (comma == TStringBuf::npos) {
+            break;
+        }
+        offset = comma + 1;
+        Y_ENSURE(
+            offset < value.size(),
+            "latency thresholds v1 config has empty bucket");
+    }
+
+    return result;
+}
+
+TString SerializeLatencyThresholdsConfigV1(const TLatencyThresholdLadder* ladder)
+{
+    if (!ladder) {
+        return "unconfigured";
+    }
+
+    TStringBuilder result;
+    bool first = true;
+    for (const auto& bucket: *ladder) {
+        if (!first) {
+            result << ',';
+        }
+        first = false;
+        result << bucket.MinRequestBytes << ':'
+               << bucket.ReadThreshold.MilliSeconds() << ':'
+               << bucket.WriteThreshold.MilliSeconds();
+    }
+    return result;
+}
+
+}   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds_config.h
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds_config.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "latency_thresholds.h"
+
+#include <util/generic/strbuf.h>
+#include <util/generic/string.h>
+
+namespace NCloud::NBlockStore::NVHostServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+inline constexpr TStringBuf LatencyThresholdsConfigV1EnvName =
+    "NBS_VHOST_LATENCY_THRESHOLDS_CONFIG_V1";
+
+// The v1 value is either "unconfigured" (feature enabled, selected media kind
+// has no ladder) or a comma-separated list of
+// min_request_bytes:read_threshold_ms:write_threshold_ms buckets.
+TLatencyThresholdLadder ParseLatencyThresholdsConfigV1(TStringBuf value);
+
+TString SerializeLatencyThresholdsConfigV1(const TLatencyThresholdLadder* ladder);
+
+}   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp
@@ -93,6 +93,40 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsValidationTest)
         UNIT_ASSERT(!result.IsValid());
     }
 
+    Y_UNIT_TEST(ShouldRejectTooManyBuckets)
+    {
+        NProto::TMediaKindLatencyThresholds thresholds;
+        thresholds.SetMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
+        for (size_t i = 0;
+             i <= MaxLatencyThresholdBucketsPerMediaKind;
+             ++i)
+        {
+            *thresholds.AddBuckets() = MakeBucket(i, 10, 10);
+        }
+
+        auto result = BuildLatencyThresholdsTable({thresholds});
+
+        UNIT_ASSERT(!result.IsValid());
+        UNIT_ASSERT(!result.Table);
+    }
+
+    Y_UNIT_TEST(ShouldAcceptMaximumBucketCount)
+    {
+        NProto::TMediaKindLatencyThresholds thresholds;
+        thresholds.SetMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
+        for (size_t i = 0;
+             i < MaxLatencyThresholdBucketsPerMediaKind;
+             ++i)
+        {
+            *thresholds.AddBuckets() = MakeBucket(i, 10, 10);
+        }
+
+        auto result = BuildLatencyThresholdsTable({thresholds});
+
+        UNIT_ASSERT(result.IsValid());
+        UNIT_ASSERT(result.Table);
+    }
+
     Y_UNIT_TEST(ShouldRejectFirstBucketWithNonZeroMinRequestBytes)
     {
         TVector<NProto::TMediaKindLatencyThresholds> config = {
@@ -340,129 +374,114 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsLookupTest)
 
 Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
 {
+    TLatencyThresholdLadder MakeLadder()
+    {
+        return {{
+            .MinRequestBytes = 0,
+            .ReadThreshold = TDuration::MilliSeconds(10),
+            .WriteThreshold = TDuration::MilliSeconds(10),
+        }};
+    }
+
     Y_UNIT_TEST(ShouldSkipOperationWithNoConfiguredLadder)
     {
         auto outcome = ClassifyLatencyOutcome(
             nullptr,
-            EDiagnosticsErrorKind::Success,
+            {},
             false,
             4_KB,
             TDuration::MilliSeconds(1));
 
-        UNIT_ASSERT(outcome.MediaKindNotConfigured);
+        UNIT_ASSERT(outcome.CountSkipped);
         UNIT_ASSERT(!outcome.CountTotal);
         UNIT_ASSERT(!outcome.CountGood);
     }
 
-    Y_UNIT_TEST(ShouldCountFatalErrorAsTotalButNotGood)
+    void CheckFinalFailureIsBad(ui32 errorCode)
     {
-        TLatencyThresholdLadder ladder = {
-            {
-                .MinRequestBytes = 0,
-                .ReadThreshold = TDuration::MilliSeconds(10),
-                .WriteThreshold = TDuration::MilliSeconds(10),
-            },
-        };
+        auto ladder = MakeLadder();
 
         auto outcome = ClassifyLatencyOutcome(
             &ladder,
-            EDiagnosticsErrorKind::ErrorFatal,
+            MakeError(errorCode),
             false,
             4_KB,
             TDuration::MilliSeconds(1));
 
-        UNIT_ASSERT(!outcome.MediaKindNotConfigured);
+        UNIT_ASSERT(!outcome.CountSkipped);
         UNIT_ASSERT(outcome.CountTotal);
         UNIT_ASSERT(!outcome.CountGood);
     }
 
-    void CheckNeitherCounterMoves(EDiagnosticsErrorKind errorKind)
+    Y_UNIT_TEST(ShouldCountAllFinalServiceFailuresAsBad)
     {
-        TLatencyThresholdLadder ladder = {
-            {
-                .MinRequestBytes = 0,
-                .ReadThreshold = TDuration::MilliSeconds(10),
-                .WriteThreshold = TDuration::MilliSeconds(10),
-            },
-        };
+        CheckFinalFailureIsBad(E_FAIL);
+        CheckFinalFailureIsBad(E_RETRY_TIMEOUT);
+        CheckFinalFailureIsBad(E_REJECTED);
+        CheckFinalFailureIsBad(E_BS_INVALID_SESSION);
+        CheckFinalFailureIsBad(E_ABORTED);
+        CheckFinalFailureIsBad(E_TRANSPORT_ERROR);
+        CheckFinalFailureIsBad(E_IO_SILENT);
+    }
+
+    void CheckSkipped(const NProto::TError& error)
+    {
+        auto ladder = MakeLadder();
 
         auto outcome = ClassifyLatencyOutcome(
             &ladder,
-            errorKind,
+            error,
             false,
             4_KB,
             TDuration::MilliSeconds(1));
 
-        UNIT_ASSERT(!outcome.MediaKindNotConfigured);
+        UNIT_ASSERT(outcome.CountSkipped);
         UNIT_ASSERT(!outcome.CountTotal);
         UNIT_ASSERT(!outcome.CountGood);
     }
 
-    Y_UNIT_TEST(ShouldNotCountThrottledOperation)
+    Y_UNIT_TEST(ShouldSkipExplicitThrottlingRejection)
     {
-        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorThrottling);
+        CheckSkipped(MakeError(E_BS_THROTTLED));
+        CheckSkipped(MakeError(E_REJECTED, "Throttled"));
     }
 
-    Y_UNIT_TEST(ShouldNotCountOperationRejectedByCheckpoint)
+    Y_UNIT_TEST(ShouldSkipOperationRejectedByCheckpoint)
     {
-        CheckNeitherCounterMoves(
-            EDiagnosticsErrorKind::ErrorWriteRejectedByCheckpoint);
+        CheckSkipped(MakeError(
+            E_REJECTED,
+            "Checkpoint reject request. test"));
     }
 
-    Y_UNIT_TEST(ShouldNotCountRetriableError)
+    Y_UNIT_TEST(ShouldSkipInvalidInputAndCancellation)
     {
-        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorRetriable);
-    }
-
-    Y_UNIT_TEST(ShouldNotCountSessionError)
-    {
-        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorSession);
-    }
-
-    Y_UNIT_TEST(ShouldNotCountAbortedError)
-    {
-        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorAborted);
-    }
-
-    Y_UNIT_TEST(ShouldNotCountSilentError)
-    {
-        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorSilent);
+        CheckSkipped(MakeError(E_ARGUMENT));
+        CheckSkipped(MakeError(E_CANCELLED));
     }
 
     Y_UNIT_TEST(ShouldCountFastSuccessfulOperationAsGood)
     {
-        TLatencyThresholdLadder ladder = {
-            {
-                .MinRequestBytes = 0,
-                .ReadThreshold = TDuration::MilliSeconds(10),
-                .WriteThreshold = TDuration::MilliSeconds(10),
-            },
-        };
+        auto ladder = MakeLadder();
 
         auto outcome = ClassifyLatencyOutcome(
             &ladder,
-            EDiagnosticsErrorKind::Success,
+            {},
             false,
             4_KB,
             TDuration::MilliSeconds(1));
 
+        UNIT_ASSERT(!outcome.CountSkipped);
         UNIT_ASSERT(outcome.CountTotal);
         UNIT_ASSERT(outcome.CountGood);
     }
 
     Y_UNIT_TEST(ShouldCountSlowSuccessfulOperationAsTotalOnly)
     {
-        TLatencyThresholdLadder ladder = {
-            {
-                .MinRequestBytes = 0,
-                .ReadThreshold = TDuration::MilliSeconds(10),
-                .WriteThreshold = TDuration::MilliSeconds(10),
-            },
-        };
+        auto ladder = MakeLadder();
 
         auto outcome = ClassifyLatencyOutcome(
             &ladder,
-            EDiagnosticsErrorKind::Success,
+            {},
             false,
             4_KB,
             TDuration::MilliSeconds(20));
@@ -473,17 +492,11 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
 
     Y_UNIT_TEST(ShouldTreatExecTimeExactlyAtThresholdAsGood)
     {
-        TLatencyThresholdLadder ladder = {
-            {
-                .MinRequestBytes = 0,
-                .ReadThreshold = TDuration::MilliSeconds(10),
-                .WriteThreshold = TDuration::MilliSeconds(10),
-            },
-        };
+        auto ladder = MakeLadder();
 
         auto outcome = ClassifyLatencyOutcome(
             &ladder,
-            EDiagnosticsErrorKind::Success,
+            {},
             false,
             4_KB,
             TDuration::MilliSeconds(10));
@@ -499,17 +512,11 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
         // itself has no notion of waiting, it only sees the (small) execTime
         // that made it through. Success + a small execTime must count as
         // good, exactly like an unthrottled fast operation.
-        TLatencyThresholdLadder ladder = {
-            {
-                .MinRequestBytes = 0,
-                .ReadThreshold = TDuration::MilliSeconds(10),
-                .WriteThreshold = TDuration::MilliSeconds(10),
-            },
-        };
+        auto ladder = MakeLadder();
 
         auto outcome = ClassifyLatencyOutcome(
             &ladder,
-            EDiagnosticsErrorKind::Success,
+            {},
             false,
             4_KB,
             TDuration::MilliSeconds(1));
@@ -531,7 +538,7 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
         // 20ms is over the write threshold but under the read threshold.
         auto outcome = ClassifyLatencyOutcome(
             &ladder,
-            EDiagnosticsErrorKind::Success,
+            {},
             /*isWrite*/ false,
             4_KB,
             TDuration::MilliSeconds(20));
@@ -555,7 +562,7 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
         // execTime passes.
         auto outcome = ClassifyLatencyOutcome(
             &ladder,
-            EDiagnosticsErrorKind::Success,
+            {},
             /*isWrite*/ true,
             4_KB,
             TDuration::MilliSeconds(20));
@@ -579,20 +586,20 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
 
         const struct
         {
-            EDiagnosticsErrorKind ErrorKind;
+            NProto::TError Error;
             TDuration ExecTime;
         } ops[] = {
-            {EDiagnosticsErrorKind::Success, TDuration::MilliSeconds(1)},
-            {EDiagnosticsErrorKind::Success, TDuration::MilliSeconds(50)},
-            {EDiagnosticsErrorKind::ErrorFatal, TDuration::Zero()},
-            {EDiagnosticsErrorKind::ErrorThrottling, TDuration::Zero()},
-            {EDiagnosticsErrorKind::Success, TDuration::MilliSeconds(10)},
+            {{}, TDuration::MilliSeconds(1)},
+            {{}, TDuration::MilliSeconds(50)},
+            {MakeError(E_FAIL), TDuration::Zero()},
+            {MakeError(E_BS_THROTTLED), TDuration::Zero()},
+            {{}, TDuration::MilliSeconds(10)},
         };
 
         for (const auto& op: ops) {
             auto outcome = ClassifyLatencyOutcome(
                 &ladder,
-                op.ErrorKind,
+                op.Error,
                 false,
                 4_KB,
                 op.ExecTime);

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp
@@ -67,6 +67,21 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsValidationTest)
         UNIT_ASSERT(!result.Table);
     }
 
+    Y_UNIT_TEST(ShouldRejectEntryWithoutMediaKind)
+    {
+        // MediaKind is optional in the proto, so an entry that omits it
+        // parses cleanly and reads back as STORAGE_MEDIA_DEFAULT instead of
+        // failing - the validator has to reject it explicitly.
+        NProto::TMediaKindLatencyThresholds mkt;
+        *mkt.AddBuckets() = MakeBucket(0, 10, 10);
+
+        auto result = BuildLatencyThresholdsTable({mkt});
+
+        UNIT_ASSERT(!result.IsValid());
+        UNIT_ASSERT(!result.Error.empty());
+        UNIT_ASSERT(!result.Table);
+    }
+
     Y_UNIT_TEST(ShouldRejectMediaKindWithoutBuckets)
     {
         TVector<NProto::TMediaKindLatencyThresholds> config = {

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp
@@ -1,0 +1,594 @@
+#include "latency_thresholds.h"
+
+#include <cloud/storage/core/protos/media.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NBlockStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using EStorageMediaKind = NCloud::NProto::EStorageMediaKind;
+
+NProto::TLatencyThresholdBucket MakeBucket(
+    ui64 minRequestBytes,
+    ui32 readThresholdMs,
+    ui32 writeThresholdMs)
+{
+    NProto::TLatencyThresholdBucket bucket;
+    bucket.SetMinRequestBytes(minRequestBytes);
+    bucket.SetReadThresholdMs(readThresholdMs);
+    bucket.SetWriteThresholdMs(writeThresholdMs);
+    return bucket;
+}
+
+NProto::TMediaKindLatencyThresholds MakeMediaKindThresholds(
+    EStorageMediaKind mediaKind,
+    const TVector<NProto::TLatencyThresholdBucket>& buckets)
+{
+    NProto::TMediaKindLatencyThresholds mkt;
+    mkt.SetMediaKind(mediaKind);
+    for (const auto& bucket: buckets) {
+        *mkt.AddBuckets() = bucket;
+    }
+    return mkt;
+}
+
+// A single-media-kind, two-bucket config valid enough to exercise the
+// bucket-lookup and accounting logic: [0, 8_KB) and [8_KB, +inf), with
+// distinct read/write thresholds so the two are never accidentally swapped.
+TVector<NProto::TMediaKindLatencyThresholds> MakeValidConfig(
+    EStorageMediaKind mediaKind = NCloud::NProto::STORAGE_MEDIA_SSD)
+{
+    return {MakeMediaKindThresholds(
+        mediaKind,
+        {
+            MakeBucket(0, 10, 20),
+            MakeBucket(8_KB, 100, 200),
+        })};
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLatencyThresholdsValidationTest)
+{
+    Y_UNIT_TEST(ShouldRejectEmptyConfig)
+    {
+        auto result = BuildLatencyThresholdsTable({});
+
+        UNIT_ASSERT(!result.IsValid());
+        UNIT_ASSERT(!result.Error.empty());
+        UNIT_ASSERT(!result.Table);
+    }
+
+    Y_UNIT_TEST(ShouldRejectMediaKindWithoutBuckets)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(NCloud::NProto::STORAGE_MEDIA_SSD, {}),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(!result.IsValid());
+    }
+
+    Y_UNIT_TEST(ShouldRejectFirstBucketWithNonZeroMinRequestBytes)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {MakeBucket(4_KB, 10, 10)}),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(!result.IsValid());
+    }
+
+    Y_UNIT_TEST(ShouldRejectNonIncreasingMinRequestBytes)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {
+                    MakeBucket(0, 10, 10),
+                    MakeBucket(8_KB, 10, 10),
+                    MakeBucket(4_KB, 10, 10),
+                }),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(!result.IsValid());
+    }
+
+    Y_UNIT_TEST(ShouldRejectDuplicateMinRequestBytes)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {
+                    MakeBucket(0, 10, 10),
+                    MakeBucket(8_KB, 10, 10),
+                    MakeBucket(8_KB, 10, 10),
+                }),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(!result.IsValid());
+    }
+
+    Y_UNIT_TEST(ShouldRejectDuplicateMediaKind)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {MakeBucket(0, 10, 10)}),
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {MakeBucket(0, 20, 20)}),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(!result.IsValid());
+    }
+
+    Y_UNIT_TEST(ShouldRejectZeroReadThreshold)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {MakeBucket(0, 0, 10)}),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(!result.IsValid());
+    }
+
+    Y_UNIT_TEST(ShouldRejectZeroWriteThreshold)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {MakeBucket(0, 10, 0)}),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(!result.IsValid());
+    }
+
+    Y_UNIT_TEST(ShouldAcceptNonMonotonicThresholdsWithWarning)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {
+                    MakeBucket(0, 100, 100),
+                    // Smaller than the previous bucket's threshold - not
+                    // mechanically dangerous, just a config smell.
+                    MakeBucket(8_KB, 10, 10),
+                }),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(result.IsValid());
+        UNIT_ASSERT(result.Table);
+        UNIT_ASSERT_VALUES_EQUAL(1u, result.Warnings.size());
+    }
+
+    Y_UNIT_TEST(ShouldAcceptValidConfigWithoutWarnings)
+    {
+        auto result = BuildLatencyThresholdsTable(MakeValidConfig());
+
+        UNIT_ASSERT(result.IsValid());
+        UNIT_ASSERT(result.Table);
+        UNIT_ASSERT(result.Warnings.empty());
+    }
+
+    Y_UNIT_TEST(ShouldAcceptMultipleDistinctMediaKinds)
+    {
+        TVector<NProto::TMediaKindLatencyThresholds> config = {
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                {MakeBucket(0, 10, 10)}),
+            MakeMediaKindThresholds(
+                NCloud::NProto::STORAGE_MEDIA_HDD,
+                {MakeBucket(0, 50, 50)}),
+        };
+
+        auto result = BuildLatencyThresholdsTable(config);
+
+        UNIT_ASSERT(result.IsValid());
+        UNIT_ASSERT(
+            result.Table->FindLadder(NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT(
+            result.Table->FindLadder(NCloud::NProto::STORAGE_MEDIA_HDD));
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLatencyThresholdsLookupTest)
+{
+    Y_UNIT_TEST(ShouldReturnNullptrForUnconfiguredMediaKind)
+    {
+        auto result = BuildLatencyThresholdsTable(
+            MakeValidConfig(NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT(result.IsValid());
+
+        UNIT_ASSERT(
+            !result.Table->FindLadder(NCloud::NProto::STORAGE_MEDIA_HDD));
+    }
+
+    Y_UNIT_TEST(ShouldPlaceZeroSizeInFirstBucket)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+            },
+            {
+                .MinRequestBytes = 8_KB,
+                .ReadThreshold = TDuration::MilliSeconds(100),
+            },
+        };
+
+        const auto& bucket = FindLatencyThresholdBucket(ladder, 0);
+
+        UNIT_ASSERT_VALUES_EQUAL(0u, bucket.MinRequestBytes);
+    }
+
+    Y_UNIT_TEST(ShouldPlaceSizeStrictlyBetweenBoundariesInLowerBucket)
+    {
+        // Boundaries 0 / 8K / 16K; 6K must land in [0, 8K), not [8K, 16K).
+        // This is the exact trap described in the task: a naive lower_bound
+        // over the lower bounds would land one bucket too high here.
+        TLatencyThresholdLadder ladder = {
+            {.MinRequestBytes = 0},
+            {.MinRequestBytes = 8_KB},
+            {.MinRequestBytes = 16_KB},
+        };
+
+        const auto& bucket = FindLatencyThresholdBucket(ladder, 6_KB);
+
+        UNIT_ASSERT_VALUES_EQUAL(0u, bucket.MinRequestBytes);
+    }
+
+    Y_UNIT_TEST(ShouldPlaceSizeExactlyOnBoundaryInUpperBucket)
+    {
+        TLatencyThresholdLadder ladder = {
+            {.MinRequestBytes = 0},
+            {.MinRequestBytes = 8_KB},
+            {.MinRequestBytes = 16_KB},
+        };
+
+        {
+            const auto& bucket = FindLatencyThresholdBucket(ladder, 4_KB);
+            UNIT_ASSERT_VALUES_EQUAL(0u, bucket.MinRequestBytes);
+        }
+        {
+            const auto& bucket = FindLatencyThresholdBucket(ladder, 8_KB);
+            UNIT_ASSERT_VALUES_EQUAL(8_KB, bucket.MinRequestBytes);
+        }
+        {
+            const auto& bucket = FindLatencyThresholdBucket(ladder, 4_MB);
+            UNIT_ASSERT_VALUES_EQUAL(16_KB, bucket.MinRequestBytes);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldPlaceSizeAboveLastBoundaryInLastBucketWithoutOverrun)
+    {
+        TLatencyThresholdLadder ladder = {
+            {.MinRequestBytes = 0},
+            {.MinRequestBytes = 8_KB},
+            {.MinRequestBytes = 16_KB},
+        };
+
+        const auto& bucket = FindLatencyThresholdBucket(ladder, 8_MB);
+
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, bucket.MinRequestBytes);
+    }
+
+    Y_UNIT_TEST(ShouldApplyReadAndWriteThresholdsSeparately)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+                .WriteThreshold = TDuration::MilliSeconds(20),
+            },
+        };
+
+        const auto& bucket = FindLatencyThresholdBucket(ladder, 0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(10),
+            bucket.ReadThreshold);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(20),
+            bucket.WriteThreshold);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
+{
+    Y_UNIT_TEST(ShouldSkipOperationWithNoConfiguredLadder)
+    {
+        auto outcome = ClassifyLatencyOutcome(
+            nullptr,
+            EDiagnosticsErrorKind::Success,
+            false,
+            4_KB,
+            TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(outcome.MediaKindNotConfigured);
+        UNIT_ASSERT(!outcome.CountTotal);
+        UNIT_ASSERT(!outcome.CountGood);
+    }
+
+    Y_UNIT_TEST(ShouldCountFatalErrorAsTotalButNotGood)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        auto outcome = ClassifyLatencyOutcome(
+            &ladder,
+            EDiagnosticsErrorKind::ErrorFatal,
+            false,
+            4_KB,
+            TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(!outcome.MediaKindNotConfigured);
+        UNIT_ASSERT(outcome.CountTotal);
+        UNIT_ASSERT(!outcome.CountGood);
+    }
+
+    void CheckNeitherCounterMoves(EDiagnosticsErrorKind errorKind)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        auto outcome = ClassifyLatencyOutcome(
+            &ladder,
+            errorKind,
+            false,
+            4_KB,
+            TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(!outcome.MediaKindNotConfigured);
+        UNIT_ASSERT(!outcome.CountTotal);
+        UNIT_ASSERT(!outcome.CountGood);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountThrottledOperation)
+    {
+        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorThrottling);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountOperationRejectedByCheckpoint)
+    {
+        CheckNeitherCounterMoves(
+            EDiagnosticsErrorKind::ErrorWriteRejectedByCheckpoint);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountRetriableError)
+    {
+        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorRetriable);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountSessionError)
+    {
+        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorSession);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountAbortedError)
+    {
+        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorAborted);
+    }
+
+    Y_UNIT_TEST(ShouldNotCountSilentError)
+    {
+        CheckNeitherCounterMoves(EDiagnosticsErrorKind::ErrorSilent);
+    }
+
+    Y_UNIT_TEST(ShouldCountFastSuccessfulOperationAsGood)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        auto outcome = ClassifyLatencyOutcome(
+            &ladder,
+            EDiagnosticsErrorKind::Success,
+            false,
+            4_KB,
+            TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(outcome.CountTotal);
+        UNIT_ASSERT(outcome.CountGood);
+    }
+
+    Y_UNIT_TEST(ShouldCountSlowSuccessfulOperationAsTotalOnly)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        auto outcome = ClassifyLatencyOutcome(
+            &ladder,
+            EDiagnosticsErrorKind::Success,
+            false,
+            4_KB,
+            TDuration::MilliSeconds(20));
+
+        UNIT_ASSERT(outcome.CountTotal);
+        UNIT_ASSERT(!outcome.CountGood);
+    }
+
+    Y_UNIT_TEST(ShouldTreatExecTimeExactlyAtThresholdAsGood)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        auto outcome = ClassifyLatencyOutcome(
+            &ladder,
+            EDiagnosticsErrorKind::Success,
+            false,
+            4_KB,
+            TDuration::MilliSeconds(10));
+
+        UNIT_ASSERT(outcome.CountTotal);
+        UNIT_ASSERT(outcome.CountGood);
+    }
+
+    Y_UNIT_TEST(ShouldCountShapedButExecutedOperation)
+    {
+        // A throttled-but-executed operation is judged on its execTime with
+        // the wait already subtracted by the caller - ClassifyLatencyOutcome
+        // itself has no notion of waiting, it only sees the (small) execTime
+        // that made it through. Success + a small execTime must count as
+        // good, exactly like an unthrottled fast operation.
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        auto outcome = ClassifyLatencyOutcome(
+            &ladder,
+            EDiagnosticsErrorKind::Success,
+            false,
+            4_KB,
+            TDuration::MilliSeconds(1));
+
+        UNIT_ASSERT(outcome.CountTotal);
+        UNIT_ASSERT(outcome.CountGood);
+    }
+
+    Y_UNIT_TEST(ShouldApplyReadThresholdForReads)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(50),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        // 20ms is over the write threshold but under the read threshold.
+        auto outcome = ClassifyLatencyOutcome(
+            &ladder,
+            EDiagnosticsErrorKind::Success,
+            /*isWrite*/ false,
+            4_KB,
+            TDuration::MilliSeconds(20));
+
+        UNIT_ASSERT(outcome.CountTotal);
+        UNIT_ASSERT(outcome.CountGood);
+    }
+
+    Y_UNIT_TEST(ShouldApplyWriteThresholdForWrites)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(50),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        // Same 20ms, but now judged as a write against the stricter
+        // threshold - must fail even though the read case with the same
+        // execTime passes.
+        auto outcome = ClassifyLatencyOutcome(
+            &ladder,
+            EDiagnosticsErrorKind::Success,
+            /*isWrite*/ true,
+            4_KB,
+            TDuration::MilliSeconds(20));
+
+        UNIT_ASSERT(outcome.CountTotal);
+        UNIT_ASSERT(!outcome.CountGood);
+    }
+
+    Y_UNIT_TEST(ShouldKeepGoodNotExceedingTotalOverMixedStream)
+    {
+        TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(10),
+                .WriteThreshold = TDuration::MilliSeconds(10),
+            },
+        };
+
+        ui64 total = 0;
+        ui64 good = 0;
+
+        const struct
+        {
+            EDiagnosticsErrorKind ErrorKind;
+            TDuration ExecTime;
+        } ops[] = {
+            {EDiagnosticsErrorKind::Success, TDuration::MilliSeconds(1)},
+            {EDiagnosticsErrorKind::Success, TDuration::MilliSeconds(50)},
+            {EDiagnosticsErrorKind::ErrorFatal, TDuration::Zero()},
+            {EDiagnosticsErrorKind::ErrorThrottling, TDuration::Zero()},
+            {EDiagnosticsErrorKind::Success, TDuration::MilliSeconds(10)},
+        };
+
+        for (const auto& op: ops) {
+            auto outcome = ClassifyLatencyOutcome(
+                &ladder,
+                op.ErrorKind,
+                false,
+                4_KB,
+                op.ExecTime);
+            total += outcome.CountTotal ? 1 : 0;
+            good += outcome.CountGood ? 1 : 0;
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(4u, total);
+        UNIT_ASSERT_VALUES_EQUAL(2u, good);
+        UNIT_ASSERT(good <= total);
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp
@@ -416,6 +416,10 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
     Y_UNIT_TEST(ShouldCountAllFinalServiceFailuresAsBad)
     {
         CheckFinalFailureIsBad(E_FAIL);
+        // E_ARGUMENT is also used for malformed service responses after a
+        // valid request has executed, so the final code alone is not proof of
+        // invalid guest input.
+        CheckFinalFailureIsBad(E_ARGUMENT);
         CheckFinalFailureIsBad(E_RETRY_TIMEOUT);
         CheckFinalFailureIsBad(E_REJECTED);
         CheckFinalFailureIsBad(E_BS_INVALID_SESSION);
@@ -453,9 +457,8 @@ Y_UNIT_TEST_SUITE(TLatencyThresholdsClassificationTest)
             "Checkpoint reject request. test"));
     }
 
-    Y_UNIT_TEST(ShouldSkipInvalidInputAndCancellation)
+    Y_UNIT_TEST(ShouldSkipCancellation)
     {
-        CheckSkipped(MakeError(E_ARGUMENT));
         CheckSkipped(MakeError(E_CANCELLED));
     }
 

--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -50,10 +50,10 @@ class TServerStats final
 private:
     const IDumpablePtr Config;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
-    const bool LatencyThresholdsConfigured;
     const IProfileLogPtr ProfileLog;
     const IRequestStatsPtr RequestStats;
     const IVolumeStatsPtr VolumeStats;
+    const bool LatencyTrackingEnabled;
     const TString RequestInstanceId;
 
     TDynamicCountersPtr Counters;
@@ -215,12 +215,13 @@ TServerStats::TServerStats(
         TString requestInstanceId)
     : Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
-    , LatencyThresholdsConfigured(
-          DiagnosticsConfig &&
-          DiagnosticsConfig->GetLatencyThresholdsEnabled())
     , ProfileLog(std::move(profileLog))
     , RequestStats(std::move(requestStats))
     , VolumeStats(std::move(volumeStats))
+    , LatencyTrackingEnabled(
+          DiagnosticsConfig &&
+          VolumeStats &&
+          VolumeStats->IsLatencyTrackingEnabled())
     , RequestInstanceId(std::move(requestInstanceId))
 {
     auto counters = monitoring->GetCounters();
@@ -595,9 +596,10 @@ void TServerStats::RecordLatencyCompletion(
     ui64 requestBytes,
     const NProto::TError& error)
 {
-    // The feature is disabled by default. Avoid reading five atomic timing
-    // fields from the call context on every I/O in that common case.
-    if (!LatencyThresholdsConfigured) {
+    // Use the effective state after threshold validation, not the raw config
+    // flag. This keeps both disabled and invalid configurations off the hot
+    // path entirely.
+    if (!LatencyTrackingEnabled) {
         return;
     }
 
@@ -609,27 +611,21 @@ void TServerStats::RecordLatencyCompletion(
         return;
     }
 
-    const auto postponedTime = callContext.Time(EProcessingStage::Postponed);
-    const auto backoffTime = callContext.Time(EProcessingStage::Backoff);
-    const auto shapingTime = callContext.Time(EProcessingStage::Shaping);
-    const auto waitTime = postponedTime + backoffTime + shapingTime;
-
-    if (!HasError(error) &&
-        waitTime &&
-        callContext.GetHasParallelSubRequests())
-    {
-        // Wait intervals accumulated by concurrent subrequests may overlap,
-        // so their sum cannot be subtracted from one logical request's
-        // wall-clock latency. The successful operation is therefore unjudged.
-        RecordLatencyBatch(req, 0, 0, 1);
-        return;
+    auto shapingTime = callContext.Time(EProcessingStage::Shaping);
+    if (shapingTime && callContext.GetHasParallelSubRequests()) {
+        // Parallel parts add their shaping delays to one shared context. The
+        // sum is not the amount by which shaping extended the logical
+        // request: intervals may overlap or be hidden behind useful work in
+        // another part. Use the full elapsed time instead. This keeps the
+        // operation in the sample and can only make the verdict conservative.
+        shapingTime = TDuration::Zero();
     }
 
     req.VolumeInfo->RecordLatencyCompletion(
         req.RequestType,
         callContext.GetRequestStartedCycles(),
-        postponedTime,
-        backoffTime,
+        TDuration::Zero(),   // generic postponed time remains in latency
+        TDuration::Zero(),   // retry backoff remains in latency
         shapingTime,
         requestBytes,
         error,

--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -609,12 +609,28 @@ void TServerStats::RecordLatencyCompletion(
         return;
     }
 
+    const auto postponedTime = callContext.Time(EProcessingStage::Postponed);
+    const auto backoffTime = callContext.Time(EProcessingStage::Backoff);
+    const auto shapingTime = callContext.Time(EProcessingStage::Shaping);
+    const auto waitTime = postponedTime + backoffTime + shapingTime;
+
+    if (!HasError(error) &&
+        waitTime &&
+        callContext.GetHasParallelSubRequests())
+    {
+        // Wait intervals accumulated by concurrent subrequests may overlap,
+        // so their sum cannot be subtracted from one logical request's
+        // wall-clock latency. The successful operation is therefore unjudged.
+        RecordLatencyBatch(req, 0, 0, 1);
+        return;
+    }
+
     req.VolumeInfo->RecordLatencyCompletion(
         req.RequestType,
         callContext.GetRequestStartedCycles(),
-        callContext.Time(EProcessingStage::Postponed),
-        callContext.Time(EProcessingStage::Backoff),
-        callContext.Time(EProcessingStage::Shaping),
+        postponedTime,
+        backoffTime,
+        shapingTime,
         requestBytes,
         error,
         callContext.GetResponseSentCycles());

--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -50,6 +50,7 @@ class TServerStats final
 private:
     const IDumpablePtr Config;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
+    const bool LatencyThresholdsConfigured;
     const IProfileLogPtr ProfileLog;
     const IRequestStatsPtr RequestStats;
     const IVolumeStatsPtr VolumeStats;
@@ -126,6 +127,12 @@ public:
         TCallContext& callContext,
         const NProto::TError& error) override;
 
+    void RecordLatencyCompletion(
+        TMetricRequest& req,
+        TCallContext& callContext,
+        ui64 requestBytes,
+        const NProto::TError& error) override;
+
     void RequestFastPathHit(
         const TString& diskId,
         const TString& clientId,
@@ -160,6 +167,12 @@ public:
         ui64 errors,
         std::span<TTimeBucket> timeHist,
         std::span<TSizeBucket> sizeHist) override;
+
+    void RecordLatencyBatch(
+        TMetricRequest& metricRequest,
+        ui64 goodOps,
+        ui64 badOps,
+        ui64 skippedOps) override;
 
     void UpdateStats(bool updateIntervalFinished) override;
 
@@ -202,6 +215,9 @@ TServerStats::TServerStats(
         TString requestInstanceId)
     : Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
+    , LatencyThresholdsConfigured(
+          DiagnosticsConfig &&
+          DiagnosticsConfig->GetLatencyThresholdsEnabled())
     , ProfileLog(std::move(profileLog))
     , RequestStats(std::move(requestStats))
     , VolumeStats(std::move(volumeStats))
@@ -573,6 +589,37 @@ void TServerStats::RequestCompleted(
         << ")");
 }
 
+void TServerStats::RecordLatencyCompletion(
+    TMetricRequest& req,
+    TCallContext& callContext,
+    ui64 requestBytes,
+    const NProto::TError& error)
+{
+    // The feature is disabled by default. Avoid reading five atomic timing
+    // fields from the call context on every I/O in that common case.
+    if (!LatencyThresholdsConfigured) {
+        return;
+    }
+
+    const bool isPayloadWrite = IsWriteRequest(req.RequestType) &&
+        req.RequestType != EBlockStoreRequest::ZeroBlocks;
+    if (!req.VolumeInfo ||
+        (!IsReadRequest(req.RequestType) && !isPayloadWrite))
+    {
+        return;
+    }
+
+    req.VolumeInfo->RecordLatencyCompletion(
+        req.RequestType,
+        callContext.GetRequestStartedCycles(),
+        callContext.Time(EProcessingStage::Postponed),
+        callContext.Time(EProcessingStage::Backoff),
+        callContext.Time(EProcessingStage::Shaping),
+        requestBytes,
+        error,
+        callContext.GetResponseSentCycles());
+}
+
 void TServerStats::RequestFastPathHit(
     const TString& diskId,
     const TString& clientId,
@@ -701,6 +748,21 @@ void TServerStats::BatchCompleted(
             errors,
             timeHist,
             sizeHist);
+    }
+}
+
+void TServerStats::RecordLatencyBatch(
+    TMetricRequest& req,
+    ui64 goodOps,
+    ui64 badOps,
+    ui64 skippedOps)
+{
+    if (req.VolumeInfo) {
+        req.VolumeInfo->RecordLatencyBatch(
+            req.RequestType,
+            goodOps,
+            badOps,
+            skippedOps);
     }
 }
 

--- a/cloud/blockstore/libs/diagnostics/server_stats.h
+++ b/cloud/blockstore/libs/diagnostics/server_stats.h
@@ -143,6 +143,27 @@ struct IServerStats
         ui64 errors,
         std::span<TTimeBucket> timeHist,
         std::span<TSizeBucket> sizeHist) = 0;
+
+    // Records one final logical Read/Write at an endpoint boundary. The
+    // explicit byte count is the original endpoint request size; it may
+    // differ from the aligned byte count used by legacy request metrics.
+    // Appended after all legacy methods and defaulted to preserve existing
+    // implementations.
+    virtual void RecordLatencyCompletion(
+        TMetricRequest&,
+        TCallContext&,
+        ui64,
+        const NProto::TError&)
+    {}
+
+    // Parallel, exact batch contract for latency accounting. Kept separate from
+    // BatchCompleted so its long-standing count/error semantics stay intact.
+    virtual void RecordLatencyBatch(
+        TMetricRequest&,
+        ui64,
+        ui64,
+        ui64)
+    {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/diagnostics/server_stats.h
+++ b/cloud/blockstore/libs/diagnostics/server_stats.h
@@ -147,6 +147,8 @@ struct IServerStats
     // Records one final logical Read/Write at an endpoint boundary. The
     // explicit byte count is the original endpoint request size; it may
     // differ from the aligned byte count used by legacy request metrics.
+    // Retry backoff and generic postponed time remain in the measured
+    // service-side latency; only explicit quota shaping is excluded.
     // Appended after all legacy methods and defaulted to preserve existing
     // implementations.
     virtual void RecordLatencyCompletion(
@@ -156,7 +158,8 @@ struct IServerStats
         const NProto::TError&)
     {}
 
-    // Parallel, exact batch contract for latency accounting. Kept separate from
+    // Exact outcome-batch contract for latency accounting, including aggregate
+    // producers and explicitly recognized early rejections. Kept separate from
     // BatchCompleted so its long-standing count/error semantics stay intact.
     virtual void RecordLatencyBatch(
         TMetricRequest&,

--- a/cloud/blockstore/libs/diagnostics/server_stats_test.h
+++ b/cloud/blockstore/libs/diagnostics/server_stats_test.h
@@ -85,6 +85,15 @@ public:
             = std::bind_front(&IServerStats::RequestCompleted, Stub.get());
 
     std::function<void(
+        TMetricRequest& metricRequest,
+        TCallContext& callContext,
+        ui64 requestBytes,
+        const NProto::TError& error)> RecordLatencyCompletionHandler
+            = std::bind_front(
+                &IServerStats::RecordLatencyCompletion,
+                Stub.get());
+
+    std::function<void(
         const TString& diskId,
         const TString& clientId,
         EBlockStoreRequest requestType)> RequestFastPathHitHandler
@@ -124,6 +133,14 @@ public:
         std::span<TTimeBucket> timeHist,
         std::span<TSizeBucket> sizeHist)> BatchCompletedHandler = std::bind_front(
             &IServerStats::BatchCompleted,
+            Stub.get());
+
+    std::function<void(
+        TMetricRequest& metricRequest,
+        ui64 goodOps,
+        ui64 badOps,
+        ui64 skippedOps)> RecordLatencyBatchHandler = std::bind_front(
+            &IServerStats::RecordLatencyBatch,
             Stub.get());
 
     std::function<void(bool updateIntervalFinished)> UpdateStatsHandler
@@ -231,6 +248,19 @@ public:
         RequestCompletedHandler(log, metricRequest, callContext, error);
     }
 
+    void RecordLatencyCompletion(
+        TMetricRequest& metricRequest,
+        TCallContext& callContext,
+        ui64 requestBytes,
+        const NProto::TError& error) override
+    {
+        RecordLatencyCompletionHandler(
+            metricRequest,
+            callContext,
+            requestBytes,
+            error);
+    }
+
     void RequestFastPathHit(
         const TString& diskId,
         const TString& clientId,
@@ -301,6 +331,19 @@ public:
             errors,
             timeHist,
             sizeHist);
+    }
+
+    void RecordLatencyBatch(
+        TMetricRequest& metricRequest,
+        ui64 goodOps,
+        ui64 badOps,
+        ui64 skippedOps) override
+    {
+        RecordLatencyBatchHandler(
+            metricRequest,
+            goodOps,
+            badOps,
+            skippedOps);
     }
 
     void UpdateStats(bool updateIntervalFinished) override

--- a/cloud/blockstore/libs/diagnostics/server_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats_ut.cpp
@@ -456,7 +456,7 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
             ->GetCounter("Errors")->Val());
     }
 
-    Y_UNIT_TEST(ShouldSkipOnlySuccessfulParallelRequestWithWaits)
+    Y_UNIT_TEST(ShouldKeepParallelRequestsAndUseConservativeLatency)
     {
         auto timer = std::make_shared<TTestTimer>();
         auto monitoring = CreateMonitoringServiceStub();
@@ -509,12 +509,6 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
             false);
         UNIT_ASSERT(request.VolumeInfo);
 
-        auto callContext = MakeIntrusive<TCallContext>();
-        callContext->SetHasParallelSubRequests();
-        callContext->AddTime(
-            EProcessingStage::Postponed,
-            TDuration::MilliSeconds(1));
-
         auto counters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "sli_volume")
@@ -529,44 +523,85 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
         auto skipped =
             counters->GetCounter("LatencyThresholdsSkippedOps");
 
-        // Successful parallel requests with accumulated waits cannot be
-        // timed exactly, so the server routes exactly one skipped outcome and
-        // does not invoke ordinary completion accounting as well.
-        serverStats->RecordLatencyCompletion(
-            request,
-            *callContext,
-            4096,
-            {});
-        UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
-        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
-        UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
+        const auto makeContext = [](
+            TDuration elapsed,
+            TDuration postponed,
+            TDuration backoff,
+            TDuration shaping)
+        {
+            auto callContext = MakeIntrusive<TCallContext>();
+            callContext->SetHasParallelSubRequests();
+            callContext->SetRequestStartedCycles(1);
+            callContext->SetResponseSentCycles(
+                1 + DurationToCyclesSafe(elapsed));
+            callContext->AddTime(EProcessingStage::Postponed, postponed);
+            callContext->AddTime(EProcessingStage::Backoff, backoff);
+            callContext->AddTime(EProcessingStage::Shaping, shaping);
+            return callContext;
+        };
 
-        // Splitting alone does not reduce coverage. With no accumulated waits
-        // the same successful request follows normal latency classification.
-        auto noWaitContext = MakeIntrusive<TCallContext>();
-        noWaitContext->SetHasParallelSubRequests();
-        noWaitContext->SetRequestStartedCycles(1);
-        noWaitContext->SetResponseSentCycles(1);
+        // The two branch shaping intervals may overlap or be hidden behind
+        // useful work in another branch. Their sum cannot be subtracted
+        // exactly, so a parallel request is judged using its full elapsed
+        // time. This request would look good after subtracting 95ms, but must
+        // conservatively remain bad and in the sample.
+        auto shapedContext = makeContext(
+            TDuration::MilliSeconds(100),
+            TDuration::Zero(),
+            TDuration::Zero(),
+            TDuration::MilliSeconds(95));
         serverStats->RecordLatencyCompletion(
             request,
-            *noWaitContext,
+            *shapedContext,
             4096,
             {});
         UNIT_ASSERT_VALUES_EQUAL(1, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, skipped->Val());
+
+        // Generic postponed time and retry backoff are user-visible service
+        // latency. They neither get subtracted nor make a split request
+        // unjudged.
+        auto serviceWaitContext = makeContext(
+            TDuration::MilliSeconds(100),
+            TDuration::MilliSeconds(95),
+            TDuration::MilliSeconds(95),
+            TDuration::Zero());
+        serverStats->RecordLatencyCompletion(
+            request,
+            *serviceWaitContext,
+            4096,
+            {});
+        UNIT_ASSERT_VALUES_EQUAL(2, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, skipped->Val());
+
+        // Splitting alone does not reduce coverage or change a fast verdict.
+        auto fastContext = makeContext(
+            TDuration::MilliSeconds(1),
+            TDuration::Zero(),
+            TDuration::Zero(),
+            TDuration::Zero());
+        serverStats->RecordLatencyCompletion(
+            request,
+            *fastContext,
+            4096,
+            {});
+        UNIT_ASSERT_VALUES_EQUAL(3, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
-        UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, skipped->Val());
 
         // A final service failure does not need a latency measurement. It
         // must keep the ordinary classifier semantics: one bad operation,
-        // not another skipped operation.
+        // not a skipped operation.
         serverStats->RecordLatencyCompletion(
             request,
-            *callContext,
+            *shapedContext,
             4096,
             MakeError(E_FAIL));
-        UNIT_ASSERT_VALUES_EQUAL(2, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(4, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
-        UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, skipped->Val());
     }
 }
 

--- a/cloud/blockstore/libs/diagnostics/server_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats_ut.cpp
@@ -455,6 +455,119 @@ Y_UNIT_TEST_SUITE(TServerStatsTest)
             ->GetSubgroup("request", "DescribeVolume")
             ->GetCounter("Errors")->Val());
     }
+
+    Y_UNIT_TEST(ShouldSkipOnlySuccessfulParallelRequestWithWaits)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        auto monitoring = CreateMonitoringServiceStub();
+
+        NProto::TDiagnosticsConfig protoConfig;
+        protoConfig.SetLatencyThresholdsEnabled(true);
+        auto* mediaKindThresholds = protoConfig.AddLatencyThresholds();
+        mediaKindThresholds->SetMediaKind(NProto::STORAGE_MEDIA_SSD);
+        auto* bucket = mediaKindThresholds->AddBuckets();
+        bucket->SetMinRequestBytes(0);
+        bucket->SetReadThresholdMs(10);
+        bucket->SetWriteThresholdMs(10);
+        auto diagnosticsConfig =
+            std::make_shared<TDiagnosticsConfig>(protoConfig);
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            diagnosticsConfig,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            CreateWallClockTimer());
+
+        auto serverStats = CreateServerStats(
+            std::make_shared<TTestDumpable>(),
+            diagnosticsConfig,
+            monitoring,
+            CreateProfileLogStub(),
+            CreateServerRequestStats(
+                monitoring->GetCounters(),
+                timer,
+                EHistogramCounterOption::ReportMultipleCounters,
+                {}),
+            std::move(volumeStats));
+
+        NProto::TVolume volume;
+        volume.SetBlockSize(4096);
+        volume.SetDiskId("volume");
+        volume.SetCloudId("cloud");
+        volume.SetFolderId("folder");
+        volume.SetStorageMediaKind(NProto::STORAGE_MEDIA_SSD);
+        serverStats->MountVolume(volume, "client", "instance");
+
+        TMetricRequest request{EBlockStoreRequest::WriteBlocks};
+        serverStats->PrepareMetricRequest(
+            request,
+            "client",
+            "volume",
+            0,
+            4096,
+            false);
+        UNIT_ASSERT(request.VolumeInfo);
+
+        auto callContext = MakeIntrusive<TCallContext>();
+        callContext->SetHasParallelSubRequests();
+        callContext->AddTime(
+            EProcessingStage::Postponed,
+            TDuration::MilliSeconds(1));
+
+        auto counters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "volume")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", "cloud")
+            ->GetSubgroup("folder", "folder")
+            ->GetSubgroup("type", "network-ssd");
+        auto total = counters->GetCounter("LatencyTotalOps");
+        auto good = counters->GetCounter("LatencyGoodOps");
+        auto skipped =
+            counters->GetCounter("LatencyThresholdsSkippedOps");
+
+        // Successful parallel requests with accumulated waits cannot be
+        // timed exactly, so the server routes exactly one skipped outcome and
+        // does not invoke ordinary completion accounting as well.
+        serverStats->RecordLatencyCompletion(
+            request,
+            *callContext,
+            4096,
+            {});
+        UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
+
+        // Splitting alone does not reduce coverage. With no accumulated waits
+        // the same successful request follows normal latency classification.
+        auto noWaitContext = MakeIntrusive<TCallContext>();
+        noWaitContext->SetHasParallelSubRequests();
+        noWaitContext->SetRequestStartedCycles(1);
+        noWaitContext->SetResponseSentCycles(1);
+        serverStats->RecordLatencyCompletion(
+            request,
+            *noWaitContext,
+            4096,
+            {});
+        UNIT_ASSERT_VALUES_EQUAL(1, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
+
+        // A final service failure does not need a latency measurement. It
+        // must keep the ordinary classifier semantics: one bad operation,
+        // not another skipped operation.
+        serverStats->RecordLatencyCompletion(
+            request,
+            *callContext,
+            4096,
+            MakeError(E_FAIL));
+        UNIT_ASSERT_VALUES_EQUAL(2, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
+    }
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/ut/ya.make
+++ b/cloud/blockstore/libs/diagnostics/ut/ya.make
@@ -17,6 +17,7 @@ SRCS(
     critical_events_ut.cpp
     fault_injection_ut.cpp
     hostname_ut.cpp
+    latency_thresholds_ut.cpp
     profile_log_ut.cpp
     quota_metrics_ut.cpp
     request_stats_ut.cpp

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -203,10 +203,13 @@ struct TVolumeInfoBase
     // every volume.
     const std::shared_ptr<TLatencyThresholdsHotSwap> LatencyThresholdsHotSwap;
 
-    // Server-level (not per-volume) diagnostic counter: operations whose
-    // media kind has no configured threshold ladder are skipped entirely -
-    // never counted as bad - and tallied here instead so the gap stays
-    // visible.
+    // Server-level (not per-volume) diagnostic counter: read/write
+    // operations that were not judged against the thresholds, and so appear
+    // in neither LatencyTotalOps nor LatencyGoodOps. Two reasons feed it:
+    // the volume's media kind has no configured ladder, and the operation
+    // arrived as an aggregate through BatchCompleted (external vhost). Such
+    // operations are never counted as bad; the counter exists so that the
+    // part of the traffic the metric does not cover stays measurable.
     const TDynamicCounters::TCounterPtr LatencyThresholdsSkippedOpsCounter;
 
     TVolumeInfoBase(
@@ -428,6 +431,26 @@ public:
             VolumeBase->ThrottlerRejects.Add(1);
         }
 
+        const auto requestTime = RequestCounters.RequestCompleted(
+            static_cast<TRequestCounters::TRequestType>(
+                TranslateLocalRequestType(requestType)),
+            requestStarted,
+            postponedTime,
+            backoffTime,
+            shapingTime,
+            requestBytes,
+            errorKind,
+            errorFlags,
+            unaligned,
+            ECalcMaxTime::ENABLE,
+            responseSent).Time;
+
+        // Deliberately after RequestCounters::RequestCompleted: that method
+        // takes its own GetCycleCount() on entry, so anything done before it
+        // is measured as part of the request in the pre-existing per-volume
+        // latency histograms. The judged duration below is unaffected by the
+        // ordering - it is derived from requestStarted/responseSent and the
+        // requestCompleted captured at the top of this method.
         if (VolumeBase->LatencyThresholdsEnabled) {
             // processingCompleted excludes gRPC response-delivery time
             // (network, backpressure, a slow client), mirroring
@@ -462,19 +485,7 @@ public:
                 CyclesToDurationSafe(execTimeCycles));
         }
 
-        return RequestCounters.RequestCompleted(
-            static_cast<TRequestCounters::TRequestType>(
-                TranslateLocalRequestType(requestType)),
-            requestStarted,
-            postponedTime,
-            backoffTime,
-            shapingTime,
-            requestBytes,
-            errorKind,
-            errorFlags,
-            unaligned,
-            ECalcMaxTime::ENABLE,
-            responseSent).Time;
+        return requestTime;
     }
 
     void AddIncompleteStats(
@@ -553,6 +564,20 @@ public:
         std::span<TTimeBucket> timeHist,
         std::span<TSizeBucket> sizeHist) override
     {
+        if (VolumeBase->LatencyThresholdsEnabled &&
+            (IsPureWriteRequest(requestType) || IsReadRequest(requestType)))
+        {
+            // Operations imported as an aggregate (the external vhost
+            // dataplane, the only caller of this method) never reach
+            // RequestCompleted, so they cannot be judged: the batch carries
+            // separate time and size histograms, not the joint
+            // (size, latency) distribution a size-dependent verdict needs,
+            // and no per-operation error kind. Tallying them keeps a volume
+            // served this way distinguishable from one with no traffic,
+            // which the 0/0 in LatencyTotalOps/LatencyGoodOps alone is not.
+            *VolumeBase->LatencyThresholdsSkippedOpsCounter += count;
+        }
+
         return RequestCounters.BatchCompleted(
             static_cast<TRequestCounters::TRequestType>(
                 TranslateLocalRequestType(requestType)),

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -194,12 +194,10 @@ struct TVolumeInfoBase
     // construction and never re-read from config on the request path.
     const bool LatencyThresholdsEnabled;
 
-    // Shared (not per-volume) hot-swappable snapshot of the latency
-    // thresholds table; see latency_thresholds.h. Held via shared_ptr, not
-    // by value, so per-volume state stays cheap and the table can be
-    // replaced later (e.g. by a dynamic config source) without touching
-    // every volume.
-    const std::shared_ptr<TLatencyThresholdsHotSwap> LatencyThresholdsHotSwap;
+    // Shared immutable snapshot of the validated latency thresholds table.
+    // The intrusive pointer keeps the startup snapshot alive for as long as
+    // any mounted volume can use it; there is no atomic load per request.
+    const TIntrusivePtr<TLatencyThresholdsTable> LatencyThresholds;
 
     TVolumeInfoBase(
             NProto::TVolume volume,
@@ -208,7 +206,7 @@ struct TVolumeInfoBase
             TDynamicCountersPtr volumeGroup,
             ITimerPtr timer,
             bool latencyThresholdsEnabled,
-            std::shared_ptr<TLatencyThresholdsHotSwap> latencyThresholdsHotSwap)
+            TIntrusivePtr<TLatencyThresholdsTable> latencyThresholds)
         : Timer(timer)
         , Volume(std::move(volume))
         , PerfCalc(Volume, diagnosticsConfig)
@@ -220,7 +218,7 @@ struct TVolumeInfoBase
         , HasStorageConfigPatchCounter(
             volumeGroup->GetCounter("HasStorageConfigPatch"))
         , LatencyThresholdsEnabled(latencyThresholdsEnabled)
-        , LatencyThresholdsHotSwap(std::move(latencyThresholdsHotSwap))
+        , LatencyThresholds(std::move(latencyThresholds))
     {
         BusyIdleCalc.Register(volumeGroup);
         PerfCalc.Register(*volumeGroup, Volume);
@@ -306,16 +304,17 @@ private:
     // TVolumeInfoBase::LatencyThresholdsEnabled and latency_thresholds.h for
     // the accounting rule. Populated only when the server-wide mechanism is
     // enabled (config flag + a valid thresholds table); left null otherwise
-    // - RequestCompleted only touches them under
+    // - RecordLatencyCompletion only touches them under
     // VolumeBase->LatencyThresholdsEnabled, checked once at construction.
     TDynamicCounters::TCounterPtr LatencyTotalOpsCounter;
     TDynamicCounters::TCounterPtr LatencyGoodOpsCounter;
 
     // Read/write operations of this instance that were not judged against
-    // the thresholds, and so appear in neither counter above. Two reasons
-    // feed it: the volume's media kind has no configured ladder, and the
-    // operation arrived as an aggregate through BatchCompleted (external
-    // vhost). Such operations are never counted as bad. Published next to
+    // the thresholds, and so appear in neither counter above. This includes
+    // an unconfigured media kind and final load-shedding, checkpoint-reject,
+    // invalid-input, or cancellation outcomes. Exact aggregate producers can
+    // report the same outcome through RecordLatencyBatch. Such operations
+    // are never counted as bad. Published next to
     // the two counters above, rather than once per server, because it is
     // what explains a specific volume reading 0/0: without the volume,
     // instance and type labels, an unconfigured media kind and expected
@@ -443,47 +442,79 @@ public:
             ECalcMaxTime::ENABLE,
             responseSent).Time;
 
-        // Deliberately after RequestCounters::RequestCompleted: that method
-        // takes its own GetCycleCount() on entry, so anything done before it
-        // is measured as part of the request in the pre-existing per-volume
-        // latency histograms. The judged duration below is unaffected by the
-        // ordering - it is derived from requestStarted/responseSent and the
-        // requestCompleted captured at the top of this method.
-        if (VolumeBase->LatencyThresholdsEnabled) {
-            // processingCompleted excludes gRPC response-delivery time
-            // (network, backpressure, a slow client), mirroring
-            // TRequestCounters::RequestCompleted: responseSent is the
-            // timestamp taken right before handing the response off to the
-            // transport, and this method only runs once that hand-off has
-            // finished, so requestCompleted - responseSent is time spent
-            // delivering the response, not executing the operation.
-            const ui64 processingCompleted =
-                responseSent ? responseSent : requestCompleted;
+        return requestTime;
+    }
 
-            // execTime = requestTime - waitTime, clamped at zero, mirroring
-            // the exec-time-safe pattern already used by
-            // TVolumePerformanceCalculator::OnRequestCompleted above: the
-            // throttler's own wait is not the service's responsibility, but
-            // the operation itself is still judged (a throttled-but-executed
-            // operation is NOT excluded, only judged on the time it actually
-            // took to execute).
-            const ui64 requestTimeCycles =
-                processingCompleted > requestStarted
-                    ? processingCompleted - requestStarted
-                    : 0;
-            const ui64 waitTimeCycles = DurationToCyclesSafe(waitTime);
-            const ui64 execTimeCycles = requestTimeCycles > waitTimeCycles
-                ? requestTimeCycles - waitTimeCycles
-                : 0;
-
-            RecordLatencyThresholdOutcome(
-                requestType,
-                errorKind,
-                requestBytes,
-                CyclesToDurationSafe(execTimeCycles));
+    void RecordLatencyCompletion(
+        EBlockStoreRequest requestType,
+        ui64 requestStarted,
+        TDuration postponedTime,
+        TDuration backoffTime,
+        TDuration shapingTime,
+        ui64 requestBytes,
+        const NProto::TError& error,
+        ui64 responseSent) override
+    {
+        if (!VolumeBase->LatencyThresholdsEnabled) {
+            return;
         }
 
-        return requestTime;
+        const bool isWrite = IsPureWriteRequest(requestType);
+        if (!isWrite && !IsReadRequest(requestType)) {
+            return;
+        }
+
+        // NBD records responseSent immediately after the device future is
+        // resolved and before writing the reply to the transport. Embedded
+        // vhost has no separate response-delivery phase, so it uses now.
+        const ui64 completed = responseSent ? responseSent : GetCycleCount();
+        const ui64 elapsedCycles = completed > requestStarted
+            ? completed - requestStarted
+            : 0;
+        const ui64 waitCycles = DurationToCyclesSafe(
+            postponedTime + backoffTime + shapingTime);
+        const ui64 execCycles = elapsedCycles > waitCycles
+            ? elapsedCycles - waitCycles
+            : 0;
+
+        const auto mediaKind = VolumeBase->Volume.GetStorageMediaKind();
+        const auto* ladder = VolumeBase->LatencyThresholds
+            ? VolumeBase->LatencyThresholds->FindLadder(mediaKind)
+            : nullptr;
+        const auto outcome = ClassifyLatencyOutcome(
+            ladder,
+            error,
+            isWrite,
+            requestBytes,
+            CyclesToDurationSafe(execCycles));
+
+        if (outcome.CountSkipped) {
+            *LatencyThresholdsSkippedOpsCounter += 1;
+            return;
+        }
+        if (outcome.CountTotal) {
+            *LatencyTotalOpsCounter += 1;
+        }
+        if (outcome.CountGood) {
+            *LatencyGoodOpsCounter += 1;
+        }
+    }
+
+    void RecordLatencyBatch(
+        EBlockStoreRequest requestType,
+        ui64 goodOps,
+        ui64 badOps,
+        ui64 skippedOps) override
+    {
+        if (!VolumeBase->LatencyThresholdsEnabled ||
+            (!IsPureWriteRequest(requestType) && !IsReadRequest(requestType)))
+        {
+            return;
+        }
+
+        *LatencyTotalOpsCounter += goodOps + badOps;
+        *LatencyGoodOpsCounter += goodOps;
+        *LatencyThresholdsSkippedOpsCounter += skippedOps;
     }
 
     void AddIncompleteStats(
@@ -562,26 +593,6 @@ public:
         std::span<TTimeBucket> timeHist,
         std::span<TSizeBucket> sizeHist) override
     {
-        if (VolumeBase->LatencyThresholdsEnabled &&
-            (IsPureWriteRequest(requestType) || IsReadRequest(requestType)))
-        {
-            // Operations imported as an aggregate (the external vhost
-            // dataplane, the only caller of this method) never reach
-            // RequestCompleted, so they cannot be judged: the batch carries
-            // separate time and size histograms, not the joint
-            // (size, latency) distribution a size-dependent verdict needs,
-            // and no per-operation error kind.
-            //
-            // count and errors are disjoint totals, not a total and a subset
-            // of it: a batch reports successful completions in one and
-            // failures in the other, the same way the per-request path
-            // increments either Count or Errors but never both (see
-            // TRequestCounters). Both are operations that went unjudged, so
-            // both belong here - counting only one would hide a batch that
-            // consists entirely of failures.
-            *LatencyThresholdsSkippedOpsCounter += count + errors;
-        }
-
         return RequestCounters.BatchCompleted(
             static_cast<TRequestCounters::TRequestType>(
                 TranslateLocalRequestType(requestType)),
@@ -590,56 +601,6 @@ public:
             errors,
             timeHist,
             sizeHist);
-    }
-
-private:
-    // Judges a single completed operation against the latency thresholds
-    // table and increments LatencyTotalOpsCounter/LatencyGoodOpsCounter
-    // accordingly. Called from RequestCompleted only when
-    // VolumeBase->LatencyThresholdsEnabled - see latency_thresholds.h for
-    // the accounting rule (ClassifyLatencyOutcome) this wraps.
-    void RecordLatencyThresholdOutcome(
-        EBlockStoreRequest requestType,
-        EDiagnosticsErrorKind errorKind,
-        ui64 requestBytes,
-        TDuration execTime)
-    {
-        // Only ReadBlocks/WriteBlocks (and their *Local variants)
-        // participate; Zero/discard operations are out of scope for this
-        // iteration.
-        const bool isWrite = IsPureWriteRequest(requestType);
-        if (!isWrite && !IsReadRequest(requestType)) {
-            return;
-        }
-
-        const auto mediaKind = VolumeBase->Volume.GetStorageMediaKind();
-        const auto thresholds =
-            VolumeBase->LatencyThresholdsHotSwap->AtomicLoad();
-        const auto* ladder =
-            thresholds ? thresholds->FindLadder(mediaKind) : nullptr;
-
-        const auto outcome = ClassifyLatencyOutcome(
-            ladder,
-            errorKind,
-            isWrite,
-            requestBytes,
-            execTime);
-
-        // All three counters below are guaranteed non-null here: they are
-        // created together under VolumeBase->LatencyThresholdsEnabled in
-        // RegisterInstance, and this method only runs when that same flag is
-        // true (see the call site in RequestCompleted).
-        if (outcome.MediaKindNotConfigured) {
-            *LatencyThresholdsSkippedOpsCounter += 1;
-            return;
-        }
-
-        if (outcome.CountTotal) {
-            *LatencyTotalOpsCounter += 1;
-        }
-        if (outcome.CountGood) {
-            *LatencyGoodOpsCounter += 1;
-        }
     }
 };
 
@@ -714,15 +675,15 @@ private:
         DiagnosticsConfig->GetExecutionTimeSizeClasses();
 
     TDynamicCountersPtr Counters;
-    // Separate, narrow counters tree (component=sli_volume) for the
-    // cumulative availability counters (ObservedSeconds/AvailableSeconds/
-    // HealthySeconds) only. The main per-volume tree (component=
+    // Separate, narrow counters tree (component=sli_volume) for cumulative
+    // availability counters and, when enabled, latency counters. The main
+    // per-volume tree (component=
     // server_volume / client_volume) also carries ~200-280 other per-volume
     // perf counters, so scraping the whole subtree just to reach our ~3
     // sensors is wasteful; this sibling group lets a monitoring agent pull
-    // only these specific counters. Populated for both EServerStats and
-    // EClientStats in InitCounters; see RegisterInstance() for the per-volume
-    // subgroup layout.
+    // only these specific counters. Availability counters are populated for
+    // both EServerStats and EClientStats; latency counters are server-only.
+    // See RegisterInstance() for the per-volume subgroup layout.
     TDynamicCountersPtr AvailabilityCounters;
     std::shared_ptr<NUserCounter::IUserCounterSupplier> UserCounters;
     std::unique_ptr<TSufferCounters> SufferCounters;
@@ -748,10 +709,9 @@ private:
     // See InitLatencyThresholds.
     bool LatencyThresholdsEnabled = false;
 
-    // Shared, hot-swappable holder for the latency thresholds table; copied
-    // (as a shared_ptr) into every TVolumeInfoBase. See latency_thresholds.h.
-    std::shared_ptr<TLatencyThresholdsHotSwap> LatencyThresholdsHotSwap =
-        std::make_shared<TLatencyThresholdsHotSwap>();
+    // Immutable validated startup snapshot, copied into every
+    // TVolumeInfoBase via an intrusive pointer.
+    TIntrusivePtr<TLatencyThresholdsTable> LatencyThresholds;
 
     // Server-level (not per-volume) diagnostics: whether the configured
     // table is invalid (gauge, 0/1). Unjudged operations are counted per
@@ -778,7 +738,14 @@ public:
         }(DiagnosticsConfig->GetCloudIdsWithStrictSLA()))
         , UserCounters(CreateUserCounterSupplier())
         , Log(std::move(log))
-    {}
+    {
+        // Validate eagerly so an invalid enabled config is observable even
+        // on a host that has not mounted a volume yet. Per-volume counter
+        // trees remain lazy and are still created by RegisterInstance.
+        if (Type == EVolumeStatsType::EServerStats) {
+            InitLatencyThresholds();
+        }
+    }
 
     // Not thread-safe
     bool MountVolumeImpl(
@@ -1320,7 +1287,7 @@ private:
             volumeGroup,
             Timer,
             LatencyThresholdsEnabled,
-            LatencyThresholdsHotSwap);
+            LatencyThresholds);
 
         return TVolumeInfoHolder{
             .VolumeBase = std::move(volumeBase),
@@ -1367,7 +1334,7 @@ private:
         // produces elsewhere in the codebase.
         // All per-instance trees are rebuilt when a remount changes any label
         // used in their subgroup chains.
-        auto availabilityCountersGroup =
+        auto volumeCountersGroup =
             AvailabilityCounters
                 ->GetSubgroup("volume", volumeConfig.GetDiskId())
                 ->GetSubgroup("instance", realInstanceId.GetRealInstanceId())
@@ -1377,11 +1344,11 @@ private:
                     "type",
                     MediaKindToComputeType(volumeConfig.GetStorageMediaKind()));
         info->ObservedSecondsCounter =
-            availabilityCountersGroup->GetCounter("ObservedSeconds", true);
+            volumeCountersGroup->GetCounter("ObservedSeconds", true);
         info->AvailableSecondsCounter =
-            availabilityCountersGroup->GetCounter("AvailableSeconds", true);
+            volumeCountersGroup->GetCounter("AvailableSeconds", true);
         info->HealthySecondsCounter =
-            availabilityCountersGroup->GetCounter("HealthySeconds", true);
+            volumeCountersGroup->GetCounter("HealthySeconds", true);
 
         // Registered only when the mechanism is actually enabled (config
         // flag + a valid table), which in turn is only ever true for
@@ -1391,11 +1358,11 @@ private:
         // misleading (nothing to compare against without a threshold table).
         if (volumeBase->LatencyThresholdsEnabled) {
             info->LatencyTotalOpsCounter =
-                availabilityCountersGroup->GetCounter("LatencyTotalOps", true);
+                volumeCountersGroup->GetCounter("LatencyTotalOps", true);
             info->LatencyGoodOpsCounter =
-                availabilityCountersGroup->GetCounter("LatencyGoodOps", true);
+                volumeCountersGroup->GetCounter("LatencyGoodOps", true);
             info->LatencyThresholdsSkippedOpsCounter =
-                availabilityCountersGroup->GetCounter(
+                volumeCountersGroup->GetCounter(
                     "LatencyThresholdsSkippedOps",
                     true);
         }
@@ -1454,14 +1421,14 @@ private:
     }
 
     // Validates the configured latency thresholds table and, if valid,
-    // stores it for use by every volume. Called once, from InitCounters, so
-    // it only ever runs for EServerStats (see the call site below). Never
-    // throws: a bad config leaves the mechanism disabled, not the server
-    // dead - this runs on every server on the fleet, so a config typo must
-    // not be able to take the whole service down.
+    // stores it for use by every volume. Called once during construction for
+    // EServerStats. Never throws: a bad config leaves the mechanism disabled,
+    // not the server dead.
     void InitLatencyThresholds()
     {
-        auto serverGroup = Counters->GetSubgroup("component", "server");
+        auto serverGroup = Monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server");
         LatencyThresholdsConfigInvalidCounter =
             serverGroup->GetCounter("LatencyThresholdsConfigInvalid");
 
@@ -1486,7 +1453,7 @@ private:
             return;
         }
 
-        LatencyThresholdsHotSwap->AtomicStore(validation.Table);
+        LatencyThresholds = std::move(validation.Table);
         LatencyThresholdsEnabled = true;
         *LatencyThresholdsConfigInvalidCounter = 0;
     }
@@ -1529,8 +1496,6 @@ private:
                             ->GetCounter("DownDisks");
                     ++mk;
                 }
-
-                InitLatencyThresholds();
 
                 AvailabilityCounters = Counters
                     ->GetSubgroup("component", "sli_volume")
@@ -1660,6 +1625,22 @@ IVolumeStatsPtr CreateVolumeStats(
     TDiagnosticsConfigPtr diagnosticsConfig,
     TDuration inactiveClientsTimeout,
     EVolumeStatsType type,
+    ITimerPtr timer)
+{
+    return CreateVolumeStats(
+        std::move(monitoring),
+        std::move(diagnosticsConfig),
+        inactiveClientsTimeout,
+        type,
+        std::move(timer),
+        TLog{});
+}
+
+IVolumeStatsPtr CreateVolumeStats(
+    IMonitoringServicePtr monitoring,
+    TDiagnosticsConfigPtr diagnosticsConfig,
+    TDuration inactiveClientsTimeout,
+    EVolumeStatsType type,
     ITimerPtr timer,
     TLog log)
 {
@@ -1671,6 +1652,20 @@ IVolumeStatsPtr CreateVolumeStats(
         type,
         std::move(timer),
         std::move(log));
+}
+
+IVolumeStatsPtr CreateVolumeStats(
+    IMonitoringServicePtr monitoring,
+    TDuration inactiveClientsTimeout,
+    EVolumeStatsType type,
+    ITimerPtr timer)
+{
+    return CreateVolumeStats(
+        std::move(monitoring),
+        inactiveClientsTimeout,
+        type,
+        std::move(timer),
+        TLog{});
 }
 
 IVolumeStatsPtr CreateVolumeStats(

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -716,6 +716,7 @@ private:
     // Server-level (not per-volume) diagnostics: whether the configured
     // table is invalid (gauge, 0/1). Unjudged operations are counted per
     // instance instead, see TVolumeInfo::LatencyThresholdsSkippedOpsCounter.
+    bool LatencyThresholdsConfigInvalid = false;
     TDynamicCounters::TCounterPtr LatencyThresholdsConfigInvalidCounter;
 
     TLog Log;
@@ -739,9 +740,9 @@ public:
         , UserCounters(CreateUserCounterSupplier())
         , Log(std::move(log))
     {
-        // Validate eagerly so an invalid enabled config is observable even
-        // on a host that has not mounted a volume yet. Per-volume counter
-        // trees remain lazy and are still created by RegisterInstance.
+        // Validation is independent of monitoring lifecycle and can therefore
+        // run before a deferred monitoring proxy is initialized. The resulting
+        // gauge value is published later by InitializeMonitoringCounters.
         if (Type == EVolumeStatsType::EServerStats) {
             InitLatencyThresholds();
         }
@@ -1267,6 +1268,19 @@ public:
         return volumeIt->second.VolumeBase->HasStorageConfigPatchCounter->Val();
     }
 
+    void InitializeMonitoringCounters() override
+    {
+        TWriteGuard guard(Lock);
+
+        if (Type == EVolumeStatsType::EServerStats &&
+            !LatencyThresholdsConfigInvalidCounter)
+        {
+            InitLatencyThresholdsConfigInvalidCounter(
+                Monitoring->GetCounters()
+                    ->GetSubgroup("counters", "blockstore"));
+        }
+    }
+
 private:
     TVolumeInfoHolder RegisterVolume(NProto::TVolume volume)
     {
@@ -1422,18 +1436,12 @@ private:
 
     // Validates the configured latency thresholds table and, if valid,
     // stores it for use by every volume. Called once during construction for
-    // EServerStats. Never throws: a bad config leaves the mechanism disabled,
-    // not the server dead.
+    // EServerStats without touching monitoring, which may still be a deferred
+    // proxy at that point. Never throws: a bad config leaves the mechanism
+    // disabled, not the server dead.
     void InitLatencyThresholds()
     {
-        auto serverGroup = Monitoring->GetCounters()
-            ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server");
-        LatencyThresholdsConfigInvalidCounter =
-            serverGroup->GetCounter("LatencyThresholdsConfigInvalid");
-
         if (!DiagnosticsConfig->GetLatencyThresholdsEnabled()) {
-            *LatencyThresholdsConfigInvalidCounter = 0;
             return;
         }
 
@@ -1449,13 +1457,26 @@ private:
                 "LatencyThresholdsEnabled is set but the configured table "
                 "is invalid, the mechanism stays disabled: "
                 << validation.Error);
-            *LatencyThresholdsConfigInvalidCounter = 1;
+            LatencyThresholdsConfigInvalid = true;
             return;
         }
 
         LatencyThresholds = std::move(validation.Table);
         LatencyThresholdsEnabled = true;
-        *LatencyThresholdsConfigInvalidCounter = 0;
+    }
+
+    void InitLatencyThresholdsConfigInvalidCounter(
+        const TDynamicCountersPtr& blockStoreCounters)
+    {
+        if (LatencyThresholdsConfigInvalidCounter) {
+            return;
+        }
+
+        LatencyThresholdsConfigInvalidCounter =
+            blockStoreCounters->GetSubgroup("component", "server")
+                ->GetCounter("LatencyThresholdsConfigInvalid");
+        *LatencyThresholdsConfigInvalidCounter =
+            LatencyThresholdsConfigInvalid;
     }
 
     void InitCounters()
@@ -1465,6 +1486,8 @@ private:
 
         switch (Type) {
             case EVolumeStatsType::EServerStats: {
+                InitLatencyThresholdsConfigInvalidCounter(Counters);
+
                 SufferCounters = std::make_unique<TSufferCounters>(
                     "DisksSuffer",
                     Counters->GetSubgroup("component", "server"));

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -70,19 +70,17 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Unlike IsWriteRequest (which also matches ZeroBlocks), this matches only
-// "real" write payload requests. The latency threshold mechanism is
-// read/write-only; zero/discard operations are out of scope for this
-// iteration.
+// Write payload requests, i.e. IsWriteRequest minus the zero/discard
+// operations that are out of scope for the latency threshold mechanism in
+// this iteration. Deliberately expressed as a delta from the canonical
+// predicate rather than as its own list of request types: a payload-write
+// method added to IsWriteRequest later is then judged here too, instead of
+// silently dropping out of both the total and the good counter and
+// overstating how much of the traffic the metric covers.
 constexpr bool IsPureWriteRequest(EBlockStoreRequest requestType)
 {
-    switch (requestType) {
-        case EBlockStoreRequest::WriteBlocks:
-        case EBlockStoreRequest::WriteBlocksLocal:
-            return true;
-        default:
-            return false;
-    }
+    return IsWriteRequest(requestType) &&
+        requestType != EBlockStoreRequest::ZeroBlocks;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -203,15 +201,6 @@ struct TVolumeInfoBase
     // every volume.
     const std::shared_ptr<TLatencyThresholdsHotSwap> LatencyThresholdsHotSwap;
 
-    // Server-level (not per-volume) diagnostic counter: read/write
-    // operations that were not judged against the thresholds, and so appear
-    // in neither LatencyTotalOps nor LatencyGoodOps. Two reasons feed it:
-    // the volume's media kind has no configured ladder, and the operation
-    // arrived as an aggregate through BatchCompleted (external vhost). Such
-    // operations are never counted as bad; the counter exists so that the
-    // part of the traffic the metric does not cover stays measurable.
-    const TDynamicCounters::TCounterPtr LatencyThresholdsSkippedOpsCounter;
-
     TVolumeInfoBase(
             NProto::TVolume volume,
             TDiagnosticsConfigPtr diagnosticsConfig,
@@ -219,8 +208,7 @@ struct TVolumeInfoBase
             TDynamicCountersPtr volumeGroup,
             ITimerPtr timer,
             bool latencyThresholdsEnabled,
-            std::shared_ptr<TLatencyThresholdsHotSwap> latencyThresholdsHotSwap,
-            TDynamicCounters::TCounterPtr latencyThresholdsSkippedOpsCounter)
+            std::shared_ptr<TLatencyThresholdsHotSwap> latencyThresholdsHotSwap)
         : Timer(timer)
         , Volume(std::move(volume))
         , PerfCalc(Volume, diagnosticsConfig)
@@ -233,8 +221,6 @@ struct TVolumeInfoBase
             volumeGroup->GetCounter("HasStorageConfigPatch"))
         , LatencyThresholdsEnabled(latencyThresholdsEnabled)
         , LatencyThresholdsHotSwap(std::move(latencyThresholdsHotSwap))
-        , LatencyThresholdsSkippedOpsCounter(
-            std::move(latencyThresholdsSkippedOpsCounter))
     {
         BusyIdleCalc.Register(volumeGroup);
         PerfCalc.Register(*volumeGroup, Volume);
@@ -324,6 +310,18 @@ private:
     // VolumeBase->LatencyThresholdsEnabled, checked once at construction.
     TDynamicCounters::TCounterPtr LatencyTotalOpsCounter;
     TDynamicCounters::TCounterPtr LatencyGoodOpsCounter;
+
+    // Read/write operations of this instance that were not judged against
+    // the thresholds, and so appear in neither counter above. Two reasons
+    // feed it: the volume's media kind has no configured ladder, and the
+    // operation arrived as an aggregate through BatchCompleted (external
+    // vhost). Such operations are never counted as bad. Published next to
+    // the two counters above, rather than once per server, because it is
+    // what explains a specific volume reading 0/0: without the volume,
+    // instance and type labels, an unconfigured media kind and expected
+    // aggregate traffic are indistinguishable. Created and left null under
+    // exactly the same condition as the two counters above.
+    TDynamicCounters::TCounterPtr LatencyThresholdsSkippedOpsCounter;
 
     // Wall-clock time up to which the availability counters have been credited
     // for this instance. Seeded at construction (mount time) so that time
@@ -572,10 +570,16 @@ public:
             // RequestCompleted, so they cannot be judged: the batch carries
             // separate time and size histograms, not the joint
             // (size, latency) distribution a size-dependent verdict needs,
-            // and no per-operation error kind. Tallying them keeps a volume
-            // served this way distinguishable from one with no traffic,
-            // which the 0/0 in LatencyTotalOps/LatencyGoodOps alone is not.
-            *VolumeBase->LatencyThresholdsSkippedOpsCounter += count;
+            // and no per-operation error kind.
+            //
+            // count and errors are disjoint totals, not a total and a subset
+            // of it: a batch reports successful completions in one and
+            // failures in the other, the same way the per-request path
+            // increments either Count or Errors but never both (see
+            // TRequestCounters). Both are operations that went unjudged, so
+            // both belong here - counting only one would hide a batch that
+            // consists entirely of failures.
+            *LatencyThresholdsSkippedOpsCounter += count + errors;
         }
 
         return RequestCounters.BatchCompleted(
@@ -621,18 +625,15 @@ private:
             requestBytes,
             execTime);
 
+        // All three counters below are guaranteed non-null here: they are
+        // created together under VolumeBase->LatencyThresholdsEnabled in
+        // RegisterInstance, and this method only runs when that same flag is
+        // true (see the call site in RequestCompleted).
         if (outcome.MediaKindNotConfigured) {
-            // Guaranteed non-null: created unconditionally by
-            // InitLatencyThresholds, which always runs before any volume can
-            // be registered on this (EServerStats) TVolumeStats instance.
-            *VolumeBase->LatencyThresholdsSkippedOpsCounter += 1;
+            *LatencyThresholdsSkippedOpsCounter += 1;
             return;
         }
 
-        // Guaranteed non-null here: both counters are created together with
-        // VolumeBase->LatencyThresholdsEnabled in RegisterInstance, and this
-        // method only runs when that same flag is true (see the call site
-        // in RequestCompleted).
         if (outcome.CountTotal) {
             *LatencyTotalOpsCounter += 1;
         }
@@ -753,10 +754,9 @@ private:
         std::make_shared<TLatencyThresholdsHotSwap>();
 
     // Server-level (not per-volume) diagnostics: whether the configured
-    // table is invalid (gauge, 0/1) and how many operations were skipped
-    // because their media kind has no configured ladder (derivative).
+    // table is invalid (gauge, 0/1). Unjudged operations are counted per
+    // instance instead, see TVolumeInfo::LatencyThresholdsSkippedOpsCounter.
     TDynamicCounters::TCounterPtr LatencyThresholdsConfigInvalidCounter;
-    TDynamicCounters::TCounterPtr LatencyThresholdsSkippedOpsCounter;
 
     TLog Log;
 
@@ -1320,8 +1320,7 @@ private:
             volumeGroup,
             Timer,
             LatencyThresholdsEnabled,
-            LatencyThresholdsHotSwap,
-            LatencyThresholdsSkippedOpsCounter);
+            LatencyThresholdsHotSwap);
 
         return TVolumeInfoHolder{
             .VolumeBase = std::move(volumeBase),
@@ -1395,6 +1394,10 @@ private:
                 availabilityCountersGroup->GetCounter("LatencyTotalOps", true);
             info->LatencyGoodOpsCounter =
                 availabilityCountersGroup->GetCounter("LatencyGoodOps", true);
+            info->LatencyThresholdsSkippedOpsCounter =
+                availabilityCountersGroup->GetCounter(
+                    "LatencyThresholdsSkippedOps",
+                    true);
         }
 
         auto reportZeroBlocksMetrics =
@@ -1461,8 +1464,6 @@ private:
         auto serverGroup = Counters->GetSubgroup("component", "server");
         LatencyThresholdsConfigInvalidCounter =
             serverGroup->GetCounter("LatencyThresholdsConfigInvalid");
-        LatencyThresholdsSkippedOpsCounter =
-            serverGroup->GetCounter("LatencyThresholdsSkippedOps", true);
 
         if (!DiagnosticsConfig->GetLatencyThresholdsEnabled()) {
             *LatencyThresholdsConfigInvalidCounter = 0;

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -312,8 +312,8 @@ private:
     // Read/write operations of this instance that were not judged against
     // the thresholds, and so appear in neither counter above. This includes
     // an unconfigured media kind and final load-shedding, checkpoint-reject,
-    // invalid-input, or cancellation outcomes. Exact aggregate producers can
-    // report the same outcome through RecordLatencyBatch. Such operations
+    // or cancellation outcomes. Explicitly recognized pre-execution rejects
+    // can report the same outcome through RecordLatencyBatch. Such operations
     // are never counted as bad. Published next to
     // the two counters above, rather than once per server, because it is
     // what explains a specific volume reading 0/0: without the volume,
@@ -448,8 +448,8 @@ public:
     void RecordLatencyCompletion(
         EBlockStoreRequest requestType,
         ui64 requestStarted,
-        TDuration postponedTime,
-        TDuration backoffTime,
+        TDuration,
+        TDuration,
         TDuration shapingTime,
         ui64 requestBytes,
         const NProto::TError& error,
@@ -466,15 +466,20 @@ public:
 
         // NBD records responseSent immediately after the device future is
         // resolved and before writing the reply to the transport. Embedded
-        // vhost has no separate response-delivery phase, so it uses now.
+        // vhost invokes this hook before publishing completion to the
+        // virtqueue and uses the current time for the same endpoint boundary.
         const ui64 completed = responseSent ? responseSent : GetCycleCount();
         const ui64 elapsedCycles = completed > requestStarted
             ? completed - requestStarted
             : 0;
-        const ui64 waitCycles = DurationToCyclesSafe(
-            postponedTime + backoffTime + shapingTime);
-        const ui64 execCycles = elapsedCycles > waitCycles
-            ? elapsedCycles - waitCycles
+        // Retry backoff and generic postponed time remain part of the
+        // service-side latency: the caller is still waiting, and Postponed is
+        // not specific to quota enforcement. Shaping is the one explicit
+        // delay imposed by the configured performance quota, so only it is
+        // excluded from this latency contract.
+        const ui64 shapingCycles = DurationToCyclesSafe(shapingTime);
+        const ui64 measuredCycles = elapsedCycles > shapingCycles
+            ? elapsedCycles - shapingCycles
             : 0;
 
         const auto mediaKind = VolumeBase->Volume.GetStorageMediaKind();
@@ -486,7 +491,7 @@ public:
             error,
             isWrite,
             requestBytes,
-            CyclesToDurationSafe(execCycles));
+            CyclesToDurationSafe(measuredCycles));
 
         if (outcome.CountSkipped) {
             *LatencyThresholdsSkippedOpsCounter += 1;
@@ -1266,6 +1271,11 @@ public:
         }
 
         return volumeIt->second.VolumeBase->HasStorageConfigPatchCounter->Val();
+    }
+
+    bool IsLatencyTrackingEnabled() const override
+    {
+        return LatencyThresholdsEnabled;
     }
 
     void InitializeMonitoringCounters() override

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -1,6 +1,7 @@
 #include "volume_stats.h"
 
 #include "config.h"
+#include "latency_thresholds.h"
 #include "stats_helpers.h"
 #include "user_counter.h"
 #include "volume_perf.h"
@@ -12,6 +13,7 @@
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/common/verify.h>
 #include <cloud/storage/core/libs/diagnostics/busy_idle_calculator.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/max_calculator.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/diagnostics/postpone_time_predictor.h>
@@ -65,6 +67,23 @@ public:
             MaxPredictedPostponeTimeCalc.NextValue();
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Unlike IsWriteRequest (which also matches ZeroBlocks), this matches only
+// "real" write payload requests. The latency threshold mechanism is
+// read/write-only; zero/discard operations are out of scope for this
+// iteration.
+constexpr bool IsPureWriteRequest(EBlockStoreRequest requestType)
+{
+    switch (requestType) {
+        case EBlockStoreRequest::WriteBlocks:
+        case EBlockStoreRequest::WriteBlocksLocal:
+            return true;
+        default:
+            return false;
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -171,12 +190,34 @@ struct TVolumeInfoBase
     TMaxCalculator<DEFAULT_BUCKET_COUNT> CheckpointRejects;
     TDynamicCounters::TCounterPtr HasStorageConfigPatchCounter;
 
+    // Effective flag for the operation latency threshold mechanism: true
+    // only when the server enabled it AND the configured table passed
+    // validation (see TVolumeStats::InitLatencyThresholds). Stored once at
+    // construction and never re-read from config on the request path.
+    const bool LatencyThresholdsEnabled;
+
+    // Shared (not per-volume) hot-swappable snapshot of the latency
+    // thresholds table; see latency_thresholds.h. Held via shared_ptr, not
+    // by value, so per-volume state stays cheap and the table can be
+    // replaced later (e.g. by a dynamic config source) without touching
+    // every volume.
+    const std::shared_ptr<TLatencyThresholdsHotSwap> LatencyThresholdsHotSwap;
+
+    // Server-level (not per-volume) diagnostic counter: operations whose
+    // media kind has no configured threshold ladder are skipped entirely -
+    // never counted as bad - and tallied here instead so the gap stays
+    // visible.
+    const TDynamicCounters::TCounterPtr LatencyThresholdsSkippedOpsCounter;
+
     TVolumeInfoBase(
             NProto::TVolume volume,
             TDiagnosticsConfigPtr diagnosticsConfig,
             IPostponeTimePredictorPtr postponeTimePredictor,
             TDynamicCountersPtr volumeGroup,
-            ITimerPtr timer)
+            ITimerPtr timer,
+            bool latencyThresholdsEnabled,
+            std::shared_ptr<TLatencyThresholdsHotSwap> latencyThresholdsHotSwap,
+            TDynamicCounters::TCounterPtr latencyThresholdsSkippedOpsCounter)
         : Timer(timer)
         , Volume(std::move(volume))
         , PerfCalc(Volume, diagnosticsConfig)
@@ -187,6 +228,10 @@ struct TVolumeInfoBase
         , CheckpointRejects(timer)
         , HasStorageConfigPatchCounter(
             volumeGroup->GetCounter("HasStorageConfigPatch"))
+        , LatencyThresholdsEnabled(latencyThresholdsEnabled)
+        , LatencyThresholdsHotSwap(std::move(latencyThresholdsHotSwap))
+        , LatencyThresholdsSkippedOpsCounter(
+            std::move(latencyThresholdsSkippedOpsCounter))
     {
         BusyIdleCalc.Register(volumeGroup);
         PerfCalc.Register(*volumeGroup, Volume);
@@ -265,6 +310,17 @@ private:
     TDynamicCounters::TCounterPtr ObservedSecondsCounter;
     TDynamicCounters::TCounterPtr AvailableSecondsCounter;
     TDynamicCounters::TCounterPtr HealthySecondsCounter;
+
+    // Cumulative per-volume operation latency counters (derivative/RATE,
+    // operations). LatencyGoodOps <= LatencyTotalOps; consumers compute
+    // latency = GoodOps/TotalOps over a window. See
+    // TVolumeInfoBase::LatencyThresholdsEnabled and latency_thresholds.h for
+    // the accounting rule. Populated only when the server-wide mechanism is
+    // enabled (config flag + a valid thresholds table); left null otherwise
+    // - RequestCompleted only touches them under
+    // VolumeBase->LatencyThresholdsEnabled, checked once at construction.
+    TDynamicCounters::TCounterPtr LatencyTotalOpsCounter;
+    TDynamicCounters::TCounterPtr LatencyGoodOpsCounter;
 
     // Wall-clock time up to which the availability counters have been credited
     // for this instance. Seeded at construction (mount time) so that time
@@ -350,13 +406,15 @@ public:
         bool unaligned,
         ui64 responseSent) override
     {
+        const auto requestCompleted = GetCycleCount();
+        const auto waitTime = postponedTime + backoffTime + shapingTime;
+
         VolumeBase->BusyIdleCalc.OnRequestCompleted();
         VolumeBase->PerfCalc.OnRequestCompleted(
             TranslateLocalRequestType(requestType),
             requestStarted,
-            GetCycleCount(),   // requestCompleted
-            DurationToCyclesSafe(
-                postponedTime + backoffTime + shapingTime),   // waitTime
+            requestCompleted,
+            DurationToCyclesSafe(waitTime),
             requestBytes);
         VolumeBase->PostponeTimePredictor->Register(postponedTime);
         VolumeBase->DowntimeCalculator.RequestCompleted(
@@ -368,6 +426,40 @@ public:
             VolumeBase->CheckpointRejects.Add(1);
         } else if (errorKind == EDiagnosticsErrorKind::ErrorThrottling) {
             VolumeBase->ThrottlerRejects.Add(1);
+        }
+
+        if (VolumeBase->LatencyThresholdsEnabled) {
+            // processingCompleted excludes gRPC response-delivery time
+            // (network, backpressure, a slow client), mirroring
+            // TRequestCounters::RequestCompleted: responseSent is the
+            // timestamp taken right before handing the response off to the
+            // transport, and this method only runs once that hand-off has
+            // finished, so requestCompleted - responseSent is time spent
+            // delivering the response, not executing the operation.
+            const ui64 processingCompleted =
+                responseSent ? responseSent : requestCompleted;
+
+            // execTime = requestTime - waitTime, clamped at zero, mirroring
+            // the exec-time-safe pattern already used by
+            // TVolumePerformanceCalculator::OnRequestCompleted above: the
+            // throttler's own wait is not the service's responsibility, but
+            // the operation itself is still judged (a throttled-but-executed
+            // operation is NOT excluded, only judged on the time it actually
+            // took to execute).
+            const ui64 requestTimeCycles =
+                processingCompleted > requestStarted
+                    ? processingCompleted - requestStarted
+                    : 0;
+            const ui64 waitTimeCycles = DurationToCyclesSafe(waitTime);
+            const ui64 execTimeCycles = requestTimeCycles > waitTimeCycles
+                ? requestTimeCycles - waitTimeCycles
+                : 0;
+
+            RecordLatencyThresholdOutcome(
+                requestType,
+                errorKind,
+                requestBytes,
+                CyclesToDurationSafe(execTimeCycles));
         }
 
         return RequestCounters.RequestCompleted(
@@ -470,6 +562,59 @@ public:
             timeHist,
             sizeHist);
     }
+
+private:
+    // Judges a single completed operation against the latency thresholds
+    // table and increments LatencyTotalOpsCounter/LatencyGoodOpsCounter
+    // accordingly. Called from RequestCompleted only when
+    // VolumeBase->LatencyThresholdsEnabled - see latency_thresholds.h for
+    // the accounting rule (ClassifyLatencyOutcome) this wraps.
+    void RecordLatencyThresholdOutcome(
+        EBlockStoreRequest requestType,
+        EDiagnosticsErrorKind errorKind,
+        ui64 requestBytes,
+        TDuration execTime)
+    {
+        // Only ReadBlocks/WriteBlocks (and their *Local variants)
+        // participate; Zero/discard operations are out of scope for this
+        // iteration.
+        const bool isWrite = IsPureWriteRequest(requestType);
+        if (!isWrite && !IsReadRequest(requestType)) {
+            return;
+        }
+
+        const auto mediaKind = VolumeBase->Volume.GetStorageMediaKind();
+        const auto thresholds =
+            VolumeBase->LatencyThresholdsHotSwap->AtomicLoad();
+        const auto* ladder =
+            thresholds ? thresholds->FindLadder(mediaKind) : nullptr;
+
+        const auto outcome = ClassifyLatencyOutcome(
+            ladder,
+            errorKind,
+            isWrite,
+            requestBytes,
+            execTime);
+
+        if (outcome.MediaKindNotConfigured) {
+            // Guaranteed non-null: created unconditionally by
+            // InitLatencyThresholds, which always runs before any volume can
+            // be registered on this (EServerStats) TVolumeStats instance.
+            *VolumeBase->LatencyThresholdsSkippedOpsCounter += 1;
+            return;
+        }
+
+        // Guaranteed non-null here: both counters are created together with
+        // VolumeBase->LatencyThresholdsEnabled in RegisterInstance, and this
+        // method only runs when that same flag is true (see the call site
+        // in RequestCompleted).
+        if (outcome.CountTotal) {
+            *LatencyTotalOpsCounter += 1;
+        }
+        if (outcome.CountGood) {
+            *LatencyGoodOpsCounter += 1;
+        }
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -571,13 +716,33 @@ private:
     TDownDisksCounters DownDisksCounters;
     TDynamicCounters::TCounterPtr TotalDownDisksCounter;
 
+    // Effective flag for the operation latency threshold mechanism: only
+    // ever set for EServerStats (client-side sli_volume counters are not
+    // grown for this mechanism, unlike the older availability counters).
+    // See InitLatencyThresholds.
+    bool LatencyThresholdsEnabled = false;
+
+    // Shared, hot-swappable holder for the latency thresholds table; copied
+    // (as a shared_ptr) into every TVolumeInfoBase. See latency_thresholds.h.
+    std::shared_ptr<TLatencyThresholdsHotSwap> LatencyThresholdsHotSwap =
+        std::make_shared<TLatencyThresholdsHotSwap>();
+
+    // Server-level (not per-volume) diagnostics: whether the configured
+    // table is invalid (gauge, 0/1) and how many operations were skipped
+    // because their media kind has no configured ladder (derivative).
+    TDynamicCounters::TCounterPtr LatencyThresholdsConfigInvalidCounter;
+    TDynamicCounters::TCounterPtr LatencyThresholdsSkippedOpsCounter;
+
+    TLog Log;
+
 public:
     TVolumeStats(
             IMonitoringServicePtr monitoring,
             TDuration inactiveClientsTimeout,
             TDiagnosticsConfigPtr diagnosticsConfig,
             EVolumeStatsType type,
-            ITimerPtr timer)
+            ITimerPtr timer,
+            TLog log = {})
         : Monitoring(std::move(monitoring))
         , InactiveClientsTimeout(inactiveClientsTimeout)
         , DiagnosticsConfig(std::move(diagnosticsConfig))
@@ -587,6 +752,7 @@ public:
             return THashSet<TString>(v.begin(), v.end());
         }(DiagnosticsConfig->GetCloudIdsWithStrictSLA()))
         , UserCounters(CreateUserCounterSupplier())
+        , Log(std::move(log))
     {}
 
     // Not thread-safe
@@ -1127,7 +1293,10 @@ private:
                 DiagnosticsConfig->GetPostponeTimePredictorPercentage(),
                 DiagnosticsConfig->GetPostponeTimePredictorMaxTime()),
             volumeGroup,
-            Timer);
+            Timer,
+            LatencyThresholdsEnabled,
+            LatencyThresholdsHotSwap,
+            LatencyThresholdsSkippedOpsCounter);
 
         return TVolumeInfoHolder{
             .VolumeBase = std::move(volumeBase),
@@ -1190,6 +1359,19 @@ private:
         info->HealthySecondsCounter =
             availabilityCountersGroup->GetCounter("HealthySeconds", true);
 
+        // Registered only when the mechanism is actually enabled (config
+        // flag + a valid table), which in turn is only ever true for
+        // EServerStats - see InitLatencyThresholds. This is the "honest
+        // optionality" the counters need: unlike counters that always exist,
+        // creating LatencyTotalOps/LatencyGoodOps unconditionally would be
+        // misleading (nothing to compare against without a threshold table).
+        if (volumeBase->LatencyThresholdsEnabled) {
+            info->LatencyTotalOpsCounter =
+                availabilityCountersGroup->GetCounter("LatencyTotalOps", true);
+            info->LatencyGoodOpsCounter =
+                availabilityCountersGroup->GetCounter("LatencyGoodOps", true);
+        }
+
         auto reportZeroBlocksMetrics =
             !DiagnosticsConfig
                  ->GetSkipReportingZeroBlocksMetricsForYDBBasedDisks() ||
@@ -1243,6 +1425,46 @@ private:
             volumeBase->Volume.GetDiskId());
     }
 
+    // Validates the configured latency thresholds table and, if valid,
+    // stores it for use by every volume. Called once, from InitCounters, so
+    // it only ever runs for EServerStats (see the call site below). Never
+    // throws: a bad config leaves the mechanism disabled, not the server
+    // dead - this runs on every server on the fleet, so a config typo must
+    // not be able to take the whole service down.
+    void InitLatencyThresholds()
+    {
+        auto serverGroup = Counters->GetSubgroup("component", "server");
+        LatencyThresholdsConfigInvalidCounter =
+            serverGroup->GetCounter("LatencyThresholdsConfigInvalid");
+        LatencyThresholdsSkippedOpsCounter =
+            serverGroup->GetCounter("LatencyThresholdsSkippedOps", true);
+
+        if (!DiagnosticsConfig->GetLatencyThresholdsEnabled()) {
+            *LatencyThresholdsConfigInvalidCounter = 0;
+            return;
+        }
+
+        auto validation = BuildLatencyThresholdsTable(
+            DiagnosticsConfig->GetLatencyThresholds());
+
+        for (const auto& warning: validation.Warnings) {
+            STORAGE_WARN(warning);
+        }
+
+        if (!validation.IsValid()) {
+            STORAGE_ERROR(
+                "LatencyThresholdsEnabled is set but the configured table "
+                "is invalid, the mechanism stays disabled: "
+                << validation.Error);
+            *LatencyThresholdsConfigInvalidCounter = 1;
+            return;
+        }
+
+        LatencyThresholdsHotSwap->AtomicStore(validation.Table);
+        LatencyThresholdsEnabled = true;
+        *LatencyThresholdsConfigInvalidCounter = 0;
+    }
+
     void InitCounters()
     {
         Counters =
@@ -1281,6 +1503,8 @@ private:
                             ->GetCounter("DownDisks");
                     ++mk;
                 }
+
+                InitLatencyThresholds();
 
                 AvailabilityCounters = Counters
                     ->GetSubgroup("component", "sli_volume")
@@ -1410,7 +1634,8 @@ IVolumeStatsPtr CreateVolumeStats(
     TDiagnosticsConfigPtr diagnosticsConfig,
     TDuration inactiveClientsTimeout,
     EVolumeStatsType type,
-    ITimerPtr timer)
+    ITimerPtr timer,
+    TLog log)
 {
     Y_DEBUG_ABORT_UNLESS(diagnosticsConfig);
     return std::make_shared<TVolumeStats>(
@@ -1418,14 +1643,16 @@ IVolumeStatsPtr CreateVolumeStats(
         inactiveClientsTimeout,
         std::move(diagnosticsConfig),
         type,
-        std::move(timer));
+        std::move(timer),
+        std::move(log));
 }
 
 IVolumeStatsPtr CreateVolumeStats(
     IMonitoringServicePtr monitoring,
     TDuration inactiveClientsTimeout,
     EVolumeStatsType type,
-    ITimerPtr timer)
+    ITimerPtr timer,
+    TLog log)
 {
     NProto::TDiagnosticsConfig diagnosticsConfig;
     return std::make_shared<TVolumeStats>(
@@ -1433,7 +1660,8 @@ IVolumeStatsPtr CreateVolumeStats(
         inactiveClientsTimeout,
         std::make_shared<TDiagnosticsConfig>(diagnosticsConfig),
         type,
-        std::move(timer));
+        std::move(timer),
+        std::move(log));
 }
 
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.h
@@ -180,6 +180,14 @@ struct IVolumeStats
 
     virtual bool HasStorageConfigPatch(const TString& diskId) const = 0;
 
+    // Effective startup state after threshold validation. The default keeps
+    // existing implementations source-compatible and disables the optional
+    // request-path bookkeeping for implementations that do not provide it.
+    virtual bool IsLatencyTrackingEnabled() const
+    {
+        return false;
+    }
+
     // Publishes startup diagnostics after the monitoring service is ready,
     // without initializing the otherwise lazy volume counters. The default
     // keeps other implementations source-compatible; TVolumeStats also

--- a/cloud/blockstore/libs/diagnostics/volume_stats.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.h
@@ -10,6 +10,8 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 
+#include <library/cpp/logger/log.h>
+
 #include <util/datetime/base.h>
 #include <util/generic/ptr.h>
 #include <util/generic/string.h>
@@ -156,18 +158,25 @@ struct IVolumeStats
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// `log` is optional: a default-constructed (closed) TLog silently disables
+// the STORAGE_ERROR/STORAGE_WARN diagnostics emitted while validating the
+// latency thresholds config (see TDiagnosticsConfig::GetLatencyThresholds*),
+// so callers that do not care about that diagnostic (tools, benchmarks) do
+// not need to change.
 IVolumeStatsPtr CreateVolumeStats(
     IMonitoringServicePtr monitoring,
     TDiagnosticsConfigPtr diagnosticsConfig,
     TDuration inactiveClientsTimeout,
     EVolumeStatsType type,
-    ITimerPtr timer);
+    ITimerPtr timer,
+    TLog log = {});
 
 IVolumeStatsPtr CreateVolumeStats(
     IMonitoringServicePtr monitoring,
     TDuration inactiveClientsTimeout,
     EVolumeStatsType type,
-    ITimerPtr timer);
+    ITimerPtr timer,
+    TLog log = {});
 
 IVolumeStatsPtr CreateVolumeStatsStub();
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.h
@@ -83,6 +83,31 @@ struct IVolumeInfo
         ui64 errors,
         std::span<TTimeBucket> timeHist,
         std::span<TSizeBucket> sizeHist) = 0;
+
+    // Opt-in latency accounting path. Existing request statistics intentionally do
+    // not call this method: only an endpoint that owns the complete logical
+    // operation (after splitting and retries) may do so. Appended after all
+    // legacy methods and defaulted to preserve existing implementations.
+    virtual void RecordLatencyCompletion(
+        EBlockStoreRequest,
+        ui64,
+        TDuration,
+        TDuration,
+        TDuration,
+        ui64,
+        const NProto::TError&,
+        ui64)
+    {}
+
+    // Versioned aggregate producers (currently external vhost) report an
+    // exact, mutually exclusive partition of logical operations here. This
+    // is deliberately separate from the legacy BatchCompleted contract.
+    virtual void RecordLatencyBatch(
+        EBlockStoreRequest,
+        ui64,
+        ui64,
+        ui64)
+    {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -158,25 +183,38 @@ struct IVolumeStats
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// `log` is optional: a default-constructed (closed) TLog silently disables
-// the STORAGE_ERROR/STORAGE_WARN diagnostics emitted while validating the
-// latency thresholds config (see TDiagnosticsConfig::GetLatencyThresholds*),
-// so callers that do not care about that diagnostic (tools, benchmarks) do
-// not need to change.
+// Keep the original overloads intact: besides source compatibility, their
+// exact symbols are used by binaries that link this library independently.
+IVolumeStatsPtr CreateVolumeStats(
+    IMonitoringServicePtr monitoring,
+    TDiagnosticsConfigPtr diagnosticsConfig,
+    TDuration inactiveClientsTimeout,
+    EVolumeStatsType type,
+    ITimerPtr timer);
+
+// The extended overload lets server bootstraps provide a real log for eager
+// threshold validation. A default-constructed TLog in the original overload
+// keeps tools and tests on their previous contract.
 IVolumeStatsPtr CreateVolumeStats(
     IMonitoringServicePtr monitoring,
     TDiagnosticsConfigPtr diagnosticsConfig,
     TDuration inactiveClientsTimeout,
     EVolumeStatsType type,
     ITimerPtr timer,
-    TLog log = {});
+    TLog log);
+
+IVolumeStatsPtr CreateVolumeStats(
+    IMonitoringServicePtr monitoring,
+    TDuration inactiveClientsTimeout,
+    EVolumeStatsType type,
+    ITimerPtr timer);
 
 IVolumeStatsPtr CreateVolumeStats(
     IMonitoringServicePtr monitoring,
     TDuration inactiveClientsTimeout,
     EVolumeStatsType type,
     ITimerPtr timer,
-    TLog log = {});
+    TLog log);
 
 IVolumeStatsPtr CreateVolumeStatsStub();
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.h
@@ -179,6 +179,13 @@ struct IVolumeStats
     virtual TDowntimeHistory GetDowntimeHistory(const TString& diskId) const = 0;
 
     virtual bool HasStorageConfigPatch(const TString& diskId) const = 0;
+
+    // Publishes startup diagnostics after the monitoring service is ready,
+    // without initializing the otherwise lazy volume counters. The default
+    // keeps other implementations source-compatible; TVolumeStats also
+    // publishes the diagnostics lazily on first volume access.
+    virtual void InitializeMonitoringCounters()
+    {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -2551,12 +2551,12 @@ NProto::TDiagnosticsConfig MakeConfigWithLatencyThresholds(
     return config;
 }
 
-// Judges a single completed operation via TVolumeInfo::RequestCompleted with
+// Judges a single completed logical operation via the opt-in latency recording API
 // a chosen execTime, by backdating requestStarted from the current cycle
 // count.
 //
 // Both ends of the measured interval are passed in explicitly: with
-// responseSent left at 0, RequestCompleted measures the "completed" end
+// responseSent left at 0, RecordLatencyCompletion measures the "completed" end
 // against its own fresh GetCycleCount(), which would silently add the gap
 // between the two calls (including any preemption of this thread) to the
 // judged duration. Tests whose expected outcome depends on the duration
@@ -2568,22 +2568,20 @@ void SendRequest(
     EBlockStoreRequest requestType,
     ui64 requestBytes,
     TDuration execTime,
-    EDiagnosticsErrorKind errorKind = EDiagnosticsErrorKind::Success)
+    NProto::TError error = {})
 {
     const auto now = GetCycleCount();
     const auto durationInCycles = DurationToCyclesSafe(execTime);
     const auto requestStarted = now - Min(now, durationInCycles);
 
-    volume->RequestCompleted(
+    volume->RecordLatencyCompletion(
         requestType,
         requestStarted,
         TDuration::Zero(),   // postponedTime
         TDuration::Zero(),   // backoffTime
         TDuration::Zero(),   // shapingTime
         requestBytes,
-        errorKind,
-        NCloud::NProto::EF_NONE,
-        false,
+        error,
         requestStarted + durationInCycles);   // responseSent
 }
 
@@ -2595,21 +2593,19 @@ void SendRequestWithFreshCompletion(
     EBlockStoreRequest requestType,
     ui64 requestBytes,
     TDuration execTime,
-    EDiagnosticsErrorKind errorKind = EDiagnosticsErrorKind::Success)
+    NProto::TError error = {})
 {
     const auto now = GetCycleCount();
     const auto durationInCycles = DurationToCyclesSafe(execTime);
 
-    volume->RequestCompleted(
+    volume->RecordLatencyCompletion(
         requestType,
         now - Min(now, durationInCycles),
         TDuration::Zero(),   // postponedTime
         TDuration::Zero(),   // backoffTime
         TDuration::Zero(),   // shapingTime
         requestBytes,
-        errorKind,
-        NCloud::NProto::EF_NONE,
-        false,
+        error,
         0);
 }
 
@@ -2624,7 +2620,7 @@ void SendRequestWithResponseDelay(
     ui64 requestBytes,
     TDuration execTime,
     TDuration responseDelay,
-    EDiagnosticsErrorKind errorKind = EDiagnosticsErrorKind::Success)
+    NProto::TError error = {})
 {
     const auto now = GetCycleCount();
     const auto execCycles = DurationToCyclesSafe(execTime);
@@ -2633,17 +2629,36 @@ void SendRequestWithResponseDelay(
     const auto requestStarted = now - Min(now, totalCycles);
     const auto responseSent = requestStarted + execCycles;
 
-    volume->RequestCompleted(
+    volume->RecordLatencyCompletion(
         requestType,
         requestStarted,
         TDuration::Zero(),   // postponedTime
         TDuration::Zero(),   // backoffTime
         TDuration::Zero(),   // shapingTime
         requestBytes,
-        errorKind,
-        NCloud::NProto::EF_NONE,
-        false,
+        error,
         responseSent);
+}
+
+void SendRequestWithWaits(
+    IVolumeInfoPtr volume,
+    TDuration elapsed,
+    TDuration postponed,
+    TDuration backoff,
+    TDuration shaping)
+{
+    const auto completed = GetCycleCount();
+    const auto elapsedCycles = DurationToCyclesSafe(elapsed);
+
+    volume->RecordLatencyCompletion(
+        EBlockStoreRequest::WriteBlocks,
+        completed - Min(completed, elapsedCycles),
+        postponed,
+        backoff,
+        shaping,
+        4_KB,
+        {},
+        completed);
 }
 
 }   // namespace
@@ -2736,6 +2751,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
 
         auto total = availabilityCounters->GetCounter("LatencyTotalOps");
         auto good = availabilityCounters->GetCounter("LatencyGoodOps");
+        auto skipped =
+            availabilityCounters->GetCounter("LatencyThresholdsSkippedOps");
 
         // Fast write, well under the 10ms threshold: both counters advance.
         SendRequest(
@@ -2764,9 +2781,10 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
             EBlockStoreRequest::WriteBlocks,
             4_KB,
             TDuration::MilliSeconds(1),
-            EDiagnosticsErrorKind::ErrorFatal);
+            MakeError(E_FAIL));
         UNIT_ASSERT_VALUES_EQUAL(3, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, skipped->Val());
 
         // Throttled operations are excluded entirely, not counted as bad.
         SendRequest(
@@ -2774,9 +2792,10 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
             EBlockStoreRequest::WriteBlocks,
             4_KB,
             TDuration::MilliSeconds(1),
-            EDiagnosticsErrorKind::ErrorThrottling);
+            MakeError(E_BS_THROTTLED));
         UNIT_ASSERT_VALUES_EQUAL(3, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
     }
 
     Y_UNIT_TEST(ShouldExcludeResponseDeliveryTimeFromLatency)
@@ -2832,7 +2851,64 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
     }
 
-    Y_UNIT_TEST(ShouldKeepMechanismDisabledAndRaiseGaugeOnEmptyTable)
+    Y_UNIT_TEST(ShouldSubtractAllWaitStagesAndClampAtZero)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto config = std::make_shared<TDiagnosticsConfig>(
+            MakeConfigWithLatencyThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                10,
+                10));
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            CreateWallClockTimer());
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
+
+        auto counters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+        auto total = counters->GetCounter("LatencyTotalOps");
+        auto good = counters->GetCounter("LatencyGoodOps");
+
+        // Raw 100ms is above the 10ms threshold, but only 5ms remains after
+        // all explicitly tracked waits are removed.
+        SendRequestWithWaits(
+            volume,
+            TDuration::MilliSeconds(100),
+            TDuration::MilliSeconds(40),
+            TDuration::MilliSeconds(30),
+            TDuration::MilliSeconds(25));
+
+        // Inconsistent/rounded stage totals must never underflow into a huge
+        // duration. More wait than elapsed time clamps execution to zero.
+        SendRequestWithWaits(
+            volume,
+            TDuration::MilliSeconds(5),
+            TDuration::MilliSeconds(3),
+            TDuration::MilliSeconds(3),
+            TDuration::MilliSeconds(3));
+
+        UNIT_ASSERT_VALUES_EQUAL(2, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(2, good->Val());
+    }
+
+    Y_UNIT_TEST(ShouldRaiseInvalidConfigGaugeBeforeFirstMount)
     {
         auto monitoring = CreateMonitoringServiceStub();
         NProto::TDiagnosticsConfig protoConfig;
@@ -2849,32 +2925,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
             EVolumeStatsType::EServerStats,
             CreateWallClockTimer());
 
-        Mount(
-            volumeStats,
-            "test1",
-            "client1",
-            "instance",
-            NCloud::NProto::STORAGE_MEDIA_SSD);
-        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
-
-        // The server must stay alive and simply skip judging operations.
-        SendRequest(
-            volume,
-            EBlockStoreRequest::WriteBlocks,
-            4_KB,
-            TDuration::MilliSeconds(1));
-
-        auto availabilityCounters = monitoring->GetCounters()
-            ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "sli_volume")
-            ->GetSubgroup("host", "cluster")
-            ->GetSubgroup("volume", "test1")
-            ->GetSubgroup("instance", "instance")
-            ->GetSubgroup("cloud", DefaultCloudId)
-            ->GetSubgroup("folder", DefaultFolderId)
-            ->GetSubgroup("type", "network-ssd");
-        UNIT_ASSERT(!availabilityCounters->FindCounter("LatencyTotalOps"));
-        UNIT_ASSERT(!availabilityCounters->FindCounter("LatencyGoodOps"));
+        Y_UNUSED(volumeStats);
 
         auto invalidGauge = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
@@ -2942,7 +2993,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
     }
 
-    Y_UNIT_TEST(ShouldCountBatchImportedOperationsAsNotJudged)
+    Y_UNIT_TEST(ShouldKeepLegacyBatchUnchangedAndUseExactLatencyBatch)
     {
         auto monitoring = CreateMonitoringServiceStub();
         auto config = std::make_shared<TDiagnosticsConfig>(
@@ -2982,10 +3033,25 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         auto skipped =
             availabilityCounters->GetCounter("LatencyThresholdsSkippedOps");
 
-        // How the external vhost dataplane reports its operations: an
-        // aggregate that never passes through RequestCompleted, with
-        // separate time and size histograms (empty here, they play no part
-        // in this accounting).
+        // A legacy per-attempt completion must not affect logical latency counters
+        // counters. Otherwise a split request or retry would be counted more
+        // than once before its outer endpoint outcome arrives.
+        const auto legacyCompleted = GetCycleCount();
+        volume->RequestCompleted(
+            EBlockStoreRequest::WriteBlocks,
+            legacyCompleted,
+            TDuration::Zero(),
+            TDuration::Zero(),
+            TDuration::Zero(),
+            4_KB,
+            EDiagnosticsErrorKind::Success,
+            NCloud::NProto::EF_NONE,
+            false,
+            legacyCompleted);
+
+        // The existing aggregate contract must have no latency-counter side
+        // effect: its count/error meanings differ between producers and its
+        // time and size histograms are not a joint distribution.
         TVector<IVolumeInfo::TTimeBucket> timeHist;
         TVector<IVolumeInfo::TSizeBucket> sizeHist;
         volume->BatchCompleted(
@@ -2996,27 +3062,21 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
             timeHist,
             sizeHist);
 
-        // Not judgeable, so counted in neither the total nor the good
-        // counter - but visible as a coverage gap.
         UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
-        UNIT_ASSERT_VALUES_EQUAL(7, skipped->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, skipped->Val());
 
-        // A batch made entirely of failures: count and errors are disjoint
-        // totals, so a batch can report zero successful completions. These
-        // operations went unjudged just the same and must not vanish from
-        // the coverage gap.
-        volume->BatchCompleted(
+        // The versioned path reports a mutually exclusive partition. Total
+        // is derived from good + bad and skipped stays outside it.
+        volume->RecordLatencyBatch(
             EBlockStoreRequest::WriteBlocks,
-            0,          // count
-            0,          // bytes
-            3,          // errors
-            timeHist,
-            sizeHist);
+            7,   // good
+            3,   // bad
+            2);  // skipped
 
-        UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
-        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
-        UNIT_ASSERT_VALUES_EQUAL(10, skipped->Val());
+        UNIT_ASSERT_VALUES_EQUAL(10, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(7, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(2, skipped->Val());
     }
 
     Y_UNIT_TEST(ShouldContinueLatencyCountersUntilVolumeTrimmed)

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -11,11 +11,13 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/monlib/metrics/metric_consumer.h>
 #include <library/cpp/monlib/metrics/metric_registry.h>
+#include <library/cpp/monlib/service/pages/mon_page.h>
 #include <library/cpp/testing/hook/hook.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/datetime/cputimer.h>
 #include <util/generic/size_literals.h>
+#include <util/generic/yexception.h>
 
 #include <tuple>
 
@@ -27,6 +29,64 @@ namespace {
 
 const TString DefaultCloudId = "cloud_id";
 const TString DefaultFolderId = "folder_id";
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TDeferredMonitoringService final
+    : public IMonitoringService
+{
+private:
+    const IMonitoringServicePtr Delegate = CreateMonitoringServiceStub();
+    bool Ready = false;
+    size_t GetCountersCalls = 0;
+
+public:
+    void SetReady()
+    {
+        Ready = true;
+    }
+
+    size_t GetCountersCallCount() const
+    {
+        return GetCountersCalls;
+    }
+
+    void Start() override
+    {
+        Delegate->Start();
+    }
+
+    void Stop() override
+    {
+        Delegate->Stop();
+    }
+
+    NMonitoring::IMonPagePtr RegisterIndexPage(
+        const TString& path,
+        const TString& title) override
+    {
+        return Delegate->RegisterIndexPage(path, title);
+    }
+
+    void RegisterMonPage(NMonitoring::IMonPagePtr page) override
+    {
+        Delegate->RegisterMonPage(std::move(page));
+    }
+
+    NMonitoring::IMonPagePtr GetMonPage(const TString& path) override
+    {
+        return Delegate->GetMonPage(path);
+    }
+
+    NMonitoring::TDynamicCountersPtr GetCounters() override
+    {
+        ++GetCountersCalls;
+        if (!Ready) {
+            ythrow yexception() << "monitoring is not ready";
+        }
+        return Delegate->GetCounters();
+    }
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2908,30 +2968,75 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         UNIT_ASSERT_VALUES_EQUAL(2, good->Val());
     }
 
-    Y_UNIT_TEST(ShouldRaiseInvalidConfigGaugeBeforeFirstMount)
+    Y_UNIT_TEST(ShouldPublishConfigGaugeOnlyAfterMonitoringIsReady)
     {
-        auto monitoring = CreateMonitoringServiceStub();
-        NProto::TDiagnosticsConfig protoConfig;
-        protoConfig.SetLatencyThresholdsEnabled(true);
-        // LatencyThresholds is intentionally left empty here: a config
-        // mistake BuildLatencyThresholdsTable rejects, not a way to
-        // disable the mechanism (the flag itself already does that).
-        auto config = std::make_shared<TDiagnosticsConfig>(protoConfig);
+        const auto runCase = [](
+            const NProto::TDiagnosticsConfig& protoConfig,
+            ui64 expectedInvalid)
+        {
+            auto monitoring =
+                std::make_shared<TDeferredMonitoringService>();
+            auto config = std::make_shared<TDiagnosticsConfig>(protoConfig);
 
-        auto volumeStats = CreateVolumeStats(
-            monitoring,
-            config,
-            TDuration::Max(),
-            EVolumeStatsType::EServerStats,
-            CreateWallClockTimer());
+            IVolumeStatsPtr volumeStats;
+            UNIT_ASSERT_NO_EXCEPTION(
+                volumeStats = CreateVolumeStats(
+                    monitoring,
+                    config,
+                    TDuration::Max(),
+                    EVolumeStatsType::EServerStats,
+                    CreateWallClockTimer()));
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                monitoring->GetCountersCallCount());
 
-        Y_UNUSED(volumeStats);
+            monitoring->SetReady();
+            volumeStats->InitializeMonitoringCounters();
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                monitoring->GetCountersCallCount());
+            volumeStats->InitializeMonitoringCounters();
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                monitoring->GetCountersCallCount());
 
-        auto invalidGauge = monitoring->GetCounters()
-            ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server")
-            ->GetCounter("LatencyThresholdsConfigInvalid");
-        UNIT_ASSERT_VALUES_EQUAL(1, invalidGauge->Val());
+            auto blockStoreCounters = monitoring->GetCounters()
+                ->FindSubgroup("counters", "blockstore");
+            UNIT_ASSERT(blockStoreCounters);
+            auto serverCounters = blockStoreCounters->FindSubgroup(
+                "component",
+                "server");
+            UNIT_ASSERT(serverCounters);
+            auto invalidGauge = serverCounters->FindCounter(
+                "LatencyThresholdsConfigInvalid");
+            UNIT_ASSERT(invalidGauge);
+            UNIT_ASSERT_VALUES_EQUAL(expectedInvalid, invalidGauge->Val());
+
+            // Publishing the startup gauge must not eagerly create the large
+            // per-volume trees; their lifecycle remains tied to first mount.
+            UNIT_ASSERT(!blockStoreCounters->FindSubgroup(
+                "component",
+                "server_volume"));
+            UNIT_ASSERT(!blockStoreCounters->FindSubgroup(
+                "component",
+                "sli_volume"));
+        };
+
+        NProto::TDiagnosticsConfig disabledConfig;
+        runCase(disabledConfig, 0);
+
+        runCase(
+            MakeConfigWithLatencyThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                10,
+                10),
+            0);
+
+        NProto::TDiagnosticsConfig invalidConfig;
+        invalidConfig.SetLatencyThresholdsEnabled(true);
+        // The table is intentionally empty: this is a config mistake, not a
+        // way to disable the mechanism (the feature flag already does that).
+        runCase(invalidConfig, 1);
     }
 
     Y_UNIT_TEST(ShouldSkipOperationsForMediaKindWithoutConfiguredLadder)

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -2922,10 +2922,11 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         auto total = availabilityCounters->GetCounter("LatencyTotalOps");
         auto good = availabilityCounters->GetCounter("LatencyGoodOps");
 
-        auto skipped = monitoring->GetCounters()
-            ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server")
-            ->GetCounter("LatencyThresholdsSkippedOps");
+        // Published in the same per-instance tree as the two counters
+        // above, so that the gap is attributable to this volume and its
+        // media kind.
+        auto skipped =
+            availabilityCounters->GetCounter("LatencyThresholdsSkippedOps");
 
         SendRequest(
             volume,
@@ -2935,7 +2936,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
 
         // Neither counter moves for an unconfigured media kind - it must
         // never look like a 0% good-operation rate - but the gap is still
-        // visible via the server-level skipped-ops counter.
+        // visible via the skipped-ops counter.
         UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
@@ -2978,10 +2979,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         auto total = availabilityCounters->GetCounter("LatencyTotalOps");
         auto good = availabilityCounters->GetCounter("LatencyGoodOps");
 
-        auto skipped = monitoring->GetCounters()
-            ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server")
-            ->GetCounter("LatencyThresholdsSkippedOps");
+        auto skipped =
+            availabilityCounters->GetCounter("LatencyThresholdsSkippedOps");
 
         // How the external vhost dataplane reports its operations: an
         // aggregate that never passes through RequestCompleted, with
@@ -2998,11 +2997,26 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
             sizeHist);
 
         // Not judgeable, so counted in neither the total nor the good
-        // counter - but visible as a coverage gap, which is what makes this
-        // different from a volume with no traffic at all.
+        // counter - but visible as a coverage gap.
         UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
         UNIT_ASSERT_VALUES_EQUAL(7, skipped->Val());
+
+        // A batch made entirely of failures: count and errors are disjoint
+        // totals, so a batch can report zero successful completions. These
+        // operations went unjudged just the same and must not vanish from
+        // the coverage gap.
+        volume->BatchCompleted(
+            EBlockStoreRequest::WriteBlocks,
+            0,          // count
+            0,          // bytes
+            3,          // errors
+            timeHist,
+            sizeHist);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(10, skipped->Val());
     }
 
     Y_UNIT_TEST(ShouldContinueLatencyCountersUntilVolumeTrimmed)

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -2745,6 +2745,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
             TDuration::Max(),
             EVolumeStatsType::EServerStats,
             CreateWallClockTimer());
+        UNIT_ASSERT(!volumeStats->IsLatencyTrackingEnabled());
 
         Mount(
             volumeStats,
@@ -2790,6 +2791,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
             TDuration::Max(),
             EVolumeStatsType::EServerStats,
             CreateWallClockTimer());
+        UNIT_ASSERT(volumeStats->IsLatencyTrackingEnabled());
 
         Mount(
             volumeStats,
@@ -2911,7 +2913,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
     }
 
-    Y_UNIT_TEST(ShouldSubtractAllWaitStagesAndClampAtZero)
+    Y_UNIT_TEST(ShouldSubtractOnlyShapingAndClampAtZero)
     {
         auto monitoring = CreateMonitoringServiceStub();
         auto config = std::make_shared<TDiagnosticsConfig>(
@@ -2946,8 +2948,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         auto total = counters->GetCounter("LatencyTotalOps");
         auto good = counters->GetCounter("LatencyGoodOps");
 
-        // Raw 100ms is above the 10ms threshold, but only 5ms remains after
-        // all explicitly tracked waits are removed.
+        // Postponed and retry backoff remain visible to the caller. Even
+        // though their sum would leave only 5ms, only shaping is excluded,
+        // so the judged latency is 75ms and the operation is bad.
         SendRequestWithWaits(
             volume,
             TDuration::MilliSeconds(100),
@@ -2955,16 +2958,25 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
             TDuration::MilliSeconds(30),
             TDuration::MilliSeconds(25));
 
-        // Inconsistent/rounded stage totals must never underflow into a huge
-        // duration. More wait than elapsed time clamps execution to zero.
+        // Explicit shaping is imposed by the configured performance quota.
+        // Removing 25ms from a 30ms wall-clock latency leaves a good 5ms.
+        SendRequestWithWaits(
+            volume,
+            TDuration::MilliSeconds(30),
+            TDuration::MilliSeconds(100),
+            TDuration::MilliSeconds(100),
+            TDuration::MilliSeconds(25));
+
+        // Inconsistent/rounded shaping totals must never underflow into a
+        // huge duration. More shaping than elapsed time clamps to zero.
         SendRequestWithWaits(
             volume,
             TDuration::MilliSeconds(5),
-            TDuration::MilliSeconds(3),
-            TDuration::MilliSeconds(3),
-            TDuration::MilliSeconds(3));
+            TDuration::Zero(),
+            TDuration::Zero(),
+            TDuration::MilliSeconds(9));
 
-        UNIT_ASSERT_VALUES_EQUAL(2, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(3, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(2, good->Val());
     }
 
@@ -2986,6 +2998,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
                     TDuration::Max(),
                     EVolumeStatsType::EServerStats,
                     CreateWallClockTimer()));
+            UNIT_ASSERT_VALUES_EQUAL(
+                protoConfig.GetLatencyThresholdsEnabled() && !expectedInvalid,
+                volumeStats->IsLatencyTrackingEnabled());
             UNIT_ASSERT_VALUES_EQUAL(
                 0,
                 monitoring->GetCountersCallCount());

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -2528,4 +2528,456 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+NProto::TDiagnosticsConfig MakeConfigWithLatencyThresholds(
+    NCloud::NProto::EStorageMediaKind mediaKind,
+    ui32 readThresholdMs,
+    ui32 writeThresholdMs)
+{
+    NProto::TDiagnosticsConfig config;
+    config.SetLatencyThresholdsEnabled(true);
+
+    auto& mkt = *config.AddLatencyThresholds();
+    mkt.SetMediaKind(mediaKind);
+
+    auto& bucket = *mkt.AddBuckets();
+    bucket.SetMinRequestBytes(0);
+    bucket.SetReadThresholdMs(readThresholdMs);
+    bucket.SetWriteThresholdMs(writeThresholdMs);
+
+    return config;
+}
+
+// Judges a single completed operation via TVolumeInfo::RequestCompleted with
+// a chosen execTime, by backdating requestStarted from the current cycle
+// count (RequestCompleted itself always measures the "completed" end against
+// a fresh GetCycleCount(), so this is the only way to control execTime
+// deterministically without an actual sleep).
+void SendRequest(
+    IVolumeInfoPtr volume,
+    EBlockStoreRequest requestType,
+    ui64 requestBytes,
+    TDuration execTime,
+    EDiagnosticsErrorKind errorKind = EDiagnosticsErrorKind::Success)
+{
+    const auto now = GetCycleCount();
+    const auto durationInCycles = DurationToCyclesSafe(execTime);
+
+    volume->RequestCompleted(
+        requestType,
+        now - Min(now, durationInCycles),
+        TDuration::Zero(),   // postponedTime
+        TDuration::Zero(),   // backoffTime
+        TDuration::Zero(),   // shapingTime
+        requestBytes,
+        errorKind,
+        NCloud::NProto::EF_NONE,
+        false,
+        0);
+}
+
+// Like SendRequest, but also simulates a non-zero gap between "response
+// handed off to the transport" (responseSent) and "RequestCompleted called"
+// (now) - e.g. gRPC write-to-socket time, backpressure, a slow client. Only
+// execTime should be judged against the latency threshold; responseDelay
+// must not leak into it.
+void SendRequestWithResponseDelay(
+    IVolumeInfoPtr volume,
+    EBlockStoreRequest requestType,
+    ui64 requestBytes,
+    TDuration execTime,
+    TDuration responseDelay,
+    EDiagnosticsErrorKind errorKind = EDiagnosticsErrorKind::Success)
+{
+    const auto now = GetCycleCount();
+    const auto execCycles = DurationToCyclesSafe(execTime);
+    const auto responseDelayCycles = DurationToCyclesSafe(responseDelay);
+    const auto totalCycles = execCycles + responseDelayCycles;
+    const auto requestStarted = now - Min(now, totalCycles);
+    const auto responseSent = requestStarted + execCycles;
+
+    volume->RequestCompleted(
+        requestType,
+        requestStarted,
+        TDuration::Zero(),   // postponedTime
+        TDuration::Zero(),   // backoffTime
+        TDuration::Zero(),   // shapingTime
+        requestBytes,
+        errorKind,
+        NCloud::NProto::EF_NONE,
+        false,
+        responseSent);
+}
+
+}   // namespace
+
+Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
+{
+    Y_TEST_HOOK_BEFORE_RUN(InitTest)
+    {
+        // NHPTimer warmup, see issue #2830 for more information: SendRequest
+        // above relies on GetCycleCount()/DurationToCyclesSafe() being
+        // calibrated before the first real measurement.
+        Y_UNUSED(GetCyclesPerMillisecond());
+    }
+
+    Y_UNIT_TEST(ShouldNotCreateLatencyCountersWhenMechanismDisabled)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto config = std::make_shared<TDiagnosticsConfig>(
+            NProto::TDiagnosticsConfig());
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            CreateWallClockTimer());
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
+
+        // Must not crash even though the mechanism is off.
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1));
+
+        auto availabilityCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+
+        UNIT_ASSERT(!availabilityCounters->FindCounter("LatencyTotalOps"));
+        UNIT_ASSERT(!availabilityCounters->FindCounter("LatencyGoodOps"));
+    }
+
+    Y_UNIT_TEST(ShouldTrackLatencyCountersWhenEnabledWithValidTable)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto config = std::make_shared<TDiagnosticsConfig>(
+            MakeConfigWithLatencyThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                10,   // readThresholdMs
+                10)); // writeThresholdMs
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            CreateWallClockTimer());
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
+
+        auto availabilityCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+
+        auto total = availabilityCounters->GetCounter("LatencyTotalOps");
+        auto good = availabilityCounters->GetCounter("LatencyGoodOps");
+
+        // Fast write, well under the 10ms threshold: both counters advance.
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+
+        // Slow write, well over the threshold: only the total advances.
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(500));
+        UNIT_ASSERT_VALUES_EQUAL(2, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+
+        // A fatal error is counted as bad without a duration comparison.
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1),
+            EDiagnosticsErrorKind::ErrorFatal);
+        UNIT_ASSERT_VALUES_EQUAL(3, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+
+        // Throttled operations are excluded entirely, not counted as bad.
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1),
+            EDiagnosticsErrorKind::ErrorThrottling);
+        UNIT_ASSERT_VALUES_EQUAL(3, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+    }
+
+    Y_UNIT_TEST(ShouldExcludeResponseDeliveryTimeFromLatency)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto config = std::make_shared<TDiagnosticsConfig>(
+            MakeConfigWithLatencyThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                10,   // readThresholdMs
+                10)); // writeThresholdMs
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            CreateWallClockTimer());
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
+
+        auto availabilityCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+
+        auto total = availabilityCounters->GetCounter("LatencyTotalOps");
+        auto good = availabilityCounters->GetCounter("LatencyGoodOps");
+
+        // Real execution time is 1ms (well under the 10ms threshold), but
+        // the response then spends 50ms being delivered to the client
+        // (network/backpressure/slow client). If that delivery time leaked
+        // into the judged duration (1ms + 50ms = 51ms > 10ms), this would
+        // wrongly count as bad.
+        SendRequestWithResponseDelay(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1),
+            TDuration::MilliSeconds(50));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
+    }
+
+    Y_UNIT_TEST(ShouldKeepMechanismDisabledAndRaiseGaugeOnEmptyTable)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        NProto::TDiagnosticsConfig protoConfig;
+        protoConfig.SetLatencyThresholdsEnabled(true);
+        // LatencyThresholds is intentionally left empty here: a config
+        // mistake per BuildLatencyThresholdsTable rule 1, not a way to
+        // disable the mechanism (the flag itself already does that).
+        auto config = std::make_shared<TDiagnosticsConfig>(protoConfig);
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            CreateWallClockTimer());
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
+
+        // The server must stay alive and simply skip judging operations.
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1));
+
+        auto availabilityCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+        UNIT_ASSERT(!availabilityCounters->FindCounter("LatencyTotalOps"));
+        UNIT_ASSERT(!availabilityCounters->FindCounter("LatencyGoodOps"));
+
+        auto invalidGauge = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server")
+            ->GetCounter("LatencyThresholdsConfigInvalid");
+        UNIT_ASSERT_VALUES_EQUAL(1, invalidGauge->Val());
+    }
+
+    Y_UNIT_TEST(ShouldSkipOperationsForMediaKindWithoutConfiguredLadder)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        // The table below only configures SSD; the volume mounted below is
+        // HDD, i.e. a media kind nobody has calibrated yet.
+        auto config = std::make_shared<TDiagnosticsConfig>(
+            MakeConfigWithLatencyThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                10,
+                10));
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            CreateWallClockTimer());
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_HDD);
+        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
+
+        auto availabilityCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-hdd");
+
+        auto total = availabilityCounters->GetCounter("LatencyTotalOps");
+        auto good = availabilityCounters->GetCounter("LatencyGoodOps");
+
+        auto skipped = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server")
+            ->GetCounter("LatencyThresholdsSkippedOps");
+
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1));
+
+        // Neither counter moves for an unconfigured media kind - it must
+        // never look like a 0% good-operation rate - but the gap is still
+        // visible via the server-level skipped-ops counter.
+        UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
+    }
+
+    Y_UNIT_TEST(ShouldContinueLatencyCountersUntilVolumeTrimmed)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto config = std::make_shared<TDiagnosticsConfig>(
+            MakeConfigWithLatencyThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                10,
+                10));
+        auto timer = std::make_shared<TTestTimer>();
+
+        // Finite inactivity timeout so that TrimVolumes() actually removes
+        // the instance - mirrors
+        // ShouldStopAccruingAvailabilityAfterVolumeTrimmed above.
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Seconds(10),
+            EVolumeStatsType::EServerStats,
+            timer);
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
+
+        auto availabilityCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+        auto total = availabilityCounters->GetCounter("LatencyTotalOps");
+
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(1, total->Val());
+
+        // Unmount alone is a no-op for this class: the instance (and its
+        // counters) is not removed until TrimVolumes fires, so it must keep
+        // accruing.
+        volumeStats->UnmountVolume("test1", "client1");
+        SendRequest(
+            volume,
+            EBlockStoreRequest::WriteBlocks,
+            4_KB,
+            TDuration::MilliSeconds(1));
+        UNIT_ASSERT(availabilityCounters->FindCounter("LatencyTotalOps"));
+        UNIT_ASSERT_VALUES_EQUAL(2, total->Val());
+
+        // The instance is now inactive longer than the timeout, so
+        // TrimVolumes removes its whole subtree, LatencyTotalOps included.
+        // (`availabilityCounters` above is a pointer to the leaf subgroup
+        // itself, kept alive by this test's own shared_ptr, so it is not a
+        // reliable way to observe the removal - re-navigate from the root
+        // instead, the same way a fresh monitoring scrape would.)
+        timer->AdvanceTime(TDuration::Seconds(11));
+        volumeStats->TrimVolumes();
+
+        auto volumeGroup = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->FindSubgroup("volume", "test1");
+        UNIT_ASSERT(!volumeGroup);
+    }
+}
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -2553,10 +2553,44 @@ NProto::TDiagnosticsConfig MakeConfigWithLatencyThresholds(
 
 // Judges a single completed operation via TVolumeInfo::RequestCompleted with
 // a chosen execTime, by backdating requestStarted from the current cycle
-// count (RequestCompleted itself always measures the "completed" end against
-// a fresh GetCycleCount(), so this is the only way to control execTime
-// deterministically without an actual sleep).
+// count.
+//
+// Both ends of the measured interval are passed in explicitly: with
+// responseSent left at 0, RequestCompleted measures the "completed" end
+// against its own fresh GetCycleCount(), which would silently add the gap
+// between the two calls (including any preemption of this thread) to the
+// judged duration. Tests whose expected outcome depends on the duration
+// therefore go through this deterministic path; the responseSent == 0
+// fallback is covered separately by SendRequestWithFreshCompletion, where a
+// delay cannot change the expected verdict.
 void SendRequest(
+    IVolumeInfoPtr volume,
+    EBlockStoreRequest requestType,
+    ui64 requestBytes,
+    TDuration execTime,
+    EDiagnosticsErrorKind errorKind = EDiagnosticsErrorKind::Success)
+{
+    const auto now = GetCycleCount();
+    const auto durationInCycles = DurationToCyclesSafe(execTime);
+    const auto requestStarted = now - Min(now, durationInCycles);
+
+    volume->RequestCompleted(
+        requestType,
+        requestStarted,
+        TDuration::Zero(),   // postponedTime
+        TDuration::Zero(),   // backoffTime
+        TDuration::Zero(),   // shapingTime
+        requestBytes,
+        errorKind,
+        NCloud::NProto::EF_NONE,
+        false,
+        requestStarted + durationInCycles);   // responseSent
+}
+
+// Like SendRequest, but leaves responseSent at 0, so the operation ends at
+// the fresh GetCycleCount() taken inside RequestCompleted. Use only where a
+// longer-than-requested duration cannot flip the expected outcome.
+void SendRequestWithFreshCompletion(
     IVolumeInfoPtr volume,
     EBlockStoreRequest requestType,
     ui64 requestBytes,
@@ -2713,7 +2747,10 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         UNIT_ASSERT_VALUES_EQUAL(1, good->Val());
 
         // Slow write, well over the threshold: only the total advances.
-        SendRequest(
+        // Deliberately on the responseSent == 0 path, to cover that fallback
+        // too: an extra delay there can only make the operation look slower,
+        // which is already the expected verdict.
+        SendRequestWithFreshCompletion(
             volume,
             EBlockStoreRequest::WriteBlocks,
             4_KB,
@@ -2801,7 +2838,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         NProto::TDiagnosticsConfig protoConfig;
         protoConfig.SetLatencyThresholdsEnabled(true);
         // LatencyThresholds is intentionally left empty here: a config
-        // mistake per BuildLatencyThresholdsTable rule 1, not a way to
+        // mistake BuildLatencyThresholdsTable rejects, not a way to
         // disable the mechanism (the flag itself already does that).
         auto config = std::make_shared<TDiagnosticsConfig>(protoConfig);
 
@@ -2902,6 +2939,70 @@ Y_UNIT_TEST_SUITE(TVolumeStatsLatencyThresholdsTest)
         UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
         UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
         UNIT_ASSERT_VALUES_EQUAL(1, skipped->Val());
+    }
+
+    Y_UNIT_TEST(ShouldCountBatchImportedOperationsAsNotJudged)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto config = std::make_shared<TDiagnosticsConfig>(
+            MakeConfigWithLatencyThresholds(
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                10,
+                10));
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            CreateWallClockTimer());
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volume = volumeStats->GetVolumeInfo("test1", "client1");
+
+        auto availabilityCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+
+        auto total = availabilityCounters->GetCounter("LatencyTotalOps");
+        auto good = availabilityCounters->GetCounter("LatencyGoodOps");
+
+        auto skipped = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server")
+            ->GetCounter("LatencyThresholdsSkippedOps");
+
+        // How the external vhost dataplane reports its operations: an
+        // aggregate that never passes through RequestCompleted, with
+        // separate time and size histograms (empty here, they play no part
+        // in this accounting).
+        TVector<IVolumeInfo::TTimeBucket> timeHist;
+        TVector<IVolumeInfo::TSizeBucket> sizeHist;
+        volume->BatchCompleted(
+            EBlockStoreRequest::WriteBlocks,
+            7,          // count
+            7 * 4_KB,   // bytes
+            0,          // errors
+            timeHist,
+            sizeHist);
+
+        // Not judgeable, so counted in neither the total nor the good
+        // counter - but visible as a coverage gap, which is what makes this
+        // different from a volume with no traffic at all.
+        UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(7, skipped->Val());
     }
 
     Y_UNIT_TEST(ShouldContinueLatencyCountersUntilVolumeTrimmed)

--- a/cloud/blockstore/libs/diagnostics/ya.make
+++ b/cloud/blockstore/libs/diagnostics/ya.make
@@ -12,6 +12,7 @@ SRCS(
     incomplete_requests.cpp
     hostname.cpp
     latency_thresholds.cpp
+    latency_thresholds_config.cpp
     probes.cpp
     profile_log.cpp
     quota_metrics.cpp

--- a/cloud/blockstore/libs/diagnostics/ya.make
+++ b/cloud/blockstore/libs/diagnostics/ya.make
@@ -11,6 +11,7 @@ SRCS(
     incomplete_request_processor.cpp
     incomplete_requests.cpp
     hostname.cpp
+    latency_thresholds.cpp
     probes.cpp
     profile_log.cpp
     quota_metrics.cpp

--- a/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats.cpp
@@ -90,17 +90,28 @@ struct TLatencyCountersBatch
     TLatencyCounters Write;
 };
 
+bool TryReadUnsignedInteger(const NJson::TJsonValue& value, ui64& result)
+{
+    const auto type = value.GetType();
+    if (type != NJson::JSON_INTEGER && type != NJson::JSON_UINTEGER) {
+        return false;
+    }
+
+    unsigned long long parsed = 0;
+    if (!value.GetUInteger(&parsed)) {
+        return false;
+    }
+
+    result = parsed;
+    return true;
+}
+
 bool TryReadLatencyCounters(
     const NJson::TJsonValue& value,
     TLatencyCounters& counters)
 {
     auto read = [&] (TStringBuf key, ui64& result) {
-        unsigned long long parsed = 0;
-        if (!value[key].GetUInteger(&parsed)) {
-            return false;
-        }
-        result = parsed;
-        return true;
+        return TryReadUnsignedInteger(value[key], result);
     };
 
     if (!value.IsMap() || !read("good", counters.Good) ||
@@ -151,10 +162,11 @@ std::optional<TLatencyCountersBatch> TryReadLatencyCountersBatch(
     }
 
     const auto& latencyCounters = stats["latency_counters"];
-    unsigned long long version = 0;
+    ui64 version = 0;
     TLatencyCountersBatch batch;
     if (!latencyCounters.IsMap() ||
-        !latencyCounters["version"].GetUInteger(&version) || version != 1 ||
+        !TryReadUnsignedInteger(latencyCounters["version"], version) ||
+        version != 1 ||
         !TryReadLatencyCounters(latencyCounters["read"], batch.Read) ||
         !TryReadLatencyCounters(latencyCounters["write"], batch.Write) ||
         !FitsDynamicCounters(batch))

--- a/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats.cpp
@@ -4,6 +4,10 @@
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 #include <cloud/storage/core/libs/diagnostics/max_calculator.h>
 
+#include <library/cpp/deprecated/atomic/atomic.h>
+
+#include <limits>
+#include <optional>
 #include <type_traits>
 
 namespace NCloud::NBlockStore::NServer {
@@ -73,12 +77,128 @@ void BatchCompleted(
         sizes);
 }
 
+struct TLatencyCounters
+{
+    ui64 Good = 0;
+    ui64 Bad = 0;
+    ui64 Skipped = 0;
+};
+
+struct TLatencyCountersBatch
+{
+    TLatencyCounters Read;
+    TLatencyCounters Write;
+};
+
+bool TryReadLatencyCounters(
+    const NJson::TJsonValue& value,
+    TLatencyCounters& counters)
+{
+    auto read = [&] (TStringBuf key, ui64& result) {
+        unsigned long long parsed = 0;
+        if (!value[key].GetUInteger(&parsed)) {
+            return false;
+        }
+        result = parsed;
+        return true;
+    };
+
+    if (!value.IsMap() || !read("good", counters.Good) ||
+        !read("bad", counters.Bad) || !read("skipped", counters.Skipped))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool TryAddCounterValue(ui64 value, ui64 limit, ui64& sum)
+{
+    if (value > limit - sum) {
+        return false;
+    }
+    sum += value;
+    return true;
+}
+
+bool FitsDynamicCounters(const TLatencyCountersBatch& batch)
+{
+    // Dynamic counters use signed TAtomicBase. Validate the complete batch,
+    // including Read+Write aggregation into the same exported series, before
+    // performing any update. This also guarantees good+bad cannot overflow
+    // the ui64 intermediate in RecordLatencyBatch.
+    constexpr ui64 limit =
+        static_cast<ui64>(std::numeric_limits<TAtomicBase>::max());
+
+    ui64 good = 0;
+    ui64 total = 0;
+    ui64 skipped = 0;
+    return TryAddCounterValue(batch.Read.Good, limit, good) &&
+        TryAddCounterValue(batch.Write.Good, limit, good) &&
+        TryAddCounterValue(batch.Read.Good, limit, total) &&
+        TryAddCounterValue(batch.Read.Bad, limit, total) &&
+        TryAddCounterValue(batch.Write.Good, limit, total) &&
+        TryAddCounterValue(batch.Write.Bad, limit, total) &&
+        TryAddCounterValue(batch.Read.Skipped, limit, skipped) &&
+        TryAddCounterValue(batch.Write.Skipped, limit, skipped);
+}
+
+std::optional<TLatencyCountersBatch> TryReadLatencyCountersBatch(
+    const NJson::TJsonValue& stats)
+{
+    if (!stats.Has("latency_counters")) {
+        return std::nullopt;
+    }
+
+    const auto& latencyCounters = stats["latency_counters"];
+    unsigned long long version = 0;
+    TLatencyCountersBatch batch;
+    if (!latencyCounters.IsMap() ||
+        !latencyCounters["version"].GetUInteger(&version) || version != 1 ||
+        !TryReadLatencyCounters(latencyCounters["read"], batch.Read) ||
+        !TryReadLatencyCounters(latencyCounters["write"], batch.Write) ||
+        !FitsDynamicCounters(batch))
+    {
+        return std::nullopt;
+    }
+
+    return batch;
+}
+
+void RecordLatencyBatch(
+    IServerStats& serverStats,
+    EBlockStoreRequest kind,
+    const TLatencyCounters& counters,
+    const TString& clientId,
+    const TString& diskId)
+{
+    TMetricRequest request{kind};
+    serverStats.PrepareMetricRequest(
+        request,
+        clientId,
+        diskId,
+        0,      // startIndex
+        0,      // requestBytes
+        false); // unaligned
+
+    serverStats.RecordLatencyBatch(
+        request,
+        counters.Good,
+        counters.Bad,
+        counters.Skipped);
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void TEndpointStats::Update(const NJson::TJsonValue& stats)
 {
+    // Parse the whole versioned payload before recording either direction:
+    // malformed/unknown versions are ignored atomically and are never
+    // reconstructed from the legacy count/error/time histograms below.
+    const auto latencyCounters = TryReadLatencyCountersBatch(stats);
+
     BatchCompleted(
         *ServerStats,
         EBlockStoreRequest::ReadBlocks,
@@ -92,6 +212,21 @@ void TEndpointStats::Update(const NJson::TJsonValue& stats)
         stats["write"],
         ClientId,
         DiskId);
+
+    if (latencyCounters) {
+        RecordLatencyBatch(
+            *ServerStats,
+            EBlockStoreRequest::ReadBlocks,
+            latencyCounters->Read,
+            ClientId,
+            DiskId);
+        RecordLatencyBatch(
+            *ServerStats,
+            EBlockStoreRequest::WriteBlocks,
+            latencyCounters->Write,
+            ClientId,
+            DiskId);
+    }
 
     // Report critical events
     if (stats.Has("crit_events")) {

--- a/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp
@@ -16,6 +16,7 @@
 #include <util/generic/size_literals.h>
 
 #include <chrono>
+#include <limits>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -109,19 +110,31 @@ struct TFixture
     {
         auto monitoring = CreateMonitoringServiceStub();
 
+        NProto::TDiagnosticsConfig protoConfig;
+        protoConfig.SetLatencyThresholdsEnabled(true);
+        auto* media = protoConfig.AddLatencyThresholds();
+        media->SetMediaKind(NProto::STORAGE_MEDIA_SSD_LOCAL);
+        auto* bucket = media->AddBuckets();
+        bucket->SetMinRequestBytes(0);
+        bucket->SetReadThresholdMs(10);
+        bucket->SetWriteThresholdMs(10);
+        auto diagnosticsConfig =
+            std::make_shared<TDiagnosticsConfig>(std::move(protoConfig));
+
         auto serverGroup = Monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "server");
 
         auto volumeStats = CreateVolumeStats(
             Monitoring,
-            {},
+            diagnosticsConfig,
+            TDuration::Max(),
             EVolumeStatsType::EServerStats,
             CreateWallClockTimer());
 
         ServerStats = CreateServerStats(
             std::make_shared<TTestDumpable>(),
-            std::make_shared<TDiagnosticsConfig>(),
+            diagnosticsConfig,
             Monitoring,
             CreateProfileLogStub(),
             CreateServerRequestStats(
@@ -136,6 +149,19 @@ struct TFixture
         volume.SetStorageMediaKind(NProto::STORAGE_MEDIA_SSD_LOCAL);
 
         ServerStats->MountVolume(volume, ClientId, "instance");
+    }
+
+    auto GetLatencyCounters()
+    {
+        return Monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", DiskId)
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", "")
+            ->GetSubgroup("folder", "")
+            ->GetSubgroup("type", "unknown");
     }
 
     void UpdateStats(
@@ -155,6 +181,95 @@ struct TFixture
 
 Y_UNIT_TEST_SUITE(TEndpointStatsTest)
 {
+    Y_UNIT_TEST(ShouldValidateVersionedLatencyCountersPayloadAtomically)
+    {
+        auto makeCounters = [] (ui64 good, ui64 bad, ui64 skipped) {
+            return NJson::TJsonMap{
+                {"good", good},
+                {"bad", bad},
+                {"skipped", skipped},
+            };
+        };
+        auto makePayload = [&] (ui64 version) {
+            return NJson::TJsonMap{
+                {"latency_counters", NJson::TJsonMap{
+                    {"version", version},
+                    {"read", makeCounters(3, 2, 1)},
+                    {"write", makeCounters(5, 4, 3)},
+                }},
+            };
+        };
+
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(NJson::TJsonMap{}));
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(makePayload(2)));
+
+        auto valid = TryReadLatencyCountersBatch(makePayload(1));
+        UNIT_ASSERT(valid);
+        UNIT_ASSERT_VALUES_EQUAL(3, valid->Read.Good);
+        UNIT_ASSERT_VALUES_EQUAL(2, valid->Read.Bad);
+        UNIT_ASSERT_VALUES_EQUAL(1, valid->Read.Skipped);
+        UNIT_ASSERT_VALUES_EQUAL(5, valid->Write.Good);
+        UNIT_ASSERT_VALUES_EQUAL(4, valid->Write.Bad);
+        UNIT_ASSERT_VALUES_EQUAL(3, valid->Write.Skipped);
+
+        auto malformed = makePayload(1);
+        malformed["latency_counters"]["write"]["bad"] = "not-a-counter";
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(malformed));
+
+        auto overflow = makePayload(1);
+        overflow["latency_counters"]["read"]["good"] =
+            static_cast<unsigned long long>(std::numeric_limits<ui64>::max());
+        overflow["latency_counters"]["read"]["bad"] = 1;
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(overflow));
+
+        auto signedOverflow = makePayload(1);
+        signedOverflow["latency_counters"]["read"]["good"] =
+            static_cast<unsigned long long>(
+                std::numeric_limits<TAtomicBase>::max());
+        signedOverflow["latency_counters"]["read"]["bad"] = 0;
+        signedOverflow["latency_counters"]["read"]["skipped"] = 0;
+        signedOverflow["latency_counters"]["write"]["good"] = 1;
+        signedOverflow["latency_counters"]["write"]["bad"] = 0;
+        signedOverflow["latency_counters"]["write"]["skipped"] = 0;
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(signedOverflow));
+    }
+
+    Y_UNIT_TEST_F(ShouldConsumeOnlyExplicitLatencyCountersPayload, TFixture)
+    {
+        TEndpointStats stats{ClientId, DiskId, ServerStats};
+        auto counters = GetLatencyCounters();
+        auto total = counters->GetCounter("LatencyTotalOps");
+        auto good = counters->GetCounter("LatencyGoodOps");
+        auto skipped = counters->GetCounter("LatencyThresholdsSkippedOps");
+
+        // A legacy-only batch must not be guessed from count/errors or the
+        // independent time/size histograms.
+        UpdateStats(stats, TVolumeStats{.Read = {.Count = 100}});
+        UNIT_ASSERT_VALUES_EQUAL(0, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, skipped->Val());
+
+        auto value = Dump(1s, {});
+        value["latency_counters"] = NJson::TJsonMap{
+            {"version", 1},
+            {"read", NJson::TJsonMap{
+                {"good", 3}, {"bad", 2}, {"skipped", 1}}},
+            {"write", NJson::TJsonMap{
+                {"good", 5}, {"bad", 4}, {"skipped", 3}}},
+        };
+        stats.Update(value);
+
+        UNIT_ASSERT_VALUES_EQUAL(14, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(8, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(4, skipped->Val());
+
+        value["latency_counters"]["version"] = 2;
+        stats.Update(value);
+        UNIT_ASSERT_VALUES_EQUAL(14, total->Val());
+        UNIT_ASSERT_VALUES_EQUAL(8, good->Val());
+        UNIT_ASSERT_VALUES_EQUAL(4, skipped->Val());
+    }
+
     Y_UNIT_TEST_F(ShouldCalcMaxValues, TFixture)
     {
         TEndpointStats stats {ClientId, DiskId, ServerStats};

--- a/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp
@@ -216,6 +216,22 @@ Y_UNIT_TEST_SUITE(TEndpointStatsTest)
         malformed["latency_counters"]["write"]["bad"] = "not-a-counter";
         UNIT_ASSERT(!TryReadLatencyCountersBatch(malformed));
 
+        auto fractional = makePayload(1);
+        fractional["latency_counters"]["read"]["good"] = 1.5;
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(fractional));
+
+        auto negative = makePayload(1);
+        negative["latency_counters"]["read"]["bad"] = -1;
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(negative));
+
+        auto outOfRangeDouble = makePayload(1);
+        outOfRangeDouble["latency_counters"]["write"]["skipped"] = 1e300;
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(outOfRangeDouble));
+
+        auto doubleVersion = makePayload(1);
+        doubleVersion["latency_counters"]["version"] = 1.0;
+        UNIT_ASSERT(!TryReadLatencyCountersBatch(doubleVersion));
+
         auto overflow = makePayload(1);
         overflow["latency_counters"]["read"]["good"] =
             static_cast<unsigned long long>(std::numeric_limits<ui64>::max());

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -7,12 +7,14 @@
 #include <cloud/blockstore/libs/common/device_path.h>
 #include <cloud/blockstore/libs/common/public.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/config.h>
+#include <cloud/blockstore/libs/diagnostics/latency_thresholds_config.h>
+#include <cloud/blockstore/libs/diagnostics/latency_thresholds.h>
 #include <cloud/blockstore/libs/diagnostics/server_stats.h>
 #include <cloud/blockstore/libs/encryption/model/utils.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_listener.h>
 #include <cloud/blockstore/libs/server/config.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
-#include <cloud/blockstore/vhost-server/options.h>
 
 #include <cloud/storage/core/libs/common/backoff_delay_provider.h>
 #include <cloud/storage/core/libs/common/media.h>
@@ -46,7 +48,10 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <optional>
 #include <thread>
+
+extern char** environ;
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -72,6 +77,14 @@ constexpr auto RestartMinDelay = TDuration::MilliSeconds(100);
 constexpr auto RestartMaxDelay = TDuration::Seconds(30);
 constexpr auto RestartWasTooLongAgo = TDuration::Seconds(60);
 
+using TInternalExternalEndpointFactory =
+    std::function<IExternalEndpointPtr(
+        const TString& clientId,
+        const TString& diskId,
+        TVector<TString> args,
+        TVector<TString> cgroups,
+        std::optional<TString> latencyThresholdsConfigV1)>;
+
 enum class EEndpointType
 {
     Local,
@@ -91,6 +104,35 @@ const char* GetEndpointTypeName(EEndpointType state)
         return names[(size_t)state];
     }
     return "UNDEFINED";
+}
+
+TIntrusivePtr<TLatencyThresholdsTable> BuildConfiguredLatencyThresholds(
+    const TDiagnosticsConfigPtr& diagnosticsConfig)
+{
+    if (!diagnosticsConfig ||
+        !diagnosticsConfig->GetLatencyThresholdsEnabled())
+    {
+        return {};
+    }
+
+    auto validation = BuildLatencyThresholdsTable(
+        diagnosticsConfig->GetLatencyThresholds());
+    if (!validation.IsValid()) {
+        return {};
+    }
+    return std::move(validation.Table);
+}
+
+std::optional<TString> SerializeLatencyThresholdsConfigV1(
+    const TLatencyThresholdsTable* thresholds,
+    NProto::EStorageMediaKind mediaKind)
+{
+    if (!thresholds) {
+        return std::nullopt;
+    }
+
+    return NVHostServer::SerializeLatencyThresholdsConfigV1(
+        thresholds->FindLadder(mediaKind));
 }
 
 TString ReadFromFile(const TString& fileName)
@@ -282,7 +324,8 @@ struct TPipe
 
 TChild SpawnChild(
     const TString& binaryPath,
-    TVector<TString> args)
+    TVector<TString> args,
+    const std::optional<TString>& latencyThresholdsConfigV1)
 {
     args.push_back("--blockstore-service-pid=" + ToString(::getpid()));
 
@@ -295,6 +338,37 @@ TChild SpawnChild(
     // duplicated in the child.
     TVector<char*> qargs;
     qargs.reserve(args.size() + 2);
+    qargs.push_back(const_cast<char*>(binaryPath.data()));
+    for (auto& arg: args) {
+        qargs.push_back(const_cast<char*>(arg.data()));
+    }
+    qargs.emplace_back();
+
+    TString latencyThresholdsEnv;
+    if (latencyThresholdsConfigV1) {
+        latencyThresholdsEnv = TStringBuilder()
+            << NVHostServer::LatencyThresholdsConfigV1EnvName << '='
+            << *latencyThresholdsConfigV1;
+    }
+
+    // Build a complete child environment before fork(). Besides adding the
+    // selected v1 config, this deliberately removes any ambient value when
+    // the feature is disabled or the global config is invalid.
+    TVector<char*> qenv;
+    for (char** env = environ; *env; ++env) {
+        const TStringBuf entry{*env};
+        const auto name = NVHostServer::LatencyThresholdsConfigV1EnvName;
+        if (entry.size() > name.size() && entry.StartsWith(name) &&
+            entry[name.size()] == '=')
+        {
+            continue;
+        }
+        qenv.push_back(*env);
+    }
+    if (latencyThresholdsConfigV1) {
+        qenv.push_back(const_cast<char*>(latencyThresholdsEnv.data()));
+    }
+    qenv.emplace_back();
 
     pid_t childPid = ::fork();
 
@@ -322,14 +396,12 @@ TChild SpawnChild(
         // stdout); freopen((TString("/tmp/err.") +
         // ToString(::getpid())).c_str(), "w", stderr);
 
-        // Following "const_cast"s are safe:
-        // http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
-        qargs.push_back(const_cast<char*>(binaryPath.data()));
-        for (auto& arg: args) {
-            qargs.push_back(const_cast<char*>(arg.data()));
-        }
-        qargs.emplace_back();
-
+        // Do not call setenv()/putenv() after fork: they may allocate or lock.
+        // Repointing environ only changes the forked child. argv/envp were
+        // fully built before fork(), and keeping execvp preserves the existing
+        // PATH lookup behavior. An older child safely ignores the unknown
+        // environment variable.
+        environ = qenv.data();
         ::execvp(binaryPath.c_str(), qargs.data());
     }
 
@@ -563,6 +635,7 @@ private:
     const TString BinaryPath;
     const TVector<TString> Args;
     const TVector<TString> Cgroups;
+    const std::optional<TString> LatencyThresholdsConfigV1;
 
     TLog Log;
 
@@ -586,13 +659,15 @@ public:
             TEndpointStats stats,
             TString binaryPath,
             TVector<TString> args,
-            TVector<TString> cgroups)
+            TVector<TString> cgroups,
+            std::optional<TString> latencyThresholdsConfigV1)
         : Logging{std::move(logging)}
         , Executor{std::move(executor)}
         , ClientId{std::move(clientId)}
         , BinaryPath{std::move(binaryPath)}
         , Args{std::move(args)}
         , Cgroups{std::move(cgroups)}
+        , LatencyThresholdsConfigV1{std::move(latencyThresholdsConfigV1)}
         , Log{Logging->CreateLog("BLOCKSTORE_EXTERNAL_ENDPOINT")}
         , Stats{std::move(stats)}
         , LogPrefix{
@@ -680,7 +755,7 @@ private:
 
     TIntrusivePtr<TEndpointProcess> StartProcess()
     {
-        auto process = SpawnChild(BinaryPath, Args);
+        auto process = SpawnChild(BinaryPath, Args, LatencyThresholdsConfigV1);
 
         STORAGE_INFO(
             LogPrefix << "Endpoint process has been started, PID:"
@@ -760,8 +835,9 @@ private:
     const ui32 SocketAccessMode;
     const bool IsAlignedDataEnabled;
     const IEndpointListenerPtr FallbackListener;
-    const TExternalEndpointFactory EndpointFactory;
+    const TInternalExternalEndpointFactory EndpointFactory;
     const TDuration VhostServerTimeoutAfterParentExit;
+    const TIntrusivePtr<TLatencyThresholdsTable> LatencyThresholds;
 
     TLog Log;
 
@@ -777,7 +853,8 @@ public:
             TString localAgentId,
             bool isAlignedDataEnabled,
             IEndpointListenerPtr fallbackListener,
-            TExternalEndpointFactory endpointFactory)
+            TInternalExternalEndpointFactory endpointFactory,
+            TDiagnosticsConfigPtr diagnosticsConfig)
         : ServerConfig{std::move(serverConfig)}
         , Logging{std::move(logging)}
         , ServerStats{std::move(serverStats)}
@@ -789,6 +866,8 @@ public:
         , EndpointFactory{std::move(endpointFactory)}
         , VhostServerTimeoutAfterParentExit{ServerConfig
                                                 ->GetVhostServerTimeoutAfterParentExit()}
+        , LatencyThresholds{
+              BuildConfiguredLatencyThresholds(diagnosticsConfig)}
         , Log{Logging->CreateLog("BLOCKSTORE_SERVER")}
     {
         FindRunningEndpoints();
@@ -1143,7 +1222,10 @@ private:
             clientId,
             request.GetDiskId(),
             std::move(args),
-            std::move(cgroups)
+            std::move(cgroups),
+            SerializeLatencyThresholdsConfigV1(
+                LatencyThresholds.Get(),
+                volume.GetStorageMediaKind())
         );
 
         ep->PrepareToStart();
@@ -1264,11 +1346,33 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     bool isAlignedDataEnabled,
     IEndpointListenerPtr fallbackListener)
 {
+    return CreateExternalVhostEndpointListenerWithDiagnostics(
+        std::move(serverConfig),
+        std::move(logging),
+        std::move(serverStats),
+        std::move(executor),
+        std::move(localAgentId),
+        isAlignedDataEnabled,
+        std::move(fallbackListener),
+        TDiagnosticsConfigPtr{});
+}
+
+IEndpointListenerPtr CreateExternalVhostEndpointListenerWithDiagnostics(
+    TServerAppConfigPtr serverConfig,
+    ILoggingServicePtr logging,
+    IServerStatsPtr serverStats,
+    TExecutorPtr executor,
+    TString localAgentId,
+    bool isAlignedDataEnabled,
+    IEndpointListenerPtr fallbackListener,
+    TDiagnosticsConfigPtr diagnosticsConfig)
+{
     auto defaultFactory = [=] (
         const TString& clientId,
         const TString& diskId,
         TVector<TString> args,
-        TVector<TString> cgroups)
+        TVector<TString> cgroups,
+        std::optional<TString> latencyThresholdsConfigV1)
     {
         return std::make_shared<TEndpoint>(
             clientId,
@@ -1281,7 +1385,8 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
             },
             serverConfig->GetVhostServerPath(),
             std::move(args),
-            std::move(cgroups)
+            std::move(cgroups),
+            std::move(latencyThresholdsConfigV1)
         );
     };
 
@@ -1293,7 +1398,8 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
         std::move(localAgentId),
         isAlignedDataEnabled,
         std::move(fallbackListener),
-        std::move(defaultFactory));
+        std::move(defaultFactory),
+        std::move(diagnosticsConfig));
 }
 
 IEndpointListenerPtr CreateExternalVhostEndpointListener(
@@ -1306,6 +1412,22 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     IEndpointListenerPtr fallbackListener,
     TExternalEndpointFactory factory)
 {
+    TInternalExternalEndpointFactory adapter =
+        [factory = std::move(factory)] (
+            const TString& clientId,
+            const TString& diskId,
+            TVector<TString> args,
+            TVector<TString> cgroups,
+            std::optional<TString> latencyThresholdsConfigV1)
+        {
+            Y_UNUSED(latencyThresholdsConfigV1);
+            return factory(
+                clientId,
+                diskId,
+                std::move(args),
+                std::move(cgroups));
+        };
+
     return std::make_shared<TExternalVhostEndpointListener>(
         std::move(serverConfig),
         std::move(logging),
@@ -1314,7 +1436,8 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
         std::move(localAgentId),
         isAlignedDataEnabled,
         std::move(fallbackListener),
-        std::move(factory));
+        std::move(adapter),
+        TDiagnosticsConfigPtr{});
 }
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.h
@@ -43,6 +43,16 @@ IEndpointListenerPtr CreateExternalVhostEndpointListener(
     bool isAlignedDataEnabled,
     IEndpointListenerPtr fallbackListener);
 
+IEndpointListenerPtr CreateExternalVhostEndpointListenerWithDiagnostics(
+    TServerAppConfigPtr serverConfig,
+    ILoggingServicePtr logging,
+    IServerStatsPtr serverStats,
+    TExecutorPtr executor,
+    TString localAgentId,
+    bool isAlignedDataEnabled,
+    IEndpointListenerPtr fallbackListener,
+    TDiagnosticsConfigPtr diagnosticsConfig);
+
 IEndpointListenerPtr CreateExternalVhostEndpointListener(
     TServerAppConfigPtr serverConfig,
     ILoggingServicePtr logging,

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -567,6 +567,26 @@ void TServerHandler::ProcessRequests(
 
             case NBD_CMD_WRITE: {
                 if (Options.CheckpointId) {
+                    // The write payload is part of the NBD request and must be
+                    // consumed even though checkpoint exports are read-only.
+                    TBuffer ignoredRequestData;
+                    in.ReadOrFail(ignoredRequestData, request.Length);
+
+                    // This request is rejected before RegisterRequest, so it
+                    // must use the latency-only batch hook. Do not register a
+                    // legacy request just to account for the new diagnostic.
+                    TMetricRequest metricRequest(
+                        EBlockStoreRequest::WriteBlocks);
+                    ServerStats->PrepareMetricRequest(
+                        metricRequest,
+                        Options.ClientId,
+                        Options.DiskId,
+                        Options.BlockSize
+                            ? request.From / Options.BlockSize
+                            : 0,
+                        request.Length,
+                        false);
+                    ServerStats->RecordLatencyBatch(metricRequest, 0, 0, 1);
                     replyError(E_ARGUMENT, "invalid write request");
                     break;
                 }

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -93,7 +93,11 @@ public:
                 response.RequestBytes);
         }
 
-        UnregisterRequest(response.RequestContext, response.Error);
+        UnregisterRequest(
+            response.RequestContext,
+            response.Error,
+            false   // already recorded before response delivery
+        );
     }
 
     void ProcessRequests(
@@ -157,6 +161,11 @@ private:
         EBlockStoreRequest requestType);
 
     void UnregisterRequest(
+        const TRequestContextPtr& requestCtx,
+        const NProto::TError& error,
+        bool recordLatency = true);
+
+    void RecordLatencyCompletion(
         const TRequestContextPtr& requestCtx,
         const NProto::TError& error);
 
@@ -671,6 +680,7 @@ void TServerHandler::ProcessReadRequest(
     }
 
     ServerStats->ResponseSent(requestCtx->MetricRequest, *requestCtx->CallContext);
+    RecordLatencyCompletion(requestCtx, error);
     STORAGE_DEBUG(CreateRequestInfo(*requestCtx)
         << " PROCESS ReadResponse"
         << " #" << request.Handle
@@ -741,6 +751,7 @@ void TServerHandler::ProcessWriteRequest(
     }
 
     ServerStats->ResponseSent(requestCtx->MetricRequest, *requestCtx->CallContext);
+    RecordLatencyCompletion(requestCtx, error);
     STORAGE_DEBUG(CreateRequestInfo(*requestCtx)
         << " PROCESS WriteResponse"
         << " #" << request.Handle
@@ -832,6 +843,7 @@ TRequestContextPtr TServerHandler::RegisterRequest(
         endIndex * Options.BlockSize != request.From + request.Length;
 
     auto requestCtx = MakeIntrusive<TRequestContext>(request.Handle, requestType);
+    requestCtx->LatencyRequestBytes = request.Length;
 
     ServerStats->PrepareMetricRequest(
         requestCtx->MetricRequest,
@@ -853,15 +865,35 @@ TRequestContextPtr TServerHandler::RegisterRequest(
 
 void TServerHandler::UnregisterRequest(
     const TRequestContextPtr& requestCtx,
-    const NProto::TError& error)
+    const NProto::TError& error,
+    bool recordLatency)
 {
     requestCtx->Unlink();
+
+    if (recordLatency) {
+        RecordLatencyCompletion(requestCtx, error);
+    }
 
     ServerStats->RequestCompleted(
         Log,
         requestCtx->MetricRequest,
         *requestCtx->CallContext,
         error);
+}
+
+void TServerHandler::RecordLatencyCompletion(
+    const TRequestContextPtr& requestCtx,
+    const NProto::TError& error)
+{
+    if (IsReadWriteRequest(requestCtx->MetricRequest.RequestType) &&
+        requestCtx->MetricRequest.RequestType != EBlockStoreRequest::ZeroBlocks)
+    {
+        ServerStats->RecordLatencyCompletion(
+            requestCtx->MetricRequest,
+            *requestCtx->CallContext,
+            requestCtx->LatencyRequestBytes,
+            error);
+    }
 }
 
 size_t TServerHandler::CollectRequests(

--- a/cloud/blockstore/libs/nbd/server_handler.h
+++ b/cloud/blockstore/libs/nbd/server_handler.h
@@ -30,6 +30,7 @@ struct TRequestContext
 {
     TCallContextPtr CallContext;
     TMetricRequest MetricRequest;
+    ui64 LatencyRequestBytes = 0;
 
     TRequestContext(ui64 requestId, EBlockStoreRequest requestType)
         : CallContext(MakeIntrusive<TCallContext>(requestId))

--- a/cloud/blockstore/libs/nbd/server_handler_ut.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler_ut.cpp
@@ -87,11 +87,18 @@ class TServerContext
     : public IServerContext
 {
 private:
+    IServerHandler& Handler;
     IOutputStream& Out;
+    const bool DeliverResponses;
 
 public:
-    TServerContext(IOutputStream& out)
-        : Out(out)
+    TServerContext(
+            IServerHandler& handler,
+            IOutputStream& out,
+            bool deliverResponses = true)
+        : Handler(handler)
+        , Out(out)
+        , DeliverResponses(deliverResponses)
     {}
 
     void Start() override
@@ -133,10 +140,8 @@ public:
 
     void SendResponse(TServerResponsePtr response) override
     {
-        Out.Write(response->HeaderBuffer.Data(), response->HeaderBuffer.Size());
-
-        if (response->DataBuffer) {
-            Out.Write(response->DataBuffer.get(), response->RequestBytes);
+        if (DeliverResponses) {
+            Handler.SendResponse(Out, *response);
         }
     }
 };
@@ -342,7 +347,7 @@ void ProcessRequests(
         writer.WriteRequest(request);
     }
 
-    auto ctx = MakeIntrusive<TServerContext>(in);
+    auto ctx = MakeIntrusive<TServerContext>(handler, in);
     handler.ProcessRequests(ctx, out, in, nullptr);
 
     {
@@ -420,7 +425,7 @@ void ProcessUnalignedRequests(
         writer.WriteRequest(request);
     }
 
-    auto ctx = MakeIntrusive<TServerContext>(in);
+    auto ctx = MakeIntrusive<TServerContext>(handler, in);
     handler.ProcessRequests(ctx, out, in, nullptr);
 
     {
@@ -626,6 +631,7 @@ Y_UNIT_TEST_SUITE(TServerHandlerTest)
 
         ui32 requestCounter = 0;
         ui32 expectedRequestCounter = 0;
+        TVector<ui64> latencyRequestBytes;
 
         serverStats->PrepareMetricRequestHandler = [&] (
             TMetricRequest& metricRequest,
@@ -661,6 +667,20 @@ Y_UNIT_TEST_SUITE(TServerHandlerTest)
             ++requestCounter;
         };
 
+        serverStats->RecordLatencyCompletionHandler = [&] (
+            TMetricRequest& metricRequest,
+            TCallContext& callContext,
+            ui64 requestBytes,
+            const NProto::TError& error)
+        {
+            Y_UNUSED(callContext);
+            UNIT_ASSERT(
+                metricRequest.RequestType == EBlockStoreRequest::ReadBlocks ||
+                metricRequest.RequestType == EBlockStoreRequest::WriteBlocks);
+            UNIT_ASSERT(!HasError(error));
+            latencyRequestBytes.push_back(requestBytes);
+        };
+
         auto factory = CreateServerHandlerFactory(
             CreateDefaultDeviceHandlerFactory(),
             bootstrap->GetLogging(),
@@ -683,12 +703,87 @@ Y_UNIT_TEST_SUITE(TServerHandlerTest)
 
         ProcessRequests(*handler, in, out);
         UNIT_ASSERT_VALUES_EQUAL(expectedRequestCounter, requestCounter);
+        UNIT_ASSERT_VALUES_EQUAL(2, latencyRequestBytes.size());
+        UNIT_ASSERT_VALUES_EQUAL(4 * 1024, latencyRequestBytes[0]);
+        UNIT_ASSERT_VALUES_EQUAL(4 * 1024, latencyRequestBytes[1]);
 
         expectedUnaligned = true;
         expectedStartIndex = 1;
         expectedBlockCount = 2;
         expectedRequestCounter += 3;
         ProcessUnalignedRequests(*handler, in, out);
+
+        // Each top-level Read/Write is reported once. Zero is out of scope,
+        // and the exact logical byte lengths are preserved instead of the
+        // aligned byte counts used by legacy metrics.
+        UNIT_ASSERT_VALUES_EQUAL(4, latencyRequestBytes.size());
+        UNIT_ASSERT_VALUES_EQUAL(11 * 512, latencyRequestBytes[2]);
+        UNIT_ASSERT_VALUES_EQUAL(13 * 512, latencyRequestBytes[3]);
+
+        bootstrap->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldRecordLatencyBeforeNbdResponseDelivery)
+    {
+        auto storage = std::make_shared<TTestStorage>();
+        SetupStorage(*storage);
+
+        auto bootstrap = CreateBootstrap(storage);
+        bootstrap->Start();
+
+        TStorageOptions options;
+        options.DiskId = DefaultDiskId;
+        options.BlockSize = DefaultBlockSize;
+        options.BlocksCount = DefaultBlocksCount;
+
+        auto serverStats = std::make_shared<TTestServerStats>();
+        ui32 latencyCompletions = 0;
+        serverStats->RecordLatencyCompletionHandler = [&] (
+            TMetricRequest& metricRequest,
+            TCallContext& callContext,
+            ui64 requestBytes,
+            const NProto::TError& error)
+        {
+            Y_UNUSED(metricRequest);
+            Y_UNUSED(callContext);
+            Y_UNUSED(requestBytes);
+            Y_UNUSED(error);
+            ++latencyCompletions;
+        };
+
+        auto handler = CreateServerHandlerFactory(
+            CreateDefaultDeviceHandlerFactory(),
+            bootstrap->GetLogging(),
+            bootstrap->GetStorage(),
+            serverStats,
+            CreateErrorHandlerStub(),
+            options)->CreateHandler();
+
+        TStringStream clientToServer;
+        TStringStream serverToClient;
+        TRequestWriter writer(clientToServer);
+
+        TRequest request;
+        request.Magic = NBD_REQUEST_MAGIC;
+        request.Flags = 0;
+        request.Type = NBD_CMD_READ;
+        request.Handle = 1;
+        request.From = 0;
+        request.Length = DefaultBlockSize;
+        writer.WriteRequest(request);
+
+        auto ctx = MakeIntrusive<TServerContext>(
+            *handler,
+            serverToClient,
+            false   // model a response dropped by the connection layer
+        );
+        handler->ProcessRequests(
+            ctx,
+            clientToServer,
+            serverToClient,
+            nullptr);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, latencyCompletions);
 
         bootstrap->Stop();
     }

--- a/cloud/blockstore/libs/nbd/server_handler_ut.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler_ut.cpp
@@ -788,6 +788,96 @@ Y_UNIT_TEST_SUITE(TServerHandlerTest)
         bootstrap->Stop();
     }
 
+    Y_UNIT_TEST(ShouldRecordCheckpointWriteAsLatencySkippedOnly)
+    {
+        auto storage = std::make_shared<TTestStorage>();
+        SetupStorage(*storage);
+
+        auto bootstrap = CreateBootstrap(storage);
+        bootstrap->Start();
+
+        TStorageOptions options;
+        options.DiskId = DefaultDiskId;
+        options.ClientId = "client";
+        options.BlockSize = DefaultBlockSize;
+        options.BlocksCount = DefaultBlocksCount;
+        options.CheckpointId = "checkpoint";
+
+        auto serverStats = std::make_shared<TTestServerStats>();
+        ui32 requestStarts = 0;
+        ui32 latencyCompletions = 0;
+        ui32 latencyBatches = 0;
+
+        serverStats->RequestStartedHandler = [&] (
+            TLog&,
+            TMetricRequest&,
+            TCallContext&,
+            const TString&)
+        {
+            ++requestStarts;
+        };
+        serverStats->RecordLatencyCompletionHandler = [&] (
+            TMetricRequest&,
+            TCallContext&,
+            ui64,
+            const NProto::TError&)
+        {
+            ++latencyCompletions;
+        };
+        serverStats->RecordLatencyBatchHandler = [&] (
+            TMetricRequest& metricRequest,
+            ui64 goodOps,
+            ui64 badOps,
+            ui64 skippedOps)
+        {
+            UNIT_ASSERT_VALUES_EQUAL(
+                EBlockStoreRequest::WriteBlocks,
+                metricRequest.RequestType);
+            UNIT_ASSERT_VALUES_EQUAL(0, goodOps);
+            UNIT_ASSERT_VALUES_EQUAL(0, badOps);
+            UNIT_ASSERT_VALUES_EQUAL(1, skippedOps);
+            ++latencyBatches;
+        };
+
+        auto handler = CreateServerHandlerFactory(
+            CreateDefaultDeviceHandlerFactory(),
+            bootstrap->GetLogging(),
+            bootstrap->GetStorage(),
+            serverStats,
+            CreateErrorHandlerStub(),
+            options)->CreateHandler();
+
+        TStringStream clientToServer;
+        TStringStream serverToClient;
+        TRequestWriter writer(clientToServer);
+
+        TRequest request;
+        request.Magic = NBD_REQUEST_MAGIC;
+        request.Flags = 0;
+        request.Type = NBD_CMD_WRITE;
+        request.Handle = 1;
+        request.From = 0;
+        request.Length = DefaultBlockSize;
+        // The checkpoint branch rejects the request before using its body,
+        // but the NBD request itself must still contain the declared payload.
+        writer.WriteRequest(request, TString(request.Length, 'a'));
+
+        auto ctx = MakeIntrusive<TServerContext>(*handler, serverToClient);
+        handler->ProcessRequests(
+            ctx,
+            clientToServer,
+            serverToClient,
+            nullptr);
+
+        // The old request-statistics lifecycle is untouched. The early
+        // checkpoint rejection appears only in the new coverage counter.
+        UNIT_ASSERT_VALUES_EQUAL(0, requestStarts);
+        UNIT_ASSERT_VALUES_EQUAL(0, latencyCompletions);
+        UNIT_ASSERT_VALUES_EQUAL(1, latencyBatches);
+
+        bootstrap->Stop();
+    }
+
     // TODO: simple/structured
 }
 

--- a/cloud/blockstore/libs/service/context.cpp
+++ b/cloud/blockstore/libs/service/context.cpp
@@ -31,6 +31,16 @@ void TCallContext::SetHasUncountableRejects()
     AtomicSet(HasUncountableRejects, true);
 }
 
+bool TCallContext::GetHasParallelSubRequests() const
+{
+    return AtomicGet(HasParallelSubRequests);
+}
+
+void TCallContext::SetHasParallelSubRequests()
+{
+    AtomicSet(HasParallelSubRequests, true);
+}
+
 TCallContextPtr ToBlockStoreCallContext(TCallContextBasePtr callContext)
 {
     if (!callContext) {

--- a/cloud/blockstore/libs/service/context.h
+++ b/cloud/blockstore/libs/service/context.h
@@ -14,6 +14,12 @@ private:
     TAtomic SilenceRetriableErrors = false;
     TAtomic HasUncountableRejects = false;
 
+    // Latency accounting cannot reconstruct wall-clock execution time when
+    // several subrequests add overlapping waits to this shared context. This
+    // marker is deliberately separate from the legacy timing fields: existing
+    // request metrics keep their current summed-wait semantics.
+    TAtomic HasParallelSubRequests = false;
+
 public:
     TCallContext(ui64 requestId = 0);
 
@@ -22,6 +28,9 @@ public:
 
     bool GetHasUncountableRejects() const;
     void SetHasUncountableRejects();
+
+    bool GetHasParallelSubRequests() const;
+    void SetHasParallelSubRequests();
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -193,6 +193,15 @@ public:
             return MakeFuture(std::move(response));
         }
 
+        // All parts share one call context and execute concurrently. Their
+        // stage waits are accumulated independently and may overlap in wall
+        // time, so latency accounting must not subtract the sum as if the
+        // waits were sequential. Legacy request timings intentionally retain
+        // their existing behavior.
+        if (subRequests.size() > 1 && callContext) {
+            callContext->SetHasParallelSubRequests();
+        }
+
         SubResponses.resize(subRequests.size());
 
         // Acquire the future before subscribing to sub-request callbacks.

--- a/cloud/blockstore/libs/service/split_request_service_ut.cpp
+++ b/cloud/blockstore/libs/service/split_request_service_ut.cpp
@@ -837,6 +837,56 @@ Y_UNIT_TEST_SUITE(TSplitRequestServiceTest)
             FormatError(result.GetError()));
     }
 
+    Y_UNIT_TEST(ShouldMarkOnlyParallelSplitRequestsForLatency)
+    {
+        TTestEnvironment env;
+        env.MountVolume();
+        TTestBlockStore& testBlockStore = *env.Storage;
+
+        const TString splitData = "aabbccddeeffgghhjjkk";
+        auto splitContext = MakeIntrusive<TCallContext>();
+        auto splitRequest = std::make_shared<NProto::TWriteBlocksRequest>();
+        env.SetupRequest(
+            splitRequest,
+            TBlockRange64::WithLength(1, 10),
+            splitData);
+
+        auto splitFuture = env.SplitRequestService->WriteBlocks(
+            splitContext,
+            std::move(splitRequest));
+        UNIT_ASSERT(splitContext->GetHasParallelSubRequests());
+
+        auto* firstPart = testBlockStore.WriteBlocksPromises.FindPtr(
+            TBlockRange64::WithLength(1, 5));
+        auto* secondPart = testBlockStore.WriteBlocksPromises.FindPtr(
+            TBlockRange64::WithLength(6, 5));
+        UNIT_ASSERT(firstPart);
+        UNIT_ASSERT(secondPart);
+        firstPart->Promise.SetValue(NProto::TWriteBlocksResponse());
+        secondPart->Promise.SetValue(NProto::TWriteBlocksResponse());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            splitFuture.GetValueSync().GetError().GetCode());
+
+        auto directContext = MakeIntrusive<TCallContext>();
+        auto directRequest = std::make_shared<NProto::TWriteBlocksRequest>();
+        const auto directRange = TBlockRange64::WithLength(0, 3);
+        env.SetupRequest(directRequest, directRange, "aabbcc");
+
+        auto directFuture = env.SplitRequestService->WriteBlocks(
+            directContext,
+            std::move(directRequest));
+        UNIT_ASSERT(!directContext->GetHasParallelSubRequests());
+
+        auto* directPart =
+            testBlockStore.WriteBlocksPromises.FindPtr(directRange);
+        UNIT_ASSERT(directPart);
+        directPart->Promise.SetValue(NProto::TWriteBlocksResponse());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            directFuture.GetValueSync().GetError().GetCode());
+    }
+
     Y_UNIT_TEST(ShouldForwardRequestIfSplittingIsNotRequired)
     {
         TTestEnvironment env;

--- a/cloud/blockstore/libs/service_local/compound_storage.cpp
+++ b/cloud/blockstore/libs/service_local/compound_storage.cpp
@@ -421,6 +421,10 @@ TFuture<NProto::TReadBlocksLocalResponse> TCompoundStorage::ReadBlocksLocal(
             std::move(request));
     }
 
+    if (callContext) {
+        callContext->SetHasParallelSubRequests();
+    }
+
     TSgListBlockRange src(guard.Get(), BlockSize);
 
     auto requestContext = std::make_shared<TReadBlocksLocalCtx>(
@@ -493,6 +497,10 @@ TFuture<NProto::TWriteBlocksLocalResponse> TCompoundStorage::WriteBlocksLocal(
         return Storages[storageBlockRange.Storage]->WriteBlocksLocal(
             std::move(callContext),
             std::move(request));
+    }
+
+    if (callContext) {
+        callContext->SetHasParallelSubRequests();
     }
 
     TSgListBlockRange dst(guard.Get(), BlockSize);

--- a/cloud/blockstore/libs/service_local/compound_storage_ut.cpp
+++ b/cloud/blockstore/libs/service_local/compound_storage_ut.cpp
@@ -192,7 +192,11 @@ IStoragePtr CreateTestStorage(
         std::move(serverStats));
 }
 
-auto RequestReadBlocksLocal(IStoragePtr storage, ui64 startIndex, ui32 blockCount)
+auto RequestReadBlocksLocal(
+    IStoragePtr storage,
+    ui64 startIndex,
+    ui32 blockCount,
+    TCallContextPtr callContext = MakeIntrusive<TCallContext>())
 {
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
@@ -207,7 +211,7 @@ auto RequestReadBlocksLocal(IStoragePtr storage, ui64 startIndex, ui32 blockCoun
     }
 
     return storage->ReadBlocksLocal(
-        MakeIntrusive<TCallContext>(),
+        std::move(callContext),
         std::move(request)).ExtractValueSync();
 }
 
@@ -248,7 +252,8 @@ auto RequestWriteBlocksLocal(
     IStoragePtr storage,
     ui64 startIndex,
     ui32 blockCount,
-    char value)
+    char value,
+    TCallContextPtr callContext = MakeIntrusive<TCallContext>())
 {
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
@@ -265,7 +270,7 @@ auto RequestWriteBlocksLocal(
     }
 
     return storage->WriteBlocksLocal(
-        MakeIntrusive<TCallContext>(),
+        std::move(callContext),
         std::move(request)).ExtractValueSync();
 }
 
@@ -487,6 +492,55 @@ Y_UNIT_TEST_SUITE(TCompoundStorageTest)
         ValidateBlocks(storage, 0, 200, 'X');
         ValidateBlocks(storage, 200, 100, 'Y');
         ValidateBlocks(storage, 300, 300, 'Z');
+    }
+
+    Y_UNIT_TEST(ShouldMarkOnlyMultiStorageReadAndWriteAsParallel)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+        auto storage = CreateTestStorage(
+            {
+                std::make_shared<TTestStorage>(100, 'A'),
+                std::make_shared<TTestStorage>(100, 'B'),
+            },
+            monitoring);
+
+        auto directReadContext = MakeIntrusive<TCallContext>();
+        auto directReadResponse = RequestReadBlocksLocal(
+            storage,
+            0,
+            100,
+            directReadContext);
+        UNIT_ASSERT(!HasError(directReadResponse));
+        UNIT_ASSERT(!directReadContext->GetHasParallelSubRequests());
+
+        auto splitReadContext = MakeIntrusive<TCallContext>();
+        auto splitReadResponse = RequestReadBlocksLocal(
+            storage,
+            50,
+            100,
+            splitReadContext);
+        UNIT_ASSERT(!HasError(splitReadResponse));
+        UNIT_ASSERT(splitReadContext->GetHasParallelSubRequests());
+
+        auto directWriteContext = MakeIntrusive<TCallContext>();
+        auto directWriteResponse = RequestWriteBlocksLocal(
+            storage,
+            0,
+            100,
+            'X',
+            directWriteContext);
+        UNIT_ASSERT(!HasError(directWriteResponse));
+        UNIT_ASSERT(!directWriteContext->GetHasParallelSubRequests());
+
+        auto splitWriteContext = MakeIntrusive<TCallContext>();
+        auto splitWriteResponse = RequestWriteBlocksLocal(
+            storage,
+            50,
+            100,
+            'Y',
+            splitWriteContext);
+        UNIT_ASSERT(!HasError(splitWriteResponse));
+        UNIT_ASSERT(splitWriteContext->GetHasParallelSubRequests());
     }
 
     Y_UNIT_TEST(ShouldHandleEmptyRanges)

--- a/cloud/blockstore/libs/vhost/endpoint.cpp
+++ b/cloud/blockstore/libs/vhost/endpoint.cpp
@@ -10,6 +10,8 @@
 #include <util/string/builder.h>
 #include <util/system/datetime.h>
 
+#include <optional>
+
 namespace NCloud::NBlockStore::NVhost {
 
 using namespace NThreading;
@@ -343,6 +345,27 @@ void TEndpoint::CompleteRequest(TRequest& request, const NProto::TError& error)
 
     auto statsError = error;
     auto vhostResult = GetResult(statsError);
+
+    // During endpoint shutdown a retriable service error is deliberately
+    // exposed to the guest as CANCELLED. Keep the legacy statistics error
+    // intact, but classify the final logical outcome seen by the guest.
+    const NProto::TError* latencyError = &statsError;
+    std::optional<NProto::TError> cancelledLatencyError;
+    if (vhostResult == TVhostRequest::CANCELLED) {
+        cancelledLatencyError.emplace(statsError);
+        cancelledLatencyError->SetCode(E_CANCELLED);
+        latencyError = &*cancelledLatencyError;
+    }
+
+    if (IsReadWriteRequest(request.MetricRequest.RequestType) &&
+        request.MetricRequest.RequestType != EBlockStoreRequest::ZeroBlocks)
+    {
+        AppCtx.ServerStats->RecordLatencyCompletion(
+            request.MetricRequest,
+            *request.CallContext,
+            request.VhostRequest->Length,
+            *latencyError);
+    }
 
     AppCtx.ServerStats->RequestCompleted(
         AppCtx.Log,

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -1038,6 +1038,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
         ui32 requestCounter = 0;
         ui32 expectedRequestCounter = 0;
+        ui32 latencyCounter = 0;
 
         serverStats->PrepareMetricRequestHandler = [&] (
             TMetricRequest& metricRequest,
@@ -1071,6 +1072,23 @@ Y_UNIT_TEST_SUITE(TServerTest)
             }
 
             ++requestCounter;
+        };
+
+        serverStats->RecordLatencyCompletionHandler = [&] (
+            TMetricRequest& metricRequest,
+            TCallContext& callContext,
+            ui64 requestBytes,
+            const NProto::TError& error)
+        {
+            Y_UNUSED(callContext);
+            UNIT_ASSERT(
+                metricRequest.RequestType == EBlockStoreRequest::ReadBlocks ||
+                metricRequest.RequestType == EBlockStoreRequest::WriteBlocks);
+            UNIT_ASSERT(!HasError(error));
+            UNIT_ASSERT_VALUES_EQUAL(
+                totalSectors * sectorSize,
+                requestBytes);
+            ++latencyCounter;
         };
 
         auto testStorage = std::make_shared<TTestStorage>();
@@ -1140,6 +1158,9 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 const auto& response = future.GetValue(TDuration::Seconds(5));
                 UNIT_ASSERT(response == TVhostRequest::SUCCESS);
                 UNIT_ASSERT_VALUES_EQUAL(++expectedRequestCounter, requestCounter);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    expectedRequestCounter,
+                    latencyCounter);
             }
 
             {
@@ -1151,6 +1172,9 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 const auto& response = future.GetValue(TDuration::Seconds(5));
                 UNIT_ASSERT(response == TVhostRequest::SUCCESS);
                 UNIT_ASSERT_VALUES_EQUAL(++expectedRequestCounter, requestCounter);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    expectedRequestCounter,
+                    latencyCounter);
             }
         };
 

--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -1,6 +1,7 @@
 #include "backend_aio.h"
 
 #include "backend.h"
+#include "latency_tracker.h"
 #include "request_aio.h"
 
 #include <cloud/storage/core/libs/common/format.h>
@@ -33,7 +34,8 @@ void CompleteRequestImpl(
     IEncryptor* encryptor,
     TAioRequestHolder req,
     vhd_bdev_io_result status,
-    TAtomicStats& stats)
+    TAtomicStats& stats,
+    const TLatencyTracker& latencyTracker)
 {
     auto* bio = vhd_get_bdev_io(req->Io);
     const ui64 bytes = bio->total_sectors * VHD_SECTOR_SIZE;
@@ -68,6 +70,17 @@ void CompleteRequestImpl(
         stats.Sizes[bio->type].Increment(bytes);
     }
 
+    if (latencyTracker.IsEnabled()) {
+        latencyTracker.Record(
+            stats,
+            bio->type,
+            bytes,
+            now - req->LatencyStartTs,
+            status == VHD_BDEV_SUCCESS
+                ? ELatencyCompletion::Success
+                : ELatencyCompletion::Error);
+    }
+
     vhd_complete_bio(req->Io, status);
 }
 
@@ -76,7 +89,8 @@ void CompleteCompoundRequestImpl(
     IEncryptor* encryptor,
     TAioSubRequestHolder sub,
     vhd_bdev_io_result status,
-    TAtomicStats& stats)
+    TAtomicStats& stats,
+    const TLatencyTracker& latencyTracker)
 {
     auto* req = sub->GetParentRequest();
 
@@ -117,6 +131,17 @@ void CompleteCompoundRequestImpl(
             stats.Sizes[bio->type].Increment(bytes);
         }
 
+        if (latencyTracker.IsEnabled()) {
+            latencyTracker.Record(
+                stats,
+                bio->type,
+                bytes,
+                now - req->LatencyStartTs,
+                status == VHD_BDEV_SUCCESS && req->Errors.load() == 0
+                    ? ELatencyCompletion::Success
+                    : ELatencyCompletion::Error);
+        }
+
         vhd_complete_bio(req->Io, status);
     }
 }
@@ -143,6 +168,8 @@ private:
     ICompletionStatsPtr CompletionStats;
 
     ITaskQueuePtr ThreadPool;
+
+    TLatencyTracker LatencyTracker;
 
 public:
     TAioBackend(
@@ -234,6 +261,9 @@ vhd_bdev_info TAioBackend::Init(const TOptions& options)
         STORAGE_INFO("Encryption enabled");
     }
     BatchSize = options.BatchSize;
+    LatencyTracker = TLatencyTracker(
+        options.LatencyTrackingEnabled,
+        options.LatencyThresholds);
 
     IoSetup();
 
@@ -414,14 +444,16 @@ void TAioBackend::ProcessQueue(
                     Encryptor.get(),
                     TAioSubRequest::FromIocb(batch[0]),
                     VHD_BDEV_IOERR,
-                    stats);
+                    stats,
+                    LatencyTracker);
             } else {
                 CompleteRequestImpl(
                     Log,
                     Encryptor.get(),
                     TAioRequest::FromIocb(batch[0]),
                     VHD_BDEV_IOERR,
-                    stats);
+                    stats,
+                    LatencyTracker);
             }
 
             queueStats += stats;
@@ -460,7 +492,8 @@ size_t TAioBackend::PrepareBatch(
             req.io,
             batch,
             now,
-            queueStats);
+            queueStats,
+            &LatencyTracker);
     }
 
     return batch.size() - initialSize;
@@ -484,7 +517,8 @@ void TAioBackend::CompleteCompoundRequest(
             Encryptor.get(),
             std::move(sub),
             result,
-            stats);
+            stats,
+            LatencyTracker);
         stats.Completed += 1;
     };
 
@@ -517,7 +551,8 @@ void TAioBackend::CompleteRequest(
             Encryptor.get(),
             std::move(req),
             result,
-            stats);
+            stats,
+            LatencyTracker);
         stats.Completed += 1;
     };
 

--- a/cloud/blockstore/vhost-server/backend_null.cpp
+++ b/cloud/blockstore/vhost-server/backend_null.cpp
@@ -1,6 +1,7 @@
 #include "backend_null.h"
 
 #include "backend.h"
+#include "latency_tracker.h"
 
 #include <cloud/contrib/vhost/include/vhost/server.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -18,6 +19,7 @@ private:
     TLog Log;
 
     ui32 BlockSize = 0;
+    TLatencyTracker LatencyTracker;
 
 public:
     explicit TNullBackend(ILoggingServicePtr logging);
@@ -50,6 +52,9 @@ vhd_bdev_info TNullBackend::Init(const TOptions& options)
         totalBytes += chunk.ByteCount;
     }
     BlockSize = options.BlockSize;
+    LatencyTracker = TLatencyTracker(
+        options.LatencyTrackingEnabled,
+        options.LatencyThresholds);
 
     return {
         .serial = options.Serial.c_str(),
@@ -73,10 +78,10 @@ void TNullBackend::ProcessQueue(
     TSimpleStats& queueStats)
 {
     Y_UNUSED(queueIndex);
-    Y_UNUSED(queueStats);
-
     vhd_request req{};
     while (vhd_dequeue_request(queue, &req)) {
+        const TCpuCycles started =
+            LatencyTracker.IsEnabled() ? GetCycleCount() : 0;
         vhd_bdev_io* bio = vhd_get_bdev_io(req.io);
         STORAGE_DEBUG(
             "%s Index=%lu, BlocksCount=%lu, BlockSize=%u",
@@ -85,6 +90,15 @@ void TNullBackend::ProcessQueue(
             bio->total_sectors,
             BlockSize);
 
+        if (LatencyTracker.IsEnabled()) {
+            LatencyTracker.Record(
+                queueStats,
+                bio->type,
+                bio->total_sectors * VHD_SECTOR_SIZE,
+                GetCycleCount() - started,
+                ELatencyCompletion::Success);
+        }
+
         vhd_complete_bio(req.io, VHD_BDEV_SUCCESS);
     }
 }
@@ -92,7 +106,9 @@ void TNullBackend::ProcessQueue(
 std::optional<TSimpleStats> TNullBackend::GetCompletionStats(TDuration timeout)
 {
     Y_UNUSED(timeout);
-    return {};
+    return LatencyTracker.IsEnabled()
+        ? std::optional<TSimpleStats>(TSimpleStats{})
+        : std::nullopt;
 }
 
 }   // namespace

--- a/cloud/blockstore/vhost-server/backend_rdma.cpp
+++ b/cloud/blockstore/vhost-server/backend_rdma.cpp
@@ -134,7 +134,7 @@ private:
     NProto::TVolume Volume;
     TString ClientId;
     ICompletionStatsPtr CompletionStats;
-    TSimpleStats CompletionStatsData;
+    TAtomicStats CompletionStatsData;
     bool ReadOnly = false;
     ui32 BlockSize = 0;
     ui32 SectorsToBlockShift = 0;
@@ -480,15 +480,16 @@ void TRdmaBackend::CompleteRequest(
 
     if (LatencyTracker.IsEnabled()) {
         Y_DEBUG_ABORT_UNLESS(callContext);
+        const TCpuCycles elapsed = completed - startCycles;
+        const TCpuCycles latency = AdjustLatencyForShaping(
+            elapsed,
+            callContext->Time(EProcessingStage::Shaping),
+            callContext->GetHasParallelSubRequests());
         LatencyTracker.Record(
             CompletionStatsData,
             bio->type,
             bytes,
-            SubtractLatencyWaitTime(
-                completed - startCycles,
-                callContext->Time(EProcessingStage::Postponed) +
-                    callContext->Time(EProcessingStage::Backoff) +
-                    callContext->Time(EProcessingStage::Shaping)),
+            latency,
             error);
     }
 

--- a/cloud/blockstore/vhost-server/backend_rdma.cpp
+++ b/cloud/blockstore/vhost-server/backend_rdma.cpp
@@ -1,6 +1,7 @@
 #include "backend_rdma.h"
 
 #include "backend.h"
+#include "latency_tracker.h"
 
 #include <cloud/blockstore/libs/client/config.h>
 #include <cloud/blockstore/libs/client/durable.h>
@@ -9,6 +10,7 @@
 #include <cloud/blockstore/libs/diagnostics/server_stats.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/rdma/helper.h>
+#include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/blockstore/libs/service/storage.h>
@@ -136,6 +138,7 @@ private:
     bool ReadOnly = false;
     ui32 BlockSize = 0;
     ui32 SectorsToBlockShift = 0;
+    TLatencyTracker LatencyTracker;
 
 public:
     explicit TRdmaBackend(ILoggingServicePtr logging);
@@ -155,7 +158,8 @@ private:
     void CompleteRequest(
         struct vhd_io* io,
         TCpuCycles startCycles,
-        bool isError);
+        const TCallContext* callContext,
+        const NProto::TError& error);
     IBlockStorePtr CreateDataClient(IStoragePtr storage);
 };
 
@@ -177,6 +181,9 @@ vhd_bdev_info TRdmaBackend::Init(const TOptions& options)
 
     ClientId = options.ClientId;
     ReadOnly = options.ReadOnly;
+    LatencyTracker = TLatencyTracker(
+        options.LatencyTrackingEnabled,
+        options.LatencyThresholds);
 
     BlockSize = options.BlockSize;
     STORAGE_VERIFY(
@@ -365,6 +372,10 @@ void TRdmaBackend::ProcessReadRequest(struct vhd_io* io, TCpuCycles startCycles)
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     auto requestId = CreateRequestId();
     auto callContext = MakeIntrusive<TCallContext>(requestId);
+    TCallContextPtr latencyCallContext;
+    if (LatencyTracker.IsEnabled()) {
+        latencyCallContext = callContext;
+    }
 
     auto* reqHeaders = request->MutableHeaders();
     reqHeaders->SetRequestId(requestId);
@@ -385,7 +396,7 @@ void TRdmaBackend::ProcessReadRequest(struct vhd_io* io, TCpuCycles startCycles)
     auto future =
         DataClient->ReadBlocksLocal(std::move(callContext), std::move(request));
     future.Subscribe(
-        [this, io, requestId, startCycles](const auto& future)
+        [this, io, requestId, startCycles, latencyCallContext](const auto& future)
         {
             const auto& response = future.GetValue();
             auto& error = response.GetError();
@@ -394,7 +405,7 @@ void TRdmaBackend::ProcessReadRequest(struct vhd_io* io, TCpuCycles startCycles)
                 requestId,
                 error.GetCode(),
                 error.GetMessage().c_str());
-            CompleteRequest(io, startCycles, HasError(error));
+            CompleteRequest(io, startCycles, latencyCallContext.Get(), error);
         });
 }
 
@@ -407,6 +418,10 @@ void TRdmaBackend::ProcessWriteRequest(
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     auto requestId = CreateRequestId();
     auto callContext = MakeIntrusive<TCallContext>(requestId);
+    TCallContextPtr latencyCallContext;
+    if (LatencyTracker.IsEnabled()) {
+        latencyCallContext = callContext;
+    }
 
     auto* reqHeaders = request->MutableHeaders();
     reqHeaders->SetRequestId(requestId);
@@ -427,7 +442,7 @@ void TRdmaBackend::ProcessWriteRequest(
     auto future =
         DataClient->WriteBlocksLocal(std::move(callContext), std::move(request));
     future.Subscribe(
-        [this, io, requestId, startCycles](const auto& future)
+        [this, io, requestId, startCycles, latencyCallContext](const auto& future)
         {
             const auto& response = future.GetValue();
             auto& error = response.GetError();
@@ -436,28 +451,45 @@ void TRdmaBackend::ProcessWriteRequest(
                 requestId,
                 error.GetCode(),
                 error.GetMessage().c_str());
-            CompleteRequest(io, startCycles, HasError(error));
+            CompleteRequest(io, startCycles, latencyCallContext.Get(), error);
         });
 }
 
 void TRdmaBackend::CompleteRequest(
     struct vhd_io* io,
     TCpuCycles startCycles,
-    bool isError)
+    const TCallContext* callContext,
+    const NProto::TError& error)
 {
     auto* bio = vhd_get_bdev_io(io);
+    const bool isError = HasError(error);
+    const TCpuCycles completed = GetCycleCount();
+    const ui64 bytes = bio->total_sectors * VHD_SECTOR_SIZE;
 
     ++CompletionStatsData.Completed;
 
     if (!isError) {
-        const ui64 bytes = bio->total_sectors * VHD_SECTOR_SIZE;
         CompletionStatsData.Requests[bio->type].Count += 1;
         CompletionStatsData.Requests[bio->type].Bytes += bytes;
         CompletionStatsData.Sizes[bio->type].Increment(bytes);
         CompletionStatsData.Times[bio->type].Increment(
-            GetCycleCount() - startCycles);
+            completed - startCycles);
     } else {
         CompletionStatsData.Requests[bio->type].Errors += 1;
+    }
+
+    if (LatencyTracker.IsEnabled()) {
+        Y_DEBUG_ABORT_UNLESS(callContext);
+        LatencyTracker.Record(
+            CompletionStatsData,
+            bio->type,
+            bytes,
+            SubtractLatencyWaitTime(
+                completed - startCycles,
+                callContext->Time(EProcessingStage::Postponed) +
+                    callContext->Time(EProcessingStage::Backoff) +
+                    callContext->Time(EProcessingStage::Shaping)),
+            error);
     }
 
     vhd_complete_bio(io, isError ? VHD_BDEV_IOERR : VHD_BDEV_SUCCESS);

--- a/cloud/blockstore/vhost-server/gtest/ya.make
+++ b/cloud/blockstore/vhost-server/gtest/ya.make
@@ -22,6 +22,7 @@ ADDINCL(
 
 PEERDIR(
     cloud/blockstore/libs/common
+    cloud/blockstore/libs/diagnostics
     cloud/blockstore/libs/encryption
     cloud/blockstore/libs/encryption/model
     cloud/contrib/vhost

--- a/cloud/blockstore/vhost-server/latency_tracker.h
+++ b/cloud/blockstore/vhost-server/latency_tracker.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "stats.h"
+
+#include <cloud/blockstore/libs/diagnostics/latency_thresholds.h>
+
+#include <util/datetime/cputimer.h>
+
+#include <utility>
+
+namespace NCloud::NBlockStore::NVHostServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class ELatencyCompletion
+{
+    Success,
+    Error,
+    Skipped,
+};
+
+inline TCpuCycles SubtractLatencyWaitTime(
+    TCpuCycles elapsedCycles,
+    TDuration waitTime)
+{
+    const ui64 waitCycles = DurationToCyclesSafe(waitTime);
+    return elapsedCycles > waitCycles ? elapsedCycles - waitCycles : 0;
+}
+
+// Classifies only final guest-visible read/write completions. The selected
+// ladder is copied at endpoint startup and is never refreshed in the child.
+// Enabled + an empty ladder is an explicit "media kind is unconfigured" mode:
+// every operation is reported as skipped rather than making the payload
+// disappear.
+class TLatencyTracker
+{
+private:
+    bool Enabled = false;
+    TLatencyThresholdLadder Ladder;
+
+public:
+    TLatencyTracker() = default;
+
+    TLatencyTracker(bool enabled, TLatencyThresholdLadder ladder)
+        : Enabled(enabled)
+        , Ladder(std::move(ladder))
+    {}
+
+    [[nodiscard]] bool IsEnabled() const
+    {
+        return Enabled;
+    }
+
+    template <typename T>
+    void Record(
+        TStats<T>& stats,
+        int requestType,
+        ui64 requestBytes,
+        TCpuCycles elapsedCycles,
+        ELatencyCompletion completion) const
+    {
+        if (!Enabled || requestType < 0 || requestType >= 2) {
+            return;
+        }
+
+        auto& counters = stats.LatencyCounters[requestType];
+        if (Ladder.empty() || completion == ELatencyCompletion::Skipped) {
+            counters.Skipped += 1;
+            return;
+        }
+
+        if (completion == ELatencyCompletion::Error) {
+            counters.Bad += 1;
+            return;
+        }
+
+        const auto& bucket = FindLatencyThresholdBucket(Ladder, requestBytes);
+        const auto threshold = requestType == 1
+            ? bucket.WriteThreshold
+            : bucket.ReadThreshold;
+
+        if (CyclesToDurationSafe(elapsedCycles) <= threshold) {
+            counters.Good += 1;
+        } else {
+            counters.Bad += 1;
+        }
+    }
+
+    template <typename T>
+    void Record(
+        TStats<T>& stats,
+        int requestType,
+        ui64 requestBytes,
+        TCpuCycles elapsedCycles,
+        const NProto::TError& error) const
+    {
+        if (!Enabled || requestType < 0 || requestType >= 2) {
+            return;
+        }
+
+        const auto outcome = ClassifyLatencyOutcome(
+            Ladder.empty() ? nullptr : &Ladder,
+            error,
+            requestType == 1,
+            requestBytes,
+            CyclesToDurationSafe(elapsedCycles));
+
+        auto& counters = stats.LatencyCounters[requestType];
+        if (outcome.CountSkipped) {
+            counters.Skipped += 1;
+        } else if (outcome.CountGood) {
+            counters.Good += 1;
+        } else if (outcome.CountTotal) {
+            counters.Bad += 1;
+        }
+    }
+};
+
+}   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/vhost-server/latency_tracker.h
+++ b/cloud/blockstore/vhost-server/latency_tracker.h
@@ -19,16 +19,28 @@ enum class ELatencyCompletion
     Skipped,
 };
 
-inline TCpuCycles SubtractLatencyWaitTime(
+inline TCpuCycles AdjustLatencyForShaping(
     TCpuCycles elapsedCycles,
-    TDuration waitTime)
+    TDuration shapingTime,
+    bool hasParallelSubRequests)
 {
-    const ui64 waitCycles = DurationToCyclesSafe(waitTime);
-    return elapsedCycles > waitCycles ? elapsedCycles - waitCycles : 0;
+    // Parallel parts contribute only a sum of shaping durations. It is not
+    // the amount by which shaping extended the logical request, so judging
+    // the full elapsed time is the conservative choice.
+    if (hasParallelSubRequests) {
+        return elapsedCycles;
+    }
+
+    const ui64 shapingCycles = DurationToCyclesSafe(shapingTime);
+    return elapsedCycles > shapingCycles
+        ? elapsedCycles - shapingCycles
+        : 0;
 }
 
-// Classifies only final guest-visible read/write completions. The selected
-// ladder is copied at endpoint startup and is never refreshed in the child.
+// Classifies final logical read/write completions at the endpoint boundary.
+// This is service-side latency, not full delivery time observed inside the VM.
+// The selected ladder is copied at endpoint startup and is never refreshed in
+// the child.
 // Enabled + an empty ladder is an explicit "media kind is unconfigured" mode:
 // every operation is reported as skipped rather than making the payload
 // disappear.

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -5,15 +5,16 @@
 #include <library/cpp/getopt/small/last_getopt.h>
 
 #include <util/generic/strbuf.h>
+#include <util/generic/yexception.h>
 #include <util/string/cast.h>
 #include <util/string/join.h>
 #include <util/string/split.h>
 
+#include <cstdlib>
+
 using namespace NLastGetopt;
 
 namespace NCloud::NBlockStore::NVHostServer {
-
-////////////////////////////////////////////////////////////////////////////////
 
 void CheckOneOf(
     const TVector<TString>& values,
@@ -193,6 +194,14 @@ void TOptions::Parse(int argc, char** argv)
 
     if (!QueueCount) {
         QueueCount = Min<ui32>(8, Layout.size());
+    }
+
+    if (const char* latencyThresholdsConfig = std::getenv(
+            LatencyThresholdsConfigV1EnvName.data()))
+    {
+        LatencyThresholds =
+            ParseLatencyThresholdsConfigV1(latencyThresholdsConfig);
+        LatencyTrackingEnabled = true;
     }
 }
 

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cloud/blockstore/libs/diagnostics/latency_thresholds_config.h>
 #include <cloud/blockstore/public/api/protos/encryption.pb.h>
 #include <cloud/storage/core/libs/common/affinity.h>
 
@@ -36,6 +37,9 @@ struct TOptions
     ui64 PteFlushByteThreshold = 0;
     ui32 SocketAccessMode = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
     ui64 ThreadPoolSize = 0;
+
+    bool LatencyTrackingEnabled = false;
+    TLatencyThresholdLadder LatencyThresholds;
 
     TString LogType = "json";
     TString VerboseLevel = "info";

--- a/cloud/blockstore/vhost-server/options_ut.cpp
+++ b/cloud/blockstore/vhost-server/options_ut.cpp
@@ -2,6 +2,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/yexception.h>
+
 namespace NCloud::NBlockStore::NVHostServer {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -52,6 +54,92 @@ Y_UNIT_TEST_SUITE(TOptionsTest)
         UNIT_ASSERT_VALUES_EQUAL(0, options.Layout[0].Offset);
         UNIT_ASSERT_VALUES_EQUAL(1111111, options.Layout[1].Offset);
         UNIT_ASSERT_VALUES_EQUAL(0, options.Layout[2].Offset);
+    }
+
+    Y_UNIT_TEST(ShouldParseLatencyThresholdsConfigV1)
+    {
+        const auto ladder = ParseLatencyThresholdsConfigV1("0:5:7,4096:11:13");
+
+        UNIT_ASSERT_VALUES_EQUAL(2, ladder.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, ladder[0].MinRequestBytes);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(5),
+            ladder[0].ReadThreshold);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(7),
+            ladder[0].WriteThreshold);
+        UNIT_ASSERT_VALUES_EQUAL(4096, ladder[1].MinRequestBytes);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(11),
+            ladder[1].ReadThreshold);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(13),
+            ladder[1].WriteThreshold);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "0:5:7,4096:11:13",
+            SerializeLatencyThresholdsConfigV1(&ladder));
+
+        UNIT_ASSERT(ParseLatencyThresholdsConfigV1("unconfigured").empty());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "unconfigured",
+            SerializeLatencyThresholdsConfigV1(nullptr));
+    }
+
+    Y_UNIT_TEST(ShouldRejectInvalidLatencyThresholdsConfigV1)
+    {
+        for (TStringBuf value: {
+                 "",
+                 "1:5:7",
+                 "0:0:7",
+                 "0:5:0",
+                 "0:5:7,0:11:13",
+                 "0:5:7,4096:11",
+                 "0:5:7,",
+             })
+        {
+            UNIT_ASSERT_EXCEPTION(
+                ParseLatencyThresholdsConfigV1(value),
+                yexception);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRejectTooManyLatencyBuckets)
+    {
+        TStringBuilder config;
+        for (size_t i = 0;
+             i <= MaxLatencyThresholdBucketsPerMediaKind;
+             ++i)
+        {
+            if (i) {
+                config << ',';
+            }
+            config << i << ":1:1";
+        }
+        const TString value = config;
+
+        UNIT_ASSERT_EXCEPTION(
+            ParseLatencyThresholdsConfigV1(value),
+            yexception);
+    }
+
+    Y_UNIT_TEST(ShouldAcceptMaximumLatencyBucketCount)
+    {
+        TStringBuilder config;
+        for (size_t i = 0;
+             i < MaxLatencyThresholdBucketsPerMediaKind;
+             ++i)
+        {
+            if (i) {
+                config << ',';
+            }
+            config << i << ":1:1";
+        }
+        const TString value = config;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxLatencyThresholdBucketsPerMediaKind,
+            ParseLatencyThresholdsConfigV1(value).size());
     }
 }
 

--- a/cloud/blockstore/vhost-server/request_aio.cpp
+++ b/cloud/blockstore/vhost-server/request_aio.cpp
@@ -1,6 +1,7 @@
 #include "request_aio.h"
 
 #include "critical_event.h"
+#include "latency_tracker.h"
 
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -23,7 +24,10 @@ bool IsBrokenDevice(const TAioDevice& device)
     return !device.File.IsOpen();
 }
 
-void DiscardRequest(vhd_io* io, TSimpleStats& queueStats)
+void DiscardRequest(
+    vhd_io* io,
+    TSimpleStats& queueStats,
+    const TLatencyTracker* latencyTracker)
 {
     ++queueStats.SubFailed;
     auto* bio = vhd_get_bdev_io(io);
@@ -32,6 +36,15 @@ void DiscardRequest(vhd_io* io, TSimpleStats& queueStats)
     auto& requestStat = queueStats.Requests[bio->type];
     requestStat.Errors += 1;
     requestStat.Bytes += bytes;
+
+    if (latencyTracker && latencyTracker->IsEnabled()) {
+        latencyTracker->Record(
+            queueStats,
+            bio->type,
+            bytes,
+            0,
+            ELatencyCompletion::Error);
+    }
 
     vhd_complete_bio(io, VHD_BDEV_IOERR);
 }
@@ -103,7 +116,9 @@ void PrepareCompoundIO(
     vhd_io* io,
     TVector<iocb*>& batch,
     TCpuCycles now,
-    TSimpleStats& queueStats)
+    TCpuCycles latencyStartTs,
+    TSimpleStats& queueStats,
+    const TLatencyTracker* latencyTracker)
 {
     auto* bio = vhd_get_bdev_io(io);
     const ui64 logicalOffset = bio->first_sector * VHD_SECTOR_SIZE;
@@ -129,7 +144,7 @@ void PrepareCompoundIO(
     Y_DEBUG_ABORT_UNLESS(deviceCount > 1);
 
     if (std::any_of(it, end, IsBrokenDevice)) {
-        DiscardRequest(io, queueStats);
+        DiscardRequest(io, queueStats, latencyTracker);
         return;
     }
 
@@ -150,6 +165,9 @@ void PrepareCompoundIO(
         io,
         totalBytes,
         now);
+    if (latencyTracker && latencyTracker->IsEnabled()) {
+        req->LatencyStartTs = latencyStartTs;
+    }
 
     if (bio->type == VHD_BDEV_WRITE) {
         const bool success = SgListCopyWithOptionalEncryption(
@@ -160,6 +178,14 @@ void PrepareCompoundIO(
             bio->first_sector);
         if (!success) {
             ++queueStats.EncryptorErrors;
+            if (latencyTracker && latencyTracker->IsEnabled()) {
+                latencyTracker->Record(
+                    queueStats,
+                    bio->type,
+                    bio->total_sectors * VHD_SECTOR_SIZE,
+                    GetCycleCount() - latencyStartTs,
+                    ELatencyCompletion::Error);
+            }
             vhd_complete_bio(req->Io, VHD_BDEV_IOERR);
             return;
         }
@@ -310,7 +336,32 @@ void PrepareIO(
     TCpuCycles now,
     TSimpleStats& queueStats)
 {
+    PrepareIO(
+        Log,
+        encryptor,
+        devices,
+        io,
+        batch,
+        now,
+        queueStats,
+        nullptr);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void PrepareIO(
+    TLog& Log,
+    IEncryptor* encryptor,
+    const TVector<TAioDevice>& devices,
+    vhd_io* io,
+    TVector<iocb*>& batch,
+    TCpuCycles now,
+    TSimpleStats& queueStats,
+    const TLatencyTracker* latencyTracker)
+{
     auto* bio = vhd_get_bdev_io(io);
+    const TCpuCycles latencyStartTs =
+        latencyTracker && latencyTracker->IsEnabled() ? GetCycleCount() : now;
     const ui64 logicalOffset = bio->first_sector * VHD_SECTOR_SIZE;
     const ui64 totalBytes = bio->total_sectors * VHD_SECTOR_SIZE;
 
@@ -327,7 +378,16 @@ void PrepareIO(
 
     if (device.EndOffset < logicalOffset + totalBytes) {
         // The request is cross-device, so we split it into two.
-        PrepareCompoundIO(encryptor, Log, devices, io, batch, now, queueStats);
+        PrepareCompoundIO(
+            encryptor,
+            Log,
+            devices,
+            io,
+            batch,
+            now,
+            latencyStartTs,
+            queueStats,
+            latencyTracker);
         return;
     }
 
@@ -343,7 +403,7 @@ void PrepareIO(
         !device.File.IsOpen());
 
     if (IsBrokenDevice(device)) {
-        DiscardRequest(io, queueStats);
+        DiscardRequest(io, queueStats, latencyTracker);
         return;
     }
 
@@ -374,6 +434,9 @@ void PrepareIO(
         device.BlockSize,
         io,
         now);
+    if (latencyTracker && latencyTracker->IsEnabled()) {
+        req->LatencyStartTs = latencyStartTs;
+    }
 
     if (needToAllocateBuffer) {
         req->Unaligned = !isAllBuffersAligned;
@@ -386,6 +449,14 @@ void PrepareIO(
                 bio->first_sector);
             if (!success) {
                 ++queueStats.EncryptorErrors;
+                if (latencyTracker && latencyTracker->IsEnabled()) {
+                    latencyTracker->Record(
+                        queueStats,
+                        bio->type,
+                        totalBytes,
+                        GetCycleCount() - latencyStartTs,
+                        ELatencyCompletion::Error);
+                }
                 vhd_complete_bio(req->Io, VHD_BDEV_IOERR);
                 return;
             }
@@ -446,6 +517,7 @@ TAioRequest::TAioRequest(
     : iocb()
     , Io(io)
     , SubmitTs(submitTs)
+    , LatencyStartTs(submitTs)
     , BufferAllocated(allocatedBufferSize != 0)
     , BufferCount(bufferCount)
 {
@@ -531,6 +603,7 @@ TAioCompoundRequest::TAioCompoundRequest(
     : Inflight(inflight)
     , Io(io)
     , SubmitTs(submitTs)
+    , LatencyStartTs(submitTs)
     , BufferSize(bufferSize)
     , Buffer{
           static_cast<char*>(std::aligned_alloc(blockSize, bufferSize)),

--- a/cloud/blockstore/vhost-server/request_aio.h
+++ b/cloud/blockstore/vhost-server/request_aio.h
@@ -25,6 +25,7 @@ namespace NCloud::NBlockStore::NVHostServer {
 struct TAioRequest;
 struct TAioSubRequest;
 struct TAioCompoundRequest;
+class TLatencyTracker;
 
 // The unique_ptr<> deleter that performs release via std std::free(). It used
 // for memory blocks allocated via std::calloc().
@@ -63,6 +64,7 @@ struct TAioRequest
 {
     vhd_io* Io;
     TCpuCycles SubmitTs;
+    TCpuCycles LatencyStartTs;
     bool BufferAllocated = false;
     bool Unaligned = false;
     ui32 BufferCount = 0;
@@ -112,6 +114,7 @@ struct TAioCompoundRequest
     std::atomic<ui32> Errors;
     vhd_io* Io;
     TCpuCycles SubmitTs;
+    TCpuCycles LatencyStartTs;
     size_t BufferSize;
     std::unique_ptr<char, TFreeDeleter> Buffer;
 
@@ -142,6 +145,16 @@ void PrepareIO(
     TVector<iocb*>& batch,
     TCpuCycles now,
     TSimpleStats& queueStats);
+
+void PrepareIO(
+    TLog& log,
+    IEncryptor* encryptor,
+    const TVector<TAioDevice>& devices,
+    vhd_io* io,
+    TVector<iocb*>& batch,
+    TCpuCycles now,
+    TSimpleStats& queueStats,
+    const TLatencyTracker* latencyTracker);
 
 // Copies the data, and if an encryptor is specified, encrypt it. Returns true
 // if successful.

--- a/cloud/blockstore/vhost-server/request_aio_ut.cpp
+++ b/cloud/blockstore/vhost-server/request_aio_ut.cpp
@@ -1,4 +1,5 @@
 #include "request_aio.h"
+#include "latency_tracker.h"
 
 #include <cloud/contrib/vhost/bio.h>
 
@@ -153,6 +154,45 @@ TEST_P(TRequestAIOTest, ShouldPrepareIO)
 
     EXPECT_EQ(buffers[1].base, req->Data[1].iov_base);
     EXPECT_EQ(buffers[1].len, req->Data[1].iov_len);
+}
+
+TEST_P(TRequestAIOTest, ShouldKeepSeparateTimestampForLatency)
+{
+    InitDevices(93_GB);
+
+    std::array buffers{
+        vhd_buffer{.base = reinterpret_cast<void*>(0x1000000), .len = 4_KB}};
+    virtio_blk_io bio{
+        .bdev_io = {
+            .type = VHD_BDEV_READ,
+            .total_sectors = 4_KB / VHD_SECTOR_SIZE,
+            .sglist = {.nbuffers = buffers.size(), .buffers = buffers.data()}}};
+
+    TLatencyTracker latencyTracker(
+        true,
+        {{
+            .MinRequestBytes = 0,
+            .ReadThreshold = TDuration::Seconds(1),
+            .WriteThreshold = TDuration::Seconds(1),
+        }});
+
+    constexpr TCpuCycles legacyBatchTimestamp = 1;
+    TVector<iocb*> batch;
+    TSimpleStats queueStats;
+    PrepareIO(
+        Log,
+        nullptr,
+        Devices,
+        &bio.io,
+        batch,
+        legacyBatchTimestamp,
+        queueStats,
+        &latencyTracker);
+
+    ASSERT_EQ(1u, batch.size());
+    auto req = TAioRequest::FromIocb(batch[0]);
+    EXPECT_EQ(legacyBatchTimestamp, req->SubmitTs);
+    EXPECT_GT(req->LatencyStartTs, legacyBatchTimestamp);
 }
 
 TEST_P(TRequestAIOTest, ShouldAllocateBounceBuf)

--- a/cloud/blockstore/vhost-server/server.cpp
+++ b/cloud/blockstore/vhost-server/server.cpp
@@ -98,6 +98,8 @@ private:
     TVector<vhd_request_queue*> Queues;
     std::unique_ptr<TAtomicStats[]> QueueStats;
 
+    bool LatencyTrackingEnabled = false;
+
     TVector<std::thread> QueueThreads;
 
 public:
@@ -127,6 +129,7 @@ void TServer::Start(const TOptions& options)
     STORAGE_INFO("Starting the server");
 
     SocketPath = options.SocketPath;
+    LatencyTrackingEnabled = options.LatencyTrackingEnabled;
 
     Info = Backend->Init(options);
 
@@ -221,12 +224,14 @@ TCompleteStats TServer::GetStats(const TSimpleStats& prevStats)
     if (!completionStats) {
         return TCompleteStats{
             .SimpleStats{prevStats},
-            .CriticalEvents{TakeAccumulatedCriticalEvents()}};
+            .CriticalEvents{TakeAccumulatedCriticalEvents()},
+            .LatencyTrackingEnabled = LatencyTrackingEnabled};
     }
 
     TCompleteStats result{
         .SimpleStats{*completionStats},
-        .CriticalEvents = TakeAccumulatedCriticalEvents()};
+        .CriticalEvents = TakeAccumulatedCriticalEvents(),
+        .LatencyTrackingEnabled = LatencyTrackingEnabled};
 
     for (ui32 i = 0; i != Queues.size(); ++i) {
         result.SimpleStats += QueueStats[i];
@@ -270,6 +275,10 @@ void TServer::SyncQueueStats(ui32 queueIndex, const TSimpleStats& queueStats)
 
     stats.Requests[0] = queueStats.Requests[VHD_BDEV_READ];
     stats.Requests[1] = queueStats.Requests[VHD_BDEV_WRITE];
+    if (LatencyTrackingEnabled) {
+        stats.LatencyCounters[0] = queueStats.LatencyCounters[VHD_BDEV_READ];
+        stats.LatencyCounters[1] = queueStats.LatencyCounters[VHD_BDEV_WRITE];
+    }
 }
 
 }   // namespace

--- a/cloud/blockstore/vhost-server/stats.cpp
+++ b/cloud/blockstore/vhost-server/stats.cpp
@@ -8,6 +8,7 @@
 #include <util/stream/output.h>
 #include <util/system/event.h>
 
+#include <algorithm>
 #include <numeric>
 
 namespace NCloud::NBlockStore::NVHostServer {
@@ -64,7 +65,9 @@ public:
 
     void Sync(const TAtomicStats& stats) override
     {
-        if (!NeedUpdateCompletionStats) {
+        // RDMA completion callbacks may call Sync concurrently. Claim the
+        // pending snapshot before writing to the shared publication buffer.
+        if (!NeedUpdateCompletionStats.exchange(false)) {
             return;
         }
 
@@ -79,7 +82,6 @@ public:
             stats.LatencyCounters,
             CompletionStats.LatencyCounters.begin());
 
-        NeedUpdateCompletionStats = false;
         CompletionStatsEvent.Signal();
     }
 };

--- a/cloud/blockstore/vhost-server/stats.cpp
+++ b/cloud/blockstore/vhost-server/stats.cpp
@@ -56,6 +56,7 @@ public:
         CompletionStats.Requests = stats.Requests;
         CompletionStats.Times = stats.Times;
         CompletionStats.Sizes = stats.Sizes;
+        CompletionStats.LatencyCounters = stats.LatencyCounters;
 
         NeedUpdateCompletionStats = false;
         CompletionStatsEvent.Signal();
@@ -74,6 +75,9 @@ public:
         std::ranges::copy(stats.Requests, CompletionStats.Requests.begin());
         std::ranges::copy(stats.Times, CompletionStats.Times.begin());
         std::ranges::copy(stats.Sizes, CompletionStats.Sizes.begin());
+        std::ranges::copy(
+            stats.LatencyCounters,
+            CompletionStats.LatencyCounters.begin());
 
         NeedUpdateCompletionStats = false;
         CompletionStatsEvent.Signal();
@@ -199,6 +203,27 @@ void DumpStats(
             buf.EndObject();
         }
         buf.EndList();
+    }
+
+    if (completeStats.LatencyTrackingEnabled) {
+        auto latencyCounters = [&] (int kind, TStringBuf key) {
+            const auto counters =
+                stats.LatencyCounters[kind] - old.LatencyCounters[kind];
+
+            buf.WriteKey(key);
+            buf.BeginObject();
+            write("good", counters.Good);
+            write("bad", counters.Bad);
+            write("skipped", counters.Skipped);
+            buf.EndObject();
+        };
+
+        buf.WriteKey("latency_counters");
+        buf.BeginObject();
+        write("version", 1);
+        latencyCounters(0, "read");
+        latencyCounters(1, "write");
+        buf.EndObject();
     }
 
     request(0, "read");

--- a/cloud/blockstore/vhost-server/stats.h
+++ b/cloud/blockstore/vhost-server/stats.h
@@ -68,6 +68,55 @@ struct TRequestStats
 };
 
 template <typename T>
+struct TLatencyCounters
+{
+    T Good = {};
+    T Bad = {};
+    T Skipped = {};
+
+    TLatencyCounters() = default;
+
+    template <typename U>
+    explicit TLatencyCounters(const TLatencyCounters<U>& rhs) noexcept
+        : Good{rhs.Good}
+        , Bad{rhs.Bad}
+        , Skipped{rhs.Skipped}
+    {}
+
+    template <typename U>
+    TLatencyCounters& operator=(const TLatencyCounters<U>& rhs) noexcept
+    {
+        Good = rhs.Good;
+        Bad = rhs.Bad;
+        Skipped = rhs.Skipped;
+
+        return *this;
+    }
+
+    template <typename U>
+    TLatencyCounters& operator+=(const TLatencyCounters<U>& rhs) noexcept
+    {
+        Good += rhs.Good;
+        Bad += rhs.Bad;
+        Skipped += rhs.Skipped;
+
+        return *this;
+    }
+};
+
+template <typename T>
+TLatencyCounters<T> operator-(
+    TLatencyCounters<T> lhs,
+    const TLatencyCounters<T>& rhs) noexcept
+{
+    lhs.Good -= rhs.Good;
+    lhs.Bad -= rhs.Bad;
+    lhs.Skipped -= rhs.Skipped;
+
+    return lhs;
+}
+
+template <typename T>
 TRequestStats<T> operator-(TRequestStats<T> lhs, TRequestStats<T>& rhs) noexcept
 {
     lhs.Count -= rhs.Count;
@@ -91,6 +140,7 @@ struct TStats
     std::array<TRequestStats<T>, 2> Requests = {};
     std::array<TTimeHistogram<T>, 2> Times = {};
     std::array<TSizeHistogram<T>, 2> Sizes = {};
+    std::array<TLatencyCounters<T>, 2> LatencyCounters = {};
 
     TStats() = default;
 
@@ -105,6 +155,7 @@ struct TStats
         , Requests{rhs.Requests[0], rhs.Requests[1]}
         , Times{rhs.Times[0], rhs.Times[1]}
         , Sizes{rhs.Sizes[0], rhs.Sizes[1]}
+        , LatencyCounters{rhs.LatencyCounters[0], rhs.LatencyCounters[1]}
     {}
 
     template <typename U>
@@ -119,6 +170,7 @@ struct TStats
         Requests = rhs.Requests;
         Times = rhs.Times;
         Sizes = rhs.Sizes;
+        LatencyCounters = rhs.LatencyCounters;
 
         return *this;
     }
@@ -145,6 +197,10 @@ struct TStats
             Sizes[i] += rhs.Sizes[i];
         }
 
+        for (size_t i = 0; i != LatencyCounters.size(); ++i) {
+            LatencyCounters[i] += rhs.LatencyCounters[i];
+        }
+
         return *this;
     }
 };
@@ -153,9 +209,11 @@ using TAtomicStats = TStats<std::atomic<ui64>>;
 using TSimpleStats = TStats<ui64>;
 
 ////////////////////////////////////////////////////////////////////////////////
-struct TCompleteStats {
+struct TCompleteStats
+{
     TSimpleStats SimpleStats;
     TCriticalEvents CriticalEvents;
+    bool LatencyTrackingEnabled = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/vhost-server/stats_ut.cpp
+++ b/cloud/blockstore/vhost-server/stats_ut.cpp
@@ -10,6 +10,7 @@
 #include <util/stream/str.h>
 
 #include <chrono>
+#include <thread>
 #include <tuple>
 
 using namespace std::chrono_literals;
@@ -458,20 +459,120 @@ Y_UNIT_TEST_SUITE(TStatsTest)
         UNIT_ASSERT_VALUES_EQUAL(1, stats.LatencyCounters[1].Skipped);
     }
 
-    Y_UNIT_TEST(ShouldExcludeWaitTimeFromLatencyDuration)
+    Y_UNIT_TEST(ShouldSynchronizeLatencyCountersFromConcurrentCallbacks)
+    {
+        constexpr ui64 cyclesPerSecond = 2000000000;
+        constexpr ui64 recordsPerThread = 10000;
+        constexpr int readRequest = 0;
+        SetCyclesPerSecond(cyclesPerSecond);
+
+        NCloud::NBlockStore::TLatencyThresholdLadder ladder = {{
+            .MinRequestBytes = 0,
+            .ReadThreshold = TDuration::MilliSeconds(5),
+            .WriteThreshold = TDuration::MilliSeconds(5),
+        }};
+        TLatencyTracker latencyTracker(true, std::move(ladder));
+        TAtomicStats stats;
+
+        std::array<std::thread, 4> workers;
+        for (size_t i = 0; i != workers.size(); ++i) {
+            workers[i] = std::thread([&, i] {
+                const auto completion = i == 2
+                    ? ELatencyCompletion::Error
+                    : i == 3 ? ELatencyCompletion::Skipped
+                             : ELatencyCompletion::Success;
+                const auto elapsed = i == 1
+                    ? TDuration::MilliSeconds(10)
+                    : TDuration::MilliSeconds(1);
+
+                for (ui64 j = 0; j != recordsPerThread; ++j) {
+                    latencyTracker.Record(
+                        stats,
+                        readRequest,
+                        4096,
+                        DurationToCyclesSafe(elapsed),
+                        completion);
+                }
+            });
+        }
+
+        for (auto& worker: workers) {
+            worker.join();
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            recordsPerThread,
+            stats.LatencyCounters[readRequest].Good.load());
+        UNIT_ASSERT_VALUES_EQUAL(
+            2 * recordsPerThread,
+            stats.LatencyCounters[readRequest].Bad.load());
+        UNIT_ASSERT_VALUES_EQUAL(
+            recordsPerThread,
+            stats.LatencyCounters[readRequest].Skipped.load());
+
+        auto completionStats = CreateCompletionStats();
+        std::atomic_bool readerStarted = false;
+        std::atomic_bool readerDone = false;
+        std::optional<TSimpleStats> snapshot;
+
+        std::thread reader([&] {
+            readerStarted = true;
+            snapshot = completionStats->Get(TDuration::Seconds(5));
+            readerDone = true;
+        });
+        while (!readerStarted) {
+            std::this_thread::yield();
+        }
+
+        std::array<std::thread, 4> publishers;
+        for (auto& publisher: publishers) {
+            publisher = std::thread([&] {
+                while (!readerDone) {
+                    completionStats->Sync(stats);
+                    std::this_thread::yield();
+                }
+            });
+        }
+
+        reader.join();
+        for (auto& publisher: publishers) {
+            publisher.join();
+        }
+
+        UNIT_ASSERT(snapshot);
+        UNIT_ASSERT_VALUES_EQUAL(
+            recordsPerThread,
+            snapshot->LatencyCounters[readRequest].Good);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2 * recordsPerThread,
+            snapshot->LatencyCounters[readRequest].Bad);
+        UNIT_ASSERT_VALUES_EQUAL(
+            recordsPerThread,
+            snapshot->LatencyCounters[readRequest].Skipped);
+    }
+
+    Y_UNIT_TEST(ShouldAdjustLatencyForShaping)
     {
         constexpr ui64 cyclesPerSecond = 2000000000;
         SetCyclesPerSecond(cyclesPerSecond);
 
         UNIT_ASSERT_VALUES_EQUAL(
             DurationToCyclesSafe(TDuration::MilliSeconds(7)),
-            SubtractLatencyWaitTime(
+            AdjustLatencyForShaping(
                 DurationToCyclesSafe(TDuration::MilliSeconds(12)),
-                TDuration::MilliSeconds(5)));
+                TDuration::MilliSeconds(5),
+                false));
         UNIT_ASSERT_VALUES_EQUAL(
             0,
-            SubtractLatencyWaitTime(
+            AdjustLatencyForShaping(
                 DurationToCyclesSafe(TDuration::MilliSeconds(3)),
-                TDuration::MilliSeconds(5)));
+                TDuration::MilliSeconds(5),
+                false));
+        UNIT_ASSERT_VALUES_EQUAL(
+            DurationToCyclesSafe(TDuration::MilliSeconds(12)),
+            AdjustLatencyForShaping(
+                DurationToCyclesSafe(TDuration::MilliSeconds(12)),
+                TDuration::MilliSeconds(5),
+                true));
     }
 }

--- a/cloud/blockstore/vhost-server/stats_ut.cpp
+++ b/cloud/blockstore/vhost-server/stats_ut.cpp
@@ -1,5 +1,6 @@
 #include "stats.h"
 #include "critical_event.h"
+#include "latency_tracker.h"
 
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -339,5 +340,138 @@ Y_UNIT_TEST_SUITE(TStatsTest)
                 UNIT_ASSERT_VALUES_EQUAL(false, stats.Has("crit_events"));
             }
         }
+    }
+
+    Y_UNIT_TEST(ShouldKeepLatencyCountersPayloadSeparateAndVersioned)
+    {
+        TSimpleStats oldStats;
+        TCompleteStats completeStats;
+
+        auto dump = [&] (bool enabled) {
+            TStringStream ss;
+            completeStats.LatencyTrackingEnabled = enabled;
+            DumpStats(
+                completeStats,
+                oldStats,
+                TDuration::Seconds(1),
+                ss,
+                1);
+
+            NJson::TJsonValue json;
+            NJson::ReadJsonTree(ss.Str(), &json, true);
+            return json;
+        };
+
+        auto json = dump(false);
+        UNIT_ASSERT(!json.Has("latency_counters"));
+
+        completeStats.SimpleStats.LatencyCounters[0].Good += 3;
+        completeStats.SimpleStats.LatencyCounters[0].Bad += 2;
+        completeStats.SimpleStats.LatencyCounters[0].Skipped += 1;
+        completeStats.SimpleStats.LatencyCounters[1].Good += 5;
+        completeStats.SimpleStats.LatencyCounters[1].Bad += 4;
+        completeStats.SimpleStats.LatencyCounters[1].Skipped += 3;
+
+        json = dump(true);
+        const auto& counters = json["latency_counters"];
+        UNIT_ASSERT_VALUES_EQUAL(1, counters["version"].GetUInteger());
+        UNIT_ASSERT_VALUES_EQUAL(3, counters["read"]["good"].GetUInteger());
+        UNIT_ASSERT_VALUES_EQUAL(2, counters["read"]["bad"].GetUInteger());
+        UNIT_ASSERT_VALUES_EQUAL(1, counters["read"]["skipped"].GetUInteger());
+        UNIT_ASSERT_VALUES_EQUAL(5, counters["write"]["good"].GetUInteger());
+        UNIT_ASSERT_VALUES_EQUAL(4, counters["write"]["bad"].GetUInteger());
+        UNIT_ASSERT_VALUES_EQUAL(3, counters["write"]["skipped"].GetUInteger());
+
+        completeStats.SimpleStats.LatencyCounters[0].Bad += 7;
+        json = dump(true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            json["latency_counters"]["read"]["good"].GetUInteger());
+        UNIT_ASSERT_VALUES_EQUAL(
+            7,
+            json["latency_counters"]["read"]["bad"].GetUInteger());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            json["latency_counters"]["read"]["skipped"].GetUInteger());
+    }
+
+    Y_UNIT_TEST(ShouldClassifyExactlyOneLatencyOutcome)
+    {
+        constexpr ui64 cyclesPerSecond = 2000000000;
+        SetCyclesPerSecond(cyclesPerSecond);
+
+        NCloud::NBlockStore::TLatencyThresholdLadder ladder = {
+            {
+                .MinRequestBytes = 0,
+                .ReadThreshold = TDuration::MilliSeconds(5),
+                .WriteThreshold = TDuration::MilliSeconds(7),
+            },
+            {
+                .MinRequestBytes = 4096,
+                .ReadThreshold = TDuration::MilliSeconds(11),
+                .WriteThreshold = TDuration::MilliSeconds(13),
+            },
+        };
+        TLatencyTracker latencyTracker(true, std::move(ladder));
+        TSimpleStats stats;
+
+        latencyTracker.Record(
+            stats,
+            0,
+            4096,
+            DurationToCyclesSafe(TDuration::MilliSeconds(10)),
+            ELatencyCompletion::Success);
+        latencyTracker.Record(
+            stats,
+            0,
+            4096,
+            DurationToCyclesSafe(TDuration::MilliSeconds(12)),
+            ELatencyCompletion::Success);
+        latencyTracker.Record(
+            stats,
+            0,
+            4096,
+            0,
+            ELatencyCompletion::Error);
+        latencyTracker.Record(
+            stats,
+            0,
+            4096,
+            0,
+            ELatencyCompletion::Skipped);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.LatencyCounters[0].Good);
+        UNIT_ASSERT_VALUES_EQUAL(2, stats.LatencyCounters[0].Bad);
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.LatencyCounters[0].Skipped);
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            stats.LatencyCounters[0].Good + stats.LatencyCounters[0].Bad +
+                stats.LatencyCounters[0].Skipped);
+
+        TLatencyTracker skipAll(true, {});
+        skipAll.Record(
+            stats,
+            1,
+            4096,
+            0,
+            ELatencyCompletion::Error);
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.LatencyCounters[1].Skipped);
+    }
+
+    Y_UNIT_TEST(ShouldExcludeWaitTimeFromLatencyDuration)
+    {
+        constexpr ui64 cyclesPerSecond = 2000000000;
+        SetCyclesPerSecond(cyclesPerSecond);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            DurationToCyclesSafe(TDuration::MilliSeconds(7)),
+            SubtractLatencyWaitTime(
+                DurationToCyclesSafe(TDuration::MilliSeconds(12)),
+                TDuration::MilliSeconds(5)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            SubtractLatencyWaitTime(
+                DurationToCyclesSafe(TDuration::MilliSeconds(3)),
+                TDuration::MilliSeconds(5)));
     }
 }

--- a/cloud/blockstore/vhost-server/ut/ya.make
+++ b/cloud/blockstore/vhost-server/ut/ya.make
@@ -26,6 +26,7 @@ ADDINCL(
 
 PEERDIR(
     cloud/blockstore/libs/common
+    cloud/blockstore/libs/diagnostics
     cloud/blockstore/libs/encryption/model
     cloud/contrib/vhost
     cloud/storage/core/libs/common

--- a/cloud/blockstore/vhost-server/ya.make
+++ b/cloud/blockstore/vhost-server/ya.make
@@ -29,6 +29,7 @@ ADDINCL(
 PEERDIR(
     cloud/blockstore/libs/client
     cloud/blockstore/libs/common
+    cloud/blockstore/libs/diagnostics
     cloud/blockstore/libs/encryption
     cloud/blockstore/libs/encryption/model
     cloud/blockstore/libs/rdma


### PR DESCRIPTION
## Summary

This PR adds optional threshold-based latency accounting for completed logical Read and Write operations.

The implementation covers NBD, embedded vhost, and external vhost while preserving existing request metrics and endpoint contracts.

For each volume instance, the existing `component=sli_volume` monitoring tree receives three cumulative counters:

- `LatencyGoodOps` — judged operations completed within the configured threshold.
- `LatencyTotalOps` — all judged operations, including good and bad outcomes.
- `LatencyThresholdsSkippedOps` — operations intentionally excluded from latency evaluation.

The latency SLI for a monitoring window is calculated from reset-aware counter deltas:

`LatencyGoodOps / LatencyTotalOps`

A zero `LatencyTotalOps` value means that there is no latency data for the window, not that the SLI is 100%.

## Current state

Existing latency histograms describe aggregate latency distributions, but they cannot reliably reconstruct the relationship between:

- the original request size;
- the final result after retries;
- internal request splitting;
- the threshold applicable to that particular operation.

As a result, an exact operation-based latency SLI cannot be derived from the existing metrics alone.

## Goals

- Evaluate each completed guest-visible Read or Write operation against a size-dependent threshold.
- Count one logical operation even when it is internally split or retried.
- Use the final result after the complete retry chain.
- Support different threshold ladders for Read and Write operations and for different storage media kinds.
- Keep existing metrics, error handling, retry behavior, and endpoint contracts unchanged.
- Keep latency tracking disabled by default.

## Scope and non-goals

This PR does not:

- change client-visible I/O behavior;
- change existing availability accounting;
- change existing request counters, latency histograms, or `BatchCompleted` semantics;
- add a saturation guard that excludes operations during high load;
- support dynamic threshold reloads;
- create production dashboards, alerts, or SLO configuration;
- classify operations other than Read and Write;
- turn incomplete or permanently hung operations into bad latency outcomes.

Incomplete operations require a separate in-flight or request-stall signal.

## Accounting model

Each completed logical Read or Write operation produces exactly one of the following outcomes.

### Good

An operation is good when:

- its final result is successful; and
- its cleaned execution time is less than or equal to the selected threshold.

It increments both `LatencyGoodOps` and `LatencyTotalOps`.

An operation completed exactly at the threshold is considered good.

### Bad

An operation is bad when:

- it succeeds but exceeds the threshold; or
- it finishes with a service failure that is not explicitly excluded.

This includes failures after all retries have been exhausted, including final retriable, session, and transport failures.

A bad operation increments only `LatencyTotalOps`.

There is no separate exported `LatencyBadOps` counter:

`Bad = Total - Good`

### Skipped

An operation is skipped when it cannot or should not be evaluated against a latency threshold. This includes:

- no threshold ladder configured for the volume's media kind;
- explicit throttling or checkpoint rejection;
- invalid input (`E_ARGUMENT`);
- cancellation (`E_CANCELLED`).

A skipped operation increments only `LatencyThresholdsSkippedOps` and is outside both the SLI numerator and denominator.

Operators must monitor skipped operations separately: a large skipped count means that the SLI covers only part of the traffic.

## Latency definition

The measured value is cleaned endpoint execution time, not full network or wire latency.

Where available, the implementation subtracts time recorded as:

- postponed wait;
- retry backoff;
- shaping wait.

The result is clamped at zero.

Response delivery time is not included. For external-vhost AIO, measurement starts after the request is dequeued, while existing legacy timestamps keep their previous semantics.

The original logical request size selects the threshold bucket. Internal request fragments do not select independent buckets and do not become separate SLI operations.

Read and Write operations use independent threshold ladders, but their outcomes are currently aggregated into the same three exported counters.

## Configuration

The diagnostics configuration receives two optional fields:

- `LatencyThresholdsEnabled`;
- `LatencyThresholds`.

The feature is disabled by default.

Thresholds are configured by:

- storage media kind;
- operation direction: Read or Write;
- original logical request size.

Configuration validation requires:

- an explicit media kind;
- no duplicate media-kind entries;
- at least one size bucket;
- the first size bucket to start at zero;
- strictly increasing size bounds;
- positive latency thresholds;
- no more than 1024 buckets per media kind.

The bucket limit also keeps the external-vhost environment payload within a predictable size.

Thresholds are expected to be non-decreasing as request size grows. A decreasing threshold produces a warning but is accepted.

Invalid configuration does not prevent the service from starting. Latency tracking remains disabled, and the server-level `LatencyThresholdsConfigInvalid` gauge is set.

The validated threshold table is immutable and shared for the process lifetime. Runtime reload is intentionally not implemented because threshold changes are expected to be rare. Applying a new threshold profile requires a controlled process restart.

## Endpoint integration

### NBD

NBD records one logical operation after the final backend or session future completes and before the response is delivered.

The original request size is retained across retries, and unregister or cleanup paths do not record the same request twice.

### Embedded vhost

Embedded vhost records one operation at its final guest-visible completion boundary.

Shutdown cancellation is classified as cancellation for the new latency accounting without changing legacy request-statistics semantics.

### External vhost

External vhost performs classification in the child process, where the final guest-visible operation outcome is available.

The parent passes the selected media-specific threshold ladder through the versioned `NBS_VHOST_LATENCY_THRESHOLDS_CONFIG_V1` environment value.

The child collects separate Read and Write counts for:

- good;
- bad;
- skipped.

It exports them in a separate versioned `latency_counters` JSON object. The parent validates the complete payload, including its version, value types, monotonicity, and overflow bounds, before applying any values.

The parent calculates safe deltas and aggregates Read and Write results into the three public per-volume counters.

Latency outcomes are never reconstructed from legacy external-vhost request counts, error counts, or histograms. Existing JSON fields and legacy batch accounting remain unchanged.

## Compatibility and rollout

- Latency tracking is opt-in and disabled by default.
- Existing request metrics, availability counters, latency histograms, and `BatchCompleted` behavior are unchanged.
- Client-visible I/O, retries, and error codes are unchanged.
- Existing public factory entry points remain available.
- Invalid configuration fails safely by disabling latency tracking.
- Mixed parent and external-vhost child versions remain compatible for I/O and legacy metrics. A new parent with an older child simply receives no latency payload.
- Rollback consists of disabling `LatencyThresholdsEnabled` and restarting the affected processes.

Threshold profile identifiers are not included in metric labels. During a rolling restart, one time series may temporarily contain results produced with different threshold profiles. SLO windows overlapping a threshold change must therefore be excluded or treated separately.

A recommended rollout is:

1. Configure monitoring queries using reset-aware counter deltas.
2. Add monitoring for invalid configuration and skipped operations.
3. Enable the feature for a limited NBD or embedded-vhost scope.
4. Validate counter coverage and threshold behavior.
5. Expand the rollout after every process uses the same threshold profile.
6. Keep external-vhost data in shadow or pilot mode until its telemetry completeness and freshness limitations are addressed.

## External-vhost telemetry limitation

External-vhost latency telemetry is not currently lossless:

- counters are transferred as periodically collected interval deltas;
- a failed or malformed read can lose an interval;
- the current reader may stop collecting after an error;
- the final interval may be lost when the child process stops;
- there is no freshness or readiness metric;
- missing or unsupported latency payloads are ignored for compatibility.

For this reason, external-vhost counters are suitable for comparison and shadow validation but must not yet be used as the source of a contractual SLO.

## Alternatives considered

### Derive the SLI from existing histograms

Rejected because existing histograms cannot preserve the exact relationship between request size, final result, retries, and internal splitting.

### Account latency in the generic request-completion path

Rejected because that path may observe internal attempts or fragments instead of the final logical operation. The new accounting uses explicit endpoint-owned completion boundaries.

### Reuse legacy external-vhost counters

Rejected because their semantics are insufficient for exact good, bad, and skipped classification. A separate versioned payload preserves the existing contract.

### Dynamically reload thresholds

Not implemented because threshold changes are expected to be rare. An immutable startup snapshot reduces complexity and avoids synchronization in the request path.

## End-to-end flow

1. The service validates the threshold configuration at startup.
2. A Read or Write operation enters its endpoint.
3. Internal fragments and retries remain part of the same logical operation.
4. The endpoint receives the final result and cleaned execution time.
5. The original request size selects the configured threshold.
6. The operation is classified as good, bad, or skipped.
7. The corresponding cumulative per-volume counters are updated.
8. Monitoring calculates the windowed ratio from reset-aware counter deltas.

The three new derivative counters add three monitoring series per active volume instance when the feature is enabled.

<details>
<summary>File summaries</summary>

| File or group | Summary |
| --- | --- |
| `cloud/blockstore/libs/diagnostics/latency_thresholds.h` *(new)* | Defines the immutable threshold-table model, size ladders, validation result, and good/total/skipped classification contract. |
| `cloud/blockstore/libs/diagnostics/latency_thresholds.cpp` *(new)* | Validates threshold tables, selects size buckets, and classifies final operations. |
| `cloud/blockstore/libs/diagnostics/latency_thresholds_config.h` *(new)* | Defines the versioned environment contract used to configure an external-vhost process. |
| `cloud/blockstore/libs/diagnostics/latency_thresholds_config.cpp` *(new)* | Serializes and parses the external-vhost threshold configuration. |
| `cloud/blockstore/vhost-server/latency_tracker.h` *(new)* | Tracks final Read and Write outcomes inside the external-vhost process. |
| `cloud/blockstore/config/diagnostics.proto`, `cloud/blockstore/libs/diagnostics/config.{h,cpp}` | Add the optional threshold configuration and expose it through the diagnostics configuration wrapper. |
| `cloud/blockstore/libs/daemon/{common,ydb}/bootstrap.cpp` | Pass validated configuration into volume statistics and external-vhost startup. |
| `cloud/blockstore/libs/diagnostics/server_stats.{h,cpp}` | Add opt-in methods for recording individual and aggregated latency outcomes while preserving existing completion methods. |
| `cloud/blockstore/libs/diagnostics/volume_stats.{h,cpp}` | Build the immutable threshold snapshot, calculate cleaned latency, and publish the per-volume counters. |
| `cloud/blockstore/libs/endpoints_vhost/external_vhost_server.{h,cpp}` | Select the volume's threshold ladder and pass it to the external child process. |
| `cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats.cpp` | Validate child counters, calculate safe deltas, and import aggregated latency outcomes. |
| `cloud/blockstore/libs/nbd/server_handler.{h,cpp}` | Record one final logical NBD Read or Write using the original request size. |
| `cloud/blockstore/libs/vhost/endpoint.cpp` | Record embedded-vhost operations at the final guest-visible completion boundary. |
| `cloud/blockstore/vhost-server/backend_{aio,null,rdma}.cpp` | Add backend-specific final-completion hooks while preserving one outcome across splits and retries. |
| `cloud/blockstore/vhost-server/request_aio.{h,cpp}` | Preserve the original logical-operation timestamp through AIO preparation, splitting, rejection, and completion. |
| `cloud/blockstore/vhost-server/options.{h,cpp}` | Read the versioned threshold configuration during child startup. |
| `cloud/blockstore/vhost-server/server.cpp`, `cloud/blockstore/vhost-server/stats.{h,cpp}` | Aggregate per-queue outcomes and export the versioned latency payload. |
| `cloud/blockstore/libs/diagnostics/latency_thresholds_ut.cpp`, `cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp`, `cloud/blockstore/libs/diagnostics/server_stats_test.h` | Cover validation, bucket boundaries, classification, cleaned latency, counter lifecycle, and test hooks. |
| `cloud/blockstore/libs/endpoints_vhost/external_endpoint_stats_ut.cpp`, `cloud/blockstore/libs/nbd/server_handler_ut.cpp`, `cloud/blockstore/libs/vhost/server_ut.cpp` | Cover external aggregation and NBD/embedded-vhost integration. |
| `cloud/blockstore/vhost-server/{options,request_aio,stats}_ut.cpp` | Cover child configuration parsing, logical AIO accounting, and statistics export. |
| `cloud/blockstore/libs/diagnostics/{ya.make,ut/ya.make}`, `cloud/blockstore/vhost-server/{ya.make,ut/ya.make,gtest/ya.make}` | Register the new implementation, dependencies, and tests. |

</details>

## Verification

The affected targets were rebuilt and rerun on Linux with a RelWithDebInfo build:

- `cloud/blockstore/libs/diagnostics/ut`
- `cloud/blockstore/libs/nbd/ut`
- `cloud/blockstore/libs/vhost/ut`
- `cloud/blockstore/libs/endpoints_vhost/ut`
- `cloud/blockstore/vhost-server/ut`
- `cloud/blockstore/vhost-server/gtest`

Results:

- unit tests: 221/221 passed;
- vhost-server gtests: 662/662 passed;
- total: 883/883 passed.