### PR TITLE
Scale Fresh capacity by media kind and partition size; Existing fresh settings were converted from ui32 to ui64

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -208,7 +208,8 @@ message TStorageServiceConfig
     optional uint32 WriteBlobThreshold = 6;
 
     // The size of data (in bytes) in the fresh blocks table that triggers flushing.
-    optional uint32 FlushThreshold = 7;
+    // An upper bound; see BytesPerFreshCapacityUnitHDD.
+    optional uint64 FlushThreshold = 7;
 
     // Maximum number of fresh blocks to keep.
     // optional uint32 MaxFreshBlocks = 8; // obsolete
@@ -337,8 +338,10 @@ message TStorageServiceConfig
     optional uint32 CompactionScoreLimitForBackpressure = 64;
     optional uint32 CompactionScoreThresholdForBackpressure = 65;
     optional uint32 CompactionScoreFeatureMaxValue = 66;
-    optional uint32 FreshByteCountLimitForBackpressure = 67;
-    optional uint32 FreshByteCountThresholdForBackpressure = 68;
+    // The two Fresh settings below are upper bounds;
+    // see BytesPerFreshCapacityUnitHDD.
+    optional uint64 FreshByteCountLimitForBackpressure = 67;
+    optional uint64 FreshByteCountThresholdForBackpressure = 68;
     optional uint32 FreshByteCountFeatureMaxValue = 69;
     optional uint64 CleanupQueueBytesLimitForBackpressure = 311;
     optional uint64 CleanupQueueBytesThresholdForBackpressure = 312;
@@ -635,7 +638,8 @@ message TStorageServiceConfig
     optional uint32 MigrationIndexCachingInterval = 189;
 
     // Flush threshold for fresh blobs count in fresh channel.
-    optional uint32 FreshBlobCountFlushThreshold = 190;
+    // An upper bound; see BytesPerFreshCapacityUnitHDD.
+    optional uint64 FreshBlobCountFlushThreshold = 190;
 
     // Max bandwidth used by migration in MiB/s (actual bandwidth is x2 due to
     // the need to read and write).
@@ -704,7 +708,8 @@ message TStorageServiceConfig
     optional uint32 MaxLocalVolumes = 211;
 
     // Flush threshold for fresh blob byte count.
-    optional uint32 FreshBlobByteCountFlushThreshold = 212;
+    // An upper bound; see BytesPerFreshCapacityUnitHDD.
+    optional uint64 FreshBlobByteCountFlushThreshold = 212;
 
     // Max block count in one transaction for updating logicalUsedBlocks.
     optional uint32 LogicalUsedBlocksUpdateBlockCount = 213;
@@ -881,7 +886,8 @@ message TStorageServiceConfig
     optional string DiskRegistryCountersHost = 283;
 
     // Maximum allowed fresh byte count after which we start to reject writes.
-    optional uint32 FreshByteCountHardLimit = 284;
+    // An upper bound; see BytesPerFreshCapacityUnitHDD.
+    optional uint64 FreshByteCountHardLimit = 284;
 
     // Interval to postpone volume push/pull.
     optional uint32 BalancerActionDelayInterval = 285;
@@ -1697,22 +1703,39 @@ message TStorageServiceConfig
     // fresh after which we start to reject write and zero requests.
     optional uint64 FreshLogicalBlocksByteCountHardLimit = 529;
 
+    // SSD-specific Fresh limits, used by partition v1 for STORAGE_MEDIA_SSD;
+    // the unsuffixed settings are used for HDD and other replicated media.
+    // Upper bounds; see BytesPerFreshCapacityUnitSSD below.
+    optional uint64 FlushThresholdSSD = 530;
+    optional uint64 FreshByteCountLimitForBackpressureSSD = 531;
+    optional uint64 FreshByteCountThresholdForBackpressureSSD = 532;
+    optional uint64 FreshBlobCountFlushThresholdSSD = 533;
+    optional uint64 FreshBlobByteCountFlushThresholdSSD = 534;
+    optional uint64 FreshByteCountHardLimitSSD = 535;
+
+    // Partition bytes granting one unit of Fresh capacity. Partition v1
+    // resolves each Fresh limit of the selected media kind as
+    //     min(limit, compiledDefault * ceil(partitionBytes / unitBytes))
+    // Zero - the default - turns scaling off and makes the limits exact.
+    optional uint64 BytesPerFreshCapacityUnitHDD = 536;
+    optional uint64 BytesPerFreshCapacityUnitSSD = 537;
+
     // Enables compaction triggered by the number of mixed blocks for HDD
     // volumes.
-    optional bool MixedBlocksCountCompactionEnabledHDD = 530;
+    optional bool MixedBlocksCountCompactionEnabledHDD = 538;
 
     // Enables compaction triggered by the number of mixed blocks for SSD
     // volumes.
-    optional bool MixedBlocksCountCompactionEnabledSSD = 531;
+    optional bool MixedBlocksCountCompactionEnabledSSD = 539;
 
     // Number of mixed bytes in a compaction range that triggers compaction for
     // HDD volumes. Zero means using WriteBlobThreshold.
-    optional uint32 MixedBytesCountCompactionThresholdHDD = 532;
+    optional uint32 MixedBytesCountCompactionThresholdHDD = 540;
 
     // Number of mixed bytes in a compaction range that triggers compaction for
     // SSD volumes. Zero means using WriteBlobThresholdSSD.
-    optional uint32 MixedBytesCountCompactionThresholdSSD = 533;
+    optional uint32 MixedBytesCountCompactionThresholdSSD = 541;
 
     // Number of ranges to process in a single mixed-block-count compaction run.
-    optional uint32 MixedBlocksCountCompactionRangeCountPerRun = 534;
+    optional uint32 MixedBlocksCountCompactionRangeCountPerRun = 542;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -202,12 +202,17 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
 
 // clang-format off
 #define BLOCKSTORE_STORAGE_CONFIG_RW(xxx)                                      \
-    xxx(WriteBlobThreshold,            ui32,      1_MB                        )\
-    xxx(WriteBlobThresholdSSD,         ui32,      128_KB                      )\
-    xxx(WriteMixedBlobThresholdHDD,    ui32,      0                           )\
-    xxx(FlushThreshold,                ui32,      4_MB                        )\
-    xxx(FreshBlobCountFlushThreshold,  ui32,      3200                        )\
-    xxx(FreshBlobByteCountFlushThreshold,   ui32,      16_MB                  )\
+    xxx(WriteBlobThreshold,                    ui32,      1_MB                )\
+    xxx(WriteBlobThresholdSSD,                 ui32,      128_KB              )\
+    xxx(WriteMixedBlobThresholdHDD,            ui32,      0                   )\
+    xxx(FlushThreshold,                        ui64,      4_MB                )\
+    xxx(FlushThresholdSSD,                     ui64,      4_MB                )\
+    xxx(FreshBlobCountFlushThreshold,          ui64,      3200                )\
+    xxx(FreshBlobCountFlushThresholdSSD,       ui64,      3200                )\
+    xxx(FreshBlobByteCountFlushThreshold,      ui64,      16_MB               )\
+    xxx(FreshBlobByteCountFlushThresholdSSD,   ui64,      16_MB               )\
+    xxx(BytesPerFreshCapacityUnitHDD,  ui64,      0                           )\
+    xxx(BytesPerFreshCapacityUnitSSD,  ui64,      0                           )\
                                                                                \
     xxx(SSDCompactionType,                                                     \
             NProto::ECompactionType,                                           \
@@ -405,10 +410,13 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(CompactionScoreThresholdForBackpressure,        ui32,   100           )\
     xxx(CompactionScoreFeatureMaxValue,                 ui32,   10            )\
                                                                                \
-    xxx(FreshByteCountLimitForBackpressure,             ui32,   128_MB        )\
-    xxx(FreshByteCountThresholdForBackpressure,         ui32,   40_MB         )\
+    xxx(FreshByteCountLimitForBackpressure,             ui64,   128_MB        )\
+    xxx(FreshByteCountLimitForBackpressureSSD,          ui64,   128_MB        )\
+    xxx(FreshByteCountThresholdForBackpressure,         ui64,   40_MB         )\
+    xxx(FreshByteCountThresholdForBackpressureSSD,      ui64,   40_MB         )\
     xxx(FreshByteCountFeatureMaxValue,                  ui32,   10            )\
-    xxx(FreshByteCountHardLimit,                        ui32,   256_MB        )\
+    xxx(FreshByteCountHardLimit,                        ui64,   256_MB        )\
+    xxx(FreshByteCountHardLimitSSD,                     ui64,   256_MB        )\
     xxx(FreshLogicalBlocksByteCountHardLimit,           ui64,   512_TB        )\
                                                                                \
     xxx(CleanupQueueBytesLimitForBackpressure,            ui64,   4_TB        )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -165,9 +165,14 @@ public:
     ui32 GetWriteBlobThreshold() const;
     ui32 GetWriteBlobThresholdSSD() const;
     [[nodiscard]] ui32 GetWriteMixedBlobThresholdHDD() const;
-    ui32 GetFlushThreshold() const;
-    ui32 GetFreshBlobCountFlushThreshold() const;
-    ui32 GetFreshBlobByteCountFlushThreshold() const;
+    ui64 GetFlushThreshold() const;
+    ui64 GetFlushThresholdSSD() const;
+    ui64 GetFreshBlobCountFlushThreshold() const;
+    ui64 GetFreshBlobCountFlushThresholdSSD() const;
+    ui64 GetFreshBlobByteCountFlushThreshold() const;
+    ui64 GetFreshBlobByteCountFlushThresholdSSD() const;
+    ui64 GetBytesPerFreshCapacityUnitHDD() const;
+    ui64 GetBytesPerFreshCapacityUnitSSD() const;
     ui32 GetFlushBlobSizeThreshold() const;
     bool GetFlushToDevNull() const;
 
@@ -346,14 +351,17 @@ public:
     ui32 GetCompactionScoreThresholdForBackpressure() const;
     ui32 GetCompactionScoreLimitForBackpressure() const;
     ui32 GetCompactionScoreFeatureMaxValue() const;
-    ui32 GetFreshByteCountThresholdForBackpressure() const;
-    ui32 GetFreshByteCountLimitForBackpressure() const;
+    ui64 GetFreshByteCountThresholdForBackpressure() const;
+    ui64 GetFreshByteCountThresholdForBackpressureSSD() const;
+    ui64 GetFreshByteCountLimitForBackpressure() const;
+    ui64 GetFreshByteCountLimitForBackpressureSSD() const;
     ui32 GetFreshByteCountFeatureMaxValue() const;
     ui64 GetCleanupQueueBytesThresholdForBackpressure() const;
     ui64 GetCleanupQueueBytesLimitForBackpressure() const;
     ui32 GetCleanupQueueBytesFeatureMaxValue() const;
     ui32 GetMaxWriteCostMultiplier() const;
-    ui32 GetFreshByteCountHardLimit() const;
+    ui64 GetFreshByteCountHardLimit() const;
+    ui64 GetFreshByteCountHardLimitSSD() const;
     ui64 GetFreshLogicalBlocksByteCountHardLimit() const;
     bool GetDiskSpaceScoreThrottlingEnabled() const;
 

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -9,9 +9,34 @@
 
 #include <cloud/storage/core/libs/common/media.h>
 
+#include <util/generic/size_literals.h>
+
+#include <limits>
+
 namespace NCloud::NBlockStore::NStorage {
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// The amount of Fresh capacity granted by one unit. The size of unit controlled
+// by BytesPerFreshCapacityUnitHDD and BytesPerFreshCapacityUnitSSD.
+constexpr ui64 LegacyFlushThreshold = 4_MB;
+constexpr ui64 LegacyFreshByteCountLimitForBackpressure = 128_MB;
+constexpr ui64 LegacyFreshByteCountThresholdForBackpressure = 40_MB;
+constexpr ui64 LegacyFreshBlobCountFlushThreshold = 3200;
+constexpr ui64 LegacyFreshBlobByteCountFlushThreshold = 16_MB;
+constexpr ui64 LegacyFreshByteCountHardLimit = 256_MB;
+
+ui64 ScaleFreshCapacityLimit(ui64 cap, ui64 base, ui64 units)
+{
+    const ui64 unitsToCap = cap / base + (cap % base != 0);
+    if (units >= unitsToCap) {
+        return cap;
+    }
+
+    return base * units;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -332,6 +357,84 @@ ui32 GetWriteMixedBlobThreshold(
 
     return config.GetWriteMixedBlobThresholdHDD();
 }
+
+TFreshCapacityLimits GetEffectiveFreshCapacityLimits(
+    const TStorageConfig& config,
+    const NProto::TPartitionConfig& partitionConfig)
+{
+    TFreshCapacityLimits limits;
+
+    const bool isSSD =
+        partitionConfig.GetStorageMediaKind() ==
+        NCloud::NProto::STORAGE_MEDIA_SSD;
+
+    if (isSSD) {
+        limits.FlushThreshold = config.GetFlushThresholdSSD();
+        limits.FreshByteCountLimitForBackpressure =
+            config.GetFreshByteCountLimitForBackpressureSSD();
+        limits.FreshByteCountThresholdForBackpressure =
+            config.GetFreshByteCountThresholdForBackpressureSSD();
+        limits.FreshBlobCountFlushThreshold =
+            config.GetFreshBlobCountFlushThresholdSSD();
+        limits.FreshBlobByteCountFlushThreshold =
+            config.GetFreshBlobByteCountFlushThresholdSSD();
+        limits.FreshByteCountHardLimit =
+            config.GetFreshByteCountHardLimitSSD();
+        limits.BytesPerFreshCapacityUnit =
+            config.GetBytesPerFreshCapacityUnitSSD();
+    } else {
+        limits.FlushThreshold = config.GetFlushThreshold();
+        limits.FreshByteCountLimitForBackpressure =
+            config.GetFreshByteCountLimitForBackpressure();
+        limits.FreshByteCountThresholdForBackpressure =
+            config.GetFreshByteCountThresholdForBackpressure();
+        limits.FreshBlobCountFlushThreshold =
+            config.GetFreshBlobCountFlushThreshold();
+        limits.FreshBlobByteCountFlushThreshold =
+            config.GetFreshBlobByteCountFlushThreshold();
+        limits.FreshByteCountHardLimit = config.GetFreshByteCountHardLimit();
+        limits.BytesPerFreshCapacityUnit =
+            config.GetBytesPerFreshCapacityUnitHDD();
+    }
+
+    if (!limits.BytesPerFreshCapacityUnit) {
+        return limits;
+    }
+
+    const ui64 partitionBytes =
+        partitionConfig.GetBlocksCount() * partitionConfig.GetBlockSize();
+    limits.Units = partitionBytes / limits.BytesPerFreshCapacityUnit +
+                   (partitionBytes % limits.BytesPerFreshCapacityUnit != 0);
+    limits.Units = Max<ui64>(1, limits.Units);
+
+    limits.FlushThreshold = ScaleFreshCapacityLimit(
+        limits.FlushThreshold,
+        LegacyFlushThreshold,
+        limits.Units);
+    limits.FreshByteCountLimitForBackpressure = ScaleFreshCapacityLimit(
+        limits.FreshByteCountLimitForBackpressure,
+        LegacyFreshByteCountLimitForBackpressure,
+        limits.Units);
+    limits.FreshByteCountThresholdForBackpressure = ScaleFreshCapacityLimit(
+        limits.FreshByteCountThresholdForBackpressure,
+        LegacyFreshByteCountThresholdForBackpressure,
+        limits.Units);
+    limits.FreshBlobCountFlushThreshold = ScaleFreshCapacityLimit(
+        limits.FreshBlobCountFlushThreshold,
+        LegacyFreshBlobCountFlushThreshold,
+        limits.Units);
+    limits.FreshBlobByteCountFlushThreshold = ScaleFreshCapacityLimit(
+        limits.FreshBlobByteCountFlushThreshold,
+        LegacyFreshBlobByteCountFlushThreshold,
+        limits.Units);
+    limits.FreshByteCountHardLimit = ScaleFreshCapacityLimit(
+        limits.FreshByteCountHardLimit,
+        LegacyFreshByteCountHardLimit,
+        limits.Units);
+
+    return limits;
+}
+
 
 bool IsFreshRequest(
     const TStorageConfig& config,

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -9,6 +9,8 @@
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/protos/disk.pb.h>
 
+#include <cloud/storage/core/protos/media.pb.h>
+
 #include <util/generic/string.h>
 #include <util/generic/typetraits.h>
 
@@ -160,6 +162,27 @@ ui32 GetWriteBlobThreshold(
 ui32 GetWriteMixedBlobThreshold(
     const TStorageConfig& config,
     const NCloud::NProto::EStorageMediaKind mediaKind);
+
+struct TFreshCapacityLimits
+{
+    ui64 FlushThreshold = 0;
+    ui64 FreshByteCountLimitForBackpressure = 0;
+    ui64 FreshByteCountThresholdForBackpressure = 0;
+    ui64 FreshBlobCountFlushThreshold = 0;
+    ui64 FreshBlobByteCountFlushThreshold = 0;
+    ui64 FreshByteCountHardLimit = 0;
+
+    // The selected media-specific BytesPerFreshCapacityUnit and the resulting
+    // unit count. Both are zero when scaling is off, in which case the limits
+    // above are the configured media-specific values verbatim.
+    ui64 BytesPerFreshCapacityUnit = 0;
+    ui64 Units = 0;
+};
+
+[[nodiscard]] TFreshCapacityLimits GetEffectiveFreshCapacityLimits(
+    const TStorageConfig& config,
+    const NProto::TPartitionConfig& partitionConfig);
+
 
 bool IsFreshRequest(
     const TStorageConfig& config,

--- a/cloud/blockstore/libs/storage/core/proto_helpers_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers_ut.cpp
@@ -3,6 +3,10 @@
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/size_literals.h>
+
+#include <limits>
+
 namespace NCloud::NBlockStore::NStorage {
 
 namespace {
@@ -16,6 +20,58 @@ void InitDev(const TString& uuid, NProto::TDeviceConfig* d)
     d->SetTransportId(uuid + "-t");
     d->SetBlockSize(DefaultBlockSize);
     d->SetBlocksCount(100);
+}
+
+NProto::TPartitionConfig MakePartitionConfig(
+    ui64 blocksCount,
+    ui32 blockSize,
+    NCloud::NProto::EStorageMediaKind mediaKind)
+{
+    NProto::TPartitionConfig config;
+    config.SetBlocksCount(blocksCount);
+    config.SetBlockSize(blockSize);
+    config.SetStorageMediaKind(mediaKind);
+    return config;
+}
+
+NProto::TStorageServiceConfig MakeTargetFreshCapacityConfig()
+{
+    NProto::TStorageServiceConfig config;
+    config.SetBytesPerFreshCapacityUnitSSD(32_GB);
+    config.SetFlushThresholdSSD(64_MB);
+    config.SetFreshByteCountLimitForBackpressureSSD(2_GB);
+    config.SetFreshByteCountThresholdForBackpressureSSD(320_MB);
+    config.SetFreshBlobCountFlushThresholdSSD(49152);
+    config.SetFreshBlobByteCountFlushThresholdSSD(256_MB);
+    config.SetFreshByteCountHardLimitSSD(1_GB);
+    return config;
+}
+
+void AssertFreshCapacityLimits(
+    const TFreshCapacityLimits& limits,
+    ui64 units,
+    ui64 flushThreshold,
+    ui64 blobCountFlushThreshold,
+    ui64 blobByteCountFlushThreshold,
+    ui64 backpressureThreshold,
+    ui64 backpressureLimit,
+    ui64 hardLimit)
+{
+    UNIT_ASSERT_VALUES_EQUAL(units, limits.Units);
+    UNIT_ASSERT_VALUES_EQUAL(flushThreshold, limits.FlushThreshold);
+    UNIT_ASSERT_VALUES_EQUAL(
+        blobCountFlushThreshold,
+        limits.FreshBlobCountFlushThreshold);
+    UNIT_ASSERT_VALUES_EQUAL(
+        blobByteCountFlushThreshold,
+        limits.FreshBlobByteCountFlushThreshold);
+    UNIT_ASSERT_VALUES_EQUAL(
+        backpressureThreshold,
+        limits.FreshByteCountThresholdForBackpressure);
+    UNIT_ASSERT_VALUES_EQUAL(
+        backpressureLimit,
+        limits.FreshByteCountLimitForBackpressure);
+    UNIT_ASSERT_VALUES_EQUAL(hardLimit, limits.FreshByteCountHardLimit);
 }
 
 }   // namespace
@@ -229,6 +285,369 @@ Y_UNIT_TEST_SUITE(TProtoHelpersTest)
                 GetThrottlingEnabledZeroBlocks(config, partitionConfig));
         }
     }
+
+    Y_UNIT_TEST(ShouldPreserveLegacyFreshDefaultsForEveryPartitionSize)
+    {
+        const TStorageConfig config(
+            NProto::TStorageServiceConfig{},
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        // Scaling is off by default, so the limits are the legacy defaults
+        // verbatim regardless of partition size.
+        const auto hdd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                2 * 256_GB / DefaultBlockSize,
+                DefaultBlockSize,
+                NCloud::NProto::STORAGE_MEDIA_HDD));
+        UNIT_ASSERT_VALUES_EQUAL(0, hdd.BytesPerFreshCapacityUnit);
+        AssertFreshCapacityLimits(
+            hdd,
+            0,
+            4_MB,
+            3200,
+            16_MB,
+            40_MB,
+            128_MB,
+            256_MB);
+
+        const auto ssd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                16 * 32_GB / DefaultBlockSize,
+                DefaultBlockSize,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(0, ssd.BytesPerFreshCapacityUnit);
+        AssertFreshCapacityLimits(
+            ssd,
+            0,
+            4_MB,
+            3200,
+            16_MB,
+            40_MB,
+            128_MB,
+            256_MB);
+    }
+
+    Y_UNIT_TEST(ShouldPreserveLegacyFreshDefaultsWhenScalingIsEnabled)
+    {
+        // Every default cap equals its one-unit legacy base, so turning
+        // scaling on without raising a cap changes nothing at any size.
+        NProto::TStorageServiceConfig proto;
+        proto.SetBytesPerFreshCapacityUnitHDD(256_GB);
+        proto.SetBytesPerFreshCapacityUnitSSD(32_GB);
+        const TStorageConfig config(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        const auto hdd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                2 * 256_GB / DefaultBlockSize,
+                DefaultBlockSize,
+                NCloud::NProto::STORAGE_MEDIA_HDD));
+        UNIT_ASSERT_VALUES_EQUAL(256_GB, hdd.BytesPerFreshCapacityUnit);
+        AssertFreshCapacityLimits(
+            hdd,
+            2,
+            4_MB,
+            3200,
+            16_MB,
+            40_MB,
+            128_MB,
+            256_MB);
+
+        const auto ssd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                16 * 32_GB / DefaultBlockSize,
+                DefaultBlockSize,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(32_GB, ssd.BytesPerFreshCapacityUnit);
+        AssertFreshCapacityLimits(
+            ssd,
+            16,
+            4_MB,
+            3200,
+            16_MB,
+            40_MB,
+            128_MB,
+            256_MB);
+    }
+
+    Y_UNIT_TEST(ShouldScaleTargetSSDFreshCapacityAtUnitBoundaries)
+    {
+        const TStorageConfig config(
+            MakeTargetFreshCapacityConfig(),
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        struct TTestCase
+        {
+            ui64 PartitionBytes;
+            ui64 Units;
+            ui64 FlushThreshold;
+            ui64 BlobCountFlushThreshold;
+            ui64 BlobByteCountFlushThreshold;
+            ui64 BackpressureThreshold;
+            ui64 BackpressureLimit;
+            ui64 HardLimit;
+        };
+
+        const TTestCase testCases[] = {
+            {32_GB, 1, 4_MB, 3200, 16_MB, 40_MB, 128_MB, 256_MB},
+            {128_GB, 4, 16_MB, 12800, 64_MB, 160_MB, 512_MB, 1_GB},
+            {256_GB, 8, 32_MB, 25600, 128_MB, 320_MB, 1_GB, 1_GB},
+            {512_GB, 16, 64_MB, 49152, 256_MB, 320_MB, 2_GB, 1_GB},
+        };
+
+        for (const auto& testCase: testCases) {
+            const auto limits = GetEffectiveFreshCapacityLimits(
+                config,
+                MakePartitionConfig(
+                    testCase.PartitionBytes / DefaultBlockSize,
+                    DefaultBlockSize,
+                    NCloud::NProto::STORAGE_MEDIA_SSD));
+            AssertFreshCapacityLimits(
+                limits,
+                testCase.Units,
+                testCase.FlushThreshold,
+                testCase.BlobCountFlushThreshold,
+                testCase.BlobByteCountFlushThreshold,
+                testCase.BackpressureThreshold,
+                testCase.BackpressureLimit,
+                testCase.HardLimit);
+        }
+
+        const auto aboveBoundary = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                32_GB / DefaultBlockSize + 1,
+                DefaultBlockSize,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(2, aboveBoundary.Units);
+        UNIT_ASSERT_VALUES_EQUAL(8_MB, aboveBoundary.FlushThreshold);
+    }
+
+    Y_UNIT_TEST(ShouldResolveZeroAndExactFreshCapacityUnitsSafely)
+    {
+        NProto::TStorageServiceConfig proto;
+        proto.SetBytesPerFreshCapacityUnitSSD(0);
+        proto.SetFlushThresholdSSD(123);
+        proto.SetFreshByteCountLimitForBackpressureSSD(456);
+        proto.SetFreshByteCountThresholdForBackpressureSSD(78);
+        proto.SetFreshBlobCountFlushThresholdSSD(9);
+        proto.SetFreshBlobByteCountFlushThresholdSSD(10);
+        proto.SetFreshByteCountHardLimitSSD(0);
+        TStorageConfig config(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        const auto exact = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                std::numeric_limits<ui64>::max(),
+                std::numeric_limits<ui32>::max(),
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(0, exact.BytesPerFreshCapacityUnit);
+        AssertFreshCapacityLimits(exact, 0, 123, 9, 10, 78, 456, 0);
+
+        proto.SetBytesPerFreshCapacityUnitSSD(32_GB);
+        TStorageConfig scaledConfig(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+        const auto zeroSize = GetEffectiveFreshCapacityLimits(
+            scaledConfig,
+            MakePartitionConfig(
+                0,
+                DefaultBlockSize,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(1, zeroSize.Units);
+
+        const auto oneBlock = GetEffectiveFreshCapacityLimits(
+            scaledConfig,
+            MakePartitionConfig(
+                1,
+                DefaultBlockSize,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(1, oneBlock.Units);
+    }
+
+    Y_UNIT_TEST(ShouldScaleFreshCapacityWithNonStandardBlockSize)
+    {
+        NProto::TStorageServiceConfig proto =
+            MakeTargetFreshCapacityConfig();
+        proto.SetBytesPerFreshCapacityUnitSSD(10);
+        TStorageConfig config(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        const auto exact = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                5,
+                2,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(1, exact.Units);
+
+        const auto above = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                2,
+                6,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(2, above.Units);
+        UNIT_ASSERT_VALUES_EQUAL(8_MB, above.FlushThreshold);
+    }
+
+    Y_UNIT_TEST(ShouldKeepHDDAndSSDFreshCapacityIndependent)
+    {
+        NProto::TStorageServiceConfig proto;
+        proto.SetBytesPerFreshCapacityUnitHDD(10);
+        proto.SetBytesPerFreshCapacityUnitSSD(20);
+        proto.SetFlushThreshold(12_MB);
+        proto.SetFlushThresholdSSD(16_MB);
+        TStorageConfig config(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        const auto hdd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                3,
+                10,
+                NCloud::NProto::STORAGE_MEDIA_HDD));
+        UNIT_ASSERT_VALUES_EQUAL(3, hdd.Units);
+        UNIT_ASSERT_VALUES_EQUAL(12_MB, hdd.FlushThreshold);
+
+        const auto ssd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                3,
+                10,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(2, ssd.Units);
+        UNIT_ASSERT_VALUES_EQUAL(8_MB, ssd.FlushThreshold);
+    }
+
+    Y_UNIT_TEST(ShouldSelectAllFreshCapacityCapsByMediaKind)
+    {
+        NProto::TStorageServiceConfig proto;
+        proto.SetBytesPerFreshCapacityUnitHDD(0);
+        proto.SetFlushThreshold(11);
+        proto.SetFreshByteCountLimitForBackpressure(12);
+        proto.SetFreshByteCountThresholdForBackpressure(13);
+        proto.SetFreshBlobCountFlushThreshold(14);
+        proto.SetFreshBlobByteCountFlushThreshold(15);
+        proto.SetFreshByteCountHardLimit(16);
+
+        proto.SetBytesPerFreshCapacityUnitSSD(0);
+        proto.SetFlushThresholdSSD(21);
+        proto.SetFreshByteCountLimitForBackpressureSSD(22);
+        proto.SetFreshByteCountThresholdForBackpressureSSD(23);
+        proto.SetFreshBlobCountFlushThresholdSSD(24);
+        proto.SetFreshBlobByteCountFlushThresholdSSD(25);
+        proto.SetFreshByteCountHardLimitSSD(26);
+
+        TStorageConfig config(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        const auto hdd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                1,
+                1,
+                NCloud::NProto::STORAGE_MEDIA_HDD));
+        AssertFreshCapacityLimits(hdd, 0, 11, 14, 15, 13, 12, 16);
+
+        const auto ssd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                1,
+                1,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        AssertFreshCapacityLimits(ssd, 0, 21, 24, 25, 23, 22, 26);
+    }
+
+    Y_UNIT_TEST(ShouldMapOnlySSDToSSDFreshCapacity)
+    {
+        NProto::TStorageServiceConfig proto;
+        proto.SetBytesPerFreshCapacityUnitHDD(0);
+        proto.SetBytesPerFreshCapacityUnitSSD(0);
+        proto.SetFlushThreshold(111);
+        proto.SetFlushThresholdSSD(222);
+        TStorageConfig config(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        const NCloud::NProto::EStorageMediaKind hddKinds[] = {
+            NCloud::NProto::STORAGE_MEDIA_DEFAULT,
+            NCloud::NProto::STORAGE_MEDIA_HDD,
+            NCloud::NProto::STORAGE_MEDIA_HYBRID,
+            static_cast<NCloud::NProto::EStorageMediaKind>(999),
+        };
+        for (const auto mediaKind: hddKinds) {
+            const auto limits = GetEffectiveFreshCapacityLimits(
+                config,
+                MakePartitionConfig(1, 1, mediaKind));
+            UNIT_ASSERT_VALUES_EQUAL(111, limits.FlushThreshold);
+        }
+
+        const auto ssd = GetEffectiveFreshCapacityLimits(
+            config,
+            MakePartitionConfig(
+                1,
+                1,
+                NCloud::NProto::STORAGE_MEDIA_SSD));
+        UNIT_ASSERT_VALUES_EQUAL(222, ssd.FlushThreshold);
+    }
+
+    Y_UNIT_TEST(ShouldSupportSSDFreshCapacityLimitsAbove4GiB)
+    {
+        NProto::TStorageServiceConfig proto;
+        proto.SetFlushThresholdSSD(8_GB);
+        proto.SetFreshByteCountLimitForBackpressureSSD(64_GB);
+        proto.SetFreshByteCountThresholdForBackpressureSSD(32_GB);
+        proto.SetFreshBlobCountFlushThresholdSSD(8_GB);
+        proto.SetFreshBlobByteCountFlushThresholdSSD(16_GB);
+        proto.SetFreshByteCountHardLimitSSD(128_GB);
+        TStorageConfig config(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+
+        const auto partitionConfig = MakePartitionConfig(
+            1_TB / DefaultBlockSize,
+            DefaultBlockSize,
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+
+        // Scaling is off by default, so the limits survive unclamped.
+        AssertFreshCapacityLimits(
+            GetEffectiveFreshCapacityLimits(config, partitionConfig),
+            0,
+            8_GB,
+            8_GB,
+            16_GB,
+            32_GB,
+            64_GB,
+            128_GB);
+
+        // With scaling on, a 1TiB partition is 32 units, which is not enough
+        // to reach any of these caps.
+        proto.SetBytesPerFreshCapacityUnitSSD(32_GB);
+        TStorageConfig scaledConfig(
+            proto,
+            std::make_shared<NFeatures::TFeaturesConfig>());
+        AssertFreshCapacityLimits(
+            GetEffectiveFreshCapacityLimits(scaledConfig, partitionConfig),
+            32,
+            32 * 4_MB,
+            32 * 3200,
+            32 * 16_MB,
+            32 * 40_MB,
+            32 * 128_MB,
+            32 * 256_MB);
+    }
+
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/proto_helpers_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers_ut.cpp
@@ -5,8 +5,6 @@
 
 #include <util/generic/size_literals.h>
 
-#include <limits>
-
 namespace NCloud::NBlockStore::NStorage {
 
 namespace {
@@ -286,14 +284,17 @@ Y_UNIT_TEST_SUITE(TProtoHelpersTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldPreserveLegacyFreshDefaultsForEveryPartitionSize)
+    Y_UNIT_TEST(ShouldDisableFreshCapacityScalingByDefault)
     {
+        // Both byte quanta default to zero, so an out-of-the-box config
+        // resolves to the legacy defaults for both media kinds. Partition size
+        // plays no part - see
+        // ShouldPreserveLegacyFreshDefaultsWhenScalingIsEnabled for the
+        // size-independence of the default caps.
         const TStorageConfig config(
             NProto::TStorageServiceConfig{},
             std::make_shared<NFeatures::TFeaturesConfig>());
 
-        // Scaling is off by default, so the limits are the legacy defaults
-        // verbatim regardless of partition size.
         const auto hdd = GetEffectiveFreshCapacityLimits(
             config,
             MakePartitionConfig(
@@ -426,86 +427,78 @@ Y_UNIT_TEST_SUITE(TProtoHelpersTest)
                 NCloud::NProto::STORAGE_MEDIA_SSD));
         UNIT_ASSERT_VALUES_EQUAL(2, aboveBoundary.Units);
         UNIT_ASSERT_VALUES_EQUAL(8_MB, aboveBoundary.FlushThreshold);
-    }
 
-    Y_UNIT_TEST(ShouldResolveZeroAndExactFreshCapacityUnitsSafely)
-    {
-        NProto::TStorageServiceConfig proto;
-        proto.SetBytesPerFreshCapacityUnitSSD(0);
-        proto.SetFlushThresholdSSD(123);
-        proto.SetFreshByteCountLimitForBackpressureSSD(456);
-        proto.SetFreshByteCountThresholdForBackpressureSSD(78);
-        proto.SetFreshBlobCountFlushThresholdSSD(9);
-        proto.SetFreshBlobByteCountFlushThresholdSSD(10);
-        proto.SetFreshByteCountHardLimitSSD(0);
-        TStorageConfig config(
-            proto,
-            std::make_shared<NFeatures::TFeaturesConfig>());
-
-        const auto exact = GetEffectiveFreshCapacityLimits(
+        // Block size only enters the calculation as a multiplier: 48 GiB made
+        // of 64 KiB blocks rounds up to the same two units.
+        const auto nonStandardBlockSize = GetEffectiveFreshCapacityLimits(
             config,
             MakePartitionConfig(
-                std::numeric_limits<ui64>::max(),
-                std::numeric_limits<ui32>::max(),
+                48_GB / 64_KB,
+                64_KB,
                 NCloud::NProto::STORAGE_MEDIA_SSD));
-        UNIT_ASSERT_VALUES_EQUAL(0, exact.BytesPerFreshCapacityUnit);
-        AssertFreshCapacityLimits(exact, 0, 123, 9, 10, 78, 456, 0);
+        UNIT_ASSERT_VALUES_EQUAL(2, nonStandardBlockSize.Units);
+        UNIT_ASSERT_VALUES_EQUAL(8_MB, nonStandardBlockSize.FlushThreshold);
+    }
 
-        proto.SetBytesPerFreshCapacityUnitSSD(32_GB);
-        TStorageConfig scaledConfig(
-            proto,
+    Y_UNIT_TEST(ShouldGrantAtLeastOneFreshCapacityUnit)
+    {
+        const TStorageConfig config(
+            MakeTargetFreshCapacityConfig(),
             std::make_shared<NFeatures::TFeaturesConfig>());
-        const auto zeroSize = GetEffectiveFreshCapacityLimits(
-            scaledConfig,
-            MakePartitionConfig(
-                0,
-                DefaultBlockSize,
-                NCloud::NProto::STORAGE_MEDIA_SSD));
-        UNIT_ASSERT_VALUES_EQUAL(1, zeroSize.Units);
 
-        const auto oneBlock = GetEffectiveFreshCapacityLimits(
-            scaledConfig,
-            MakePartitionConfig(
+        // A partition below one 32 GiB quantum - an empty one included - earns
+        // a full unit rather than a zeroed set of limits.
+        for (const ui64 blocksCount: {ui64(0), ui64(1)}) {
+            const auto limits = GetEffectiveFreshCapacityLimits(
+                config,
+                MakePartitionConfig(
+                    blocksCount,
+                    DefaultBlockSize,
+                    NCloud::NProto::STORAGE_MEDIA_SSD));
+            AssertFreshCapacityLimits(
+                limits,
                 1,
-                DefaultBlockSize,
-                NCloud::NProto::STORAGE_MEDIA_SSD));
-        UNIT_ASSERT_VALUES_EQUAL(1, oneBlock.Units);
+                4_MB,
+                3200,
+                16_MB,
+                40_MB,
+                128_MB,
+                256_MB);
+        }
     }
 
-    Y_UNIT_TEST(ShouldScaleFreshCapacityWithNonStandardBlockSize)
+    Y_UNIT_TEST(ShouldClampFreshCapacityToCapsBelowLegacyBases)
     {
-        NProto::TStorageServiceConfig proto =
-            MakeTargetFreshCapacityConfig();
-        proto.SetBytesPerFreshCapacityUnitSSD(10);
-        TStorageConfig config(
+        // A cap below its legacy base is returned as is, however many units the
+        // partition earns. A zero cap stays a literal zero.
+        NProto::TStorageServiceConfig proto;
+        proto.SetBytesPerFreshCapacityUnitSSD(4_KB);
+        proto.SetFlushThresholdSSD(1_MB);
+        proto.SetFreshBlobCountFlushThresholdSSD(100);
+        proto.SetFreshBlobByteCountFlushThresholdSSD(2_MB);
+        proto.SetFreshByteCountThresholdForBackpressureSSD(3_MB);
+        proto.SetFreshByteCountLimitForBackpressureSSD(4_MB);
+        proto.SetFreshByteCountHardLimitSSD(0);
+        const TStorageConfig config(
             proto,
             std::make_shared<NFeatures::TFeaturesConfig>());
 
-        const auto exact = GetEffectiveFreshCapacityLimits(
+        const auto limits = GetEffectiveFreshCapacityLimits(
             config,
-            MakePartitionConfig(
-                5,
-                2,
-                NCloud::NProto::STORAGE_MEDIA_SSD));
-        UNIT_ASSERT_VALUES_EQUAL(1, exact.Units);
-
-        const auto above = GetEffectiveFreshCapacityLimits(
-            config,
-            MakePartitionConfig(
-                2,
-                6,
-                NCloud::NProto::STORAGE_MEDIA_SSD));
-        UNIT_ASSERT_VALUES_EQUAL(2, above.Units);
-        UNIT_ASSERT_VALUES_EQUAL(8_MB, above.FlushThreshold);
+            MakePartitionConfig(8, 4_KB, NCloud::NProto::STORAGE_MEDIA_SSD));
+        AssertFreshCapacityLimits(limits, 8, 1_MB, 100, 2_MB, 3_MB, 4_MB, 0);
     }
 
     Y_UNIT_TEST(ShouldKeepHDDAndSSDFreshCapacityIndependent)
     {
+        // The same partition earns three HDD units and two SSD units. Both caps
+        // are far above the scaled values, so each result is unambiguously its
+        // own base times its own unit count.
         NProto::TStorageServiceConfig proto;
         proto.SetBytesPerFreshCapacityUnitHDD(10);
         proto.SetBytesPerFreshCapacityUnitSSD(20);
-        proto.SetFlushThreshold(12_MB);
-        proto.SetFlushThresholdSSD(16_MB);
+        proto.SetFlushThreshold(100_MB);
+        proto.SetFlushThresholdSSD(100_MB);
         TStorageConfig config(
             proto,
             std::make_shared<NFeatures::TFeaturesConfig>());
@@ -517,7 +510,7 @@ Y_UNIT_TEST_SUITE(TProtoHelpersTest)
                 10,
                 NCloud::NProto::STORAGE_MEDIA_HDD));
         UNIT_ASSERT_VALUES_EQUAL(3, hdd.Units);
-        UNIT_ASSERT_VALUES_EQUAL(12_MB, hdd.FlushThreshold);
+        UNIT_ASSERT_VALUES_EQUAL(3 * 4_MB, hdd.FlushThreshold);
 
         const auto ssd = GetEffectiveFreshCapacityLimits(
             config,
@@ -526,7 +519,7 @@ Y_UNIT_TEST_SUITE(TProtoHelpersTest)
                 10,
                 NCloud::NProto::STORAGE_MEDIA_SSD));
         UNIT_ASSERT_VALUES_EQUAL(2, ssd.Units);
-        UNIT_ASSERT_VALUES_EQUAL(8_MB, ssd.FlushThreshold);
+        UNIT_ASSERT_VALUES_EQUAL(2 * 4_MB, ssd.FlushThreshold);
     }
 
     Y_UNIT_TEST(ShouldSelectAllFreshCapacityCapsByMediaKind)
@@ -647,7 +640,6 @@ Y_UNIT_TEST_SUITE(TProtoHelpersTest)
             32 * 128_MB,
             32 * 256_MB);
     }
-
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
@@ -79,6 +79,8 @@ TFreshBlocksWriterActor::TFreshBlocksWriterActor(
         IProfileLogPtr profileLog)
     : Config(std::move(config))
     , PartitionConfig(std::move(partitionConfig))
+    , FreshCapacityLimits(
+          GetEffectiveFreshCapacityLimits(*Config, PartitionConfig))
     , VolumeLabels(MakeVolumeLabels(
           PartitionConfig.GetDiskId(),
           PartitionConfig.GetCloudId(),

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
@@ -6,6 +6,7 @@
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/core/pending_request.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/model/log_title.h>
 #include <cloud/blockstore/libs/storage/partition/part_events_private.h>
@@ -37,6 +38,7 @@ class TFreshBlocksWriterActor final
 private:
     const TStorageConfigPtr Config;
     const NProto::TPartitionConfig PartitionConfig;
+    const TFreshCapacityLimits FreshCapacityLimits;
     const TVolumeLabelsConstPtr VolumeLabels;
     const EStorageAccessMode StorageAccessMode;
     const ui64 PartitionTabletID;

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -269,6 +269,8 @@ NProto::TStorageServiceConfig DefaultConfig(ui32 flushBlobSizeThreshold = 4_KB)
     config.SetFlushBlobSizeThreshold(flushBlobSizeThreshold);
     config.SetFreshByteCountThresholdForBackpressure(400_KB);
     config.SetFreshByteCountLimitForBackpressure(1200_KB);
+    config.SetFreshByteCountThresholdForBackpressureSSD(400_KB);
+    config.SetFreshByteCountLimitForBackpressureSSD(1200_KB);
     config.SetFreshByteCountFeatureMaxValue(6);
     config.SetCollectGarbageThreshold(10);
     config.SetDiskPrefixLengthWithBlockChecksumsInBlobs(1_GB);
@@ -969,8 +971,8 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
     {
         auto config = DefaultConfig();
         config.SetFreshBlocksWriterEnabled(true);
-        config.SetFreshByteCountHardLimit(8_KB);
-        config.SetFlushThreshold(4_MB);
+        config.SetFreshByteCountHardLimitSSD(8_KB);
+        config.SetFlushThresholdSSD(4_MB);
 
         TMyTestEnv testEnv;
         InitTestActorRuntime(testEnv, config);
@@ -1086,6 +1088,65 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
             S_OK,
             zeroResponse->GetStatus(),
             zeroResponse->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ShouldUseEffectiveSSDHardLimitForWritesAndZeros)
+    {
+        for (const ui32 blocksCount: {1, 2}) {
+            auto config = DefaultConfig();
+            config.SetFreshByteCountHardLimit(8_KB);
+            config.SetFreshByteCountHardLimitSSD(512_MB);
+            config.SetBytesPerFreshCapacityUnitSSD(DefaultBlockSize);
+
+            TMyTestEnv testEnv;
+            InitTestActorRuntime(testEnv, config, blocksCount);
+            auto& runtime = testEnv.GetRuntime();
+
+            TPartitionThreadSafeStatePtr sharedState;
+            runtime.SetEventFilter(
+                [&](TTestActorRuntimeBase& runtime,
+                    TAutoPtr<IEventHandle>& event)
+                {
+                    Y_UNUSED(runtime);
+
+                    if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::
+                            EvGetFreshChannelsInfoResponse)
+                    {
+                        sharedState =
+                            event
+                                ->Get<TEvPartitionCommonPrivate::
+                                          TEvGetFreshChannelsInfoResponse>()
+                                ->SharedState;
+                    }
+                    return false;
+                });
+
+            auto partition = testEnv.GetPartitionClient();
+            partition.WaitReady();
+
+            auto fbwClient = testEnv.GetFreshBlocksWriterClient();
+            fbwClient.WaitReady();
+
+            UNIT_ASSERT(sharedState);
+            sharedState->UnflushedFreshBlobByteCount.store(256_MB);
+
+            fbwClient.SendWriteBlocksRequest(TBlockRange32::MakeOneBlock(0), 1);
+            auto writeResponse = fbwClient.RecvWriteBlocksResponse();
+
+            fbwClient.SendZeroBlocksRequest(0);
+            auto zeroResponse = fbwClient.RecvZeroBlocksResponse();
+
+            const ui32 expectedStatus = blocksCount == 1 ? E_REJECTED : S_OK;
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                expectedStatus,
+                writeResponse->GetStatus(),
+                writeResponse->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                expectedStatus,
+                zeroResponse->GetStatus(),
+                zeroResponse->GetErrorReason());
+        }
     }
 
     Y_UNIT_TEST(ShouldNotTrimInProgressWrites)
@@ -1751,8 +1812,8 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
     {
         auto config = DefaultConfig();
         config.SetFreshBlocksWriterEnabled(true);
-        config.SetFreshByteCountHardLimit(8_KB);
-        config.SetFlushThreshold(4_MB);
+        config.SetFreshByteCountHardLimitSSD(8_KB);
+        config.SetFlushThresholdSSD(4_MB);
 
         TMyTestEnv testEnv;
         InitTestActorRuntime(testEnv, config);

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
@@ -35,7 +35,7 @@ void TFreshBlocksWriterActor::WriteFreshBlocks(
             SharedState->UnflushedFreshBlobByteCount.load(),
             SharedState->UnflushedFreshBlocksCount.load() *
                 PartitionConfig.GetBlockSize(),
-            Config->GetFreshByteCountHardLimit(),
+            FreshCapacityLimits.FreshByteCountHardLimit,
             Config->GetFreshLogicalBlocksByteCountHardLimit());
         HasError(error))
     {
@@ -144,7 +144,7 @@ void TFreshBlocksWriterActor::ZeroFreshBlocks(
             SharedState->UnflushedFreshBlobByteCount.load(),
             SharedState->UnflushedFreshBlocksCount.load() *
                 PartitionConfig.GetBlockSize(),
-            Config->GetFreshByteCountHardLimit(),
+            FreshCapacityLimits.FreshByteCountHardLimit,
             Config->GetFreshLogicalBlocksByteCountHardLimit());
         HasError(error))
     {

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -94,6 +94,9 @@ TPartitionActor::TPartitionActor(
     SharedState = std::make_shared<TPartitionThreadSafeState>(
         PartitionConfig.GetDiskId(),
         TabletID());
+
+    FreshCapacityLimits =
+        GetEffectiveFreshCapacityLimits(*Config, PartitionConfig);
 }
 
 TPartitionActor::~TPartitionActor()
@@ -711,6 +714,12 @@ void TPartitionActor::HandleUpdateCounters(
     UpdateCountersScheduled = false;
 
     UpdateCounters(ctx);
+
+    // Pick up immediate-control changes without paying for the resolution on
+    // the data path.
+    FreshCapacityLimits =
+        GetEffectiveFreshCapacityLimits(*Config, PartitionConfig);
+
     ScheduleCountersUpdate(ctx);
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -21,6 +21,7 @@
 #include <cloud/blockstore/libs/storage/core/partition_statistics_counters.h>
 #include <cloud/blockstore/libs/storage/core/pending_request.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/core/tablet.h>
@@ -167,6 +168,8 @@ private:
 
     bool FirstGarbageCollectionCompleted = false;
     bool IsGarbageCompactionThrottlingMisconfigured = false;
+
+    TFreshCapacityLimits FreshCapacityLimits;
 
     TTransactionTimeTracker TransactionTimeTracker;
     TBSGroupOperationTimeTracker BSGroupOperationTimeTracker;

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -446,16 +446,19 @@ void TPartitionActor::EnqueueFlushIfNeeded(const TActorContext& ctx)
         return;
     }
 
-    const auto freshBlockByteCount =
-        State->GetUnflushedFreshBlocksCount() * State->GetBlockSize();
+    const ui64 freshBlockByteCount =
+        static_cast<ui64>(State->GetUnflushedFreshBlocksCount()) *
+        State->GetBlockSize();
     const auto freshBlobCount = State->GetUnflushedFreshBlobCount();
     const auto freshBlobByteCount = State->GetUnflushedFreshBlobByteCount();
 
     const bool shouldFlush =
         !State->IsLoadStateFinished() ||
-        freshBlockByteCount >= Config->GetFlushThreshold() ||
-        freshBlobCount >= Config->GetFreshBlobCountFlushThreshold() ||
-        freshBlobByteCount >= Config->GetFreshBlobByteCountFlushThreshold();
+        freshBlockByteCount >= FreshCapacityLimits.FlushThreshold ||
+        freshBlobCount >=
+            FreshCapacityLimits.FreshBlobCountFlushThreshold ||
+        freshBlobByteCount >=
+            FreshCapacityLimits.FreshBlobByteCountFlushThreshold;
 
     if (!shouldFlush) {
         return;

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -162,6 +162,8 @@ void TPartitionActor::CompleteLoadState(
     TTxPartition::TLoadState& args)
 {
     const auto& partitionConfig = args.Meta->GetConfig();
+    FreshCapacityLimits =
+        GetEffectiveFreshCapacityLimits(*Config, partitionConfig);
 
     // initialize state
     TBackpressureFeaturesConfig bpConfig {
@@ -171,8 +173,8 @@ void TPartitionActor::CompleteLoadState(
             static_cast<double>(Config->GetCompactionScoreFeatureMaxValue()),
         },
         {
-            Config->GetFreshByteCountLimitForBackpressure(),
-            Config->GetFreshByteCountThresholdForBackpressure(),
+            FreshCapacityLimits.FreshByteCountLimitForBackpressure,
+            FreshCapacityLimits.FreshByteCountThresholdForBackpressure,
             static_cast<double>(Config->GetFreshByteCountFeatureMaxValue()),
         },
         {

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -44,7 +44,7 @@ void TPartitionActor::WriteFreshBlocks(
             State->GetUnflushedFreshBlobByteCount(),
             static_cast<ui64>(State->GetUnflushedFreshBlocksCount()) *
                 State->GetBlockSize(),
-            Config->GetFreshByteCountHardLimit(),
+            FreshCapacityLimits.FreshByteCountHardLimit,
             Config->GetFreshLogicalBlocksByteCountHardLimit());
         HasError(error))
     {
@@ -465,7 +465,7 @@ void TPartitionActor::ZeroFreshBlocks(
             State->GetUnflushedFreshBlobByteCount(),
             static_cast<ui64>(State->GetUnflushedFreshBlocksCount()) *
                 State->GetBlockSize(),
-            Config->GetFreshByteCountHardLimit(),
+            FreshCapacityLimits.FreshByteCountHardLimit,
             Config->GetFreshLogicalBlocksByteCountHardLimit());
         HasError(error))
     {

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -2227,43 +2227,77 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         // logical flush threshold is 2 * 4_MB. The cap is above that product
         // and the HDD setting is far below it, so neither a raw SSD read nor a
         // raw unsuffixed read can produce 8_MB.
+        constexpr ui32 BlockCount = 2048;
+        constexpr ui32 BlocksPerWrite = 512;
+        constexpr ui32 WriteCount = BlockCount / BlocksPerWrite;
+        constexpr ui64 ExpectedThreshold = 2 * 4_MB;
+
+        // Half the workload stays below the threshold and the whole workload
+        // lands exactly on it, so this also covers the >= boundary.
+        static_assert(
+            ui64(BlockCount / 2) * DefaultBlockSize < ExpectedThreshold);
+        static_assert(ui64(BlockCount) * DefaultBlockSize == ExpectedThreshold);
+
+        // The physical blob count and blob byte thresholds are scaled too, so
+        // they cannot be disabled by a large cap. These are their effective
+        // values. Each write produces one fresh blob, and both thresholds keep
+        // a 4x margin over the whole workload, so neither can preempt the
+        // logical one - not even with per-blob overhead on top of the payload.
+        constexpr ui64 BlobCountThreshold = 2 * 3200;
+        constexpr ui64 BlobByteCountThreshold = 2 * 16_MB;
+        static_assert(WriteCount * 4 < BlobCountThreshold);
+        static_assert(
+            ui64(BlockCount) * DefaultBlockSize * 4 <= BlobByteCountThreshold);
+
         auto config = DefaultConfig();
         config.SetWriteBlobThresholdSSD(16_MB);
         config.SetFreshChannelWriteRequestsEnabled(true);
         config.SetBytesPerFreshCapacityUnitSSD(4_MB);
         config.SetFlushThresholdSSD(64_MB);
         config.SetFlushThreshold(1_MB);
-        config.SetFreshBlobCountFlushThresholdSSD(Max<ui32>());
-        config.SetFreshBlobByteCountFlushThresholdSSD(Max<ui32>());
+        config.SetFreshBlobCountFlushThresholdSSD(BlobCountThreshold);
+        config.SetFreshBlobByteCountFlushThresholdSSD(BlobByteCountThreshold);
 
         auto runtime = PrepareTestActorRuntime(
             config,
-            2048,
+            BlockCount,
             {},
             {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
 
         TPartitionClient partition(*runtime);
         partition.WaitReady();
 
-        partition.WriteBlocks(TBlockRange32::WithLength(0, 512));
-        partition.WriteBlocks(TBlockRange32::WithLength(512, 512));
+        for (ui32 i = 0; i < WriteCount / 2; ++i) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(i * BlocksPerWrite, BlocksPerWrite));
+        }
 
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                BlockCount / 2,
+                stats.GetFreshBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+            // One fresh blob per write, as the margins above assume.
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteCount / 2,
+                stats.GetFreshBlobsCount());
         }
 
-        partition.WriteBlocks(TBlockRange32::WithLength(1024, 512));
-        partition.WriteBlocks(TBlockRange32::WithLength(1536, 512));
+        for (ui32 i = WriteCount / 2; i < WriteCount; ++i) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(i * BlocksPerWrite, BlocksPerWrite));
+        }
         runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 
         {
             const auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(2048, stats.GetMixedIndexBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                BlockCount,
+                stats.GetMixedIndexBlocksCount());
         }
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -2223,11 +2223,16 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
     Y_UNIT_TEST(ShouldUseSizeScaledSSDFreshFlushThreshold)
     {
+        // 2048 * 4_KB = 8_MB partition, one unit per 4_MB, so the effective
+        // logical flush threshold is 2 * 4_MB. The cap is above that product
+        // and the HDD setting is far below it, so neither a raw SSD read nor a
+        // raw unsuffixed read can produce 8_MB.
         auto config = DefaultConfig();
         config.SetWriteBlobThresholdSSD(16_MB);
         config.SetFreshChannelWriteRequestsEnabled(true);
         config.SetBytesPerFreshCapacityUnitSSD(4_MB);
-        config.SetFlushThresholdSSD(8_MB);
+        config.SetFlushThresholdSSD(64_MB);
+        config.SetFlushThreshold(1_MB);
         config.SetFreshBlobCountFlushThresholdSSD(Max<ui32>());
         config.SetFreshBlobByteCountFlushThresholdSSD(Max<ui32>());
 
@@ -2264,15 +2269,26 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
     Y_UNIT_TEST(ShouldUseSizeScaledSSDFreshBlobCountFlushThreshold)
     {
+        // 2048 * 4_KB = 8_MB partition, one unit per 4_MB, so the effective
+        // blob count threshold is 2 * 3200 = 6400. The cap is above that
+        // product and the HDD setting is far below it, so neither a raw SSD
+        // read nor a raw unsuffixed read can produce 6400.
+        constexpr ui32 BlockCount = 2048;
+        constexpr ui32 ExpectedThreshold = 2 * 3200;
+
         auto config = DefaultConfig();
         config.SetBytesPerFreshCapacityUnitSSD(4_MB);
-        config.SetFlushThresholdSSD(Max<ui32>());
-        config.SetFreshBlobCountFlushThresholdSSD(3201);
-        config.SetFreshBlobByteCountFlushThresholdSSD(Max<ui32>());
+        config.SetFreshBlobCountFlushThresholdSSD(10000);
+        config.SetFreshBlobCountFlushThreshold(10);
+        // The logical byte and blob byte thresholds are scaled too, so they
+        // cannot be disabled by a large cap. These are their effective values;
+        // both stay far above what this test writes.
+        config.SetFlushThresholdSSD(2 * 4_MB);
+        config.SetFreshBlobByteCountFlushThresholdSSD(2 * 16_MB);
 
         auto runtime = PrepareTestActorRuntime(
             config,
-            1024,
+            BlockCount,
             {},
             {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
 
@@ -2292,42 +2308,64 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 return false;
             });
 
-        for (ui32 i = 0; i < 3199; ++i) {
-            AddFreshBlobToPartitionState(
-                partition,
-                MakeCommitId(1, i + 1),
-                1);
-        }
+        // Generation 1 is never used by the tablet itself, so these synthetic
+        // commit ids cannot collide with the ones assigned to real writes.
+        ui32 blobCount = 0;
+        const auto addFreshBlobs = [&](ui32 count)
+        {
+            for (ui32 i = 0; i < count; ++i) {
+                AddFreshBlobToPartitionState(
+                    partition,
+                    MakeCommitId(1, ++blobCount),
+                    1);
+            }
+        };
 
-        partition.WriteBlocks(0, 1);
-        runtime->DispatchEvents(
-            TDispatchOptions(),
-            TDuration::MilliSeconds(100));
+        const auto pokeFlush = [&](ui32 blockIndex)
+        {
+            partition.WriteBlocks(blockIndex, 1);
+            runtime->DispatchEvents(
+                TDispatchOptions(),
+                TDuration::MilliSeconds(100));
+        };
+
+        // One unit would already have flushed here.
+        addFreshBlobs(3200);
+        pokeFlush(0);
         UNIT_ASSERT_VALUES_EQUAL(0, flushRequestCount);
 
-        AddFreshBlobToPartitionState(
-            partition,
-            MakeCommitId(1, 3200),
-            1);
-        partition.WriteBlocks(1, 1);
-        runtime->DispatchEvents(
-            TDispatchOptions(),
-            TDuration::MilliSeconds(100));
+        addFreshBlobs(ExpectedThreshold - 1 - blobCount);
+        pokeFlush(1);
+        UNIT_ASSERT_VALUES_EQUAL(0, flushRequestCount);
 
+        addFreshBlobs(1);
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedThreshold, blobCount);
+        pokeFlush(2);
         UNIT_ASSERT_VALUES_EQUAL(1, flushRequestCount);
     }
 
     Y_UNIT_TEST(ShouldUseSizeScaledSSDFreshBlobByteFlushThreshold)
     {
+        // 2048 * 4_KB = 8_MB partition, one unit per 4_MB, so the effective
+        // blob byte threshold is 2 * 16_MB = 32_MB. The cap is above that
+        // product and the HDD setting is far below it, so neither a raw SSD
+        // read nor a raw unsuffixed read can produce 32_MB.
+        constexpr ui32 BlockCount = 2048;
+        constexpr ui64 ExpectedThreshold = 2 * 16_MB;
+
         auto config = DefaultConfig();
         config.SetBytesPerFreshCapacityUnitSSD(4_MB);
-        config.SetFlushThresholdSSD(Max<ui32>());
-        config.SetFreshBlobCountFlushThresholdSSD(Max<ui32>());
-        config.SetFreshBlobByteCountFlushThresholdSSD(16_MB + 1);
+        config.SetFreshBlobByteCountFlushThresholdSSD(100_MB);
+        config.SetFreshBlobByteCountFlushThreshold(1_MB);
+        // The logical byte and blob count thresholds are scaled too, so they
+        // cannot be disabled by a large cap. These are their effective values;
+        // both stay far above what this test writes.
+        config.SetFlushThresholdSSD(2 * 4_MB);
+        config.SetFreshBlobCountFlushThresholdSSD(2 * 3200);
 
         auto runtime = PrepareTestActorRuntime(
             config,
-            1024,
+            BlockCount,
             {},
             {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
 
@@ -2347,43 +2385,61 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 return false;
             });
 
-        AddFreshBlobToPartitionState(
-            partition,
-            MakeCommitId(1, 1),
-            16_MB - 1);
-        partition.WriteBlocks(0, 1);
-        runtime->DispatchEvents(
-            TDispatchOptions(),
-            TDuration::MilliSeconds(100));
+        // Generation 1 is never used by the tablet itself, so these synthetic
+        // commit ids cannot collide with the ones assigned to real writes.
+        const auto pokeFlush = [&](ui32 blockIndex)
+        {
+            partition.WriteBlocks(blockIndex, 1);
+            runtime->DispatchEvents(
+                TDispatchOptions(),
+                TDuration::MilliSeconds(100));
+        };
+
+        // One unit would already have flushed here.
+        AddFreshBlobToPartitionState(partition, MakeCommitId(1, 1), 16_MB);
+        pokeFlush(0);
         UNIT_ASSERT_VALUES_EQUAL(0, flushRequestCount);
 
         AddFreshBlobToPartitionState(
             partition,
             MakeCommitId(1, 2),
-            1);
-        partition.WriteBlocks(1, 1);
-        runtime->DispatchEvents(
-            TDispatchOptions(),
-            TDuration::MilliSeconds(100));
+            ExpectedThreshold - 16_MB - 1);
+        pokeFlush(1);
+        UNIT_ASSERT_VALUES_EQUAL(0, flushRequestCount);
 
+        AddFreshBlobToPartitionState(partition, MakeCommitId(1, 3), 1);
+        pokeFlush(2);
         UNIT_ASSERT_VALUES_EQUAL(1, flushRequestCount);
     }
 
     Y_UNIT_TEST(ShouldUseSizeScaledSSDFreshBackpressureThresholds)
     {
+        // 3072 * 32_KB = 96_MB partition, one unit per 64_MB, so backpressure
+        // starts at 2 * 40_MB and saturates at 2 * 128_MB. Both caps are above
+        // those products, and the unsuffixed settings from DefaultConfig are
+        // far below them, so neither a raw SSD read nor a raw unsuffixed read
+        // can produce these thresholds.
+        constexpr ui32 BlocksPerWrite = 128;
+        constexpr ui32 WriteCount = 24;
+        constexpr ui32 BlockCount = BlocksPerWrite * WriteCount;
+        constexpr ui32 BlockSize = 32_KB;
+
+        constexpr ui64 Units = 2;
+        constexpr ui64 ExpectedThreshold = Units * 40_MB;
+        constexpr ui64 ExpectedLimit = Units * 128_MB;
+        constexpr ui64 FreshByteCount = ui64(BlockCount) * BlockSize;
+        static_assert(ExpectedThreshold < FreshByteCount);
+        static_assert(FreshByteCount < ExpectedLimit);
+
         auto config = DefaultConfig();
         config.SetWriteBlobThresholdSSD(8_MB);
         config.SetBytesPerFreshCapacityUnitSSD(64_MB);
-        config.SetFreshByteCountThresholdForBackpressureSSD(80_MB);
-        config.SetFreshByteCountLimitForBackpressureSSD(256_MB);
+        config.SetFreshByteCountThresholdForBackpressureSSD(200_MB);
+        config.SetFreshByteCountLimitForBackpressureSSD(1_GB);
 
         TTestPartitionInfo partitionInfo;
         partitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
-        partitionInfo.BlockSize = 32_KB;
-
-        constexpr ui32 BlocksPerWrite = 128;
-        constexpr ui32 WriteCount = 12;
-        constexpr ui32 BlockCount = BlocksPerWrite * WriteCount;
+        partitionInfo.BlockSize = BlockSize;
 
         auto runtime = PrepareTestActorRuntime(
             config,
@@ -2437,8 +2493,13 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         };
         runtime->DispatchEvents(options, TDuration::Seconds(5));
 
-        constexpr double expectedScore =
-            1.0 + 5.0 * (48.0 - 40.0) / (128.0 - 40.0);
+        // BPFeature() interpolates between 1 and FreshByteCountFeatureMaxValue
+        // over [threshold, limit].
+        const double maxValue = config.GetFreshByteCountFeatureMaxValue();
+        const double expectedScore =
+            1.0 + (maxValue - 1.0) *
+                      static_cast<double>(FreshByteCount - ExpectedThreshold) /
+                      static_cast<double>(ExpectedLimit - ExpectedThreshold);
         UNIT_ASSERT_DOUBLES_EQUAL(
             expectedScore,
             report.FreshIndexScore,
@@ -10909,13 +10970,23 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             writeResponse->GetErrorReason());
     }
 
-    Y_UNIT_TEST(ShouldUseEffectiveSSDHardLimitForWritesAndZeros)
+    void DoTestEffectiveFreshHardLimitForWritesAndZeros(
+        NCloud::NProto::EStorageMediaKind mediaKind)
     {
+        const bool isSSD = mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD;
+
+        // One unit per block, so a one-block partition gets the 256_MB legacy
+        // base and a two-block partition gets 2 * 256_MB, capped at 512_MB.
+        // The other media kind is configured far below both values, so a
+        // request admitted/rejected here can only come from the selected one.
         for (const ui32 blocksCount: {1, 2}) {
             auto config = DefaultConfig();
-            config.SetFreshByteCountHardLimit(8_KB);
-            config.SetFreshByteCountHardLimitSSD(512_MB);
-            config.SetBytesPerFreshCapacityUnitSSD(DefaultBlockSize);
+            config.SetFreshByteCountHardLimit(isSSD ? 8_KB : 512_MB);
+            config.SetFreshByteCountHardLimitSSD(isSSD ? 512_MB : 8_KB);
+            config.SetBytesPerFreshCapacityUnitHDD(
+                isSSD ? 0 : DefaultBlockSize);
+            config.SetBytesPerFreshCapacityUnitSSD(
+                isSSD ? DefaultBlockSize : 0);
             config.SetFreshChannelWriteRequestsEnabled(true);
             config.SetFreshChannelZeroRequestsEnabled(true);
 
@@ -10923,7 +10994,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 config,
                 blocksCount,
                 {},
-                {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+                {.MediaKind = mediaKind});
 
             TPartitionClient partition(*runtime);
             partition.WaitReady();
@@ -10959,6 +11030,18 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 zeroResponse->GetStatus(),
                 zeroResponse->GetErrorReason());
         }
+    }
+
+    Y_UNIT_TEST(ShouldUseEffectiveSSDHardLimitForWritesAndZeros)
+    {
+        DoTestEffectiveFreshHardLimitForWritesAndZeros(
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+    }
+
+    Y_UNIT_TEST(ShouldUseEffectiveHDDHardLimitForWritesAndZeros)
+    {
+        DoTestEffectiveFreshHardLimitForWritesAndZeros(
+            NCloud::NProto::STORAGE_MEDIA_DEFAULT);
     }
 
     Y_UNIT_TEST(ShouldCorrectlyScanDiskWithoutBrokenBlobs)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -113,6 +113,23 @@ void WriteBlocksWithBlockSize(
         response->GetErrorReason());
 }
 
+void AddFreshBlobToPartitionState(
+    TPartitionClient& partition,
+    ui64 commitId,
+    ui64 blobSize)
+{
+    partition.SendToPipe(
+        std::make_unique<
+            TEvPartitionCommonPrivate::TEvAddFreshBlocksRequest>(
+            commitId,
+            blobSize,
+            TPartialBlobId{},
+            TVector<TBlockRange32>{},
+            TVector<IWriteBlocksHandlerPtr>{}));
+    partition.RecvResponse<
+        TEvPartitionCommonPrivate::TEvAddFreshBlocksResponse>();
+}
+
 void CheckRangesArePartition(
     TVector<TBlockRange32> ranges,
     const TBlockRange32& unionRange)
@@ -2202,6 +2219,230 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(MaxBlocksCount, stats.GetMixedBlocksCount());
             UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
         }
+    }
+
+    Y_UNIT_TEST(ShouldUseSizeScaledSSDFreshFlushThreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThresholdSSD(16_MB);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetBytesPerFreshCapacityUnitSSD(4_MB);
+        config.SetFlushThresholdSSD(8_MB);
+        config.SetFreshBlobCountFlushThresholdSSD(Max<ui32>());
+        config.SetFreshBlobByteCountFlushThresholdSSD(Max<ui32>());
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            2048,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 512));
+        partition.WriteBlocks(TBlockRange32::WithLength(512, 512));
+
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedIndexBlocksCount());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 512));
+        partition.WriteBlocks(TBlockRange32::WithLength(1536, 512));
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2048, stats.GetMixedIndexBlocksCount());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldUseSizeScaledSSDFreshBlobCountFlushThreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetBytesPerFreshCapacityUnitSSD(4_MB);
+        config.SetFlushThresholdSSD(Max<ui32>());
+        config.SetFreshBlobCountFlushThresholdSSD(3201);
+        config.SetFreshBlobByteCountFlushThresholdSSD(Max<ui32>());
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 flushRequestCount = 0;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvFlushRequest)
+                {
+                    ++flushRequestCount;
+                    return true;
+                }
+                return false;
+            });
+
+        for (ui32 i = 0; i < 3199; ++i) {
+            AddFreshBlobToPartitionState(
+                partition,
+                MakeCommitId(1, i + 1),
+                1);
+        }
+
+        partition.WriteBlocks(0, 1);
+        runtime->DispatchEvents(
+            TDispatchOptions(),
+            TDuration::MilliSeconds(100));
+        UNIT_ASSERT_VALUES_EQUAL(0, flushRequestCount);
+
+        AddFreshBlobToPartitionState(
+            partition,
+            MakeCommitId(1, 3200),
+            1);
+        partition.WriteBlocks(1, 1);
+        runtime->DispatchEvents(
+            TDispatchOptions(),
+            TDuration::MilliSeconds(100));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, flushRequestCount);
+    }
+
+    Y_UNIT_TEST(ShouldUseSizeScaledSSDFreshBlobByteFlushThreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetBytesPerFreshCapacityUnitSSD(4_MB);
+        config.SetFlushThresholdSSD(Max<ui32>());
+        config.SetFreshBlobCountFlushThresholdSSD(Max<ui32>());
+        config.SetFreshBlobByteCountFlushThresholdSSD(16_MB + 1);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 flushRequestCount = 0;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvFlushRequest)
+                {
+                    ++flushRequestCount;
+                    return true;
+                }
+                return false;
+            });
+
+        AddFreshBlobToPartitionState(
+            partition,
+            MakeCommitId(1, 1),
+            16_MB - 1);
+        partition.WriteBlocks(0, 1);
+        runtime->DispatchEvents(
+            TDispatchOptions(),
+            TDuration::MilliSeconds(100));
+        UNIT_ASSERT_VALUES_EQUAL(0, flushRequestCount);
+
+        AddFreshBlobToPartitionState(
+            partition,
+            MakeCommitId(1, 2),
+            1);
+        partition.WriteBlocks(1, 1);
+        runtime->DispatchEvents(
+            TDispatchOptions(),
+            TDuration::MilliSeconds(100));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, flushRequestCount);
+    }
+
+    Y_UNIT_TEST(ShouldUseSizeScaledSSDFreshBackpressureThresholds)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThresholdSSD(8_MB);
+        config.SetBytesPerFreshCapacityUnitSSD(64_MB);
+        config.SetFreshByteCountThresholdForBackpressureSSD(80_MB);
+        config.SetFreshByteCountLimitForBackpressureSSD(256_MB);
+
+        TTestPartitionInfo partitionInfo;
+        partitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        partitionInfo.BlockSize = 32_KB;
+
+        constexpr ui32 BlocksPerWrite = 128;
+        constexpr ui32 WriteCount = 12;
+        constexpr ui32 BlockCount = BlocksPerWrite * WriteCount;
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            BlockCount,
+            {},
+            partitionInfo);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        TBackpressureReport report;
+        bool reportUpdated = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvFlushRequest)
+                {
+                    return true;
+                }
+
+                if (event->GetTypeRewrite() ==
+                    TEvPartition::EvBackpressureReport)
+                {
+                    report = *event->Get<
+                        TEvPartition::TEvBackpressureReport>();
+                    reportUpdated = true;
+                }
+                return false;
+            });
+
+        for (ui32 i = 0; i < WriteCount; ++i) {
+            WriteBlocksWithBlockSize(
+                partition,
+                TBlockRange32::WithLength(
+                    i * BlocksPerWrite,
+                    BlocksPerWrite),
+                i,
+                partitionInfo.BlockSize);
+        }
+
+        reportUpdated = false;
+        partition.SendToPipe(
+            std::make_unique<
+                TEvPartitionPrivate::TEvSendBackpressureReport>());
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]
+        {
+            return reportUpdated;
+        };
+        runtime->DispatchEvents(options, TDuration::Seconds(5));
+
+        constexpr double expectedScore =
+            1.0 + 5.0 * (48.0 - 40.0) / (128.0 - 40.0);
+        UNIT_ASSERT_DOUBLES_EQUAL(
+            expectedScore,
+            report.FreshIndexScore,
+            1e-5);
     }
 
     Y_UNIT_TEST(ShouldAutomaticallyFlushBlocksWhenFreshBlobCountThresholdIsReached)
@@ -10668,6 +10909,58 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             writeResponse->GetErrorReason());
     }
 
+    Y_UNIT_TEST(ShouldUseEffectiveSSDHardLimitForWritesAndZeros)
+    {
+        for (const ui32 blocksCount: {1, 2}) {
+            auto config = DefaultConfig();
+            config.SetFreshByteCountHardLimit(8_KB);
+            config.SetFreshByteCountHardLimitSSD(512_MB);
+            config.SetBytesPerFreshCapacityUnitSSD(DefaultBlockSize);
+            config.SetFreshChannelWriteRequestsEnabled(true);
+            config.SetFreshChannelZeroRequestsEnabled(true);
+
+            auto runtime = PrepareTestActorRuntime(
+                config,
+                blocksCount,
+                {},
+                {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+            TPartitionClient partition(*runtime);
+            partition.WaitReady();
+
+            AddFreshBlobToPartitionState(
+                partition,
+                MakeCommitId(1, 1),
+                256_MB);
+
+            runtime->SetEventFilter(
+                [](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+                {
+                    return event->GetTypeRewrite() ==
+                           TEvPartitionPrivate::EvFlushRequest;
+                });
+
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::MakeOneBlock(0),
+                1);
+            auto writeResponse = partition.RecvWriteBlocksResponse();
+
+            partition.SendZeroBlocksRequest(0);
+            auto zeroResponse = partition.RecvZeroBlocksResponse();
+
+            const ui32 expectedStatus =
+                blocksCount == 1 ? E_REJECTED : S_OK;
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                expectedStatus,
+                writeResponse->GetStatus(),
+                writeResponse->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                expectedStatus,
+                zeroResponse->GetStatus(),
+                zeroResponse->GetErrorReason());
+        }
+    }
+
     Y_UNIT_TEST(ShouldCorrectlyScanDiskWithoutBrokenBlobs)
     {
         constexpr ui32 blockCount = 1024 * 1024;
@@ -16741,6 +17034,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         config.SetCleanupThreshold(1000);
         config.SetSSDMaxBlobsPerRange(1000);
         config.SetFlushThreshold(1000_MB);
+        config.SetFlushThresholdSSD(1000_MB);
         config.SetV1GarbageCompactionEnabled(true);
         config.SetIgnoringZeroedCompactionEnabled(ignoringZeroedCompactionEnabled);
         config.SetCompactionGarbageThreshold(999999);


### PR DESCRIPTION
### Notes
Fresh limits in partition were global constants, so a 4TiB SSD and a 32GiB HDD got the same 4MiB flush threshold and 256MiB hard limit. Add SSD counterparts for all six Fresh settings and an optional size scaling factor, so a larger partition can aggregate more Fresh data before flushing.

**No behaviour change at defaults** — BytesPerFreshCapacityUnit{HDD,SSD} default to 0, which disables scaling, and the SSD caps default to the old global values.

`Effective Limit = min(configured, compiledDefault * ceil(partitionBytes / BytesPerFreshCapacityUnit{HDD,SSD}))`. A zero byte unit – the default – turns scaling off, so behaviour is unchanged out of the box.

### Issue
#7059
