### PR TITLE
Add journalled_device folders to approvals exemptRightFolders

### DIFF
--- a/.github/workflows/approvals.yaml
+++ b/.github/workflows/approvals.yaml
@@ -28,6 +28,8 @@ jobs:
                     'cloud/blockstore/tests/csi_driver/',
                     'cloud/filestore/libs/storage/fastshard/',
                     'cloud/filestore/tests/fastshard/',
+                    'cloud/storage/core/libs/journalled_device/',
+                    'cloud/storage/core/libs/journalled_device_tcp_server/',
                     'doc/filestore/design/storage/fastshard/',
                     '.github/',
                 ];


### PR DESCRIPTION
### Notes
Add journalled_device folders to approvals exemptRightFolders.

### Issue
https://github.com/ydb-platform/nbs/issues/6956
