### PR TITLE
Add TJournal stub and journalled device v2 implementation

### DIFF
--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_journalled_device_tcp_server.cpp
@@ -57,6 +57,12 @@ public:
 
     // IServerBackend
 
+    void Start() override
+    {}
+
+    void Stop() override
+    {}
+
     [[nodiscard]] auto AcquireDevices(
         NCloud::NProto::TAcquireDevicesRequest request)
         -> TFuture<NCloud::NProto::TAcquireDevicesResponse> final

--- a/cloud/storage/core/libs/journalled_device/journal.cpp
+++ b/cloud/storage/core/libs/journalled_device/journal.cpp
@@ -1,0 +1,83 @@
+#include "journal.h"
+
+namespace NCloud::NJournalled {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TJournal final: public IJournal
+{
+public:
+    TFuture<NCloud::NProto::TError> Restore() override
+    {
+        return MakeFuture(MakeError(E_NOT_IMPLEMENTED, "Restore"));
+    }
+
+    TFuture<NCloud::NProto::TWriteLogRecordResponse> Write(
+        NCloud::NProto::TWriteLogRecordRequest request) override
+    {
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "Write"));
+    }
+
+    TFuture<NCloud::NProto::TReadPagesResponse> Read(
+        NCloud::NProto::TReadPagesRequest request) const override
+    {
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TReadPagesResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "Read"));
+    }
+
+    auto ReadTail(NCloud::NProto::TReadJournalTailRequest request) const
+        -> TFuture<NCloud::NProto::TReadJournalTailResponse> override
+    {
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TReadJournalTailResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "ReadTail"));
+    }
+
+    auto AdvanceLastAckedLsn(
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> override
+    {
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
+            TErrorResponse(E_NOT_IMPLEMENTED, "AdvanceLastAckedLsn"));
+    }
+
+    auto GetFirstRecordToFlush() const
+        -> TFuture<TResultOrError<NCloud::NProto::TJournalRecord>> override
+    {
+        return MakeFuture<TResultOrError<NCloud::NProto::TJournalRecord>>(
+            MakeError(E_NOT_IMPLEMENTED, "GetFirstRecordToFlush"));
+    }
+
+    void MarkRecordAsFlushed(ui64 lsn) override
+    {
+        Y_UNUSED(lsn);
+    }
+
+    TFuture<NCloud::NProto::TError> CleanupFlushedRecords() override
+    {
+        return MakeFuture(MakeError(E_NOT_IMPLEMENTED, "CleanupFlushedRecords"));
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IJournalPtr CreateJournal()
+{
+    return std::make_shared<TJournal>();
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journal.h
+++ b/cloud/storage/core/libs/journalled_device/journal.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <library/cpp/threading/future/future.h>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IJournal
+{
+    virtual ~IJournal() = default;
+
+    // Restoring
+
+    [[nodiscard]] virtual auto Restore()
+        -> NThreading::TFuture<NCloud::NProto::TError> = 0;
+
+    // Device API
+
+    [[nodiscard]] virtual auto Write(
+        NCloud::NProto::TWriteLogRecordRequest request)
+        -> NThreading::TFuture<NCloud::NProto::TWriteLogRecordResponse> = 0;
+
+    [[nodiscard]] virtual auto Read(
+        NCloud::NProto::TReadPagesRequest request) const
+        -> NThreading::TFuture<NCloud::NProto::TReadPagesResponse> = 0;
+
+    [[nodiscard]] virtual auto ReadTail(
+        NCloud::NProto::TReadJournalTailRequest request) const
+        -> NThreading::TFuture<NCloud::NProto::TReadJournalTailResponse> = 0;
+
+    [[nodiscard]] virtual auto AdvanceLastAckedLsn(
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> NThreading::TFuture<
+            NCloud::NProto::TAdvanceLsnLowWatermarkResponse> = 0;
+
+    // Background cleanup
+
+    [[nodiscard]] virtual auto GetFirstRecordToFlush() const
+        -> NThreading::TFuture<
+            TResultOrError<NCloud::NProto::TJournalRecord>> = 0;
+
+    virtual void MarkRecordAsFlushed(ui64 lsn) = 0;
+
+    [[nodiscard]] virtual auto CleanupFlushedRecords()
+        -> NThreading::TFuture<NCloud::NProto::TError> = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+IJournalPtr CreateJournal();
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journalled_device.cpp
+++ b/cloud/storage/core/libs/journalled_device/journalled_device.cpp
@@ -32,6 +32,12 @@ public:
 
     // IJournalledDevice
 
+    void Start() override
+    {}
+
+    void Stop() override
+    {}
+
     [[nodiscard]] auto ReadPages(
         NCloud::NProto::TReadPagesRequest request)
         -> TFuture<NCloud::NProto::TReadPagesResponse> final

--- a/cloud/storage/core/libs/journalled_device/journalled_device.h
+++ b/cloud/storage/core/libs/journalled_device/journalled_device.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include <cloud/storage/core/libs/common/startable.h>
 #include <cloud/storage/core/protos/device.pb.h>
 
 #include <library/cpp/threading/future/future.h>
@@ -10,7 +11,7 @@ namespace NCloud::NJournalled {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IJournalledDevice
+struct IJournalledDevice : public IStartable
 {
     virtual ~IJournalledDevice() = default;
 

--- a/cloud/storage/core/libs/journalled_device/journalled_device_v2.cpp
+++ b/cloud/storage/core/libs/journalled_device/journalled_device_v2.cpp
@@ -1,0 +1,380 @@
+#include "journalled_device_v2.h"
+
+#include "device.h"
+#include "journal.h"
+#include "journalled_device.h"
+
+#include <cloud/storage/core/libs/common/verify.h>
+#include <cloud/storage/core/libs/coroutine/executor.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/coroutine/engine/impl.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/map.h>
+#include <util/generic/scope.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NJournalled {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr TDuration IdleFlushDelay = TDuration::MilliSeconds(100);
+
+////////////////////////////////////////////////////////////////////////////////
+
+NCloud::NProto::TReadPagesRequest MakeMissingRequest(
+    const NCloud::NProto::TReadPagesRequest& originalRequest,
+    const NCloud::NProto::TReadPagesResponse& journalResponse)
+{
+    TMap<ui64, ui64> covered;
+    for (const auto& group: journalResponse.GetPageGroups()) {
+        if (!group.ContentSize()) {
+            continue;
+        }
+
+        const ui64 firstPageNo = group.GetFirstPageNo();
+        covered.emplace(firstPageNo, firstPageNo + group.ContentSize());
+    }
+
+    NCloud::NProto::TReadPagesRequest missing;
+    missing.MutableHeaders()->CopyFrom(originalRequest.GetHeaders());
+    missing.SetDeviceUUID(originalRequest.GetDeviceUUID());
+
+    for (const auto& ref: originalRequest.GetPageGroupRefs()) {
+        const ui64 endPageNo = ref.GetFirstPageNo() + ref.GetPageCount();
+        ui64 pageNo = ref.GetFirstPageNo();
+
+        auto addRef = [&] (ui64 begin, ui64 end)
+        {
+            if (begin >= end) {
+                return;
+            }
+
+            auto& missingRef = *missing.AddPageGroupRefs();
+            missingRef.SetFirstPageNo(begin);
+            missingRef.SetPageCount(end - begin);
+            missingRef.SetPageSize(ref.GetPageSize());
+        };
+
+        auto it = covered.upper_bound(pageNo);
+        if (it != covered.begin() && std::prev(it)->second > pageNo) {
+            --it;
+        }
+
+        for (; it != covered.end() && it->first < endPageNo; ++it) {
+            addRef(pageNo, it->first);
+            pageNo = it->second;
+
+            if (pageNo >= endPageNo) {
+                break;
+            }
+        }
+
+        addRef(pageNo, endPageNo);
+    }
+
+    return missing;
+}
+
+NCloud::NProto::TReadPagesResponse MergeResponses(
+    const NCloud::NProto::TReadPagesRequest& request,
+    NCloud::NProto::TReadPagesResponse* journalResp,
+    NCloud::NProto::TReadPagesResponse* deviceResp)
+{
+    THashMap<ui64, TString*> pages;
+
+    auto index = [&] (NCloud::NProto::TReadPagesResponse* source)
+    {
+        if (!source) {
+            return;
+        }
+
+        for (auto& group: *source->MutablePageGroups()) {
+            ui64 pageNo = group.GetFirstPageNo();
+            for (auto& content: *group.MutableContent()) {
+                pages.emplace(pageNo++, &content);
+            }
+        }
+    };
+
+    index(journalResp);
+    index(deviceResp);
+
+    NCloud::NProto::TReadPagesResponse response;
+
+    for (const auto& ref: request.GetPageGroupRefs()) {
+        if (!ref.GetPageCount()) {
+            continue;
+        }
+
+        auto* group = response.AddPageGroups();
+        group->SetFirstPageNo(ref.GetFirstPageNo());
+
+        for (ui64 i = 0; i < ref.GetPageCount(); ++i) {
+            const ui64 pageNo = ref.GetFirstPageNo() + i;
+
+            auto it = pages.find(pageNo);
+            if (it == pages.end()) {
+                return ErrorResponse<NCloud::NProto::TReadPagesResponse>(
+                    E_INVALID_STATE,
+                    TStringBuilder() << "page " << pageNo << " is missing"
+                        " in both the journal and the device responses");
+            }
+
+            *group->AddContent() = std::move(*it->second);
+        }
+    }
+
+    return response;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TJournalledDeviceV2 final
+    : public IJournalledDevice
+    , public std::enable_shared_from_this<TJournalledDeviceV2>
+{
+private:
+    const ILoggingServicePtr Logging;
+    const TExecutorPtr Executor;
+    const IJournalPtr Journal;
+    const IDevicePtr DataStore;
+
+    TLog Log;
+
+    std::atomic_bool ShouldStop = false;
+
+    TPromise<void> FlushCycleStopped;
+
+public:
+    TJournalledDeviceV2(
+            ILoggingServicePtr logging,
+            TExecutorPtr executor,
+            IJournalPtr journal,
+            IDevicePtr dataStore)
+        : Logging(std::move(logging))
+        , Executor(std::move(executor))
+        , Journal(std::move(journal))
+        , DataStore(std::move(dataStore))
+        , Log(Logging->CreateLog("JOURNALLED_DEVICE"))
+    {}
+
+    void Start() override {
+        auto future = Executor->Execute(
+            [weakSelf = weak_from_this()] () {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    return MakeError(E_FAIL, "TJournalledDevice is destroyed");
+                }
+
+                return self->DoStart();
+            });
+
+        auto error = future.GetValueSync();
+        Y_ENSURE(!HasError(error), FormatError(error));
+    }
+
+    void Stop() override {
+        ShouldStop.store(true);
+
+        if (FlushCycleStopped.Initialized()) {
+            FlushCycleStopped.GetFuture().Wait();
+        }
+    }
+
+    TFuture<NCloud::NProto::TReadPagesResponse> ReadPages(
+        NCloud::NProto::TReadPagesRequest request) override
+    {
+        return Execute<NCloud::NProto::TReadPagesResponse>(
+            [request = std::move(request)] (auto& self) mutable
+            {
+                return self.DoReadPages(std::move(request));
+            });
+    }
+
+    TFuture<NCloud::NProto::TWriteLogRecordResponse> WriteLogRecord(
+        NCloud::NProto::TWriteLogRecordRequest request) override
+    {
+        return Execute<NCloud::NProto::TWriteLogRecordResponse>(
+            [request = std::move(request)] (auto& self) mutable
+            {
+                return self.Executor->ExtractResponse(
+                    self.Journal->Write(std::move(request)));
+            });
+    }
+
+    TFuture<NCloud::NProto::TReadJournalTailResponse> ReadJournalTail(
+        NCloud::NProto::TReadJournalTailRequest request) override
+    {
+        return Execute<NCloud::NProto::TReadJournalTailResponse>(
+            [request = std::move(request)] (auto& self) mutable
+            {
+                return self.Executor->ExtractResponse(
+                    self.Journal->ReadTail(std::move(request)));
+            });
+    }
+
+    auto AdvanceLsnLowWatermark(
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> override
+    {
+        return Execute<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
+            [request = std::move(request)] (auto& self) mutable
+            {
+                return self.Executor->ExtractResponse(
+                    self.Journal->AdvanceLastAckedLsn(std::move(request)));
+            });
+    }
+
+private:
+    template <typename T, typename F>
+    TFuture<T> Execute(F func)
+    {
+        return Executor->Execute(
+            [weakSelf = weak_from_this(), func = std::move(func)] () mutable -> T
+            {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    return ErrorResponse<T>(
+                        E_FAIL,
+                        "TJournalledDevice is destroyed");
+                }
+
+                return func(*self);
+            });
+    }
+
+    NCloud::NProto::TError DoStart() {
+        auto error = Executor->ExtractResponse(Journal->Restore());
+        if (HasError(error)) {
+            return error;
+        }
+
+        FlushCycleStopped = NewPromise<void>();
+        ScheduleFlushCycle();
+
+        return {};
+    }
+
+    NCloud::NProto::TReadPagesResponse DoReadPages(
+        NCloud::NProto::TReadPagesRequest request)
+    {
+        auto journalFuture = Journal->Read(request);
+        auto journalResp = Executor->ExtractResponse(std::move(journalFuture));
+        if (HasError(journalResp)) {
+            return journalResp;
+        }
+
+        auto lastAckedLsn = journalResp.GetLastAckedLogSequenceNumber();
+
+        auto missing = MakeMissingRequest(request, journalResp);
+
+        NCloud::NProto::TReadPagesResponse deviceResp;
+
+        if (missing.PageGroupRefsSize()) {
+            auto deviceFuture = DataStore->ReadPages(std::move(missing));
+            deviceResp = Executor->ExtractResponse(std::move(deviceFuture));
+            if (HasError(deviceResp)) {
+                return deviceResp;
+            }
+        }
+
+        auto response = MergeResponses(request, &journalResp, &deviceResp);
+        if (HasError(response)) {
+            return response;
+        }
+
+        response.SetLastAckedLogSequenceNumber(lastAckedLsn);
+        return response;
+    }
+
+    void ScheduleFlushCycle() {
+        Executor->Execute([weakSelf = weak_from_this()] () {
+            auto self = weakSelf.lock();
+            if (!self) {
+                return;
+            }
+
+            self->RunFlushCycle();
+        });
+    }
+
+    void RunFlushCycle()
+    {
+        ui64 lastFlushedLsn = 0;
+
+        while (!ShouldStop.load()) {
+            auto future = Journal->GetFirstRecordToFlush();
+            auto response = Executor->ExtractResponse(future);
+            if (HasError(response)) {
+                STORAGE_ERROR(
+                    "unable to get the next record to flush: "
+                    << FormatError(response.GetError()));
+                break;
+            }
+
+            auto record = response.ExtractResult();
+            auto lsn = record.GetLogSequenceNumber();
+            if (!lsn) {
+                // no record to flush
+                break;
+            }
+
+            NCloud::NProto::TWriteLogRecordRequest request;
+            request.MutablePageGroups()->Swap(record.MutablePageGroups());
+
+            auto writeFuture = DataStore->WritePages(std::move(request));
+            auto writeResponse = Executor->WaitFor(writeFuture);
+            if (HasError(writeResponse)) {
+                STORAGE_ERROR(
+                    "unable to flush the record with lsn " << lsn << ": "
+                    << FormatError(writeResponse.GetError()));
+                break;
+            }
+
+            Journal->MarkRecordAsFlushed(lsn);
+            lastFlushedLsn = lsn;
+        }
+
+        if (ShouldStop.load()) {
+            FlushCycleStopped.SetValue();
+            return;
+        }
+
+        auto future = Journal->CleanupFlushedRecords();
+        const auto& response = Executor->WaitFor(future);
+        if (HasError(response)) {
+            STORAGE_ERROR(
+                "unable to cleanup flushed records to lsn " << lastFlushedLsn
+                << ": " << FormatError(response));
+        }
+
+        RunningCont()->SleepT(IdleFlushDelay);
+
+        ScheduleFlushCycle();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IJournalledDevicePtr CreateJournalledDeviceV2(
+    ILoggingServicePtr logging,
+    TExecutorPtr executor,
+    IJournalPtr journal,
+    IDevicePtr dataStore)
+{
+    return std::make_shared<TJournalledDeviceV2>(
+        std::move(logging),
+        std::move(executor),
+        std::move(journal),
+        std::move(dataStore));
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journalled_device_v2.h
+++ b/cloud/storage/core/libs/journalled_device/journalled_device_v2.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "public.h"
+
+#include "journalled_device.h"
+
+#include <cloud/storage/core/libs/coroutine/public.h>
+#include <cloud/storage/core/libs/diagnostics/public.h>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+IJournalledDevicePtr CreateJournalledDeviceV2(
+    ILoggingServicePtr logging,
+    TExecutorPtr executor,
+    IJournalPtr journal,
+    IDevicePtr dataStore);
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journalled_device_v2_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/journalled_device_v2_ut.cpp
@@ -1,0 +1,777 @@
+#include "journalled_device_v2.h"
+
+#include "device.h"
+#include "journal.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/coroutine/executor.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/deque.h>
+#include <util/generic/vector.h>
+#include <util/string/builder.h>
+#include <util/string/join.h>
+#include <util/system/event.h>
+#include <util/system/mutex.h>
+
+#include <functional>
+
+namespace NCloud::NJournalled {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 DefaultPageSize = 4096;
+constexpr TStringBuf DefaultDeviceUUID = "uuid";
+constexpr TStringBuf DefaultClientId = "test-client";
+
+////////////////////////////////////////////////////////////////////////////////
+
+NCloud::NProto::TDevicePageGroup MakeGroup(
+    ui64 firstPageNo,
+    ui64 pageCount,
+    TStringBuf prefix)
+{
+    NCloud::NProto::TDevicePageGroup group;
+    group.SetFirstPageNo(firstPageNo);
+
+    for (ui64 i = 0; i < pageCount; ++i) {
+        *group.AddContent() = TStringBuilder() << prefix << firstPageNo + i;
+    }
+
+    return group;
+}
+
+NCloud::NProto::TReadPagesRequest MakeReadRequest(
+    const TVector<std::pair<ui64 /*firstPageNo*/, ui64 /*pageCount*/>>& refs)
+{
+    NCloud::NProto::TReadPagesRequest request;
+    request.MutableHeaders()->SetClientId(TString{DefaultClientId});
+    request.SetDeviceUUID(TString{DefaultDeviceUUID});
+
+    for (const auto& [firstPageNo, pageCount]: refs) {
+        auto& ref = *request.AddPageGroupRefs();
+        ref.SetFirstPageNo(firstPageNo);
+        ref.SetPageCount(pageCount);
+        ref.SetPageSize(DefaultPageSize);
+    }
+
+    return request;
+}
+
+NCloud::NProto::TReadPagesResponse MakeReadResponse(
+    TVector<NCloud::NProto::TDevicePageGroup> groups,
+    ui64 lastAckedLsn = 0)
+{
+    NCloud::NProto::TReadPagesResponse response;
+    response.SetLastAckedLogSequenceNumber(lastAckedLsn);
+
+    for (auto& group: groups) {
+        response.AddPageGroups()->Swap(&group);
+    }
+
+    return response;
+}
+
+NCloud::NProto::TJournalRecord MakeRecord(
+    ui64 lsn,
+    ui64 firstPageNo,
+    ui64 pageCount)
+{
+    NCloud::NProto::TJournalRecord record;
+    record.SetLogSequenceNumber(lsn);
+    record.SetPrevLogSequenceNumber(lsn - 1);
+    *record.AddPageGroups() = MakeGroup(firstPageNo, pageCount, "J");
+
+    return record;
+}
+
+// Serves every requested page group ref with pages named after the device.
+NCloud::NProto::TReadPagesResponse ServePagesFromDevice(
+    const NCloud::NProto::TReadPagesRequest& request)
+{
+    NCloud::NProto::TReadPagesResponse response;
+
+    for (const auto& ref: request.GetPageGroupRefs()) {
+        *response.AddPageGroups() =
+            MakeGroup(ref.GetFirstPageNo(), ref.GetPageCount(), "D");
+    }
+
+    return response;
+}
+
+// "10+2@4096, 15+5@4096"
+TString DescribeRefs(const NCloud::NProto::TReadPagesRequest& request)
+{
+    TVector<TString> refs;
+
+    for (const auto& ref: request.GetPageGroupRefs()) {
+        refs.push_back(TStringBuilder()
+            << ref.GetFirstPageNo() << "+" << ref.GetPageCount()
+            << "@" << ref.GetPageSize());
+    }
+
+    return JoinSeq(", ", refs);
+}
+
+// "10:[D10,D11,J12] 20:[J20]"
+template <typename T>
+TString DescribeGroups(const T& source)
+{
+    TVector<TString> groups;
+
+    for (const auto& group: source.GetPageGroups()) {
+        groups.push_back(TStringBuilder()
+            << group.GetFirstPageNo()
+            << ":[" << JoinSeq(",", group.GetContent()) << "]");
+    }
+
+    return JoinSeq(" ", groups);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestJournal final: public IJournal
+{
+    using TReadHandler = std::function<NCloud::NProto::TReadPagesResponse(
+        const NCloud::NProto::TReadPagesRequest&)>;
+
+    NCloud::NProto::TError RestoreError;
+
+    TReadHandler ReadHandler = [] (const auto& request) {
+        Y_UNUSED(request);
+        return NCloud::NProto::TReadPagesResponse();
+    };
+
+    mutable TManualEvent AllRecordsFlushed;
+
+    mutable TMutex Mutex;
+    mutable TVector<NCloud::NProto::TReadPagesRequest> ReadRequests;
+    mutable TDeque<NCloud::NProto::TJournalRecord> RecordsToFlush;
+    TVector<ui64> FlushedLsns;
+    ui32 RestoreCount = 0;
+    ui32 CleanupCount = 0;
+
+    // IJournal
+
+    TFuture<NCloud::NProto::TError> Restore() override
+    {
+        with_lock (Mutex) {
+            ++RestoreCount;
+        }
+
+        return MakeFuture(RestoreError);
+    }
+
+    TFuture<NCloud::NProto::TWriteLogRecordResponse> Write(
+        NCloud::NProto::TWriteLogRecordRequest request) override
+    {
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>();
+    }
+
+    TFuture<NCloud::NProto::TReadPagesResponse> Read(
+        NCloud::NProto::TReadPagesRequest request) const override
+    {
+        with_lock (Mutex) {
+            ReadRequests.push_back(request);
+        }
+
+        return MakeFuture(ReadHandler(request));
+    }
+
+    auto ReadTail(NCloud::NProto::TReadJournalTailRequest request) const
+        -> TFuture<NCloud::NProto::TReadJournalTailResponse> override
+    {
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TReadJournalTailResponse>();
+    }
+
+    auto AdvanceLastAckedLsn(
+        NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
+        -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> override
+    {
+        Y_UNUSED(request);
+
+        return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>();
+    }
+
+    auto GetFirstRecordToFlush() const
+        -> TFuture<TResultOrError<NCloud::NProto::TJournalRecord>> override
+    {
+        NCloud::NProto::TJournalRecord record;
+
+        with_lock (Mutex) {
+            if (RecordsToFlush.empty()) {
+                AllRecordsFlushed.Signal();
+            } else {
+                // the record is kept until it gets acked
+                record = RecordsToFlush.front();
+            }
+        }
+
+        return MakeFuture<TResultOrError<NCloud::NProto::TJournalRecord>>(
+            std::move(record));
+    }
+
+    void MarkRecordAsFlushed(ui64 lsn) override
+    {
+        with_lock (Mutex) {
+            if (!RecordsToFlush.empty() &&
+                RecordsToFlush.front().GetLogSequenceNumber() == lsn)
+            {
+                RecordsToFlush.pop_front();
+            }
+
+            FlushedLsns.push_back(lsn);
+        }
+    }
+
+    TFuture<NCloud::NProto::TError> CleanupFlushedRecords() override
+    {
+        with_lock (Mutex) {
+            ++CleanupCount;
+        }
+
+        return MakeFuture(NCloud::NProto::TError());
+    }
+
+    // helpers
+
+    void AddRecordToFlush(NCloud::NProto::TJournalRecord record)
+    {
+        with_lock (Mutex) {
+            RecordsToFlush.push_back(std::move(record));
+        }
+    }
+
+    TVector<ui64> GetFlushedLsns() const
+    {
+        with_lock (Mutex) {
+            return FlushedLsns;
+        }
+    }
+
+    ui32 GetCleanupCount() const
+    {
+        with_lock (Mutex) {
+            return CleanupCount;
+        }
+    }
+
+    ui32 GetRestoreCount() const
+    {
+        with_lock (Mutex) {
+            return RestoreCount;
+        }
+    }
+
+    TVector<NCloud::NProto::TReadPagesRequest> GetReadRequests() const
+    {
+        with_lock (Mutex) {
+            return ReadRequests;
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestDevice final: public IDevice
+{
+    using TReadHandler = std::function<NCloud::NProto::TReadPagesResponse(
+        const NCloud::NProto::TReadPagesRequest&)>;
+    using TWriteHandler =
+        std::function<NCloud::NProto::TWriteLogRecordResponse(
+            const NCloud::NProto::TWriteLogRecordRequest&)>;
+
+    TReadHandler ReadHandler = ServePagesFromDevice;
+
+    TWriteHandler WriteHandler = [] (const auto& request) {
+        Y_UNUSED(request);
+        return NCloud::NProto::TWriteLogRecordResponse();
+    };
+
+    mutable TMutex Mutex;
+    TVector<NCloud::NProto::TReadPagesRequest> ReadRequests;
+    TVector<NCloud::NProto::TWriteLogRecordRequest> WriteRequests;
+
+    // IDevice
+
+    TFuture<NCloud::NProto::TReadPagesResponse> ReadPages(
+        NCloud::NProto::TReadPagesRequest request) override
+    {
+        with_lock (Mutex) {
+            ReadRequests.push_back(request);
+        }
+
+        return MakeFuture(ReadHandler(request));
+    }
+
+    TFuture<NCloud::NProto::TWriteLogRecordResponse> WritePages(
+        NCloud::NProto::TWriteLogRecordRequest request) override
+    {
+        with_lock (Mutex) {
+            WriteRequests.push_back(request);
+        }
+
+        return MakeFuture(WriteHandler(request));
+    }
+
+    // helpers
+
+    TVector<NCloud::NProto::TReadPagesRequest> GetReadRequests() const
+    {
+        with_lock (Mutex) {
+            return ReadRequests;
+        }
+    }
+
+    TVector<NCloud::NProto::TWriteLogRecordRequest> GetWriteRequests() const
+    {
+        with_lock (Mutex) {
+            return WriteRequests;
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    ILoggingServicePtr Logging;
+    TExecutorPtr Executor;
+
+    std::shared_ptr<TTestJournal> Journal;
+    std::shared_ptr<TTestDevice> DataStore;
+
+    IJournalledDevicePtr Device;
+
+    void SetUp(NUnitTest::TTestContext& /*context*/) override
+    {
+        Logging = CreateLoggingService(
+            "console",
+            {.FiltrationLevel = TLOG_RESOURCES});
+        Logging->Start();
+
+        Executor = TExecutor::Create("TestExecutor");
+        Executor->Start();
+
+        Journal = std::make_shared<TTestJournal>();
+        DataStore = std::make_shared<TTestDevice>();
+
+        Device = CreateJournalledDeviceV2(Logging, Executor, Journal, DataStore);
+    }
+
+    void TearDown(NUnitTest::TTestContext& /*context*/) override
+    {
+        Device->Stop();
+        Executor->Stop();
+        Logging->Stop();
+    }
+
+    NCloud::NProto::TReadPagesResponse ReadPages(
+        NCloud::NProto::TReadPagesRequest request)
+    {
+        return Device->ReadPages(std::move(request)).GetValueSync();
+    }
+
+    void WaitForAllRecordsToBeFlushed()
+    {
+        UNIT_ASSERT(Journal->AllRecordsFlushed.WaitT(TDuration::Seconds(30)));
+        Journal->AllRecordsFlushed.Reset();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TJournalledDeviceV2Test)
+{
+    Y_UNIT_TEST_F(ShouldReadAllPagesFromTheJournal, TFixture)
+    {
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse({MakeGroup(10, 4, "J")}, 42);
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 4}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "10:[J10,J11,J12,J13]",
+            DescribeGroups(response));
+        UNIT_ASSERT_VALUES_EQUAL(42, response.GetLastAckedLogSequenceNumber());
+
+        // the data store has not been touched at all
+
+        UNIT_ASSERT_VALUES_EQUAL(0, DataStore->GetReadRequests().size());
+    }
+
+    Y_UNIT_TEST_F(ShouldReadAllPagesFromTheDataStore, TFixture)
+    {
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse({}, 7);
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 4}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        // the whole request has been forwarded to the data store as is
+
+        const auto deviceRequests = DataStore->GetReadRequests();
+        UNIT_ASSERT_VALUES_EQUAL(1, deviceRequests.size());
+        UNIT_ASSERT_VALUES_EQUAL("10+4@4096", DescribeRefs(deviceRequests[0]));
+        UNIT_ASSERT_VALUES_EQUAL(
+            DefaultDeviceUUID,
+            deviceRequests[0].GetDeviceUUID());
+        UNIT_ASSERT_VALUES_EQUAL(
+            DefaultClientId,
+            deviceRequests[0].GetHeaders().GetClientId());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "10:[D10,D11,D12,D13]",
+            DescribeGroups(response));
+
+        // the lsn is taken from the journal response
+
+        UNIT_ASSERT_VALUES_EQUAL(7, response.GetLastAckedLogSequenceNumber());
+    }
+
+    Y_UNIT_TEST_F(ShouldRequestOnlyMissingPagesFromTheDataStore, TFixture)
+    {
+        // the journal covers the middle of the requested range
+
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse({MakeGroup(12, 3, "J")}, 100);
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 10}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        const auto deviceRequests = DataStore->GetReadRequests();
+        UNIT_ASSERT_VALUES_EQUAL(1, deviceRequests.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "10+2@4096, 15+5@4096",
+            DescribeRefs(deviceRequests[0]));
+
+        // the response is shaped after the request, not after the sources
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "10:[D10,D11,J12,J13,J14,D15,D16,D17,D18,D19]",
+            DescribeGroups(response));
+        UNIT_ASSERT_VALUES_EQUAL(100, response.GetLastAckedLogSequenceNumber());
+    }
+
+    Y_UNIT_TEST_F(ShouldRequestMissingPagesForEveryPageGroupRef, TFixture)
+    {
+        // the first journal group covers the tail of the first ref and goes
+        // beyond it, the second one covers the head of the second ref
+
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse(
+                {MakeGroup(2, 4, "J"), MakeGroup(100, 2, "J")});
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{0, 4}, {100, 4}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        const auto deviceRequests = DataStore->GetReadRequests();
+        UNIT_ASSERT_VALUES_EQUAL(1, deviceRequests.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "0+2@4096, 102+2@4096",
+            DescribeRefs(deviceRequests[0]));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "0:[D0,D1,J2,J3] 100:[J100,J101,D102,D103]",
+            DescribeGroups(response));
+    }
+
+    Y_UNIT_TEST_F(ShouldIgnoreEmptyJournalPageGroups, TFixture)
+    {
+        // a page group without content covers nothing
+
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse(
+                {MakeGroup(10, 0, "J"), MakeGroup(20, 2, "J")});
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 4}, {20, 2}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        const auto deviceRequests = DataStore->GetReadRequests();
+        UNIT_ASSERT_VALUES_EQUAL(1, deviceRequests.size());
+        UNIT_ASSERT_VALUES_EQUAL("10+4@4096", DescribeRefs(deviceRequests[0]));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "10:[D10,D11,D12,D13] 20:[J20,J21]",
+            DescribeGroups(response));
+    }
+
+    Y_UNIT_TEST_F(ShouldSkipEmptyPageGroupRefs, TFixture)
+    {
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return NCloud::NProto::TReadPagesResponse();
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 0}, {20, 2}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        const auto deviceRequests = DataStore->GetReadRequests();
+        UNIT_ASSERT_VALUES_EQUAL(1, deviceRequests.size());
+        UNIT_ASSERT_VALUES_EQUAL("20+2@4096", DescribeRefs(deviceRequests[0]));
+
+        UNIT_ASSERT_VALUES_EQUAL("20:[D20,D21]", DescribeGroups(response));
+    }
+
+    Y_UNIT_TEST_F(ShouldShapeTheResponseAfterTheRequest, TFixture)
+    {
+        // the journal holds a wider page group than the requested one
+
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse({MakeGroup(8, 8, "J")}, 42);
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 4}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        // only the requested pages are returned
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "10:[J10,J11,J12,J13]",
+            DescribeGroups(response));
+        UNIT_ASSERT_VALUES_EQUAL(42, response.GetLastAckedLogSequenceNumber());
+        UNIT_ASSERT_VALUES_EQUAL(0, DataStore->GetReadRequests().size());
+    }
+
+    Y_UNIT_TEST_F(ShouldPreferJournalPagesOverDataStorePages, TFixture)
+    {
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse({MakeGroup(12, 2, "J")});
+        };
+
+        // the data store returns more pages than it has been asked for
+
+        DataStore->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse({MakeGroup(10, 4, "D")});
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 4}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "10:[D10,D11,J12,J13]",
+            DescribeGroups(response));
+    }
+
+    Y_UNIT_TEST_F(ShouldFailIfAPageIsMissingInBothResponses, TFixture)
+    {
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse({MakeGroup(10, 1, "J")});
+        };
+
+        // the data store does not return the missing page
+
+        DataStore->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return NCloud::NProto::TReadPagesResponse();
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 2}}));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_INVALID_STATE,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+        UNIT_ASSERT_STRING_CONTAINS(
+            response.GetError().GetMessage(),
+            "page 11 is missing");
+    }
+
+    Y_UNIT_TEST_F(ShouldHandleJournalReadError, TFixture)
+    {
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return NCloud::NProto::TReadPagesResponse(
+                TErrorResponse(E_IO, "journal is broken"));
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 4}}));
+
+        UNIT_ASSERT_VALUES_EQUAL(E_IO, response.GetError().GetCode());
+        UNIT_ASSERT_STRING_CONTAINS(
+            response.GetError().GetMessage(),
+            "journal is broken");
+
+        // the data store has not been touched
+
+        UNIT_ASSERT_VALUES_EQUAL(0, DataStore->GetReadRequests().size());
+    }
+
+    Y_UNIT_TEST_F(ShouldHandleDataStoreReadError, TFixture)
+    {
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return NCloud::NProto::TReadPagesResponse();
+        };
+
+        DataStore->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return NCloud::NProto::TReadPagesResponse(
+                TErrorResponse(E_IO, "device is broken"));
+        };
+
+        const auto response = ReadPages(MakeReadRequest({{10, 4}}));
+
+        UNIT_ASSERT_VALUES_EQUAL(E_IO, response.GetError().GetCode());
+        UNIT_ASSERT_STRING_CONTAINS(
+            response.GetError().GetMessage(),
+            "device is broken");
+    }
+
+    Y_UNIT_TEST_F(ShouldFlushJournalRecordsToTheDataStore, TFixture)
+    {
+        Journal->AddRecordToFlush(MakeRecord(1, 10, 2));
+        Journal->AddRecordToFlush(MakeRecord(2, 20, 1));
+        Journal->AddRecordToFlush(MakeRecord(3, 30, 3));
+
+        Device->Start();
+        UNIT_ASSERT_VALUES_EQUAL(1, Journal->GetRestoreCount());
+
+        WaitForAllRecordsToBeFlushed();
+        Device->Stop();
+
+        const auto writes = DataStore->GetWriteRequests();
+        UNIT_ASSERT_VALUES_EQUAL(3, writes.size());
+        UNIT_ASSERT_VALUES_EQUAL("10:[J10,J11]", DescribeGroups(writes[0]));
+        UNIT_ASSERT_VALUES_EQUAL("20:[J20]", DescribeGroups(writes[1]));
+        UNIT_ASSERT_VALUES_EQUAL("30:[J30,J31,J32]", DescribeGroups(writes[2]));
+
+        // every flushed record has been acked in the journal
+
+        const auto flushedLsns = Journal->GetFlushedLsns();
+        UNIT_ASSERT_VALUES_EQUAL(3, flushedLsns.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, flushedLsns[0]);
+        UNIT_ASSERT_VALUES_EQUAL(2, flushedLsns[1]);
+        UNIT_ASSERT_VALUES_EQUAL(3, flushedLsns[2]);
+
+        UNIT_ASSERT_GE(Journal->GetCleanupCount(), 1);
+    }
+
+    Y_UNIT_TEST_F(ShouldRetryFlushAfterDataStoreWriteError, TFixture)
+    {
+        std::atomic<ui32> writeCount = 0;
+
+        DataStore->WriteHandler = [&] (const auto& request)
+            -> NCloud::NProto::TWriteLogRecordResponse
+        {
+            Y_UNUSED(request);
+
+            if (++writeCount == 1) {
+                return TErrorResponse(E_IO, "device is busy");
+            }
+
+            return {};
+        };
+
+        Journal->AddRecordToFlush(MakeRecord(1, 10, 2));
+
+        Device->Start();
+        WaitForAllRecordsToBeFlushed();
+        Device->Stop();
+
+        // the record has been written twice: the failed attempt and the retry
+
+        const auto writes = DataStore->GetWriteRequests();
+        UNIT_ASSERT_VALUES_EQUAL(2, writes.size());
+        UNIT_ASSERT_VALUES_EQUAL("10:[J10,J11]", DescribeGroups(writes[0]));
+        UNIT_ASSERT_VALUES_EQUAL("10:[J10,J11]", DescribeGroups(writes[1]));
+
+        // the record has been acked only once, after the successful write
+
+        const auto flushedLsns = Journal->GetFlushedLsns();
+        UNIT_ASSERT_VALUES_EQUAL(1, flushedLsns.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, flushedLsns[0]);
+    }
+
+    Y_UNIT_TEST_F(ShouldNotStartWhenJournalRestoreFails, TFixture)
+    {
+        Journal->RestoreError = MakeError(E_IO, "journal is broken");
+        Journal->AddRecordToFlush(MakeRecord(1, 10, 2));
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            Device->Start(),
+            yexception,
+            "journal is broken");
+
+        // the flush cycle has not been started
+
+        UNIT_ASSERT_VALUES_EQUAL(0, DataStore->GetWriteRequests().size());
+        UNIT_ASSERT_VALUES_EQUAL(0, Journal->GetCleanupCount());
+    }
+
+    Y_UNIT_TEST_F(ShouldStopFlushCycle, TFixture)
+    {
+        Device->Start();
+        WaitForAllRecordsToBeFlushed();
+        Device->Stop();
+
+        const auto cleanupCount = Journal->GetCleanupCount();
+
+        // nothing happens after the device has been stopped
+
+        Journal->AddRecordToFlush(MakeRecord(1, 10, 2));
+
+        UNIT_ASSERT_VALUES_EQUAL(cleanupCount, Journal->GetCleanupCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, DataStore->GetWriteRequests().size());
+    }
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/public.h
+++ b/cloud/storage/core/libs/journalled_device/public.h
@@ -9,6 +9,9 @@ namespace NCloud::NJournalled {
 struct IDevice;
 using IDevicePtr = std::shared_ptr<IDevice>;
 
+struct IJournal;
+using IJournalPtr = std::shared_ptr<IJournal>;
+
 struct IJournalledDevice;
 using IJournalledDevicePtr = std::shared_ptr<IJournalledDevice>;
 

--- a/cloud/storage/core/libs/journalled_device/ut/ya.make
+++ b/cloud/storage/core/libs/journalled_device/ut/ya.make
@@ -4,6 +4,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
     journalled_device_ut.cpp
+    journalled_device_v2_ut.cpp
 )
 
 PEERDIR(

--- a/cloud/storage/core/libs/journalled_device/ya.make
+++ b/cloud/storage/core/libs/journalled_device/ya.make
@@ -2,11 +2,15 @@ LIBRARY()
 
 SRCS(
     device.cpp
+    journal.cpp
     journalled_device.cpp
+    journalled_device_v2.cpp
 )
 
 PEERDIR(
     cloud/storage/core/libs/common
+    cloud/storage/core/libs/coroutine
+    cloud/storage/core/libs/diagnostics
     cloud/storage/core/protos
 )
 

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server_ut.cpp
@@ -53,6 +53,12 @@ struct TTestBackend: public IServerBackend
     TReadJournalTailFunc ReadJournalTailImpl;
     TAdvanceLsnLowWatermarkFunc AdvanceLsnLowWatermarkImpl;
 
+    void Start() override
+    {}
+
+    void Stop() override
+    {}
+
     [[nodiscard]] auto AcquireDevices(
         NProto::TAcquireDevicesRequest request)
         -> TFuture<NProto::TAcquireDevicesResponse> final


### PR DESCRIPTION
### Notes
Introduce a TJournal class with the device/cleanup API declared and stubbed out with E_NOT_IMPLEMENTED, and a journalled device v2 built on top of it that combines journal and data store reads.

### Issue
https://github.com/ydb-platform/nbs/issues/6956
