### PR TITLE
Change default filestore-client verbose level from 'info' to 'warn'

### DIFF
--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -62,7 +62,7 @@ TCommand::TCommand()
 
     Opts.AddLongOption("verbose")
         .OptionalArgument("STR")
-        .DefaultValue("info")
+        .DefaultValue("warn")
         .StoreResult(&VerboseLevel);
 
     Opts.AddLongOption("mon-address")


### PR DESCRIPTION
### Notes
Right now, by default, the filestore client seems to print some info that is useful for debugging the client, but not on day-to-day basis:

```
$ filestore-client listfilestores
2026-09-07T16:15:15.651249Z :NFS_CLIENT INFO: cloud/filestore/apps/client/lib/command.cpp:199: Using config file /Berkanavt/nfs-server/cfg/nfs-client.txt
2026-09-07T16:15:15.654030Z :NFS_CLIENT INFO: cloud/filestore/libs/client/client.cpp:795: Connect to "/run/nbsd/nfs.sock" socket
...
2026-09-07T16:15:15.687050Z :NFS_CLIENT INFO: cloud/filestore/libs/client/client.cpp:656: Shutting down
```

Changed here: https://github.com/ydb-platform/nbs/pull/5532

### Issue
+1/-1 change, so no issue