### PR TITLE
issue-6957: proper storage group initialization and journal restoration

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.cpp
@@ -2174,6 +2174,8 @@ struct TStorageGroupFactory: IStorageGroupFactory
                 TDuration::MilliSeconds(config.GetRetryBackoffIncrementMs());
         }
 
+        groupConfig.JournalRestoreEnabled = config.GetJournalRestoreEnabled();
+
         if (sg.GetType() == NProtoPrivate::TStorageGroup::E_SG_QUORUM_MIRROR) {
             return CreateQuorumMirroredStorageGroup(
                 std::move(groupConfig),

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
@@ -86,6 +86,12 @@ struct TStorageGroupConfig
     ui64 AcquireGeneration = 0;
 
     TStorageGroupRetryPolicy RetryPolicy;
+
+    // How often the low watermark is pushed to the devices; zero never.
+    TDuration LowWatermarkPeriod = TDuration::Seconds(1);
+
+    // TODO(#6956): drop once every device supports the journal.
+    bool JournalRestoreEnabled = false;
 };
 
 /**

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_helpers.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_helpers.cpp
@@ -27,6 +27,18 @@ NProto::TWriteLogRecordRequest MakeWriteLogRecordRequest(
     return request;
 }
 
+NProto::TWriteLogRecordRequest MakeReplayRequest(
+    NProto::TDeviceRequestHeaders headers,
+    const NProto::TJournalRecord& record)
+{
+    NProto::TWriteLogRecordRequest request;
+    *request.MutableHeaders() = std::move(headers);
+    *request.MutablePageGroups() = record.GetPageGroups();
+    request.SetLogSequenceNumber(record.GetLogSequenceNumber());
+    request.SetPrevLogSequenceNumber(record.GetPrevLogSequenceNumber());
+    return request;
+}
+
 NProto::TReadPagesRequest MakeReadPagesRequest(
     NProto::TDeviceRequestHeaders headers,
     const TVector<TPageGroupRef>& pageGroupRefs)

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_helpers.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_helpers.h
@@ -4,17 +4,13 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 
-#include <silk/fibers/event.h>
 #include <silk/fibers/fiber.h>
 #include <silk/fibers/future.h>
-#include <silk/fibers/mutex.h>
 #include <silk/util/logger.h>
+
 #include <util/datetime/base.h>
 #include <util/generic/vector.h>
 #include <util/string/builder.h>
-
-#include <atomic>
-#include <mutex>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
@@ -77,6 +73,10 @@ NProto::TWriteLogRecordRequest MakeWriteLogRecordRequest(
     NProto::TDeviceRequestHeaders headers,
     const TVector<TPageGroup>& pageGroups,
     ui64 lsn);
+
+NProto::TWriteLogRecordRequest MakeReplayRequest(
+    NProto::TDeviceRequestHeaders headers,
+    const NProto::TJournalRecord& record);
 
 NProto::TReadPagesRequest MakeReadPagesRequest(
     NProto::TDeviceRequestHeaders headers,

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_quorum.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_quorum.cpp
@@ -262,7 +262,8 @@ int WriteDispatchFiberMain(TWriteDispatchParams* params) noexcept
 
 ////////////////////////////////////////////////////////////////////////////////
 
-using TJournalRecords = google::protobuf::RepeatedPtrField<NProto::TJournalRecord>;
+using TJournalRecords =
+    google::protobuf::RepeatedPtrField<NProto::TJournalRecord>;
 
 ui64 GetLastLsn(const NProto::TReadJournalTailResponse& journal)
 {
@@ -302,21 +303,21 @@ int ReplayFiberMain(TReplayParams* params) noexcept
 
 NProto::TError ReplayOnDevicesBehind(
     const TGroupStatePtr& state,
-    const TVector<ui64>& lsns,
+    const TVector<ui64>& maxLsnPerDevice,
     ui64 maxKnownLsn,
     const TJournalRecords& records)
 {
     TVector<ui32> proxyIndexesToReplay;
     TVector<ui32> journalPositionsToStartReplay;
-    for (ui32 i = 0; i < lsns.size(); ++i) {
-        if (lsns[i] == maxKnownLsn) {
+    for (ui32 i = 0; i < maxLsnPerDevice.size(); ++i) {
+        if (maxLsnPerDevice[i] == maxKnownLsn) {
             continue;
         }
 
         const auto it = std::upper_bound(
             records.begin(),
             records.end(),
-            lsns[i],
+            maxLsnPerDevice[i],
             [](ui64 lsn, const NProto::TJournalRecord& record)
             {
                 return lsn < record.GetLogSequenceNumber();
@@ -330,7 +331,7 @@ NProto::TError ReplayOnDevicesBehind(
                 TStringBuilder()
                     << "journal tail does not continue "
                     << state->Proxies[i]->DeviceUUID << " from lsn "
-                    << lsns[i]);
+                    << maxLsnPerDevice[i]);
         }
 
         proxyIndexesToReplay.push_back(i);
@@ -360,7 +361,8 @@ NProto::TError ReplayOnDevicesBehind(
             error = MakeError(
                 errors[i].GetCode(),
                 TStringBuilder()
-                    << "replay onto " << state->Proxies[proxyIndexesToReplay[i]]->DeviceUUID
+                    << "replay onto "
+                    << state->Proxies[proxyIndexesToReplay[i]]->DeviceUUID
                     << " failed: " << FormatError(errors[i]));
         }
     }
@@ -389,7 +391,8 @@ NProto::TError ReadRecordsAbove(
             E_INVALID_STATE,
             TStringBuilder()
                 << "journal of " << source.DeviceUUID
-                << " does not reach from lsn " << afterLsn << " to " << maxKnownLsn);
+                << " does not reach from lsn " << afterLsn << " to "
+                << maxKnownLsn);
     }
 
     return {};
@@ -404,7 +407,7 @@ struct TQueryPositionParams
 
 NProto::TError QueryCurrentJournalPosition(
     TGroupState& state,
-    TVector<ui64>& lsns)
+    TVector<ui64>& maxLsnPerDevice)
 {
     const ui32 count = state.Proxies.size();
 
@@ -430,7 +433,7 @@ NProto::TError QueryCurrentJournalPosition(
             },
             TQueryPositionParams{
                 .Proxy = state.Proxies[i],
-                .Lsn = &lsns[i],
+                .Lsn = &maxLsnPerDevice[i],
                 .Error = &errors[i]
             },
             &futures[i]);
@@ -462,20 +465,22 @@ NProto::TError QueryCurrentJournalPosition(
 // most advanced one and replays it onto everyone behind.
 NProto::TError RebuildJournal(const TGroupStatePtr& state)
 {
-    TVector<ui64> lsns(state->Proxies.size());
-    auto error = QueryCurrentJournalPosition(*state, lsns);
+    TVector<ui64> maxLsnPerDevice(state->Proxies.size());
+    auto error = QueryCurrentJournalPosition(*state, maxLsnPerDevice);
     if (HasError(error)) {
         return error;
     }
 
-    for (ui32 i = 0; i < lsns.size(); ++i) {
-        state->Proxies[i]->Seed(lsns[i]);
+    for (ui32 i = 0; i < maxLsnPerDevice.size(); ++i) {
+        state->Proxies[i]->Seed(maxLsnPerDevice[i]);
     }
 
-    auto low = std::min_element(lsns.begin(), lsns.end());
-    auto high = std::max_element(lsns.begin(), lsns.end());
+    auto low =
+        std::min_element(maxLsnPerDevice.begin(), maxLsnPerDevice.end());
+    auto high =
+        std::max_element(maxLsnPerDevice.begin(), maxLsnPerDevice.end());
     if (*low < *high) {
-        const ui32 source = std::distance(lsns.begin(), high);
+        const ui32 source = std::distance(maxLsnPerDevice.begin(), high);
 
         NProto::TReadJournalTailResponse tail;
         error = ReadRecordsAbove(*state->Proxies[source], *low, *high, &tail);
@@ -483,7 +488,11 @@ NProto::TError RebuildJournal(const TGroupStatePtr& state)
             return error;
         }
 
-        error = ReplayOnDevicesBehind(state, lsns, *high, tail.GetRecords());
+        error = ReplayOnDevicesBehind(
+            state,
+            maxLsnPerDevice,
+            *high,
+            tail.GetRecords());
         if (HasError(error)) {
             return error;
         }
@@ -598,7 +607,8 @@ public:
                     State->Timer));
         }
 
-        // Allow TearDown to pass by default. Init resets it upon launching loop.
+        // Allow TearDown to pass by default. Init resets it upon launching
+        // the loop.
         State->WatermarkLoopStopped.set(0);
     }
 

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_quorum.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_quorum.cpp
@@ -5,6 +5,7 @@
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
 #include <silk/fibers/mutex.h>
 #include <silk/fibers/sequencer.h>
 #include <silk/util/logger.h>
@@ -12,6 +13,7 @@
 #include <util/generic/vector.h>
 #include <util/string/builder.h>
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -67,11 +69,11 @@ class TDeviceProxy
 public:
     TDeviceProxy(
             TStorageDevice device,
-            TStorageGroupRetryPolicy retryPolicy,
+            TStorageGroupConfig config,
             ITimerPtr timer)
         : DeviceUUID(std::move(device.DeviceUUID))
         , StorageNode(std::move(device.Node))
-        , RetryPolicy(retryPolicy)
+        , Config(std::move(config))
         , Timer(std::move(timer))
     {}
 
@@ -83,7 +85,7 @@ public:
     NProto::TError Write(const NProto::TWriteLogRecordRequest& request)
     {
         auto response = CallWithRetries(
-            RetryPolicy,
+            Config.RetryPolicy,
             *Timer,
             [&]
             {
@@ -105,7 +107,7 @@ public:
         NProto::TReadPagesResponse* response)
     {
         *response = CallWithRetries(
-            RetryPolicy,
+            Config.RetryPolicy,
             *Timer,
             [&]
             {
@@ -117,12 +119,59 @@ public:
         return response->GetError();
     }
 
+    NProto::TError ReadJournalTail(
+        ui64 afterLsn,
+        ui32 maxRecords,
+        NProto::TReadJournalTailResponse* response)
+    {
+        NProto::TReadJournalTailRequest request;
+        FillHeaders(Config, request.MutableHeaders());
+        request.SetAfterLogSequenceNumber(afterLsn);
+        request.SetMaxRecordCount(maxRecords);
+
+        *response = CallWithRetries(
+            Config.RetryPolicy,
+            *Timer,
+            [&]
+            {
+                NProto::TReadJournalTailRequest deviceRequest = request;
+                deviceRequest.SetDeviceUUID(DeviceUUID);
+                return StorageNode->ReadJournalTail(std::move(deviceRequest));
+            });
+
+        return response->GetError();
+    }
+
+    // What the device reported at Init.
+    void Seed(ui64 lsn)
+    {
+        Acked.advance(lsn);
+    }
+
+    NProto::TError AdvanceLsnLowWatermark(ui64 lsn)
+    {
+        NProto::TAdvanceLsnLowWatermarkRequest request;
+        FillHeaders(Config, request.MutableHeaders());
+        request.SetDeviceUUID(DeviceUUID);
+        request.SetLsnLowWatermark(lsn);
+
+        auto response = CallWithRetries(
+            Config.RetryPolicy,
+            *Timer,
+            [&]
+            {
+                return StorageNode->AdvanceLsnLowWatermark(request);
+            });
+
+        return response.GetError();
+    }
+
 public:
     const TString DeviceUUID;
     const IStorageNodePtr StorageNode;
 
 private:
-    const TStorageGroupRetryPolicy RetryPolicy;
+    const TStorageGroupConfig Config;
     const ITimerPtr Timer;
 
     silk::FiberSequencer Acked;
@@ -134,6 +183,8 @@ using TDeviceProxyPtr = std::shared_ptr<TDeviceProxy>;
 
 struct TGroupState
 {
+    TStorageGroupConfig Config;
+    ITimerPtr Timer;
     TGroupHealth Health;
     TVector<TDeviceProxyPtr> Proxies;
     ui32 WriteQuorum = 0;
@@ -143,6 +194,14 @@ struct TGroupState
     // Highest lsn the group has acked so far. Readers use it as a basic filter
     // for the devices.
     silk::FiberSequencer QuorumLsn;
+
+    // Highest lsn acked by every device.
+    silk::FiberSequencer LowWatermarkLsn;
+
+    std::atomic<bool> Initialized = false;
+    std::atomic<bool> Stopped = false;
+
+    silk::FiberFuture WatermarkLoopStopped;
 };
 
 using TGroupStatePtr = std::shared_ptr<TGroupState>;
@@ -185,7 +244,8 @@ int WriteDispatchFiberMain(TWriteDispatchParams* params) noexcept
     auto& proxy = *params->Proxy;
 
     auto error = proxy.Write(params->Op->Request);
-    // Expect non-retriable code
+    // The proxy has already retried per the policy: whatever error is left
+    // is final for this device.
     if (HasError(error)) {
         // Break the group first, so the writer this wakes finds it broken.
         state.Health.Fail(error, proxy.DeviceUUID);
@@ -193,7 +253,322 @@ int WriteDispatchFiberMain(TWriteDispatchParams* params) noexcept
         return 0;
     }
 
-    params->Op->Acks.increment();
+    if (params->Op->Acks.increment() == state.Proxies.size()) {
+        state.LowWatermarkLsn.advance(params->Op->Lsn);
+    }
+
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TJournalRecords = google::protobuf::RepeatedPtrField<NProto::TJournalRecord>;
+
+ui64 GetLastLsn(const NProto::TReadJournalTailResponse& journal)
+{
+    if (!journal.GetRecords().empty()) {
+        return journal.GetRecords().rbegin()->GetLogSequenceNumber();
+    }
+
+    return 0;
+}
+
+struct TReplayParams
+{
+    TGroupStatePtr State;
+    TDeviceProxyPtr Proxy;
+    const TJournalRecords* Records;
+    ui32 StartPosition;
+    NProto::TError* Error;
+};
+
+int ReplayFiberMain(TReplayParams* params) noexcept
+{
+    const auto& records = *params->Records;
+    for (int i = params->StartPosition; i < records.size(); ++i) {
+        NProto::TDeviceRequestHeaders headers;
+        FillHeaders(params->State->Config, &headers);
+        auto error = params->Proxy->Write(
+            MakeReplayRequest(std::move(headers), records[i]));
+
+        if (HasError(error)) {
+            *params->Error = std::move(error);
+            break;
+        }
+    }
+
+    return 0;
+}
+
+NProto::TError ReplayOnDevicesBehind(
+    const TGroupStatePtr& state,
+    const TVector<ui64>& lsns,
+    ui64 maxKnownLsn,
+    const TJournalRecords& records)
+{
+    TVector<ui32> proxyIndexesToReplay;
+    TVector<ui32> journalPositionsToStartReplay;
+    for (ui32 i = 0; i < lsns.size(); ++i) {
+        if (lsns[i] == maxKnownLsn) {
+            continue;
+        }
+
+        const auto it = std::upper_bound(
+            records.begin(),
+            records.end(),
+            lsns[i],
+            [](ui64 lsn, const NProto::TJournalRecord& record)
+            {
+                return lsn < record.GetLogSequenceNumber();
+            });
+
+        auto startPos = std::distance(records.begin(), it);
+        if (startPos == records.size())
+        {
+            return MakeError(
+                E_INVALID_STATE,
+                TStringBuilder()
+                    << "journal tail does not continue "
+                    << state->Proxies[i]->DeviceUUID << " from lsn "
+                    << lsns[i]);
+        }
+
+        proxyIndexesToReplay.push_back(i);
+        journalPositionsToStartReplay.push_back(startPos);
+    }
+
+    TVector<silk::FiberFuture> futures(proxyIndexesToReplay.size());
+    TVector<NProto::TError> errors(proxyIndexesToReplay.size());
+    for (ui32 i = 0; i < proxyIndexesToReplay.size(); ++i) {
+        const int r = silk::FiberScheduler::run(
+            ReplayFiberMain,
+            TReplayParams{
+                .State = state,
+                .Proxy = state->Proxies[proxyIndexesToReplay[i]],
+                .Records = &records,
+                .StartPosition = journalPositionsToStartReplay[i],
+                .Error = &errors[i]
+            },
+            &futures[i]);
+        Y_ABORT_UNLESS(r == 0, "failed to spawn fiber: %s", ::strerror(r));
+    }
+
+    NProto::TError error;
+    for (ui32 i = 0; i < proxyIndexesToReplay.size(); ++i) {
+        futures[i].wait();
+        if (HasError(errors[i]) && !HasError(error)) {
+            error = MakeError(
+                errors[i].GetCode(),
+                TStringBuilder()
+                    << "replay onto " << state->Proxies[proxyIndexesToReplay[i]]->DeviceUUID
+                    << " failed: " << FormatError(errors[i]));
+        }
+    }
+
+    return error;
+}
+
+// Read records above @p afterLsn, from a device at @p maxKnownLsn.
+NProto::TError ReadRecordsAbove(
+    TDeviceProxy& source,
+    ui64 afterLsn,
+    ui64 maxKnownLsn,
+    NProto::TReadJournalTailResponse* tail)
+{
+    auto error = source.ReadJournalTail(afterLsn, 0 /*no limit*/, tail);
+    if (HasError(error)) {
+        return MakeError(
+            error.GetCode(),
+            TStringBuilder()
+                << "journal of " << source.DeviceUUID << " after lsn "
+                << afterLsn << ": " << FormatError(error));
+    }
+
+    if (GetLastLsn(*tail) != maxKnownLsn) {
+        return MakeError(
+            E_INVALID_STATE,
+            TStringBuilder()
+                << "journal of " << source.DeviceUUID
+                << " does not reach from lsn " << afterLsn << " to " << maxKnownLsn);
+    }
+
+    return {};
+}
+
+struct TQueryPositionParams
+{
+    TDeviceProxyPtr Proxy;
+    ui64* Lsn = nullptr;
+    NProto::TError* Error = nullptr;
+};
+
+NProto::TError QueryCurrentJournalPosition(
+    TGroupState& state,
+    TVector<ui64>& lsns)
+{
+    const ui32 count = state.Proxies.size();
+
+    TVector<silk::FiberFuture> futures(count);
+    TVector<NProto::TError> errors(count);
+    for (ui32 i = 0; i < count; ++i) {
+        const int r = silk::FiberScheduler::run<TQueryPositionParams>(
+            [] (TQueryPositionParams* params) noexcept
+            {
+                NProto::TReadJournalTailResponse response;
+                auto error = params->Proxy->ReadJournalTail(
+                    0, // after Lsn
+                    1, // max records
+                    &response);
+
+                if (HasError(error)) {
+                    *params->Error = std::move(error);
+                } else {
+                    *params->Lsn = response.GetLastAckedLogSequenceNumber();
+                }
+
+                return 0;
+            },
+            TQueryPositionParams{
+                .Proxy = state.Proxies[i],
+                .Lsn = &lsns[i],
+                .Error = &errors[i]
+            },
+            &futures[i]);
+        Y_ABORT_UNLESS(r == 0, "failed to spawn fiber: %s", ::strerror(r));
+    }
+
+    // Join everything before touching the results: the fibers write into
+    // this frame.
+    NProto::TError error;
+    for (ui32 i = 0; i < count; ++i) {
+        futures[i].wait();
+        if (!HasError(errors[i])) {
+            continue;
+        }
+
+        SILK_ERROR(
+            "sg position of %s: %s",
+            state.Proxies[i]->DeviceUUID.c_str(),
+            FormatError(errors[i]).c_str());
+        if (!HasError(error)) {
+            error = errors[i];
+        }
+    }
+
+    return error;
+}
+
+// Finds where every device is, reads what the slowest one lacks from the
+// most advanced one and replays it onto everyone behind.
+NProto::TError RebuildJournal(const TGroupStatePtr& state)
+{
+    TVector<ui64> lsns(state->Proxies.size());
+    auto error = QueryCurrentJournalPosition(*state, lsns);
+    if (HasError(error)) {
+        return error;
+    }
+
+    for (ui32 i = 0; i < lsns.size(); ++i) {
+        state->Proxies[i]->Seed(lsns[i]);
+    }
+
+    auto low = std::min_element(lsns.begin(), lsns.end());
+    auto high = std::max_element(lsns.begin(), lsns.end());
+    if (*low < *high) {
+        const ui32 source = std::distance(lsns.begin(), high);
+
+        NProto::TReadJournalTailResponse tail;
+        error = ReadRecordsAbove(*state->Proxies[source], *low, *high, &tail);
+        if (HasError(error)) {
+            return error;
+        }
+
+        error = ReplayOnDevicesBehind(state, lsns, *high, tail.GetRecords());
+        if (HasError(error)) {
+            return error;
+        }
+    }
+
+    state->QuorumLsn.advance(*high);
+    state->LowWatermarkLsn.advance(*high);
+
+    SILK_INFO("sg rebuild: every device at lsn %lu", *high);
+    return {};
+}
+
+struct TPushWatermarkParams
+{
+    TDeviceProxyPtr Proxy;
+    ui64 Watermark;
+    NProto::TError* Error;
+};
+
+void PushLowWatermarkEverywhere(TGroupState& state, ui64 watermark)
+{
+    const ui32 count = state.Proxies.size();
+    TVector<silk::FiberFuture> futures(count);
+    TVector<NProto::TError> errors(count);
+    for (ui32 i = 0; i < count; ++i) {
+        const int r = silk::FiberScheduler::run<TPushWatermarkParams>(
+            [] (TPushWatermarkParams* params) noexcept
+            {
+                *params->Error = params->Proxy->AdvanceLsnLowWatermark(
+                    params->Watermark);
+                return 0;
+            },
+            TPushWatermarkParams{
+                .Proxy = state.Proxies[i],
+                .Watermark = watermark,
+                .Error = &errors[i]},
+            &futures[i]);
+        Y_ABORT_UNLESS(r == 0, "failed to spawn fiber: %s", ::strerror(r));
+    }
+
+    for (ui32 i = 0; i < count; ++i) {
+        futures[i].wait();
+        if (!HasError(errors[i])) {
+            continue;
+        }
+
+        if (GetErrorKind(errors[i]) != EErrorKind::ErrorRetriable) {
+            state.Health.Fail(errors[i], state.Proxies[i]->DeviceUUID);
+            continue;
+        }
+
+        SILK_WARN(
+            "sg low watermark %lu not delivered to %s: %s",
+            watermark,
+            state.Proxies[i]->DeviceUUID.c_str(),
+            FormatError(errors[i]).c_str());
+    }
+}
+
+struct TWatermarkParams
+{
+    TGroupStatePtr State;
+};
+
+int LowWatermarkFiberMain(TWatermarkParams* params) noexcept
+{
+    auto& state = *params->State;
+    ui64 pushed = 0;   // last watermark pushed
+
+    for (;;) {
+        state.Timer->Sleep(state.Config.LowWatermarkPeriod);
+        if (state.Stopped || state.Health.IsBroken()) {
+            break;
+        }
+
+        const ui64 watermark = state.LowWatermarkLsn.get();
+        if (watermark <= pushed) {
+            continue;
+        }
+
+        // A refusal breaks the group; the loop notices after its next sleep,
+        // the only place it ever leaves from.
+        PushLowWatermarkEverywhere(state, watermark);
+        pushed = watermark;
+    }
     return 0;
 }
 
@@ -207,49 +582,78 @@ public:
             TVector<TStorageDevice> devices,
             ITimerPtr timer)
         : State(std::make_shared<TGroupState>())
-        , Config(std::move(config))
-        , Timer(std::move(timer))
     {
         // TODO(#5895): handle a bad device list gracefully instead of aborting.
         Y_ABORT_UNLESS(!devices.empty(), "storage group needs a device");
 
+        State->Config = std::move(config);
+        State->Timer = std::move(timer);
         State->WriteQuorum = devices.size() / 2 + 1;
         State->Proxies.reserve(devices.size());
         for (auto& device: devices) {
             State->Proxies.push_back(
                 std::make_shared<TDeviceProxy>(
                     std::move(device),
-                    Config.RetryPolicy,
-                    Timer));
+                    State->Config,
+                    State->Timer));
         }
+
+        // Allow TearDown to pass by default. Init resets it upon launching loop.
+        State->WatermarkLoopStopped.set(0);
     }
 
-    // TODO(#6957): rebuild the journal here.
     NProto::TError Init() override
     {
-        NProto::TAcquireDevicesRequest request;
-        request.SetGeneration(Config.AcquireGeneration);
-        return MirrorRequest<NProto::TAcquireDevicesResponse>(
-            Config,
+        NProto::TAcquireDevicesRequest acquire;
+        acquire.SetGeneration(State->Config.AcquireGeneration);
+        auto error = MirrorRequest<NProto::TAcquireDevicesResponse>(
+            State->Config,
             CollectDeviceList(*State),
-            *Timer,
+            *State->Timer,
             AcquireDevicesFiberMain,
-            std::move(request));
+            std::move(acquire));
+
+        if (HasError(error)) {
+            return error;
+        }
+
+        if (!State->Config.JournalRestoreEnabled) {
+            State->Initialized = true;
+            return {};
+        }
+
+        error = RebuildJournal(State);
+        if (HasError(error)) {
+            return error;
+        }
+
+        if (State->Config.LowWatermarkPeriod != TDuration::Zero()) {
+            State->WatermarkLoopStopped.reset();
+            const int r = silk::FiberScheduler::run(
+                LowWatermarkFiberMain,
+                TWatermarkParams{.State = State},
+                &State->WatermarkLoopStopped);
+            Y_ABORT_UNLESS(r == 0, "failed to spawn fiber: %s", ::strerror(r));
+        }
+
+        State->Initialized = true;
+        return {};
     }
 
     void TearDown() override
     {
-        if (TornDown) {
-            return;
-        }
-        TornDown = true;
+        State->Stopped = true;
+
+        // TODO(#6957): Need a proper cancellation token for requests inflight
+        State->WatermarkLoopStopped.wait();
 
         auto error = MirrorRequest<NProto::TReleaseDevicesResponse>(
-            Config,
+            State->Config,
             CollectDeviceList(*State),
-            *Timer,
+            *State->Timer,
             ReleaseDevicesFiberMain,
             NProto::TReleaseDevicesRequest{});
+
         if (HasError(error)) {
             SILK_WARN("sg release error=%s", FormatError(error).c_str());
         }
@@ -260,15 +664,15 @@ public:
         TVector<TPageGroup> pageGroups,
         ui64 lsn) override
     {
-        if (State->Health.IsBroken()) {
-            return State->Health.GetError();
+        if (auto error = CheckReady(); HasError(error)) {
+            return error;
         }
 
         if (!lsn) {
             return MakeError(E_ARGUMENT, "lsn must be positive");
         }
 
-        FillHeaders(Config, &headers);
+        FillHeaders(State->Config, &headers);
         auto op = std::make_shared<TWriteState>();
         op->Lsn = lsn;
         op->Request = MakeWriteLogRecordRequest(
@@ -285,13 +689,7 @@ public:
                     .Op = op,
                     .Proxy = proxy},
                 nullptr);
-
-            if (r) {
-                State->Health.Fail(
-                    MakeError(MAKE_SYSTEM_ERROR(r), "failed to spawn fiber"),
-                    proxy->DeviceUUID);
-                op->Acks.stop();
-            }
+            Y_ABORT_UNLESS(r == 0, "failed to spawn fiber: %s", ::strerror(r));
         }
 
         const int cancelled = op->Acks.wait(State->WriteQuorum);
@@ -317,12 +715,12 @@ public:
         const TVector<TPageGroupRef>& pageGroupRefs,
         TVector<TPageGroup>* pageGroups) override
     {
-        if (State->Health.IsBroken()) {
-            return State->Health.GetError();
+        if (auto error = CheckReady(); HasError(error)) {
+            return error;
         }
 
         pageGroups->clear();
-        FillHeaders(Config, &headers);
+        FillHeaders(State->Config, &headers);
         const auto request = MakeReadPagesRequest(
             std::move(headers),
             pageGroupRefs);
@@ -334,9 +732,9 @@ public:
             std::memory_order_relaxed);
 
         NProto::TError lastError = MakeError(
-        E_INVALID_STATE,
-        TStringBuilder()
-            << "no replica has reached expected lsn " << required);
+            E_INVALID_STATE,
+            TStringBuilder()
+                << "no replica has reached expected lsn " << required);
 
         for (ui32 j = 0; j < count; ++j) {
             auto& proxy = *State->Proxies[(start + j) % count];
@@ -363,10 +761,20 @@ public:
     }
 
 private:
+    NProto::TError CheckReady() const
+    {
+        if (State->Health.IsBroken()) {
+            return State->Health.GetError();
+        }
+        if (!State->Initialized) {
+            return MakeError(E_REJECTED, "storage group is not initialized");
+        }
+
+        return {};
+    }
+
+private:
     TGroupStatePtr State;
-    const TStorageGroupConfig Config;
-    const ITimerPtr Timer;
-    bool TornDown = false;
 };
 
 }   // namespace

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
@@ -75,11 +75,14 @@ using TGroupFactory = IStorageGroupPtr (*)(
     TVector<TStorageDevice>,
     ITimerPtr);
 
+// No watermark fiber unless a test asks for one.
 TStorageGroupConfig MakeTestConfig()
 {
     TStorageGroupConfig config;
     config.ClientId = "test-client";
     config.AcquireGeneration = 42;
+    config.LowWatermarkPeriod = TDuration::Zero();
+    config.JournalRestoreEnabled = true;
     return config;
 }
 
@@ -95,7 +98,10 @@ struct TStorageFixture
     std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
     IStorageGroupPtr Group;
 
-    TStorageFixture(TGroupFactory createGroup = CreateNaiveMirroredStorageGroup)
+    TStorageFixture(
+            TGroupFactory createGroup = CreateNaiveMirroredStorageGroup,
+            TStorageGroupConfig config = MakeTestConfig(),
+            ITimerPtr timer = nullptr)
         : StorageNodes(NodeCount)
     {
         TVector<TStorageDevice> devices(NodeCount);
@@ -107,24 +113,147 @@ struct TStorageFixture
             };
         }
 
-        Group = createGroup(MakeTestConfig(), std::move(devices), Timer);
+        Group = createGroup(
+            std::move(config),
+            std::move(devices),
+            timer ? std::move(timer) : Timer);
     }
 };
 
+/**
+ * A timer whose Sleep waits for the test to call TickOnce, which lets the
+ * watermark fiber run exactly one iteration and returns once the fiber is
+ * parked in Sleep again. Sleep announces itself before waiting, so the fiber
+ * is parked exactly when Sleeps == Ticks + 1.
+ */
+struct TTickTimer: ITimer
+{
+    silk::FiberSequencer Ticks;    // test to fiber
+    silk::FiberSequencer Sleeps;   // fiber to test: Sleep calls made
+
+    TInstant Now() override
+    {
+        return TInstant::Now();
+    }
+
+    void Sleep(TDuration duration) override
+    {
+        Y_UNUSED(duration);
+        (void)Ticks.wait(Sleeps.increment());
+    }
+
+    void TickOnce()
+    {
+        (void)Sleeps.wait(Ticks.get() + 1);
+        (void)Sleeps.wait(Ticks.increment() + 1);
+    }
+
+    // Ticks until the predicate holds, each tick being one full iteration of
+    // the loop. A tick right after a write may find the third ack not yet
+    // counted, hence more than one.
+    template <typename TPredicate>
+    bool TickUntil(TPredicate predicate)
+    {
+        for (ui32 i = 0; i < 100; ++i) {
+            TickOnce();
+            if (predicate()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Lets the fiber out of Sleep for good, so TearDown can join it.
+    void Stop()
+    {
+        Ticks.stop();
+    }
+};
+
+// A quorum group over the fakes; init = false leaves it to the test, so it
+// can script the journals first.
 struct TQuorumFixture: TStorageFixture
 {
-    TQuorumFixture()
-        : TStorageFixture(CreateQuorumMirroredStorageGroup)
+    std::shared_ptr<TTickTimer> TickTimer;
+
+    TQuorumFixture(
+            bool init = true,
+            TStorageGroupConfig config = MakeTestConfig(),
+            std::shared_ptr<TTickTimer> tickTimer = nullptr)
+        : TStorageFixture(
+              CreateQuorumMirroredStorageGroup,
+              std::move(config),
+              tickTimer)
+        , TickTimer(std::move(tickTimer))
     {
-        auto error = Group->Init();
-        EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+        if (init) {
+            auto error = Group->Init();
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+        }
     }
 
     ~TQuorumFixture()
     {
+        if (TickTimer) {
+            TickTimer->Stop();
+        }
         Group->TearDown();
     }
 };
+
+// Ticks until every device has been pushed a watermark.
+void TickUntilPushed(TStorageFixture& fx, TTickTimer& timer)
+{
+    const bool pushed = timer.TickUntil(
+        [&]
+        {
+            for (const auto& sn: fx.StorageNodes) {
+                if (sn->AdvanceLsnLowWatermarkCalls.empty()) {
+                    return false;
+                }
+            }
+            return true;
+        });
+    EXPECT_TRUE(pushed) << "watermark never pushed";
+}
+
+// A group with the watermark fiber on.
+TStorageGroupConfig WatermarkConfig()
+{
+    auto config = MakeTestConfig();
+    config.LowWatermarkPeriod = TDuration::MilliSeconds(1);
+    // A refused push is reported at once instead of sleeping on the tick
+    // timer, which would count as the fiber parking in its own Sleep.
+    config.RetryPolicy.TotalTimeout = TDuration::Zero();
+    return config;
+}
+
+// What a device answers to ReadJournalTail.
+NProto::TReadJournalTailResponse JournalTail(std::initializer_list<ui64> lsns)
+{
+    NProto::TReadJournalTailResponse response;
+    for (ui64 lsn: lsns) {
+        auto* record = response.AddRecords();
+        record->SetLogSequenceNumber(lsn);
+        record->SetPrevLogSequenceNumber(lsn - 1);
+        auto* pg = record->AddPageGroups();
+        pg->SetFirstPageNo(lsn);
+        pg->AddContent(TStringBuilder() << "lsn" << lsn);
+        response.SetLastAckedLogSequenceNumber(lsn);
+    }
+    return response;
+}
+
+TVector<ui64> WrittenLsns(const TStorageFixture& fx, ui32 i)
+{
+    TVector<ui64> lsns;
+    for (const auto& w: fx.StorageNodes[i]->WriteCalls) {
+        lsns.push_back(w.GetLogSequenceNumber());
+    }
+    return lsns;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 //
 // The tests below use the default retry policy (300s total timeout, 0.5s
@@ -646,6 +775,23 @@ void WaitUntilServes(TStorageFixture& fx, ui32 i)
     EXPECT_GT(fx.StorageNodes[i]->ReadCalls.size(), 0U);
 }
 
+// Three reads hit three different replicas only if all of them are eligible.
+void ExpectEveryReplicaServes(TStorageFixture& fx)
+{
+    for (auto& sn: fx.StorageNodes) {
+        sn->ReadCalls.clear();
+        sn->ReadResp = NProto::TReadPagesResponse{};
+    }
+    for (ui32 i = 0; i < TQuorumFixture::NodeCount; ++i) {
+        TVector<TPageGroup> pageGroups;
+        auto error = ReadSomething(*fx.Group, &pageGroups);
+        EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+    }
+    for (ui32 i = 0; i < TQuorumFixture::NodeCount; ++i) {
+        EXPECT_EQ(1U, fx.StorageNodes[i]->ReadCalls.size()) << "dev " << i;
+    }
+}
+
 }   // namespace
 
 TEST(QuorumGroupTest, InitAcquiresEveryDeviceWithTheGeneration)
@@ -653,7 +799,7 @@ TEST(QuorumGroupTest, InitAcquiresEveryDeviceWithTheGeneration)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TStorageFixture fx(CreateQuorumMirroredStorageGroup);
+            TQuorumFixture fx(false);
 
             auto error = fx.Group->Init();
             EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
@@ -668,10 +814,16 @@ TEST(QuorumGroupTest, InitAcquiresEveryDeviceWithTheGeneration)
                 EXPECT_EQ(
                     "test-client",
                     sn->AcquireCalls[0].GetHeaders().GetClientId());
+                // a position query, not a journal read
+                EXPECT_EQ(1U, sn->ReadJournalTailCalls.size());
+                EXPECT_EQ(
+                    0U,
+                    sn->ReadJournalTailCalls[0].GetAfterLogSequenceNumber());
+                EXPECT_EQ(1U, sn->ReadJournalTailCalls[0].GetMaxRecordCount());
             }
 
             fx.Group->TearDown();
-            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+            for (ui32 i = 0; i < TQuorumFixture::NodeCount; ++i) {
                 EXPECT_EQ(1U, fx.StorageNodes[i]->ReleaseCalls.size());
             }
 
@@ -686,7 +838,7 @@ TEST(QuorumGroupTest, InitFailsIfAnyDeviceRefusesAcquire)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TStorageFixture fx(CreateQuorumMirroredStorageGroup);
+            TQuorumFixture fx(false);
 
             // Acquire is n/n: one bad device is enough to fail the group.
             *fx.StorageNodes[2]->AcquireResp.MutableError() =
@@ -696,6 +848,445 @@ TEST(QuorumGroupTest, InitFailsIfAnyDeviceRefusesAcquire)
             EXPECT_EQ(E_ARGUMENT, error.GetCode()) << error.GetMessage();
 
             fx.Group->TearDown();
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitFailsIfAnyDeviceCannotReportItsLsn)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            // n/n, like acquire
+            *fx.StorageNodes[2]->ReadJournalTailResp.MutableError() =
+                MakeError(E_ARGUMENT, "scripted error");
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(E_ARGUMENT, error.GetCode()) << error.GetMessage();
+
+            fx.Group->TearDown();
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitSeedsFromDevicesAndCatchesUpTheLaggingOne)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            // dev-a and dev-b at 10, dev-c at 7; dev-a serves the tail
+            fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({8, 9, 10});
+            fx.StorageNodes[1]->ReadJournalTailResp = JournalTail({10});
+            fx.StorageNodes[2]->ReadJournalTailResp = JournalTail({7});
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+
+            EXPECT_EQ((TVector<ui64>{8, 9, 10}), WrittenLsns(fx, 2));
+            if (WrittenLsns(fx, 2).size() != 3) {
+                return 1;
+            }
+            const auto& replay = fx.StorageNodes[2]->WriteCalls[0];
+            EXPECT_EQ(7U, replay.GetPrevLogSequenceNumber());
+            EXPECT_EQ("lsn8", replay.GetPageGroups(0).GetContent(0));
+            EXPECT_EQ(0U, fx.StorageNodes[0]->WriteCalls.size());
+            EXPECT_EQ(0U, fx.StorageNodes[1]->WriteCalls.size());
+
+            // dev-b included, which was never written to
+            ExpectEveryReplicaServes(fx);
+
+            error = WriteSomething(*fx.Group, 11);
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+            WaitFor([&] { return TotalWriteCalls(fx) == 6; });
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                const auto& w = fx.StorageNodes[i]->WriteCalls.back();
+                EXPECT_EQ(11U, w.GetLogSequenceNumber());
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitWithEveryDeviceAtTheSameLsnServesAtOnce)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            for (auto& sn: fx.StorageNodes) {
+                sn->ReadJournalTailResp = JournalTail({9, 10});
+            }
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+
+            EXPECT_EQ(0U, TotalWriteCalls(fx));
+            ExpectEveryReplicaServes(fx);
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitFailsIfTheTailStopsShortOfTheReportedLsn)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            // dev-a says 10, but the tail it serves stops at 9
+            fx.StorageNodes[0]->ReadJournalTailRespQueue.push_back(
+                JournalTail({8, 9, 10}));
+            fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({8, 9});
+            fx.StorageNodes[1]->ReadJournalTailResp = JournalTail({10});
+            fx.StorageNodes[2]->ReadJournalTailResp = JournalTail({7});
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(E_INVALID_STATE, error.GetCode()) << error.GetMessage();
+            EXPECT_EQ(0U, TotalWriteCalls(fx));
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitFailsIfAReplayIsRefused)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({8, 9, 10});
+            fx.StorageNodes[1]->ReadJournalTailResp = JournalTail({10});
+            fx.StorageNodes[2]->ReadJournalTailResp = JournalTail({7});
+            fx.StorageNodes[2]->WriteResp = WriteErrorResponse(E_ARGUMENT);
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(E_ARGUMENT, error.GetCode()) << error.GetMessage();
+            EXPECT_TRUE(error.GetMessage().Contains("dev-c")) << error.GetMessage();
+
+            TVector<TPageGroup> pageGroups;
+            error = ReadSomething(*fx.Group, &pageGroups);
+            EXPECT_EQ(E_REJECTED, error.GetCode()) << error.GetMessage();
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitWithoutJournalRestoreOnlyAcquires)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            // Restore off, watermark period on: neither may touch the
+            // devices, which do not implement either call.
+            auto config = WatermarkConfig();
+            config.JournalRestoreEnabled = false;
+            TQuorumFixture fx(false, config);
+
+            for (auto& sn: fx.StorageNodes) {
+                *sn->ReadJournalTailResp.MutableError() =
+                    MakeError(E_NOT_IMPLEMENTED, "ReadJournalTail");
+                *sn->AdvanceLsnLowWatermarkResp.MutableError() =
+                    MakeError(E_NOT_IMPLEMENTED, "AdvanceLsnLowWatermark");
+            }
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+            ExpectEveryReplicaServes(fx);
+
+            error = WriteSomething(*fx.Group);
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+            WaitFor([&] { return TotalWriteCalls(fx) == 3; });
+
+            for (auto& sn: fx.StorageNodes) {
+                EXPECT_EQ(0U, sn->ReadJournalTailCalls.size());
+                EXPECT_EQ(0U, sn->AdvanceLsnLowWatermarkCalls.size());
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitReplaysEverythingOntoAnEmptyDevice)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            // dev-c has nothing at all: the whole tail goes onto it
+            fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({1, 2, 3});
+            fx.StorageNodes[1]->ReadJournalTailResp = JournalTail({3});
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+
+            EXPECT_EQ((TVector<ui64>{1, 2, 3}), WrittenLsns(fx, 2));
+            EXPECT_EQ(0U, fx.StorageNodes[0]->WriteCalls.size());
+            EXPECT_EQ(0U, fx.StorageNodes[1]->WriteCalls.size());
+            ExpectEveryReplicaServes(fx);
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, TearDownBeforeInitReleasesAndReturns)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            // No watermark fiber was ever started: nothing to wait for.
+            fx.Group->TearDown();
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                EXPECT_EQ(1U, fx.StorageNodes[i]->ReleaseCalls.size());
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitTakesThePositionFromTheAckedLsnField)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            // A position query may come back without records at all.
+            for (auto& sn: fx.StorageNodes) {
+                sn->ReadJournalTailResp.SetLastAckedLogSequenceNumber(10);
+            }
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+
+            // everyone at 10: no tail read, no replay
+            for (auto& sn: fx.StorageNodes) {
+                EXPECT_EQ(1U, sn->ReadJournalTailCalls.size());
+            }
+            EXPECT_EQ(0U, TotalWriteCalls(fx));
+            ExpectEveryReplicaServes(fx);
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, InitJoinsEveryReplayEvenIfOneIsRefused)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            TQuorumFixture fx(false);
+
+            // dev-b and dev-c both lag; dev-c refuses its replay
+            fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({8, 9, 10});
+            fx.StorageNodes[1]->ReadJournalTailResp = JournalTail({7});
+            fx.StorageNodes[2]->ReadJournalTailResp = JournalTail({7});
+            fx.StorageNodes[2]->WriteResp = WriteErrorResponse(E_ARGUMENT);
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(E_ARGUMENT, error.GetCode()) << error.GetMessage();
+            EXPECT_TRUE(error.GetMessage().Contains("dev-c")) << error.GetMessage();
+
+            // dev-b was caught up regardless
+            EXPECT_EQ((TVector<ui64>{8, 9, 10}), WrittenLsns(fx, 1));
+            EXPECT_EQ(1U, fx.StorageNodes[2]->WriteCalls.size());
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, LowWatermarkFollowsTheSlowestDevice)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            auto timer = std::make_shared<TTickTimer>();
+            TQuorumFixture fx(true, WatermarkConfig(), timer);
+
+            fx.StorageNodes[2]->Paused = true;
+            auto error = WriteSomething(*fx.Group);
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+
+            // dev-c has not acked the record, so nothing may be trimmed
+            // anywhere yet: a trimmed peer could never replay it to dev-c.
+            timer->TickOnce();
+            for (ui32 i = 0; i < TQuorumFixture::NodeCount; ++i) {
+                EXPECT_EQ(
+                    0U,
+                    fx.StorageNodes[i]->AdvanceLsnLowWatermarkCalls.size());
+            }
+
+            fx.StorageNodes[2]->Unpause();
+            TickUntilPushed(fx, *timer);
+            for (ui32 i = 0; i < TQuorumFixture::NodeCount; ++i) {
+                const auto& calls = fx.StorageNodes[i]->AdvanceLsnLowWatermarkCalls;
+                EXPECT_EQ(1U, calls.size()) << "dev " << i;
+                if (calls.size() != 1) {
+                    return 1;
+                }
+                EXPECT_EQ(1234U, calls[0].GetLsnLowWatermark());
+            }
+
+            // Nothing moved: nothing is pushed again.
+            timer->TickOnce();
+            for (ui32 i = 0; i < TQuorumFixture::NodeCount; ++i) {
+                EXPECT_EQ(
+                    1U,
+                    fx.StorageNodes[i]->AdvanceLsnLowWatermarkCalls.size());
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, LowWatermarkStartsFromTheRestoredPosition)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            auto timer = std::make_shared<TTickTimer>();
+            TQuorumFixture fx(false, WatermarkConfig(), timer);
+
+            // Every device restored at 10: that is acked everywhere by
+            // definition, so the first round pushes it.
+            for (auto& sn: fx.StorageNodes) {
+                sn->ReadJournalTailResp = JournalTail({10});
+            }
+
+            auto error = fx.Group->Init();
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+
+            TickUntilPushed(fx, *timer);
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                const auto& calls = fx.StorageNodes[i]->AdvanceLsnLowWatermarkCalls;
+                EXPECT_EQ(1U, calls.size()) << "dev " << i;
+                if (calls.size() == 1) {
+                    EXPECT_EQ(10U, calls[0].GetLsnLowWatermark());
+                }
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, LowWatermarkMissedByADeviceReachesItWithTheNextOne)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            auto timer = std::make_shared<TTickTimer>();
+            TQuorumFixture fx(true, WatermarkConfig(), timer);
+
+            // Retriable and out of retries at once (see WatermarkConfig)
+            *fx.StorageNodes[2]->AdvanceLsnLowWatermarkResp.MutableError() =
+                MakeError(E_REJECTED, "scripted error");
+
+            auto error = WriteSomething(*fx.Group);
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+            TickUntilPushed(fx, *timer);
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                EXPECT_EQ(
+                    1U,
+                    fx.StorageNodes[i]->AdvanceLsnLowWatermarkCalls.size())
+                    << "dev " << i;
+            }
+
+            // The miss is not repeated: dev-c just keeps a few extra records.
+            fx.StorageNodes[2]->AdvanceLsnLowWatermarkResp = {};
+            timer->TickOnce();
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                EXPECT_EQ(
+                    1U,
+                    fx.StorageNodes[i]->AdvanceLsnLowWatermarkCalls.size())
+                    << "dev " << i;
+            }
+
+            // The next watermark reaches dev-c like everyone else.
+            error = WriteSomething(*fx.Group, 2000);
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+            WaitFor([&] { return TotalWriteCalls(fx) == 6; });
+            EXPECT_TRUE(timer->TickUntil(
+                [&]
+                {
+                    for (const auto& sn: fx.StorageNodes) {
+                        if (sn->AdvanceLsnLowWatermarkCalls.size() != 2) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }));
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                const auto& calls = fx.StorageNodes[i]->AdvanceLsnLowWatermarkCalls;
+                EXPECT_EQ(2U, calls.size()) << "dev " << i;
+                if (calls.size() == 2) {
+                    EXPECT_EQ(2000U, calls[1].GetLsnLowWatermark());
+                }
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(QuorumGroupTest, LowWatermarkRefusedOutrightBreaksTheGroup)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int
+        {
+            auto timer = std::make_shared<TTickTimer>();
+            TQuorumFixture fx(true, WatermarkConfig(), timer);
+
+            *fx.StorageNodes[2]->AdvanceLsnLowWatermarkResp.MutableError() =
+                MakeError(E_ARGUMENT, "scripted error");
+
+            auto error = WriteSomething(*fx.Group);
+            EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+            WaitFor([&] { return TotalWriteCalls(fx) == 3; });
+
+            // The refused push breaks the group before the loop parks again.
+            TickUntilPushed(fx, *timer);
+
+            error = WriteSomething(*fx.Group, 3);
+            EXPECT_EQ(E_INVALID_STATE, error.GetCode()) << error.GetMessage();
+            EXPECT_TRUE(error.GetMessage().Contains("dev-c")) << error.GetMessage();
+            EXPECT_EQ(3U, TotalWriteCalls(fx));
+
             return 0;
         },
         0);

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
@@ -139,13 +139,16 @@ struct TTickTimer: ITimer
     void Sleep(TDuration duration) override
     {
         Y_UNUSED(duration);
-        (void)Ticks.wait(Sleeps.increment());
+        int r = Ticks.wait(Sleeps.increment());
+        Y_UNUSED(r);
     }
 
     void TickOnce()
     {
-        (void)Sleeps.wait(Ticks.get() + 1);
-        (void)Sleeps.wait(Ticks.increment() + 1);
+        int r = Sleeps.wait(Ticks.get() + 1);
+        Y_UNUSED(r);
+        r = Sleeps.wait(Ticks.increment() + 1);
+        Y_UNUSED(r);
     }
 
     // Ticks until the predicate holds, each tick being one full iteration of
@@ -799,7 +802,7 @@ TEST(QuorumGroupTest, InitAcquiresEveryDeviceWithTheGeneration)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             auto error = fx.Group->Init();
             EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
@@ -838,7 +841,7 @@ TEST(QuorumGroupTest, InitFailsIfAnyDeviceRefusesAcquire)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             // Acquire is n/n: one bad device is enough to fail the group.
             *fx.StorageNodes[2]->AcquireResp.MutableError() =
@@ -859,7 +862,7 @@ TEST(QuorumGroupTest, InitFailsIfAnyDeviceCannotReportItsLsn)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             // n/n, like acquire
             *fx.StorageNodes[2]->ReadJournalTailResp.MutableError() =
@@ -880,7 +883,7 @@ TEST(QuorumGroupTest, InitSeedsFromDevicesAndCatchesUpTheLaggingOne)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             // dev-a and dev-b at 10, dev-c at 7; dev-a serves the tail
             fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({8, 9, 10});
@@ -891,12 +894,13 @@ TEST(QuorumGroupTest, InitSeedsFromDevicesAndCatchesUpTheLaggingOne)
             EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
 
             EXPECT_EQ((TVector<ui64>{8, 9, 10}), WrittenLsns(fx, 2));
-            if (WrittenLsns(fx, 2).size() != 3) {
-                return 1;
+            const auto& replays = fx.StorageNodes[2]->WriteCalls;
+            for (ui32 i = 0; i < replays.size(); ++i) {
+                EXPECT_EQ(7 + i, replays[i].GetPrevLogSequenceNumber());
+                EXPECT_EQ(
+                    TStringBuilder() << "lsn" << 8 + i,
+                    replays[i].GetPageGroups(0).GetContent(0));
             }
-            const auto& replay = fx.StorageNodes[2]->WriteCalls[0];
-            EXPECT_EQ(7U, replay.GetPrevLogSequenceNumber());
-            EXPECT_EQ("lsn8", replay.GetPageGroups(0).GetContent(0));
             EXPECT_EQ(0U, fx.StorageNodes[0]->WriteCalls.size());
             EXPECT_EQ(0U, fx.StorageNodes[1]->WriteCalls.size());
 
@@ -922,7 +926,7 @@ TEST(QuorumGroupTest, InitWithEveryDeviceAtTheSameLsnServesAtOnce)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             for (auto& sn: fx.StorageNodes) {
                 sn->ReadJournalTailResp = JournalTail({9, 10});
@@ -945,7 +949,7 @@ TEST(QuorumGroupTest, InitFailsIfTheTailStopsShortOfTheReportedLsn)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             // dev-a says 10, but the tail it serves stops at 9
             fx.StorageNodes[0]->ReadJournalTailRespQueue.push_back(
@@ -969,7 +973,7 @@ TEST(QuorumGroupTest, InitFailsIfAReplayIsRefused)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({8, 9, 10});
             fx.StorageNodes[1]->ReadJournalTailResp = JournalTail({10});
@@ -999,7 +1003,7 @@ TEST(QuorumGroupTest, InitWithoutJournalRestoreOnlyAcquires)
             // devices, which do not implement either call.
             auto config = WatermarkConfig();
             config.JournalRestoreEnabled = false;
-            TQuorumFixture fx(false, config);
+            TQuorumFixture fx(false /* init */, config);
 
             for (auto& sn: fx.StorageNodes) {
                 *sn->ReadJournalTailResp.MutableError() =
@@ -1032,7 +1036,7 @@ TEST(QuorumGroupTest, InitReplaysEverythingOntoAnEmptyDevice)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             // dev-c has nothing at all: the whole tail goes onto it
             fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({1, 2, 3});
@@ -1057,7 +1061,7 @@ TEST(QuorumGroupTest, TearDownBeforeInitReleasesAndReturns)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             // No watermark fiber was ever started: nothing to wait for.
             fx.Group->TearDown();
@@ -1076,7 +1080,7 @@ TEST(QuorumGroupTest, InitTakesThePositionFromTheAckedLsnField)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             // A position query may come back without records at all.
             for (auto& sn: fx.StorageNodes) {
@@ -1104,7 +1108,7 @@ TEST(QuorumGroupTest, InitJoinsEveryReplayEvenIfOneIsRefused)
     const int r = FiberScheduler::run(
         +[](int*) noexcept -> int
         {
-            TQuorumFixture fx(false);
+            TQuorumFixture fx(false /* init */);
 
             // dev-b and dev-c both lag; dev-c refuses its replay
             fx.StorageNodes[0]->ReadJournalTailResp = JournalTail({8, 9, 10});
@@ -1132,7 +1136,7 @@ TEST(QuorumGroupTest, LowWatermarkFollowsTheSlowestDevice)
         +[](int*) noexcept -> int
         {
             auto timer = std::make_shared<TTickTimer>();
-            TQuorumFixture fx(true, WatermarkConfig(), timer);
+            TQuorumFixture fx(true /* init */, WatermarkConfig(), timer);
 
             fx.StorageNodes[2]->Paused = true;
             auto error = WriteSomething(*fx.Group);
@@ -1178,7 +1182,7 @@ TEST(QuorumGroupTest, LowWatermarkStartsFromTheRestoredPosition)
         +[](int*) noexcept -> int
         {
             auto timer = std::make_shared<TTickTimer>();
-            TQuorumFixture fx(false, WatermarkConfig(), timer);
+            TQuorumFixture fx(false /* init */, WatermarkConfig(), timer);
 
             // Every device restored at 10: that is acked everywhere by
             // definition, so the first round pushes it.
@@ -1210,7 +1214,7 @@ TEST(QuorumGroupTest, LowWatermarkMissedByADeviceReachesItWithTheNextOne)
         +[](int*) noexcept -> int
         {
             auto timer = std::make_shared<TTickTimer>();
-            TQuorumFixture fx(true, WatermarkConfig(), timer);
+            TQuorumFixture fx(true /* init */, WatermarkConfig(), timer);
 
             // Retriable and out of retries at once (see WatermarkConfig)
             *fx.StorageNodes[2]->AdvanceLsnLowWatermarkResp.MutableError() =
@@ -1270,7 +1274,7 @@ TEST(QuorumGroupTest, LowWatermarkRefusedOutrightBreaksTheGroup)
         +[](int*) noexcept -> int
         {
             auto timer = std::make_shared<TTickTimer>();
-            TQuorumFixture fx(true, WatermarkConfig(), timer);
+            TQuorumFixture fx(true /* init */, WatermarkConfig(), timer);
 
             *fx.StorageNodes[2]->AdvanceLsnLowWatermarkResp.MutableError() =
                 MakeError(E_ARGUMENT, "scripted error");

--- a/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.cpp
+++ b/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.cpp
@@ -63,8 +63,8 @@ NCloud::NProto::TReadJournalTailResponse TFakeStorageNode::ReadJournalTail(
 {
     with_lock (Lock) {
         ReadJournalTailCalls.push_back(std::move(request));
+        return PopResponse(ReadJournalTailRespQueue, ReadJournalTailResp);
     }
-    return ReadJournalTailResp;
 }
 
 NCloud::NProto::TAdvanceLsnLowWatermarkResponse

--- a/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h
@@ -51,6 +51,7 @@ struct TFakeStorageNode: public IStorageNode
     TDeque<NCloud::NProto::TReleaseDevicesResponse> ReleaseRespQueue;
     TDeque<NCloud::NProto::TReadPagesResponse> ReadRespQueue;
     TDeque<NCloud::NProto::TWriteLogRecordResponse> WriteRespQueue;
+    TDeque<NCloud::NProto::TReadJournalTailResponse> ReadJournalTailRespQueue;
 
     NCloud::NProto::TAcquireDevicesResponse AcquireDevices(
         NCloud::NProto::TAcquireDevicesRequest request) override;

--- a/cloud/filestore/private/api/unsafe_protos/unsafe.proto
+++ b/cloud/filestore/private/api/unsafe_protos/unsafe.proto
@@ -177,6 +177,9 @@ message TPersistentFastShardConfig
     // 5min total timeout, 500ms backoff increment.
     uint64 RetryTotalTimeoutMs = 4;
     uint64 RetryBackoffIncrementMs = 5;
+
+    // TODO(#6956): drop once every device supports the journal.
+    bool JournalRestoreEnabled = 20;
 }
 
 message TMemFastShardConfig


### PR DESCRIPTION
### Notes
- added init/deinit routines for storage group
- resyncing journal across devices upon init of a storage group,  
- async wait for fastdatashard init upon tablet bootstrap
- properly bootstrapping fastdatashard across stack.

### Issue
https://github.com/ydb-platform/nbs/issues/6957
