### PR TITLE
issue-7053: hidden subdirectory with fsid special file

### DIFF
--- a/cloud/filestore/libs/storage/api/service.h
+++ b/cloud/filestore/libs/storage/api/service.h
@@ -44,7 +44,6 @@ namespace NCloud::NFileStore::NStorage {
 
 #define FILESTORE_SERVICE_REQUESTS_FWD_TO_SHARD_BY_HANDLE(xxx, ...)            \
     xxx(ConfirmCreateHandle,                __VA_ARGS__)                       \
-    xxx(DestroyHandle,                      __VA_ARGS__)                       \
     xxx(AllocateData,                       __VA_ARGS__)                       \
                                                                                \
     xxx(AcquireLock,                        __VA_ARGS__)                       \
@@ -64,6 +63,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
     xxx(RenameNode,                         __VA_ARGS__)                       \
     xxx(UnlinkNode,                         __VA_ARGS__)                       \
+    xxx(DestroyHandle,                      __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_HANDLE
 
 #define FILESTORE_SERVICE_REQUESTS(xxx, ...)                                   \

--- a/cloud/filestore/libs/storage/api/service.h
+++ b/cloud/filestore/libs/storage/api/service.h
@@ -39,7 +39,6 @@ namespace NCloud::NFileStore::NStorage {
     xxx(SetNodeAttr,                        __VA_ARGS__)                       \
     xxx(RemoveNodeXAttr,                    __VA_ARGS__)                       \
                                                                                \
-    xxx(UnlinkNode,                         __VA_ARGS__)                       \
     xxx(ReadLink,                           __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_FWD_TO_SHARD_BY_NODE_ID
 
@@ -64,6 +63,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(SetNodeXAttr,                       __VA_ARGS__)                       \
     xxx(ListNodeXAttr,                      __VA_ARGS__)                       \
     xxx(RenameNode,                         __VA_ARGS__)                       \
+    xxx(UnlinkNode,                         __VA_ARGS__)                       \
 // FILESTORE_SERVICE_REQUESTS_HANDLE
 
 #define FILESTORE_SERVICE_REQUESTS(xxx, ...)                                   \

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -30,6 +30,8 @@ namespace NCloud::NFileStore::NProto {
 
 namespace NCloud::NFileStore::NStorage {
 
+enum class EControlNamespaceEntry;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMethod>
@@ -152,6 +154,12 @@ private:
     void CompleteRequest(
         const NActors::TActorContext& ctx,
         const typename TMethod::TResponse::TPtr& ev);
+
+    bool IsControlNamespaceReservedIno(ui64 nodeId) const;
+
+    EControlNamespaceEntry ClassifyControlNamespace(
+        ui64 nodeId,
+        TStringBuf name) const;
 
     // Control namespace (".filestore-ctl") hooks - true if the request was
     // answered here and the caller should return

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -23,6 +23,7 @@
 #include <contrib/ydb/library/actors/core/mon.h>
 
 #include <util/datetime/base.h>
+#include <util/generic/maybe.h>
 
 namespace NCloud::NFileStore::NProto {
     class TProfileLogRequestInfo;
@@ -154,6 +155,15 @@ private:
     void CompleteRequest(
         const NActors::TActorContext& ctx,
         const typename TMethod::TResponse::TPtr& ev);
+
+    // Returns Nothing() when the control namespace feature is disabled,
+    // otherwise classifies the (parent, name) pair or the ino into a control
+    // namespace entry
+    TMaybe<EControlNamespaceEntry> ClassifyControlNamespace(
+        ui64 nodeId,
+        TStringBuf name) const;
+
+    TMaybe<EControlNamespaceEntry> ClassifyControlNamespace(ui64 ino) const;
 
     bool IsControlNamespaceReservedIno(ui64 nodeId) const;
 

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -183,6 +183,10 @@ private:
         const NActors::TActorContext& ctx,
         const TEvService::TEvRenameNodeRequest::TPtr& ev,
         const TSessionInfo* session);
+    bool TryHandleControlNamespaceUnlinkNode(
+        const NActors::TActorContext& ctx,
+        const TEvService::TEvUnlinkNodeRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceGetNodeXAttr(
         const NActors::TActorContext& ctx,
         const TEvService::TEvGetNodeXAttrRequest::TPtr& ev,

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -157,10 +157,6 @@ private:
 
     bool IsControlNamespaceReservedIno(ui64 nodeId) const;
 
-    EControlNamespaceEntry ClassifyControlNamespace(
-        ui64 nodeId,
-        TStringBuf name) const;
-
     // Control namespace (".filestore-ctl") hooks - true if the request was
     // answered here and the caller should return
     bool TryHandleControlNamespaceGetNodeAttr(

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -187,6 +187,10 @@ private:
         const NActors::TActorContext& ctx,
         const TEvService::TEvUnlinkNodeRequest::TPtr& ev,
         const TSessionInfo* session);
+    bool TryHandleControlNamespaceDestroyHandle(
+        const NActors::TActorContext& ctx,
+        const TEvService::TEvDestroyHandleRequest::TPtr& ev,
+        const TSessionInfo* session);
     bool TryHandleControlNamespaceGetNodeXAttr(
         const NActors::TActorContext& ctx,
         const TEvService::TEvGetNodeXAttrRequest::TPtr& ev,

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
@@ -1,19 +1,202 @@
 #include "service_actor.h"
 
+#include "service_actor_control_namespace.h"
+
+#include <cloud/filestore/libs/service/error.h>
+#include <cloud/filestore/libs/service/filestore.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs - no control namespace logic yet, every hook is a no-op.
+
+EControlNamespaceEntry ClassifyControlNamespaceEntry(ui64 nodeId)
+{
+    if (nodeId == ControlDirIno) {
+        return EControlNamespaceEntry::ControlDir;
+    }
+    if (nodeId == ControlFsIdFileIno) {
+        return EControlNamespaceEntry::FsId;
+    }
+    return EControlNamespaceEntry::None;
+}
+
+EControlNamespaceEntry ClassifyControlNamespaceEntry(
+    ui64 parentId,
+    TStringBuf name,
+    TStringBuf controlNamespaceDirName)
+{
+    if (parentId == RootNodeId && name == controlNamespaceDirName) {
+        return EControlNamespaceEntry::ControlDir;
+    }
+    if (parentId == ControlDirIno) {
+        return name == ControlFsIdFileName ? EControlNamespaceEntry::FsId
+                                           : EControlNamespaceEntry::Unknown;
+    }
+    if (parentId == ControlFsIdFileIno) {
+        // fsid is a file - it has no children, but be defensive.
+        return EControlNamespaceEntry::Unknown;
+    }
+    return EControlNamespaceEntry::None;
+}
+
+void FillControlDirAttr(NProto::TNodeAttr& attr)
+{
+    attr.SetId(ControlDirIno);
+    attr.SetType(NProto::E_DIRECTORY_NODE);
+    attr.SetMode(0555);
+    attr.SetLinks(2);
+    attr.SetSize(0);
+}
+
+void FillControlFsIdAttr(NProto::TNodeAttr& attr, const TString& fileSystemId)
+{
+    attr.SetId(ControlFsIdFileIno);
+    attr.SetType(NProto::E_REGULAR_NODE);
+    attr.SetMode(0444);
+    attr.SetLinks(1);
+    attr.SetSize(fileSystemId.size());
+}
+
+NProto::TError ControlNamespaceReadOnlyError()
+{
+    return MakeError(E_FS_ACCESS, "control namespace files are read-only");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BuildControlNamespaceResponse specializations, for the self-lookup-by-ino
+// forms reached via ForwardRequestToShard rather than a dedicated
+// TryHandleControlNamespaceXxx above.
+
+template <>
+std::unique_ptr<TEvService::TGetNodeAttrMethod::TResponse>
+BuildControlNamespaceResponse<TEvService::TGetNodeAttrMethod>(
+    const TEvService::TGetNodeAttrMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId)
+{
+    const auto& record = ev->Get()->Record;
+    auto response =
+        std::make_unique<TEvService::TGetNodeAttrMethod::TResponse>();
+    switch (ClassifyControlNamespaceEntry(record.GetNodeId())) {
+        case EControlNamespaceEntry::ControlDir:
+            FillControlDirAttr(*response->Record.MutableNode());
+            break;
+        case EControlNamespaceEntry::FsId:
+            FillControlFsIdAttr(*response->Record.MutableNode(), fileSystemId);
+            break;
+        default:
+            *response->Record.MutableError() =
+                MakeError(E_FS_NOENT, "not found");
+            break;
+    }
+    return response;
+}
+
+template <>
+std::unique_ptr<TEvService::TCreateHandleMethod::TResponse>
+BuildControlNamespaceResponse<TEvService::TCreateHandleMethod>(
+    const TEvService::TCreateHandleMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId)
+{
+    const auto& record = ev->Get()->Record;
+    auto response =
+        std::make_unique<TEvService::TCreateHandleMethod::TResponse>();
+
+    const auto entry = ClassifyControlNamespaceEntry(record.GetNodeId());
+    if (entry != EControlNamespaceEntry::ControlDir &&
+        entry != EControlNamespaceEntry::FsId)
+    {
+        *response->Record.MutableError() = MakeError(E_FS_NOENT, "not found");
+        return response;
+    }
+
+    const bool wantsWrite = HasFlag(
+        record.GetFlags(),
+        ProtoFlag(NProto::TCreateHandleRequest::E_WRITE));
+    if (wantsWrite) {
+        *response->Record.MutableError() = ControlNamespaceReadOnlyError();
+        return response;
+    }
+
+    if (entry == EControlNamespaceEntry::ControlDir) {
+        response->Record.SetHandle(ControlDirIno);
+        FillControlDirAttr(*response->Record.MutableNodeAttr());
+    } else {
+        response->Record.SetHandle(ControlFsIdFileIno);
+        FillControlFsIdAttr(*response->Record.MutableNodeAttr(), fileSystemId);
+    }
+    return response;
+}
+
+template <>
+std::unique_ptr<TEvService::TConfirmCreateHandleMethod::TResponse>
+BuildControlNamespaceResponse<TEvService::TConfirmCreateHandleMethod>(
+    const TEvService::TConfirmCreateHandleMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId)
+{
+    Y_UNUSED(ev);
+    Y_UNUSED(fileSystemId);
+    // nothing real to confirm - the handle was synthesized locally
+    return std::make_unique<
+        TEvService::TConfirmCreateHandleMethod::TResponse>();
+}
+
+template <>
+std::unique_ptr<TEvService::TDestroyHandleMethod::TResponse>
+BuildControlNamespaceResponse<TEvService::TDestroyHandleMethod>(
+    const TEvService::TDestroyHandleMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId)
+{
+    Y_UNUSED(ev);
+    Y_UNUSED(fileSystemId);
+    // nothing real to destroy - the handle was synthesized locally
+    return std::make_unique<TEvService::TDestroyHandleMethod::TResponse>();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
     const TActorContext& ctx,
     const TEvService::TEvGetNodeAttrRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    auto* msg = ev->Get();
+    const auto& controlNamespaceDirName =
+        StorageConfig->GetControlNamespaceDirName();
+
+    if (controlNamespaceDirName.empty() || msg->Record.GetName().empty()) {
+        return false;
+    }
+
+    const auto entry = ClassifyControlNamespaceEntry(
+        msg->Record.GetNodeId(),
+        msg->Record.GetName(),
+        controlNamespaceDirName);
+
+    if (Y_LIKELY(entry == EControlNamespaceEntry::None)) {
+        return false;
+    }
+
+    auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>();
+    switch (entry) {
+        case EControlNamespaceEntry::ControlDir:
+            FillControlDirAttr(*response->Record.MutableNode());
+            break;
+        case EControlNamespaceEntry::FsId:
+            FillControlFsIdAttr(
+                *response->Record.MutableNode(),
+                session->FileStore.GetFileSystemId());
+            break;
+        default:
+            *response->Record.MutableError() =
+                MakeError(E_FS_NOENT, "not found");
+            break;
+    }
+    NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
@@ -21,8 +204,45 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
     const TEvService::TEvCreateHandleRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    auto* msg = ev->Get();
+    const auto& controlNamespaceDirName =
+        StorageConfig->GetControlNamespaceDirName();
+
+    if (controlNamespaceDirName.empty() || msg->Record.GetName().empty()) {
+        return false;
+    }
+
+    const auto entry = ClassifyControlNamespaceEntry(
+        msg->Record.GetNodeId(),
+        msg->Record.GetName(),
+        controlNamespaceDirName);
+
+    if (Y_LIKELY(entry == EControlNamespaceEntry::None)) {
+        return false;
+    }
+
+    auto response = std::make_unique<TEvService::TEvCreateHandleResponse>();
+
+    const bool wantsWrite = HasFlag(
+        msg->Record.GetFlags(),
+        ProtoFlag(NProto::TCreateHandleRequest::E_WRITE));
+
+    if (entry == EControlNamespaceEntry::Unknown) {
+        *response->Record.MutableError() = MakeError(E_FS_NOENT, "not found");
+    } else if (wantsWrite) {
+        *response->Record.MutableError() = ControlNamespaceReadOnlyError();
+    } else if (entry == EControlNamespaceEntry::ControlDir) {
+        response->Record.SetHandle(ControlDirIno);
+        FillControlDirAttr(*response->Record.MutableNodeAttr());
+    } else {
+        response->Record.SetHandle(ControlFsIdFileIno);
+        FillControlFsIdAttr(
+            *response->Record.MutableNodeAttr(),
+            session->FileStore.GetFileSystemId());
+    }
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceCreateNode(
@@ -30,17 +250,71 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateNode(
     const TEvService::TEvCreateNodeRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    Y_UNUSED(session);
+    auto* msg = ev->Get();
+    const auto& controlNamespaceDirName =
+        StorageConfig->GetControlNamespaceDirName();
+
+    if (controlNamespaceDirName.empty()) {
+        return false;
+    }
+
+    const auto entry = ClassifyControlNamespaceEntry(
+        msg->Record.GetNodeId(),
+        msg->Record.GetName(),
+        controlNamespaceDirName);
+
+    // A hard link's target can also be a reserved ino - reject that too
+    const auto linkTargetEntry =
+        msg->Record.HasLink() ? ClassifyControlNamespaceEntry(
+                                    msg->Record.GetLink().GetTargetNode())
+                              : EControlNamespaceEntry::None;
+
+    if (Y_LIKELY(
+            entry == EControlNamespaceEntry::None &&
+            linkTargetEntry == EControlNamespaceEntry::None))
+    {
+        return false;
+    }
+
+    auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
+        ControlNamespaceReadOnlyError());
+    NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
 }
 
+// Handles for this namespace are just the target inodes
 bool TStorageServiceActor::TryHandleControlNamespaceReadData(
     const TActorContext& ctx,
     const TEvService::TEvReadDataRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    auto* msg = ev->Get();
+    const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetHandle());
+
+    if (StorageConfig->GetControlNamespaceDirName().empty() ||
+        Y_LIKELY(entry == EControlNamespaceEntry::None))
+    {
+        return false;
+    }
+
+    if (entry == EControlNamespaceEntry::ControlDir) {
+        auto response = std::make_unique<TEvService::TEvReadDataResponse>(
+            ErrorIsDirectory(ControlDirIno));
+        NCloud::Reply(ctx, *ev, std::move(response));
+        return true;
+    }
+
+    auto response = std::make_unique<TEvService::TEvReadDataResponse>();
+    const TString& content = session->FileStore.GetFileSystemId();
+    const ui64 offset = msg->Record.GetOffset();
+    const ui64 length = msg->Record.GetLength();
+    if (offset < content.size()) {
+        response->Record.SetBuffer(
+            content.substr(offset, Min<ui64>(content.size() - offset, length)));
+    }
+    NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceWriteData(
@@ -48,8 +322,21 @@ bool TStorageServiceActor::TryHandleControlNamespaceWriteData(
     const TEvService::TEvWriteDataRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    Y_UNUSED(session);
+    auto* msg = ev->Get();
+
+    if (StorageConfig->GetControlNamespaceDirName().empty() ||
+        Y_LIKELY(
+            ClassifyControlNamespaceEntry(msg->Record.GetHandle()) ==
+            EControlNamespaceEntry::None))
+    {
+        return false;
+    }
+
+    auto response = std::make_unique<TEvService::TEvWriteDataResponse>(
+        ControlNamespaceReadOnlyError());
+    NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceListNodes(
@@ -57,8 +344,25 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodes(
     const TEvService::TEvListNodesRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    auto* msg = ev->Get();
+
+    if (StorageConfig->GetControlNamespaceDirName().empty() ||
+        Y_LIKELY(
+            ClassifyControlNamespaceEntry(msg->Record.GetNodeId()) !=
+            EControlNamespaceEntry::ControlDir))
+    {
+        return false;
+    }
+
+    auto response = std::make_unique<TEvService::TEvListNodesResponse>();
+    if (msg->Record.GetCookie().empty()) {
+        response->Record.AddNames(TString(ControlFsIdFileName));
+        FillControlFsIdAttr(
+            *response->Record.AddNodes(),
+            session->FileStore.GetFileSystemId());
+    }
+    NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceRenameNode(
@@ -66,8 +370,35 @@ bool TStorageServiceActor::TryHandleControlNamespaceRenameNode(
     const TEvService::TEvRenameNodeRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    Y_UNUSED(session);
+    auto* msg = ev->Get();
+    const auto& controlNamespaceDirName =
+        StorageConfig->GetControlNamespaceDirName();
+
+    if (controlNamespaceDirName.empty()) {
+        return false;
+    }
+
+    const auto srcEntry = ClassifyControlNamespaceEntry(
+        msg->Record.GetNodeId(),
+        msg->Record.GetName(),
+        controlNamespaceDirName);
+    const auto dstEntry = ClassifyControlNamespaceEntry(
+        msg->Record.GetNewParentId(),
+        msg->Record.GetNewName(),
+        controlNamespaceDirName);
+
+    if (Y_LIKELY(
+            srcEntry == EControlNamespaceEntry::None &&
+            dstEntry == EControlNamespaceEntry::None))
+    {
+        return false;
+    }
+
+    auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(
+        ControlNamespaceReadOnlyError());
+    NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceGetNodeXAttr(
@@ -75,8 +406,23 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeXAttr(
     const TEvService::TEvGetNodeXAttrRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    if (StorageConfig->GetControlNamespaceDirName().empty() ||
+        Y_LIKELY(
+            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()) ==
+            EControlNamespaceEntry::None))
+    {
+        return false;
+    }
+
+    auto response =
+        std::make_unique<TEvService::TGetNodeXAttrMethod::TResponse>(
+            ErrorAttributeDoesNotExist(ev->Get()->Record.GetName()));
+    ReplyToXAttrRequest<TEvService::TGetNodeXAttrMethod>(
+        ctx,
+        ev,
+        std::move(response),
+        session);
+    return true;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceListNodeXAttr(
@@ -84,8 +430,22 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodeXAttr(
     const TEvService::TEvListNodeXAttrRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    if (StorageConfig->GetControlNamespaceDirName().empty() ||
+        Y_LIKELY(
+            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()) ==
+            EControlNamespaceEntry::None))
+    {
+        return false;
+    }
+
+    auto response =
+        std::make_unique<TEvService::TListNodeXAttrMethod::TResponse>();
+    ReplyToXAttrRequest<TEvService::TListNodeXAttrMethod>(
+        ctx,
+        ev,
+        std::move(response),
+        session);
+    return true;
 }
 
 bool TStorageServiceActor::TryHandleControlNamespaceSetNodeXAttr(
@@ -93,8 +453,23 @@ bool TStorageServiceActor::TryHandleControlNamespaceSetNodeXAttr(
     const TEvService::TEvSetNodeXAttrRequest::TPtr& ev,
     const TSessionInfo* session)
 {
-    Y_UNUSED(ctx, ev, session);
-    return false;
+    if (StorageConfig->GetControlNamespaceDirName().empty() ||
+        Y_LIKELY(
+            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()) ==
+            EControlNamespaceEntry::None))
+    {
+        return false;
+    }
+
+    auto response =
+        std::make_unique<TEvService::TSetNodeXAttrMethod::TResponse>(
+            ControlNamespaceReadOnlyError());
+    ReplyToXAttrRequest<TEvService::TSetNodeXAttrMethod>(
+        ctx,
+        ev,
+        std::move(response),
+        session);
+    return true;
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
@@ -345,13 +345,19 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodes(
     const TSessionInfo* session)
 {
     auto* msg = ev->Get();
+    const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetNodeId());
 
     if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(
-            ClassifyControlNamespaceEntry(msg->Record.GetNodeId()) !=
-            EControlNamespaceEntry::ControlDir))
+        Y_LIKELY(entry == EControlNamespaceEntry::None))
     {
         return false;
+    }
+
+    if (entry == EControlNamespaceEntry::FsId) {
+        auto response = std::make_unique<TEvService::TEvListNodesResponse>(
+            ErrorIsNotDirectory(ControlFsIdFileIno));
+        NCloud::Reply(ctx, *ev, std::move(response));
+        return true;
     }
 
     auto response = std::make_unique<TEvService::TEvListNodesResponse>();
@@ -396,6 +402,35 @@ bool TStorageServiceActor::TryHandleControlNamespaceRenameNode(
     }
 
     auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(
+        ControlNamespaceReadOnlyError());
+    NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
+}
+
+bool TStorageServiceActor::TryHandleControlNamespaceUnlinkNode(
+    const TActorContext& ctx,
+    const TEvService::TEvUnlinkNodeRequest::TPtr& ev,
+    const TSessionInfo* session)
+{
+    Y_UNUSED(session);
+    auto* msg = ev->Get();
+    const auto& controlNamespaceDirName =
+        StorageConfig->GetControlNamespaceDirName();
+
+    if (controlNamespaceDirName.empty()) {
+        return false;
+    }
+
+    const auto entry = ClassifyControlNamespaceEntry(
+        msg->Record.GetNodeId(),
+        msg->Record.GetName(),
+        controlNamespaceDirName);
+
+    if (Y_LIKELY(entry == EControlNamespaceEntry::None)) {
+        return false;
+    }
+
+    auto response = std::make_unique<TEvService::TEvUnlinkNodeResponse>(
         ControlNamespaceReadOnlyError());
     NCloud::Reply(ctx, *ev, std::move(response));
     return true;

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
@@ -78,6 +78,26 @@ NProto::TError ControlNamespaceNotPermittedError()
     return MakeError(E_FS_PERM, "not permitted on the control namespace");
 }
 
+bool TStorageServiceActor::IsControlNamespaceReservedIno(ui64 nodeId) const
+{
+    return !StorageConfig->GetControlNamespaceDirName().empty() &&
+        IsControlNamespaceEntry(ClassifyControlNamespaceEntry(nodeId));
+}
+
+EControlNamespaceEntry TStorageServiceActor::ClassifyControlNamespace(
+    ui64 nodeId,
+    TStringBuf name) const
+{
+    const auto& controlNamespaceDirName =
+        StorageConfig->GetControlNamespaceDirName();
+    if (controlNamespaceDirName.empty()) {
+        return EControlNamespaceEntry::None;
+    }
+    return name.empty()
+        ? ClassifyControlNamespaceEntry(nodeId)
+        : ClassifyControlNamespaceEntry(nodeId, name, controlNamespaceDirName);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
@@ -86,20 +106,9 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
     const TSessionInfo* session)
 {
     auto* msg = ev->Get();
-    const auto& controlNamespaceDirName =
-        StorageConfig->GetControlNamespaceDirName();
-
-    if (controlNamespaceDirName.empty()) {
-        return false;
-    }
-
-    const auto entry =
-        msg->Record.GetName().empty()
-            ? ClassifyControlNamespaceEntry(msg->Record.GetNodeId())
-            : ClassifyControlNamespaceEntry(
-                  msg->Record.GetNodeId(),
-                  msg->Record.GetName(),
-                  controlNamespaceDirName);
+    const auto entry = ClassifyControlNamespace(
+        msg->Record.GetNodeId(),
+        msg->Record.GetName());
 
     if (Y_LIKELY(!IsControlNamespaceEntry(entry))) {
         return false;
@@ -132,20 +141,9 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
     const TSessionInfo* session)
 {
     auto* msg = ev->Get();
-    const auto& controlNamespaceDirName =
-        StorageConfig->GetControlNamespaceDirName();
-
-    if (controlNamespaceDirName.empty()) {
-        return false;
-    }
-
-    const auto entry =
-        msg->Record.GetName().empty()
-            ? ClassifyControlNamespaceEntry(msg->Record.GetNodeId())
-            : ClassifyControlNamespaceEntry(
-                  msg->Record.GetNodeId(),
-                  msg->Record.GetName(),
-                  controlNamespaceDirName);
+    const auto entry = ClassifyControlNamespace(
+        msg->Record.GetNodeId(),
+        msg->Record.GetName());
 
     if (Y_LIKELY(!IsControlNamespaceEntry(entry))) {
         return false;
@@ -274,10 +272,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceWriteData(
     Y_UNUSED(session);
     auto* msg = ev->Get();
 
-    if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(!IsControlNamespaceEntry(
-            ClassifyControlNamespaceEntry(msg->Record.GetHandle()))))
-    {
+    if (Y_LIKELY(!IsControlNamespaceReservedIno(msg->Record.GetHandle()))) {
         return false;
     }
 
@@ -402,10 +397,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceDestroyHandle(
     Y_UNUSED(session);
     auto* msg = ev->Get();
 
-    if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(!IsControlNamespaceEntry(
-            ClassifyControlNamespaceEntry(msg->Record.GetHandle()))))
-    {
+    if (Y_LIKELY(!IsControlNamespaceReservedIno(msg->Record.GetHandle()))) {
         return false;
     }
 
@@ -423,10 +415,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeXAttr(
     const TSessionInfo* session)
 {
     Y_UNUSED(session);
-    if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(!IsControlNamespaceEntry(
-            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()))))
-    {
+    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId()))) {
         return false;
     }
 
@@ -443,10 +432,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodeXAttr(
     const TSessionInfo* session)
 {
     Y_UNUSED(session);
-    if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(!IsControlNamespaceEntry(
-            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()))))
-    {
+    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId()))) {
         return false;
     }
 
@@ -462,10 +448,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceSetNodeXAttr(
     const TSessionInfo* session)
 {
     Y_UNUSED(session);
-    if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(!IsControlNamespaceEntry(
-            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()))))
-    {
+    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId()))) {
         return false;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
@@ -13,14 +13,10 @@ using namespace NActors;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-EControlNamespaceEntry ClassifyControlNamespaceEntry(ui64 nodeId)
+TMaybe<EControlNamespaceEntry> ClassifyControlNamespaceEntry(ui64 nodeId)
 {
-    // A raw RPC caller can present any ino, not just ones a kernel client
-    // would ever hand back to us - anything else carrying our reserved
-    // shard number is Unknown, not None, so it doesn't fall through to
-    // real shard-number handling.
     if (ExtractShardNo(nodeId) != ControlNamespaceShardNo) {
-        return EControlNamespaceEntry::None;
+        return Nothing();
     }
     if (nodeId == ControlDirIno) {
         return EControlNamespaceEntry::ControlDir;
@@ -31,7 +27,7 @@ EControlNamespaceEntry ClassifyControlNamespaceEntry(ui64 nodeId)
     return EControlNamespaceEntry::Unknown;
 }
 
-EControlNamespaceEntry ClassifyControlNamespaceEntry(
+TMaybe<EControlNamespaceEntry> ClassifyControlNamespaceEntry(
     ui64 parentId,
     TStringBuf name,
     TStringBuf controlNamespaceDirName)
@@ -47,7 +43,7 @@ EControlNamespaceEntry ClassifyControlNamespaceEntry(
         // fsid is a file - it has no children, but be defensive.
         return EControlNamespaceEntry::Unknown;
     }
-    return EControlNamespaceEntry::None;
+    return Nothing();
 }
 
 void FillControlDirAttr(NProto::TNodeAttr& attr)
@@ -68,11 +64,6 @@ void FillControlFsIdAttr(NProto::TNodeAttr& attr, const TString& fileSystemId)
     attr.SetSize(fileSystemId.size());
 }
 
-bool IsControlNamespaceEntry(EControlNamespaceEntry entry)
-{
-    return entry != EControlNamespaceEntry::None;
-}
-
 NProto::TError ControlNamespaceNotPermittedError()
 {
     return MakeError(E_FS_PERM, "not permitted on the control namespace");
@@ -81,24 +72,29 @@ NProto::TError ControlNamespaceNotPermittedError()
 bool TStorageServiceActor::IsControlNamespaceReservedIno(ui64 nodeId) const
 {
     return !StorageConfig->GetControlNamespaceDirName().empty() &&
-        IsControlNamespaceEntry(ClassifyControlNamespaceEntry(nodeId));
+           ClassifyControlNamespaceEntry(nodeId).Defined();
 }
 
-EControlNamespaceEntry TStorageServiceActor::ClassifyControlNamespace(
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+TMaybe<EControlNamespaceEntry> ClassifyControlNamespace(
+    const TStorageConfig& storageConfig,
     ui64 nodeId,
-    TStringBuf name) const
+    TStringBuf name)
 {
     const auto& controlNamespaceDirName =
-        StorageConfig->GetControlNamespaceDirName();
+        storageConfig.GetControlNamespaceDirName();
     if (controlNamespaceDirName.empty()) {
-        return EControlNamespaceEntry::None;
+        return Nothing();
     }
     return name.empty()
         ? ClassifyControlNamespaceEntry(nodeId)
         : ClassifyControlNamespaceEntry(nodeId, name, controlNamespaceDirName);
 }
 
-////////////////////////////////////////////////////////////////////////////////
+}   // namespace
 
 bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
     const TActorContext& ctx,
@@ -107,15 +103,15 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
 {
     auto* msg = ev->Get();
     const auto entry = ClassifyControlNamespace(
+        *StorageConfig,
         msg->Record.GetNodeId(),
         msg->Record.GetName());
-
-    if (Y_LIKELY(!IsControlNamespaceEntry(entry))) {
+    if (!entry) {
         return false;
     }
 
     auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>();
-    switch (entry) {
+    switch (*entry) {
         case EControlNamespaceEntry::ControlDir:
             FillControlDirAttr(*response->Record.MutableNode());
             break;
@@ -128,8 +124,6 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
             *response->Record.MutableError() =
                 MakeError(E_FS_NOENT, "not found");
             break;
-        case EControlNamespaceEntry::None:
-            Y_UNREACHABLE();
     }
     NCloud::Reply(ctx, *ev, std::move(response));
     return true;
@@ -142,10 +136,10 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
 {
     auto* msg = ev->Get();
     const auto entry = ClassifyControlNamespace(
+        *StorageConfig,
         msg->Record.GetNodeId(),
         msg->Record.GetName());
-
-    if (Y_LIKELY(!IsControlNamespaceEntry(entry))) {
+    if (!entry) {
         return false;
     }
 
@@ -155,7 +149,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
         msg->Record.GetFlags(),
         ProtoFlag(NProto::TCreateHandleRequest::E_WRITE));
 
-    switch (entry) {
+    switch (*entry) {
         case EControlNamespaceEntry::Unknown:
             *response->Record.MutableError() =
                 MakeError(E_FS_NOENT, "not found");
@@ -174,8 +168,6 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
                     session->FileStore.GetFileSystemId());
             }
             break;
-        case EControlNamespaceEntry::None:
-            Y_UNREACHABLE();
     }
 
     NCloud::Reply(ctx, *ev, std::move(response));
@@ -201,16 +193,13 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateNode(
         msg->Record.GetName(),
         controlNamespaceDirName);
 
-    // A hard link's target can also be a reserved ino - reject that too
+    // a hard link's target can also be a reserved ino
     const auto linkTargetEntry =
         msg->Record.HasLink() ? ClassifyControlNamespaceEntry(
                                     msg->Record.GetLink().GetTargetNode())
-                              : EControlNamespaceEntry::None;
+                              : Nothing();
 
-    if (Y_LIKELY(
-            !IsControlNamespaceEntry(entry) &&
-            !IsControlNamespaceEntry(linkTargetEntry)))
-    {
+    if (Y_LIKELY(!entry && !linkTargetEntry)) {
         return false;
     }
 
@@ -233,9 +222,11 @@ bool TStorageServiceActor::TryHandleControlNamespaceReadData(
     }
 
     const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetHandle());
-    switch (entry) {
-        case EControlNamespaceEntry::None:
-            return false;
+    if (!entry) {
+        return false;
+    }
+
+    switch (*entry) {
         case EControlNamespaceEntry::ControlDir: {
             auto response = std::make_unique<TEvService::TEvReadDataResponse>(
                 ErrorIsDirectory(ControlDirIno));
@@ -294,9 +285,11 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodes(
     }
 
     const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetNodeId());
-    switch (entry) {
-        case EControlNamespaceEntry::None:
-            return false;
+    if (!entry) {
+        return false;
+    }
+
+    switch (*entry) {
         case EControlNamespaceEntry::FsId: {
             auto response = std::make_unique<TEvService::TEvListNodesResponse>(
                 ErrorIsNotDirectory(ControlFsIdFileIno));
@@ -347,10 +340,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceRenameNode(
         msg->Record.GetNewName(),
         controlNamespaceDirName);
 
-    if (Y_LIKELY(
-            !IsControlNamespaceEntry(srcEntry) &&
-            !IsControlNamespaceEntry(dstEntry)))
-    {
+    if (Y_LIKELY(!srcEntry && !dstEntry)) {
         return false;
     }
 
@@ -379,7 +369,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceUnlinkNode(
         msg->Record.GetName(),
         controlNamespaceDirName);
 
-    if (Y_LIKELY(!IsControlNamespaceEntry(entry))) {
+    if (Y_LIKELY(!entry)) {
         return false;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
@@ -15,13 +15,20 @@ using namespace NActors;
 
 EControlNamespaceEntry ClassifyControlNamespaceEntry(ui64 nodeId)
 {
+    // A raw RPC caller can present any ino, not just ones a kernel client
+    // would ever hand back to us - anything else carrying our reserved
+    // shard number is Unknown, not None, so it doesn't fall through to
+    // real shard-number handling.
+    if (ExtractShardNo(nodeId) != ControlNamespaceShardNo) {
+        return EControlNamespaceEntry::None;
+    }
     if (nodeId == ControlDirIno) {
         return EControlNamespaceEntry::ControlDir;
     }
     if (nodeId == ControlFsIdFileIno) {
         return EControlNamespaceEntry::FsId;
     }
-    return EControlNamespaceEntry::None;
+    return EControlNamespaceEntry::Unknown;
 }
 
 EControlNamespaceEntry ClassifyControlNamespaceEntry(
@@ -61,99 +68,14 @@ void FillControlFsIdAttr(NProto::TNodeAttr& attr, const TString& fileSystemId)
     attr.SetSize(fileSystemId.size());
 }
 
-NProto::TError ControlNamespaceReadOnlyError()
+bool IsControlNamespaceEntry(EControlNamespaceEntry entry)
 {
-    return MakeError(E_FS_ACCESS, "control namespace files are read-only");
+    return entry != EControlNamespaceEntry::None;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// BuildControlNamespaceResponse specializations, for the self-lookup-by-ino
-// forms reached via ForwardRequestToShard rather than a dedicated
-// TryHandleControlNamespaceXxx above.
-
-template <>
-std::unique_ptr<TEvService::TGetNodeAttrMethod::TResponse>
-BuildControlNamespaceResponse<TEvService::TGetNodeAttrMethod>(
-    const TEvService::TGetNodeAttrMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId)
+NProto::TError ControlNamespaceNotPermittedError()
 {
-    const auto& record = ev->Get()->Record;
-    auto response =
-        std::make_unique<TEvService::TGetNodeAttrMethod::TResponse>();
-    switch (ClassifyControlNamespaceEntry(record.GetNodeId())) {
-        case EControlNamespaceEntry::ControlDir:
-            FillControlDirAttr(*response->Record.MutableNode());
-            break;
-        case EControlNamespaceEntry::FsId:
-            FillControlFsIdAttr(*response->Record.MutableNode(), fileSystemId);
-            break;
-        default:
-            *response->Record.MutableError() =
-                MakeError(E_FS_NOENT, "not found");
-            break;
-    }
-    return response;
-}
-
-template <>
-std::unique_ptr<TEvService::TCreateHandleMethod::TResponse>
-BuildControlNamespaceResponse<TEvService::TCreateHandleMethod>(
-    const TEvService::TCreateHandleMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId)
-{
-    const auto& record = ev->Get()->Record;
-    auto response =
-        std::make_unique<TEvService::TCreateHandleMethod::TResponse>();
-
-    const auto entry = ClassifyControlNamespaceEntry(record.GetNodeId());
-    if (entry != EControlNamespaceEntry::ControlDir &&
-        entry != EControlNamespaceEntry::FsId)
-    {
-        *response->Record.MutableError() = MakeError(E_FS_NOENT, "not found");
-        return response;
-    }
-
-    const bool wantsWrite = HasFlag(
-        record.GetFlags(),
-        ProtoFlag(NProto::TCreateHandleRequest::E_WRITE));
-    if (wantsWrite) {
-        *response->Record.MutableError() = ControlNamespaceReadOnlyError();
-        return response;
-    }
-
-    if (entry == EControlNamespaceEntry::ControlDir) {
-        response->Record.SetHandle(ControlDirIno);
-        FillControlDirAttr(*response->Record.MutableNodeAttr());
-    } else {
-        response->Record.SetHandle(ControlFsIdFileIno);
-        FillControlFsIdAttr(*response->Record.MutableNodeAttr(), fileSystemId);
-    }
-    return response;
-}
-
-template <>
-std::unique_ptr<TEvService::TConfirmCreateHandleMethod::TResponse>
-BuildControlNamespaceResponse<TEvService::TConfirmCreateHandleMethod>(
-    const TEvService::TConfirmCreateHandleMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId)
-{
-    Y_UNUSED(ev);
-    Y_UNUSED(fileSystemId);
-    // nothing real to confirm - the handle was synthesized locally
-    return std::make_unique<
-        TEvService::TConfirmCreateHandleMethod::TResponse>();
-}
-
-template <>
-std::unique_ptr<TEvService::TDestroyHandleMethod::TResponse>
-BuildControlNamespaceResponse<TEvService::TDestroyHandleMethod>(
-    const TEvService::TDestroyHandleMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId)
-{
-    Y_UNUSED(ev);
-    Y_UNUSED(fileSystemId);
-    // nothing real to destroy - the handle was synthesized locally
-    return std::make_unique<TEvService::TDestroyHandleMethod::TResponse>();
+    return MakeError(E_FS_PERM, "not permitted on the control namespace");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -167,16 +89,19 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
     const auto& controlNamespaceDirName =
         StorageConfig->GetControlNamespaceDirName();
 
-    if (controlNamespaceDirName.empty() || msg->Record.GetName().empty()) {
+    if (controlNamespaceDirName.empty()) {
         return false;
     }
 
-    const auto entry = ClassifyControlNamespaceEntry(
-        msg->Record.GetNodeId(),
-        msg->Record.GetName(),
-        controlNamespaceDirName);
+    const auto entry =
+        msg->Record.GetName().empty()
+            ? ClassifyControlNamespaceEntry(msg->Record.GetNodeId())
+            : ClassifyControlNamespaceEntry(
+                  msg->Record.GetNodeId(),
+                  msg->Record.GetName(),
+                  controlNamespaceDirName);
 
-    if (Y_LIKELY(entry == EControlNamespaceEntry::None)) {
+    if (Y_LIKELY(!IsControlNamespaceEntry(entry))) {
         return false;
     }
 
@@ -190,10 +115,12 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
                 *response->Record.MutableNode(),
                 session->FileStore.GetFileSystemId());
             break;
-        default:
+        case EControlNamespaceEntry::Unknown:
             *response->Record.MutableError() =
                 MakeError(E_FS_NOENT, "not found");
             break;
+        case EControlNamespaceEntry::None:
+            Y_UNREACHABLE();
     }
     NCloud::Reply(ctx, *ev, std::move(response));
     return true;
@@ -208,16 +135,19 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
     const auto& controlNamespaceDirName =
         StorageConfig->GetControlNamespaceDirName();
 
-    if (controlNamespaceDirName.empty() || msg->Record.GetName().empty()) {
+    if (controlNamespaceDirName.empty()) {
         return false;
     }
 
-    const auto entry = ClassifyControlNamespaceEntry(
-        msg->Record.GetNodeId(),
-        msg->Record.GetName(),
-        controlNamespaceDirName);
+    const auto entry =
+        msg->Record.GetName().empty()
+            ? ClassifyControlNamespaceEntry(msg->Record.GetNodeId())
+            : ClassifyControlNamespaceEntry(
+                  msg->Record.GetNodeId(),
+                  msg->Record.GetName(),
+                  controlNamespaceDirName);
 
-    if (Y_LIKELY(entry == EControlNamespaceEntry::None)) {
+    if (Y_LIKELY(!IsControlNamespaceEntry(entry))) {
         return false;
     }
 
@@ -227,18 +157,27 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
         msg->Record.GetFlags(),
         ProtoFlag(NProto::TCreateHandleRequest::E_WRITE));
 
-    if (entry == EControlNamespaceEntry::Unknown) {
-        *response->Record.MutableError() = MakeError(E_FS_NOENT, "not found");
-    } else if (wantsWrite) {
-        *response->Record.MutableError() = ControlNamespaceReadOnlyError();
-    } else if (entry == EControlNamespaceEntry::ControlDir) {
-        response->Record.SetHandle(ControlDirIno);
-        FillControlDirAttr(*response->Record.MutableNodeAttr());
-    } else {
-        response->Record.SetHandle(ControlFsIdFileIno);
-        FillControlFsIdAttr(
-            *response->Record.MutableNodeAttr(),
-            session->FileStore.GetFileSystemId());
+    switch (entry) {
+        case EControlNamespaceEntry::Unknown:
+            *response->Record.MutableError() =
+                MakeError(E_FS_NOENT, "not found");
+            break;
+        case EControlNamespaceEntry::ControlDir:
+            *response->Record.MutableError() = ErrorIsDirectory(ControlDirIno);
+            break;
+        case EControlNamespaceEntry::FsId:
+            if (wantsWrite) {
+                *response->Record.MutableError() =
+                    ControlNamespaceNotPermittedError();
+            } else {
+                response->Record.SetHandle(ControlFsIdFileIno);
+                FillControlFsIdAttr(
+                    *response->Record.MutableNodeAttr(),
+                    session->FileStore.GetFileSystemId());
+            }
+            break;
+        case EControlNamespaceEntry::None:
+            Y_UNREACHABLE();
     }
 
     NCloud::Reply(ctx, *ev, std::move(response));
@@ -271,14 +210,14 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateNode(
                               : EControlNamespaceEntry::None;
 
     if (Y_LIKELY(
-            entry == EControlNamespaceEntry::None &&
-            linkTargetEntry == EControlNamespaceEntry::None))
+            !IsControlNamespaceEntry(entry) &&
+            !IsControlNamespaceEntry(linkTargetEntry)))
     {
         return false;
     }
 
     auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
-        ControlNamespaceReadOnlyError());
+        ControlNamespaceNotPermittedError());
     NCloud::Reply(ctx, *ev, std::move(response));
     return true;
 }
@@ -290,19 +229,29 @@ bool TStorageServiceActor::TryHandleControlNamespaceReadData(
     const TSessionInfo* session)
 {
     auto* msg = ev->Get();
-    const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetHandle());
 
-    if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(entry == EControlNamespaceEntry::None))
-    {
+    if (StorageConfig->GetControlNamespaceDirName().empty()) {
         return false;
     }
 
-    if (entry == EControlNamespaceEntry::ControlDir) {
-        auto response = std::make_unique<TEvService::TEvReadDataResponse>(
-            ErrorIsDirectory(ControlDirIno));
-        NCloud::Reply(ctx, *ev, std::move(response));
-        return true;
+    const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetHandle());
+    switch (entry) {
+        case EControlNamespaceEntry::None:
+            return false;
+        case EControlNamespaceEntry::ControlDir: {
+            auto response = std::make_unique<TEvService::TEvReadDataResponse>(
+                ErrorIsDirectory(ControlDirIno));
+            NCloud::Reply(ctx, *ev, std::move(response));
+            return true;
+        }
+        case EControlNamespaceEntry::FsId:
+            break;
+        case EControlNamespaceEntry::Unknown: {
+            auto response = std::make_unique<TEvService::TEvReadDataResponse>(
+                MakeError(E_FS_NOENT, "not found"));
+            NCloud::Reply(ctx, *ev, std::move(response));
+            return true;
+        }
     }
 
     auto response = std::make_unique<TEvService::TEvReadDataResponse>();
@@ -326,15 +275,14 @@ bool TStorageServiceActor::TryHandleControlNamespaceWriteData(
     auto* msg = ev->Get();
 
     if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(
-            ClassifyControlNamespaceEntry(msg->Record.GetHandle()) ==
-            EControlNamespaceEntry::None))
+        Y_LIKELY(!IsControlNamespaceEntry(
+            ClassifyControlNamespaceEntry(msg->Record.GetHandle()))))
     {
         return false;
     }
 
     auto response = std::make_unique<TEvService::TEvWriteDataResponse>(
-        ControlNamespaceReadOnlyError());
+        ControlNamespaceNotPermittedError());
     NCloud::Reply(ctx, *ev, std::move(response));
     return true;
 }
@@ -345,19 +293,29 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodes(
     const TSessionInfo* session)
 {
     auto* msg = ev->Get();
-    const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetNodeId());
 
-    if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(entry == EControlNamespaceEntry::None))
-    {
+    if (StorageConfig->GetControlNamespaceDirName().empty()) {
         return false;
     }
 
-    if (entry == EControlNamespaceEntry::FsId) {
-        auto response = std::make_unique<TEvService::TEvListNodesResponse>(
-            ErrorIsNotDirectory(ControlFsIdFileIno));
-        NCloud::Reply(ctx, *ev, std::move(response));
-        return true;
+    const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetNodeId());
+    switch (entry) {
+        case EControlNamespaceEntry::None:
+            return false;
+        case EControlNamespaceEntry::FsId: {
+            auto response = std::make_unique<TEvService::TEvListNodesResponse>(
+                ErrorIsNotDirectory(ControlFsIdFileIno));
+            NCloud::Reply(ctx, *ev, std::move(response));
+            return true;
+        }
+        case EControlNamespaceEntry::ControlDir:
+            break;
+        case EControlNamespaceEntry::Unknown: {
+            auto response = std::make_unique<TEvService::TEvListNodesResponse>(
+                MakeError(E_FS_NOENT, "not found"));
+            NCloud::Reply(ctx, *ev, std::move(response));
+            return true;
+        }
     }
 
     auto response = std::make_unique<TEvService::TEvListNodesResponse>();
@@ -395,14 +353,14 @@ bool TStorageServiceActor::TryHandleControlNamespaceRenameNode(
         controlNamespaceDirName);
 
     if (Y_LIKELY(
-            srcEntry == EControlNamespaceEntry::None &&
-            dstEntry == EControlNamespaceEntry::None))
+            !IsControlNamespaceEntry(srcEntry) &&
+            !IsControlNamespaceEntry(dstEntry)))
     {
         return false;
     }
 
     auto response = std::make_unique<TEvService::TEvRenameNodeResponse>(
-        ControlNamespaceReadOnlyError());
+        ControlNamespaceNotPermittedError());
     NCloud::Reply(ctx, *ev, std::move(response));
     return true;
 }
@@ -426,13 +384,36 @@ bool TStorageServiceActor::TryHandleControlNamespaceUnlinkNode(
         msg->Record.GetName(),
         controlNamespaceDirName);
 
-    if (Y_LIKELY(entry == EControlNamespaceEntry::None)) {
+    if (Y_LIKELY(!IsControlNamespaceEntry(entry))) {
         return false;
     }
 
     auto response = std::make_unique<TEvService::TEvUnlinkNodeResponse>(
-        ControlNamespaceReadOnlyError());
+        ControlNamespaceNotPermittedError());
     NCloud::Reply(ctx, *ev, std::move(response));
+    return true;
+}
+
+bool TStorageServiceActor::TryHandleControlNamespaceDestroyHandle(
+    const TActorContext& ctx,
+    const TEvService::TEvDestroyHandleRequest::TPtr& ev,
+    const TSessionInfo* session)
+{
+    Y_UNUSED(session);
+    auto* msg = ev->Get();
+
+    if (StorageConfig->GetControlNamespaceDirName().empty() ||
+        Y_LIKELY(!IsControlNamespaceEntry(
+            ClassifyControlNamespaceEntry(msg->Record.GetHandle()))))
+    {
+        return false;
+    }
+
+    // nothing real to destroy - the handle was synthesized locally
+    NCloud::Reply(
+        ctx,
+        *ev,
+        std::make_unique<TEvService::TEvDestroyHandleResponse>());
     return true;
 }
 
@@ -441,10 +422,10 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeXAttr(
     const TEvService::TEvGetNodeXAttrRequest::TPtr& ev,
     const TSessionInfo* session)
 {
+    Y_UNUSED(session);
     if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(
-            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()) ==
-            EControlNamespaceEntry::None))
+        Y_LIKELY(!IsControlNamespaceEntry(
+            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()))))
     {
         return false;
     }
@@ -452,11 +433,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeXAttr(
     auto response =
         std::make_unique<TEvService::TGetNodeXAttrMethod::TResponse>(
             ErrorAttributeDoesNotExist(ev->Get()->Record.GetName()));
-    ReplyToXAttrRequest<TEvService::TGetNodeXAttrMethod>(
-        ctx,
-        ev,
-        std::move(response),
-        session);
+    NCloud::Reply(ctx, *ev, std::move(response));
     return true;
 }
 
@@ -465,21 +442,17 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodeXAttr(
     const TEvService::TEvListNodeXAttrRequest::TPtr& ev,
     const TSessionInfo* session)
 {
+    Y_UNUSED(session);
     if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(
-            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()) ==
-            EControlNamespaceEntry::None))
+        Y_LIKELY(!IsControlNamespaceEntry(
+            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()))))
     {
         return false;
     }
 
     auto response =
         std::make_unique<TEvService::TListNodeXAttrMethod::TResponse>();
-    ReplyToXAttrRequest<TEvService::TListNodeXAttrMethod>(
-        ctx,
-        ev,
-        std::move(response),
-        session);
+    NCloud::Reply(ctx, *ev, std::move(response));
     return true;
 }
 
@@ -488,22 +461,18 @@ bool TStorageServiceActor::TryHandleControlNamespaceSetNodeXAttr(
     const TEvService::TEvSetNodeXAttrRequest::TPtr& ev,
     const TSessionInfo* session)
 {
+    Y_UNUSED(session);
     if (StorageConfig->GetControlNamespaceDirName().empty() ||
-        Y_LIKELY(
-            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()) ==
-            EControlNamespaceEntry::None))
+        Y_LIKELY(!IsControlNamespaceEntry(
+            ClassifyControlNamespaceEntry(ev->Get()->Record.GetNodeId()))))
     {
         return false;
     }
 
     auto response =
         std::make_unique<TEvService::TSetNodeXAttrMethod::TResponse>(
-            ControlNamespaceReadOnlyError());
-    ReplyToXAttrRequest<TEvService::TSetNodeXAttrMethod>(
-        ctx,
-        ev,
-        std::move(response),
-        session);
+            ControlNamespaceNotPermittedError());
+    NCloud::Reply(ctx, *ev, std::move(response));
     return true;
 }
 

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.cpp
@@ -11,6 +11,8 @@ namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
 
+namespace {
+
 ////////////////////////////////////////////////////////////////////////////////
 
 TMaybe<EControlNamespaceEntry> ClassifyControlNamespaceEntry(ui64 nodeId)
@@ -40,11 +42,14 @@ TMaybe<EControlNamespaceEntry> ClassifyControlNamespaceEntry(
                                            : EControlNamespaceEntry::Unknown;
     }
     if (parentId == ControlFsIdFileIno) {
-        // fsid is a file - it has no children, but be defensive.
         return EControlNamespaceEntry::Unknown;
     }
     return Nothing();
 }
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
 
 void FillControlDirAttr(NProto::TNodeAttr& attr)
 {
@@ -69,32 +74,34 @@ NProto::TError ControlNamespaceNotPermittedError()
     return MakeError(E_FS_PERM, "not permitted on the control namespace");
 }
 
-bool TStorageServiceActor::IsControlNamespaceReservedIno(ui64 nodeId) const
-{
-    return !StorageConfig->GetControlNamespaceDirName().empty() &&
-           ClassifyControlNamespaceEntry(nodeId).Defined();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-namespace {
-
-TMaybe<EControlNamespaceEntry> ClassifyControlNamespace(
-    const TStorageConfig& storageConfig,
+TMaybe<EControlNamespaceEntry> TStorageServiceActor::ClassifyControlNamespace(
     ui64 nodeId,
-    TStringBuf name)
+    TStringBuf name) const
 {
     const auto& controlNamespaceDirName =
-        storageConfig.GetControlNamespaceDirName();
+        StorageConfig->GetControlNamespaceDirName();
     if (controlNamespaceDirName.empty()) {
         return Nothing();
     }
-    return name.empty()
-        ? ClassifyControlNamespaceEntry(nodeId)
-        : ClassifyControlNamespaceEntry(nodeId, name, controlNamespaceDirName);
+    return name.empty() ? ClassifyControlNamespaceEntry(nodeId)
+                        : ClassifyControlNamespaceEntry(
+                              nodeId,
+                              name,
+                              controlNamespaceDirName);
 }
 
-}   // namespace
+TMaybe<EControlNamespaceEntry> TStorageServiceActor::ClassifyControlNamespace(
+    ui64 ino) const
+{
+    return ClassifyControlNamespace(ino, {});
+}
+
+bool TStorageServiceActor::IsControlNamespaceReservedIno(ui64 nodeId) const
+{
+    return ClassifyControlNamespace(nodeId).Defined();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
     const TActorContext& ctx,
@@ -103,7 +110,6 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeAttr(
 {
     auto* msg = ev->Get();
     const auto entry = ClassifyControlNamespace(
-        *StorageConfig,
         msg->Record.GetNodeId(),
         msg->Record.GetName());
     if (!entry) {
@@ -136,7 +142,6 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateHandle(
 {
     auto* msg = ev->Get();
     const auto entry = ClassifyControlNamespace(
-        *StorageConfig,
         msg->Record.GetNodeId(),
         msg->Record.GetName());
     if (!entry) {
@@ -181,23 +186,15 @@ bool TStorageServiceActor::TryHandleControlNamespaceCreateNode(
 {
     Y_UNUSED(session);
     auto* msg = ev->Get();
-    const auto& controlNamespaceDirName =
-        StorageConfig->GetControlNamespaceDirName();
-
-    if (controlNamespaceDirName.empty()) {
-        return false;
-    }
-
-    const auto entry = ClassifyControlNamespaceEntry(
+    const auto entry = ClassifyControlNamespace(
         msg->Record.GetNodeId(),
-        msg->Record.GetName(),
-        controlNamespaceDirName);
+        msg->Record.GetName());
 
     // a hard link's target can also be a reserved ino
     const auto linkTargetEntry =
-        msg->Record.HasLink() ? ClassifyControlNamespaceEntry(
-                                    msg->Record.GetLink().GetTargetNode())
-                              : Nothing();
+        msg->Record.HasLink()
+            ? ClassifyControlNamespace(msg->Record.GetLink().GetTargetNode())
+            : Nothing();
 
     if (Y_LIKELY(!entry && !linkTargetEntry)) {
         return false;
@@ -216,12 +213,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceReadData(
     const TSessionInfo* session)
 {
     auto* msg = ev->Get();
-
-    if (StorageConfig->GetControlNamespaceDirName().empty()) {
-        return false;
-    }
-
-    const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetHandle());
+    const auto entry = ClassifyControlNamespace(msg->Record.GetHandle());
     if (!entry) {
         return false;
     }
@@ -279,12 +271,7 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodes(
     const TSessionInfo* session)
 {
     auto* msg = ev->Get();
-
-    if (StorageConfig->GetControlNamespaceDirName().empty()) {
-        return false;
-    }
-
-    const auto entry = ClassifyControlNamespaceEntry(msg->Record.GetNodeId());
+    const auto entry = ClassifyControlNamespace(msg->Record.GetNodeId());
     if (!entry) {
         return false;
     }
@@ -324,21 +311,12 @@ bool TStorageServiceActor::TryHandleControlNamespaceRenameNode(
 {
     Y_UNUSED(session);
     auto* msg = ev->Get();
-    const auto& controlNamespaceDirName =
-        StorageConfig->GetControlNamespaceDirName();
-
-    if (controlNamespaceDirName.empty()) {
-        return false;
-    }
-
-    const auto srcEntry = ClassifyControlNamespaceEntry(
+    const auto srcEntry = ClassifyControlNamespace(
         msg->Record.GetNodeId(),
-        msg->Record.GetName(),
-        controlNamespaceDirName);
-    const auto dstEntry = ClassifyControlNamespaceEntry(
+        msg->Record.GetName());
+    const auto dstEntry = ClassifyControlNamespace(
         msg->Record.GetNewParentId(),
-        msg->Record.GetNewName(),
-        controlNamespaceDirName);
+        msg->Record.GetNewName());
 
     if (Y_LIKELY(!srcEntry && !dstEntry)) {
         return false;
@@ -357,17 +335,9 @@ bool TStorageServiceActor::TryHandleControlNamespaceUnlinkNode(
 {
     Y_UNUSED(session);
     auto* msg = ev->Get();
-    const auto& controlNamespaceDirName =
-        StorageConfig->GetControlNamespaceDirName();
-
-    if (controlNamespaceDirName.empty()) {
-        return false;
-    }
-
-    const auto entry = ClassifyControlNamespaceEntry(
+    const auto entry = ClassifyControlNamespace(
         msg->Record.GetNodeId(),
-        msg->Record.GetName(),
-        controlNamespaceDirName);
+        msg->Record.GetName());
 
     if (Y_LIKELY(!entry)) {
         return false;
@@ -405,7 +375,8 @@ bool TStorageServiceActor::TryHandleControlNamespaceGetNodeXAttr(
     const TSessionInfo* session)
 {
     Y_UNUSED(session);
-    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId()))) {
+    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId())))
+    {
         return false;
     }
 
@@ -422,7 +393,8 @@ bool TStorageServiceActor::TryHandleControlNamespaceListNodeXAttr(
     const TSessionInfo* session)
 {
     Y_UNUSED(session);
-    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId()))) {
+    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId())))
+    {
         return false;
     }
 
@@ -438,7 +410,8 @@ bool TStorageServiceActor::TryHandleControlNamespaceSetNodeXAttr(
     const TSessionInfo* session)
 {
     Y_UNUSED(session);
-    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId()))) {
+    if (Y_LIKELY(!IsControlNamespaceReservedIno(ev->Get()->Record.GetNodeId())))
+    {
         return false;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.h
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cloud/filestore/libs/storage/api/service.h>
 #include <cloud/filestore/libs/storage/core/model.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
 
@@ -30,13 +29,13 @@ static_assert(ControlNamespaceShardNo > MaxShardCount);
 
 constexpr TStringBuf ControlFsIdFileName = "fsid";
 
+// What a node or (parent, name) pair resolves to in the control namespace
 enum class EControlNamespaceEntry
 {
     None,
-    ControlDir,
-    FsId,
-    // Under the control dir, but not a name it actually exposes.
-    Unknown,
+    ControlDir, // the root control dir itself
+    FsId, // "fsid" file under the control dir, exposes the filesystem ID
+    Unknown, // under the control dir but not a known name
 };
 
 // Self-lookup form: classifies an already-resolved ino.
@@ -49,48 +48,15 @@ EControlNamespaceEntry ClassifyControlNamespaceEntry(
     TStringBuf name,
     TStringBuf controlNamespaceDirName);
 
+// True for anything under the control namespace, i.e. every value but None.
+bool IsControlNamespaceEntry(EControlNamespaceEntry entry);
+
 void FillControlDirAttr(NProto::TNodeAttr& attr);
 void FillControlFsIdAttr(NProto::TNodeAttr& attr, const TString& fileSystemId);
 
-NProto::TError ControlNamespaceReadOnlyError();
-
-////////////////////////////////////////////////////////////////////////////////
-
-// Defaults to rejecting, which is fine for everything except open/read/
-// stat/ls
-template <typename TMethod>
-std::unique_ptr<typename TMethod::TResponse> BuildControlNamespaceResponse(
-    const typename TMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId)
-{
-    Y_UNUSED(ev);
-    Y_UNUSED(fileSystemId);
-    return std::make_unique<typename TMethod::TResponse>(
-        ControlNamespaceReadOnlyError());
-}
-
-template <>
-std::unique_ptr<TEvService::TGetNodeAttrMethod::TResponse>
-BuildControlNamespaceResponse<TEvService::TGetNodeAttrMethod>(
-    const TEvService::TGetNodeAttrMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId);
-
-template <>
-std::unique_ptr<TEvService::TCreateHandleMethod::TResponse>
-BuildControlNamespaceResponse<TEvService::TCreateHandleMethod>(
-    const TEvService::TCreateHandleMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId);
-
-template <>
-std::unique_ptr<TEvService::TConfirmCreateHandleMethod::TResponse>
-BuildControlNamespaceResponse<TEvService::TConfirmCreateHandleMethod>(
-    const TEvService::TConfirmCreateHandleMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId);
-
-template <>
-std::unique_ptr<TEvService::TDestroyHandleMethod::TResponse>
-BuildControlNamespaceResponse<TEvService::TDestroyHandleMethod>(
-    const TEvService::TDestroyHandleMethod::TRequest::TPtr& ev,
-    const TString& fileSystemId);
+// The one error every control-namespace rejection replies with, whether
+// it's a dedicated hook denying a mutation or ForwardRequestToShard's
+// generic fallback denying a method with no hook of its own.
+NProto::TError ControlNamespaceNotPermittedError();
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.h
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.h
@@ -6,6 +6,7 @@
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
+#include <util/generic/maybe.h>
 #include <util/generic/string.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -32,31 +33,21 @@ constexpr TStringBuf ControlFsIdFileName = "fsid";
 // What a node or (parent, name) pair resolves to in the control namespace
 enum class EControlNamespaceEntry
 {
-    None,
     ControlDir, // the root control dir itself
     FsId, // "fsid" file under the control dir, exposes the filesystem ID
     Unknown, // under the control dir but not a known name
 };
 
-// Self-lookup form: classifies an already-resolved ino.
-EControlNamespaceEntry ClassifyControlNamespaceEntry(ui64 nodeId);
+TMaybe<EControlNamespaceEntry> ClassifyControlNamespaceEntry(ui64 nodeId);
 
-// By-name form: classifies a (parent, name) pair, e.g. from a lookup or
-// a create/rename target.
-EControlNamespaceEntry ClassifyControlNamespaceEntry(
+TMaybe<EControlNamespaceEntry> ClassifyControlNamespaceEntry(
     ui64 parentId,
     TStringBuf name,
     TStringBuf controlNamespaceDirName);
 
-// True for anything under the control namespace, i.e. every value but None.
-bool IsControlNamespaceEntry(EControlNamespaceEntry entry);
-
 void FillControlDirAttr(NProto::TNodeAttr& attr);
 void FillControlFsIdAttr(NProto::TNodeAttr& attr, const TString& fileSystemId);
 
-// The one error every control-namespace rejection replies with, whether
-// it's a dedicated hook denying a mutation or ForwardRequestToShard's
-// generic fallback denying a method with no hook of its own.
 NProto::TError ControlNamespaceNotPermittedError();
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.h
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.h
@@ -6,7 +6,6 @@
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
-#include <util/generic/maybe.h>
 #include <util/generic/string.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -37,13 +36,6 @@ enum class EControlNamespaceEntry
     FsId, // "fsid" file under the control dir, exposes the filesystem ID
     Unknown, // under the control dir but not a known name
 };
-
-TMaybe<EControlNamespaceEntry> ClassifyControlNamespaceEntry(ui64 nodeId);
-
-TMaybe<EControlNamespaceEntry> ClassifyControlNamespaceEntry(
-    ui64 parentId,
-    TStringBuf name,
-    TStringBuf controlNamespaceDirName);
 
 void FillControlDirAttr(NProto::TNodeAttr& attr);
 void FillControlFsIdAttr(NProto::TNodeAttr& attr, const TString& fileSystemId);

--- a/cloud/filestore/libs/storage/service/service_actor_control_namespace.h
+++ b/cloud/filestore/libs/storage/service/service_actor_control_namespace.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/api/service.h>
+#include <cloud/filestore/libs/storage/core/model.h>
+#include <cloud/filestore/libs/storage/model/utils.h>
+
+#include <cloud/filestore/public/api/protos/fs.pb.h>
+#include <cloud/filestore/public/api/protos/node.pb.h>
+
+#include <util/generic/string.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+// Reserved inos use the shard number one past MaxShardCount, which real
+// shards never get assigned, so they can't collide with real nodes.
+static_assert(
+    MaxShardCount < Max<ui16>(),
+    "the control namespace reserves the highest representable shard "
+    "number - MaxShardCount must leave it unassigned to real shards");
+
+constexpr ui32 ControlNamespaceShardNo = MaxShardCount + 1;
+
+constexpr ui64 ControlDirIno = ShardedId(1, ControlNamespaceShardNo);
+constexpr ui64 ControlFsIdFileIno = ShardedId(2, ControlNamespaceShardNo);
+
+static_assert(ExtractShardNo(ControlDirIno) == ControlNamespaceShardNo);
+static_assert(ExtractShardNo(ControlFsIdFileIno) == ControlNamespaceShardNo);
+static_assert(ControlNamespaceShardNo > MaxShardCount);
+
+constexpr TStringBuf ControlFsIdFileName = "fsid";
+
+enum class EControlNamespaceEntry
+{
+    None,
+    ControlDir,
+    FsId,
+    // Under the control dir, but not a name it actually exposes.
+    Unknown,
+};
+
+// Self-lookup form: classifies an already-resolved ino.
+EControlNamespaceEntry ClassifyControlNamespaceEntry(ui64 nodeId);
+
+// By-name form: classifies a (parent, name) pair, e.g. from a lookup or
+// a create/rename target.
+EControlNamespaceEntry ClassifyControlNamespaceEntry(
+    ui64 parentId,
+    TStringBuf name,
+    TStringBuf controlNamespaceDirName);
+
+void FillControlDirAttr(NProto::TNodeAttr& attr);
+void FillControlFsIdAttr(NProto::TNodeAttr& attr, const TString& fileSystemId);
+
+NProto::TError ControlNamespaceReadOnlyError();
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Defaults to rejecting, which is fine for everything except open/read/
+// stat/ls
+template <typename TMethod>
+std::unique_ptr<typename TMethod::TResponse> BuildControlNamespaceResponse(
+    const typename TMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId)
+{
+    Y_UNUSED(ev);
+    Y_UNUSED(fileSystemId);
+    return std::make_unique<typename TMethod::TResponse>(
+        ControlNamespaceReadOnlyError());
+}
+
+template <>
+std::unique_ptr<TEvService::TGetNodeAttrMethod::TResponse>
+BuildControlNamespaceResponse<TEvService::TGetNodeAttrMethod>(
+    const TEvService::TGetNodeAttrMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId);
+
+template <>
+std::unique_ptr<TEvService::TCreateHandleMethod::TResponse>
+BuildControlNamespaceResponse<TEvService::TCreateHandleMethod>(
+    const TEvService::TCreateHandleMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId);
+
+template <>
+std::unique_ptr<TEvService::TConfirmCreateHandleMethod::TResponse>
+BuildControlNamespaceResponse<TEvService::TConfirmCreateHandleMethod>(
+    const TEvService::TConfirmCreateHandleMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId);
+
+template <>
+std::unique_ptr<TEvService::TDestroyHandleMethod::TResponse>
+BuildControlNamespaceResponse<TEvService::TDestroyHandleMethod>(
+    const TEvService::TDestroyHandleMethod::TRequest::TPtr& ev,
+    const TString& fileSystemId);
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyhandle.cpp
@@ -1,0 +1,31 @@
+#include "service_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TStorageServiceActor::HandleDestroyHandle(
+    const TEvService::TEvDestroyHandleRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* session =
+        GetAndValidateSession<TEvService::TDestroyHandleMethod>(ctx, ev);
+    if (!session) {
+        return;
+    }
+
+    if (TryHandleControlNamespaceDestroyHandle(ctx, ev, session)) {
+        return;
+    }
+
+    ForwardRequestToShard<TEvService::TDestroyHandleMethod>(
+        ctx,
+        ev,
+        false /* forceBehaveAsShard */,
+        ev->Get()->Record.GetHandle(),
+        session);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -410,4 +410,12 @@ TStorageServiceActor::ForwardRequestToShard<TEvService::TRenameNodeMethod>(
     ui64 entityId,
     TSessionInfo* session);
 
+template void
+TStorageServiceActor::ForwardRequestToShard<TEvService::TUnlinkNodeMethod>(
+    const TActorContext& ctx,
+    const TEvService::TUnlinkNodeMethod::TRequest::TPtr& ev,
+    bool forceBehaveAsShard,
+    ui64 entityId,
+    TSessionInfo* session);
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -266,14 +266,13 @@ void TStorageServiceActor::ForwardRequestToShard(
         msg->CallContext->RequestId);
 
     if (!StorageConfig->GetControlNamespaceDirName().empty() &&
-        ClassifyControlNamespaceEntry(entityId) != EControlNamespaceEntry::None)
+        IsControlNamespaceEntry(ClassifyControlNamespaceEntry(entityId)))
     {
         return NCloud::Reply(
             ctx,
             *ev,
-            BuildControlNamespaceResponse<TMethod>(
-                ev,
-                session->FileStore.GetFileSystemId()));
+            std::make_unique<typename TMethod::TResponse>(
+                ControlNamespaceNotPermittedError()));
     }
 
     const NProto::TFileStore& filestore = session->FileStore;
@@ -414,6 +413,14 @@ template void
 TStorageServiceActor::ForwardRequestToShard<TEvService::TUnlinkNodeMethod>(
     const TActorContext& ctx,
     const TEvService::TUnlinkNodeMethod::TRequest::TPtr& ev,
+    bool forceBehaveAsShard,
+    ui64 entityId,
+    TSessionInfo* session);
+
+template void
+TStorageServiceActor::ForwardRequestToShard<TEvService::TDestroyHandleMethod>(
+    const TActorContext& ctx,
+    const TEvService::TDestroyHandleMethod::TRequest::TPtr& ev,
     bool forceBehaveAsShard,
     ui64 entityId,
     TSessionInfo* session);

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -1,5 +1,7 @@
 #include "service_actor.h"
 
+#include "service_actor_control_namespace.h"
+
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
@@ -262,6 +264,17 @@ void TStorageServiceActor::ForwardRequestToShard(
         seqNo,
         TMethod::Name,
         msg->CallContext->RequestId);
+
+    if (!StorageConfig->GetControlNamespaceDirName().empty() &&
+        ClassifyControlNamespaceEntry(entityId) != EControlNamespaceEntry::None)
+    {
+        return NCloud::Reply(
+            ctx,
+            *ev,
+            BuildControlNamespaceResponse<TMethod>(
+                ev,
+                session->FileStore.GetFileSystemId()));
+    }
 
     const NProto::TFileStore& filestore = session->FileStore;
 

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -265,9 +265,7 @@ void TStorageServiceActor::ForwardRequestToShard(
         TMethod::Name,
         msg->CallContext->RequestId);
 
-    if (!StorageConfig->GetControlNamespaceDirName().empty() &&
-        ClassifyControlNamespaceEntry(entityId))
-    {
+    if (ClassifyControlNamespace(entityId)) {
         return NCloud::Reply(
             ctx,
             *ev,

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -266,7 +266,7 @@ void TStorageServiceActor::ForwardRequestToShard(
         msg->CallContext->RequestId);
 
     if (!StorageConfig->GetControlNamespaceDirName().empty() &&
-        IsControlNamespaceEntry(ClassifyControlNamespaceEntry(entityId)))
+        ClassifyControlNamespaceEntry(entityId))
     {
         return NCloud::Reply(
             ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_unlinknode.cpp
@@ -1,0 +1,31 @@
+#include "service_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TStorageServiceActor::HandleUnlinkNode(
+    const TEvService::TEvUnlinkNodeRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* session =
+        GetAndValidateSession<TEvService::TUnlinkNodeMethod>(ctx, ev);
+    if (!session) {
+        return;
+    }
+
+    if (TryHandleControlNamespaceUnlinkNode(ctx, ev, session)) {
+        return;
+    }
+
+    ForwardRequestToShard<TEvService::TUnlinkNodeMethod>(
+        ctx,
+        ev,
+        false /* forceBehaveAsShard */,
+        ev->Get()->Record.GetNodeId(),
+        session);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
@@ -218,6 +218,27 @@ void TStorageServiceActor::ReplyToXAttrRequest(
     NCloud::Reply(ctx, *ev, std::move(response));
 }
 
+template void
+TStorageServiceActor::ReplyToXAttrRequest<TEvService::TGetNodeXAttrMethod>(
+    const TActorContext& ctx,
+    const TEvService::TGetNodeXAttrMethod::TRequest::TPtr& ev,
+    std::unique_ptr<TEvService::TGetNodeXAttrMethod::TResponse> response,
+    const TSessionInfo* session);
+
+template void
+TStorageServiceActor::ReplyToXAttrRequest<TEvService::TListNodeXAttrMethod>(
+    const TActorContext& ctx,
+    const TEvService::TListNodeXAttrMethod::TRequest::TPtr& ev,
+    std::unique_ptr<TEvService::TListNodeXAttrMethod::TResponse> response,
+    const TSessionInfo* session);
+
+template void
+TStorageServiceActor::ReplyToXAttrRequest<TEvService::TSetNodeXAttrMethod>(
+    const TActorContext& ctx,
+    const TEvService::TSetNodeXAttrMethod::TRequest::TPtr& ev,
+    std::unique_ptr<TEvService::TSetNodeXAttrMethod::TResponse> response,
+    const TSessionInfo* session);
+
 ///////////////////////////////////////////////////////////////////////////////
 
 void TStorageServiceActor::HandleGetNodeXAttr(

--- a/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
@@ -218,27 +218,6 @@ void TStorageServiceActor::ReplyToXAttrRequest(
     NCloud::Reply(ctx, *ev, std::move(response));
 }
 
-template void
-TStorageServiceActor::ReplyToXAttrRequest<TEvService::TGetNodeXAttrMethod>(
-    const TActorContext& ctx,
-    const TEvService::TGetNodeXAttrMethod::TRequest::TPtr& ev,
-    std::unique_ptr<TEvService::TGetNodeXAttrMethod::TResponse> response,
-    const TSessionInfo* session);
-
-template void
-TStorageServiceActor::ReplyToXAttrRequest<TEvService::TListNodeXAttrMethod>(
-    const TActorContext& ctx,
-    const TEvService::TListNodeXAttrMethod::TRequest::TPtr& ev,
-    std::unique_ptr<TEvService::TListNodeXAttrMethod::TResponse> response,
-    const TSessionInfo* session);
-
-template void
-TStorageServiceActor::ReplyToXAttrRequest<TEvService::TSetNodeXAttrMethod>(
-    const TActorContext& ctx,
-    const TEvService::TSetNodeXAttrMethod::TRequest::TPtr& ev,
-    std::unique_ptr<TEvService::TSetNodeXAttrMethod::TResponse> response,
-    const TSessionInfo* session);
-
 ///////////////////////////////////////////////////////////////////////////////
 
 void TStorageServiceActor::HandleGetNodeXAttr(

--- a/cloud/filestore/libs/storage/service/service_ut_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_control_namespace.cpp
@@ -1,0 +1,388 @@
+#include "service.h"
+
+#include "service_actor_control_namespace.h"
+#include "service_private.h"
+#include "service_ut_helpers.h"
+
+#include <cloud/filestore/libs/storage/testlib/service_client.h>
+#include <cloud/filestore/libs/storage/testlib/test_env.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr TStringBuf ControlDirName = ".filestore-ctl";
+
+template <bool Enabled = true>
+class TControlNamespaceFixture: public NUnitTest::TBaseTestCase
+{
+public:
+    THolder<TTestEnv> Env;
+    THolder<TServiceClient> Service;
+    TString FsId = "test";
+
+    void SetUp(NUnitTest::TTestContext&) override
+    {
+        NProto::TStorageConfig config;
+        if constexpr (Enabled) {
+            config.SetControlNamespaceDirName(TString(ControlDirName));
+        }
+
+        Env = MakeHolder<TTestEnv>(TTestEnvConfig{}, config);
+        ui32 nodeIdx = Env->AddDynamicNode();
+        Service = MakeHolder<TServiceClient>(Env->GetRuntime(), nodeIdx);
+        Service->CreateFileStore(FsId, 1'000);
+    }
+};
+
+using TEnabledFixture = TControlNamespaceFixture<true>;
+using TDisabledFixture = TControlNamespaceFixture<false>;
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TStorageServiceControlNamespaceTest)
+{
+    Y_UNIT_TEST_F(ShouldExposeControlDirAndFsIdViaLookup, TEnabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+
+        auto dirAttr = Service->GetNodeAttr(
+            headers,
+            FsId,
+            RootNodeId,
+            TString(ControlDirName));
+        UNIT_ASSERT_VALUES_EQUAL(
+            ControlDirIno,
+            dirAttr->Record.GetNode().GetId());
+        UNIT_ASSERT_EQUAL(
+            NProto::E_DIRECTORY_NODE,
+            dirAttr->Record.GetNode().GetType());
+
+        auto fsIdAttr =
+            Service->GetNodeAttr(headers, FsId, ControlDirIno, "fsid");
+        UNIT_ASSERT_VALUES_EQUAL(
+            ControlFsIdFileIno,
+            fsIdAttr->Record.GetNode().GetId());
+        UNIT_ASSERT_EQUAL(
+            NProto::E_REGULAR_NODE,
+            fsIdAttr->Record.GetNode().GetType());
+
+        // an unknown name inside the control dir - ENOENT, not EIO
+        Service->AssertGetNodeAttrFailed(headers, FsId, ControlDirIno, "nope");
+
+        // self-lookup by ino (empty name) also works
+        auto selfAttr =
+            Service->GetNodeAttr(headers, FsId, ControlFsIdFileIno, "");
+        UNIT_ASSERT_VALUES_EQUAL(
+            ControlFsIdFileIno,
+            selfAttr->Record.GetNode().GetId());
+    }
+
+    Y_UNIT_TEST_F(ShouldReadFsIdContent, TEnabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+
+        auto handle = Service->CreateHandle(
+            headers,
+            FsId,
+            ControlFsIdFileIno,
+            "",
+            TCreateHandleArgs::RDNLY);
+        UNIT_ASSERT_VALUES_EQUAL(
+            ControlFsIdFileIno,
+            handle->Record.GetHandle());
+
+        auto data = Service->ReadData(
+            headers,
+            FsId,
+            ControlFsIdFileIno,
+            handle->Record.GetHandle(),
+            0,
+            4_KB);
+        UNIT_ASSERT_VALUES_EQUAL(FsId, data->Record.GetBuffer());
+
+        // closing the synthesized handle must not leak to a real tablet
+        Service->DestroyHandle(
+            headers,
+            FsId,
+            ControlFsIdFileIno,
+            handle->Record.GetHandle());
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectWritesToFsId, TEnabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+
+        // a write-mode open is rejected right at CreateHandle
+        Service->AssertCreateHandleFailed(
+            headers,
+            FsId,
+            ControlFsIdFileIno,
+            "",
+            TCreateHandleArgs::WRNLY);
+
+        // create-and-open by (parent, name) is rejected the same way
+        Service->AssertCreateHandleFailed(
+            headers,
+            FsId,
+            ControlDirIno,
+            "fsid",
+            TCreateHandleArgs::CREATE);
+
+        // a plain read-only handle obtained by name, then a direct write -
+        // also rejected
+        auto handle = Service->CreateHandle(
+            headers,
+            FsId,
+            ControlDirIno,
+            "fsid",
+            TCreateHandleArgs::RDNLY);
+        UNIT_ASSERT_VALUES_EQUAL(
+            ControlFsIdFileIno,
+            handle->Record.GetHandle());
+
+        Service->AssertWriteDataFailed(
+            headers,
+            FsId,
+            ControlFsIdFileIno,
+            handle->Record.GetHandle(),
+            0,
+            TString("x"));
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldRejectCreateNodeTargetingControlNamespace,
+        TEnabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+
+        // mkdir/mknod directly under ".filestore-ctl"
+        Service->AssertCreateNodeFailed(
+            headers,
+            TCreateNodeArgs::Directory(ControlDirIno, "x"));
+
+        // and creating something literally named ".filestore-ctl" at root
+        Service->AssertCreateNodeFailed(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, TString(ControlDirName)));
+
+        // hard-linking a real name to a reserved ino as the link target -
+        // the target, not just (parent, name), must be classified too
+        auto linkToFsId = TCreateNodeArgs(ENodeType::Link, RootNodeId, "x");
+        linkToFsId.TargetNode = ControlFsIdFileIno;
+        Service->AssertCreateNodeFailed(headers, linkToFsId);
+
+        auto linkToControlDir =
+            TCreateNodeArgs(ENodeType::Link, RootNodeId, "y");
+        linkToControlDir.TargetNode = ControlDirIno;
+        Service->AssertCreateNodeFailed(headers, linkToControlDir);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectRenamesTouchingControlDir, TEnabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+
+        const auto dirId =
+            Service
+                ->CreateNode(
+                    headers,
+                    TCreateNodeArgs::Directory(RootNodeId, "dir"))
+                ->Record.GetNode()
+                .GetId();
+        Service->CreateNode(headers, TCreateNodeArgs::File(dirId, "file"));
+
+        // moving a real file into ".filestore-ctl"
+        Service->AssertRenameNodeFailed(
+            headers,
+            dirId,
+            "file",
+            ControlDirIno,
+            "x",
+            0);
+
+        // renaming a real dir onto the literal name ".filestore-ctl" at root
+        Service->AssertRenameNodeFailed(
+            headers,
+            RootNodeId,
+            "dir",
+            RootNodeId,
+            TString(ControlDirName),
+            0);
+    }
+
+    Y_UNIT_TEST_F(ShouldListControlDirContents, TEnabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+
+        auto response = Service->ListNodes(headers, FsId, ControlDirIno);
+        UNIT_ASSERT_VALUES_EQUAL(1u, response->Record.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("fsid", response->Record.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            ControlFsIdFileIno,
+            response->Record.GetNodes(0).GetId());
+
+        // the control dir's single entry always fits on the first page, so
+        // a non-empty cookie can only come from a caller ignoring the
+        // "no cookie in the response means done" contract - must not crash,
+        // and must not repeat the entry
+        auto request =
+            Service->CreateListNodesRequest(headers, FsId, ControlDirIno);
+        request->Record.SetCookie("garbage");
+        Service->SendRequest(MakeStorageServiceId(), std::move(request));
+        auto reply = Service->RecvListNodesResponse();
+        UNIT_ASSERT_C(SUCCEEDED(reply->GetStatus()), reply->GetErrorReason());
+        UNIT_ASSERT_VALUES_EQUAL(0u, reply->Record.NamesSize());
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldReadViaAForgedHandleWithoutCreateHandle,
+        TEnabledFixture)
+    {
+        // handles in this namespace are just the target ino - CreateHandle
+        // never allocates session-bound state, so a caller may present
+        // ControlFsIdFileIno as a handle directly, by design
+        auto headers = Service->InitSession(FsId, "client");
+
+        auto data = Service->ReadData(
+            headers,
+            FsId,
+            ControlFsIdFileIno,
+            ControlFsIdFileIno,
+            0,
+            4_KB);
+        UNIT_ASSERT_VALUES_EQUAL(FsId, data->Record.GetBuffer());
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectReadingTheControlDirAsAFile, TEnabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+
+        // the control dir itself is a legitimately obtainable read-only
+        // handle - reading through it must not fall back to serving fsid's
+        // content
+        auto handle = Service->CreateHandle(
+            headers,
+            FsId,
+            ControlDirIno,
+            "",
+            TCreateHandleArgs::RDNLY);
+        UNIT_ASSERT_VALUES_EQUAL(ControlDirIno, handle->Record.GetHandle());
+
+        Service->AssertReadDataFailed(
+            headers,
+            FsId,
+            ControlDirIno,
+            handle->Record.GetHandle(),
+            0,
+            4_KB);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectRequestsWithInvalidSession, TEnabledFixture)
+    {
+        // a session that was never created via InitSession
+        THeaders headers{FsId, "bogus-client", "bogus-session", 0};
+
+        // by-name form (TryHandleControlNamespaceGetNodeAttr)
+        auto attrResponse = Service->AssertGetNodeAttrFailed(
+            headers,
+            FsId,
+            RootNodeId,
+            TString(ControlDirName));
+        UNIT_ASSERT_VALUES_EQUAL(
+            attrResponse->GetError().GetCode(),
+            (ui32)E_FS_INVALID_SESSION);
+
+        // self-lookup-by-ino form (ForwardRequestToShard's control-namespace
+        // fast path)
+        auto selfAttrResponse = Service->AssertGetNodeAttrFailed(
+            headers,
+            FsId,
+            ControlFsIdFileIno,
+            "");
+        UNIT_ASSERT_VALUES_EQUAL(
+            selfAttrResponse->GetError().GetCode(),
+            (ui32)E_FS_INVALID_SESSION);
+
+        auto handleResponse = Service->AssertCreateHandleFailed(
+            headers,
+            FsId,
+            ControlFsIdFileIno,
+            "",
+            TCreateHandleArgs::RDNLY);
+        UNIT_ASSERT_VALUES_EQUAL(
+            handleResponse->GetError().GetCode(),
+            (ui32)E_FS_INVALID_SESSION);
+
+        auto listResponse =
+            Service->AssertListNodesFailed(headers, FsId, ControlDirIno);
+        UNIT_ASSERT_VALUES_EQUAL(
+            listResponse->GetError().GetCode(),
+            (ui32)E_FS_INVALID_SESSION);
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldIgnoreRequestSuppliedFileSystemIdForFsIdContent,
+        TEnabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+        const TString spoofedFsId = "some-other-filesystem";
+
+        // by-name form: session is for FsId, but the request itself claims
+        // to be for a different filesystem
+        auto attr =
+            Service->GetNodeAttr(headers, spoofedFsId, ControlDirIno, "fsid");
+        UNIT_ASSERT_VALUES_EQUAL(
+            ControlFsIdFileIno,
+            attr->Record.GetNode().GetId());
+
+        auto handle = Service->CreateHandle(
+            headers,
+            spoofedFsId,
+            ControlFsIdFileIno,
+            "",
+            TCreateHandleArgs::RDNLY);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<ui64>(FsId.size()),
+            handle->Record.GetNodeAttr().GetSize());
+
+        auto data = Service->ReadData(
+            headers,
+            spoofedFsId,
+            ControlFsIdFileIno,
+            handle->Record.GetHandle(),
+            0,
+            4_KB);
+        UNIT_ASSERT_VALUES_EQUAL(FsId, data->Record.GetBuffer());
+
+        // self-lookup-by-ino form, via ForwardRequestToShard
+        auto selfAttr =
+            Service->GetNodeAttr(headers, spoofedFsId, ControlFsIdFileIno, "");
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<ui64>(FsId.size()),
+            selfAttr->Record.GetNode().GetSize());
+    }
+
+    Y_UNIT_TEST_F(ShouldStayInertWhenDisabled, TDisabledFixture)
+    {
+        auto headers = Service->InitSession(FsId, "client");
+
+        // feature off - ".filestore-ctl" is just a nonexistent name
+        auto response = Service->AssertGetNodeAttrFailed(
+            headers,
+            FsId,
+            RootNodeId,
+            TString(ControlDirName));
+        UNIT_ASSERT_VALUES_UNEQUAL(S_OK, response->GetStatus());
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_control_namespace.cpp
@@ -241,6 +241,12 @@ Y_UNIT_TEST_SUITE(TStorageServiceControlNamespaceTest)
         auto reply = Service->RecvListNodesResponse();
         UNIT_ASSERT_C(SUCCEEDED(reply->GetStatus()), reply->GetErrorReason());
         UNIT_ASSERT_VALUES_EQUAL(0u, reply->Record.NamesSize());
+
+        auto fsIdResponse =
+            Service->AssertListNodesFailed(headers, FsId, ControlFsIdFileIno);
+        UNIT_ASSERT_VALUES_EQUAL(
+            (ui32)E_FS_NOTDIR,
+            fsIdResponse->GetError().GetCode());
     }
 
     Y_UNIT_TEST_F(

--- a/cloud/filestore/libs/storage/service/service_ut_control_namespace.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_control_namespace.cpp
@@ -268,26 +268,26 @@ Y_UNIT_TEST_SUITE(TStorageServiceControlNamespaceTest)
         UNIT_ASSERT_VALUES_EQUAL(FsId, data->Record.GetBuffer());
     }
 
-    Y_UNIT_TEST_F(ShouldRejectReadingTheControlDirAsAFile, TEnabledFixture)
+    Y_UNIT_TEST_F(ShouldRejectOpeningTheControlDirAsAFile, TEnabledFixture)
     {
         auto headers = Service->InitSession(FsId, "client");
 
-        // the control dir itself is a legitimately obtainable read-only
-        // handle - reading through it must not fall back to serving fsid's
-        // content
-        auto handle = Service->CreateHandle(
+        // matches real directories - CreateHandle doesn't support opening
+        // a directory at all
+        Service->AssertCreateHandleFailed(
             headers,
             FsId,
             ControlDirIno,
             "",
             TCreateHandleArgs::RDNLY);
-        UNIT_ASSERT_VALUES_EQUAL(ControlDirIno, handle->Record.GetHandle());
 
+        // handles here are just the target ino, so ReadData must also
+        // reject a forged handle directly
         Service->AssertReadDataFailed(
             headers,
             FsId,
             ControlDirIno,
-            handle->Record.GetHandle(),
+            ControlDirIno,
             0,
             4_KB);
     }

--- a/cloud/filestore/libs/storage/service/ut/ya.make
+++ b/cloud/filestore/libs/storage/service/ut/ya.make
@@ -6,6 +6,7 @@ SRCS(
     helpers_ut.cpp
     protobuf_utils_ut.cpp
     service_ut.cpp
+    service_ut_control_namespace.cpp
     service_ut_helpers.cpp
     service_ut_parentless.cpp
     service_ut_quotas.cpp

--- a/cloud/filestore/libs/storage/service/ya.make
+++ b/cloud/filestore/libs/storage/service/ya.make
@@ -42,6 +42,7 @@ SRCS(
     service_actor_readdata.cpp
     service_actor_renamenode.cpp
     service_actor_statfs.cpp
+    service_actor_unlinknode.cpp
     service_actor_update_stats.cpp
     service_actor_writedata.cpp
     service_actor_xattr.cpp

--- a/cloud/filestore/libs/storage/service/ya.make
+++ b/cloud/filestore/libs/storage/service/ya.make
@@ -28,6 +28,7 @@ SRCS(
     service_actor_createsession.cpp
     service_actor_describefsmodel.cpp
     service_actor_destroyfs.cpp
+    service_actor_destroyhandle.cpp
     service_actor_destroysession.cpp
     service_actor_forward.cpp
     service_actor_getfsinfo.cpp


### PR DESCRIPTION
### Notes
Example of it working:

```
$ mkdir sanity-dir && echo hi > sanity-dir/file.txt && cat sanity-dir/file.txt
hi

$ ls .filestore-ctl
fsid

$ cat .filestore-ctl/fsid
nfs

$ echo x > .filestore-ctl/fsid
permission denied

$ mkdir .filestore-ctl/newdir
Permission denied

$ mv sanity-dir/file.txt .filestore-ctl/file.txt
Permission denied

$ ln .filestore-ctl/fsid sanity-dir/link
Permission denied

$ cat .filestore-ctl
Is a directory

$ rm -rf sanity-dir
```

### Issue
#7053
#6608
