### PR TITLE
issue-6958: fastshard - open handles now prevent Node destruction

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.cpp
@@ -62,7 +62,10 @@ NProto::TError THandleTable::Put(THandleSlot v, TWriteContext& writeContext)
     return Slots->Put(writeContext.Lsn, v, writeContext.PageGroups);
 }
 
-NProto::TError THandleTable::Delete(ui64 handle, TWriteContext& writeContext)
+NProto::TError THandleTable::Delete(
+    ui64 handle,
+    TWriteContext& writeContext,
+    ui64* nodeId)
 {
     THandleSlot slot{};
     auto error = Slots->Delete(
@@ -74,6 +77,8 @@ NProto::TError THandleTable::Delete(ui64 handle, TWriteContext& writeContext)
     if (error.GetCode() == E_FS_NOENT) {
         error = ErrorInvalidHandle(handle);
     }
+
+    *nodeId = slot.NodeId;
 
     return error;
 }

--- a/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.cpp
@@ -143,6 +143,10 @@ NProto::TError THandleTable::Delete(
         return ErrorInvalidHandle(handle);
     }
 
+    if (HasError(error)) {
+        return error;
+    }
+
     ui64 slotNo = 0;
     error = NodeId2HandleCount->Get(
         writeContext.Lsn,

--- a/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.cpp
@@ -115,6 +115,10 @@ NProto::TError THandleTable::Put(
             writeContext.PageGroups);
     }
 
+    if (HasError(error)) {
+        return error;
+    }
+
     ++nodeHandles.HandleCount;
     return NodeId2HandleCount->Update(
         writeContext.Lsn,

--- a/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.cpp
@@ -11,29 +11,59 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 ////////////////////////////////////////////////////////////////////////////////
 
 ui64 THandleTable::Init(
+    ui64 nodesPerGroup,
     ui64 handlesPerGroup,
     ui64 firstPageNo,
     IPageStorePtr pageStore)
 {
-    const ui64 pageCount =
-        RoundUp(handlesPerGroup, SlotsPerPage) / SlotsPerPage;
-    THandleSlot tombstone{};
-    tombstone.Handle = Max<ui64>();
-    Slots = std::make_unique<THt>(
-        firstPageNo,
-        pageCount,
-        PageSize,
-        HandleSlotSize,
-        tombstone,
-        std::move(pageStore),
-        [](const THandleSlot& s) -> ui64 { return s.Handle; },
-        [](const ui64& handle) -> ui64 {
-            return CityHash64(
-                reinterpret_cast<const char*>(&handle),
-                sizeof(handle));
-        });
+    ui64 totalPageCount = 0;
+    {
+        const ui64 pageCount = RoundUp(handlesPerGroup, HandleSlotsPerPage)
+            / HandleSlotsPerPage;
+        THandleSlot tombstone{};
+        tombstone.Handle = Max<ui64>();
+        Handles = std::make_unique<THandles>(
+            firstPageNo,
+            pageCount,
+            PageSize,
+            HandleSlotSize,
+            tombstone,
+            pageStore,
+            [](const THandleSlot& s) -> ui64 { return s.Handle; },
+            [](const ui64& handle) -> ui64 {
+                return CityHash64(
+                    reinterpret_cast<const char*>(&handle),
+                    sizeof(handle));
+            });
 
-    return pageCount;
+        totalPageCount += pageCount;
+        firstPageNo += pageCount;
+    }
+
+    {
+        const ui64 pageCount = RoundUp(nodesPerGroup, NodeHandlesSlotsPerPage)
+            / NodeHandlesSlotsPerPage;
+        TNodeHandlesSlot tombstone{};
+        tombstone.NodeId = Max<ui64>();
+        NodeId2HandleCount = std::make_unique<TNodeId2HandleCount>(
+            firstPageNo,
+            pageCount,
+            PageSize,
+            NodeHandlesSlotSize,
+            tombstone,
+            std::move(pageStore),
+            [](const TNodeHandlesSlot& s) -> ui64 { return s.NodeId; },
+            [](const ui64& nodeId) -> ui64 {
+                return CityHash64(
+                    reinterpret_cast<const char*>(&nodeId),
+                    sizeof(nodeId));
+            });
+
+        totalPageCount += pageCount;
+        firstPageNo += pageCount;
+    }
+
+    return totalPageCount;
 }
 
 NProto::TError THandleTable::AllocateHandle(ui64* handle) const
@@ -43,7 +73,7 @@ NProto::TError THandleTable::AllocateHandle(ui64* handle) const
 
         ui64 slotNo = 0;
         THandleSlot slot{};
-        auto error = Slots->Get(0 /* lsn */, *handle, &slot, &slotNo);
+        auto error = Handles->Get(0 /* lsn */, *handle, &slot, &slotNo);
 
         if (!HasError(error)) {
             continue;
@@ -57,37 +87,120 @@ NProto::TError THandleTable::AllocateHandle(ui64* handle) const
     }
 }
 
-NProto::TError THandleTable::Put(THandleSlot v, TWriteContext& writeContext)
+NProto::TError THandleTable::Put(
+    THandleSlot handle,
+    TWriteContext& writeContext)
 {
-    return Slots->Put(writeContext.Lsn, v, writeContext.PageGroups);
+    auto error = Handles->Put(
+        writeContext.Lsn,
+        handle,
+        writeContext.PageGroups);
+    if (HasError(error)) {
+        return error;
+    }
+
+    TNodeHandlesSlot nodeHandles{};
+    ui64 slotNo = 0;
+    error = NodeId2HandleCount->Get(
+        writeContext.Lsn,
+        handle.NodeId,
+        &nodeHandles,
+        &slotNo);
+    if (error.GetCode() == E_FS_NOENT) {
+        nodeHandles.NodeId = handle.NodeId;
+        nodeHandles.HandleCount = 1;
+        return NodeId2HandleCount->Put(
+            writeContext.Lsn,
+            nodeHandles,
+            writeContext.PageGroups);
+    }
+
+    ++nodeHandles.HandleCount;
+    return NodeId2HandleCount->Update(
+        writeContext.Lsn,
+        nodeHandles,
+        slotNo,
+        writeContext.PageGroups);
 }
 
 NProto::TError THandleTable::Delete(
     ui64 handle,
     TWriteContext& writeContext,
-    ui64* nodeId)
+    TNodeHandlesSlot* nodeHandles)
 {
     THandleSlot slot{};
-    auto error = Slots->Delete(
+    auto error = Handles->Delete(
         writeContext.Lsn,
         handle,
         &slot,
         writeContext.PageGroups);
 
     if (error.GetCode() == E_FS_NOENT) {
-        error = ErrorInvalidHandle(handle);
+        return ErrorInvalidHandle(handle);
     }
 
-    *nodeId = slot.NodeId;
+    ui64 slotNo = 0;
+    error = NodeId2HandleCount->Get(
+        writeContext.Lsn,
+        slot.NodeId,
+        nodeHandles,
+        &slotNo);
+    if (HasError(error)) {
+        return error;
+    }
+
+    --nodeHandles->HandleCount;
+
+    if (nodeHandles->HandleCount) {
+        error = NodeId2HandleCount->Update(
+            writeContext.Lsn,
+            *nodeHandles,
+            slotNo,
+            writeContext.PageGroups);
+    } else {
+        TNodeHandlesSlot dummy{};
+        error = NodeId2HandleCount->Delete(
+            writeContext.Lsn,
+            nodeHandles->NodeId,
+            &dummy,
+            writeContext.PageGroups);
+    }
 
     return error;
 }
 
-NProto::TError THandleTable::Get(ui64 handle, ui64* nodeId) const
+NProto::TError THandleTable::Get(
+    ui64 handle,
+    TNodeHandlesSlot* nodeHandles) const
 {
     ui64 slotNo = 0;
     THandleSlot slot{};
-    auto error = Slots->Get(0 /* lsn */, handle, &slot, &slotNo);
+    auto error = Handles->Get(0 /* lsn */, handle, &slot, &slotNo);
+    if (error.GetCode() == E_FS_NOENT) {
+        return ErrorInvalidHandle(handle);
+    }
+
+    if (HasError(error)) {
+        return error;
+    }
+
+    error = NodeId2HandleCount->Get(
+        0 /* lsn */,
+        slot.NodeId,
+        nodeHandles,
+        &slotNo);
+    if (HasError(error)) {
+        return error;
+    }
+
+    return {};
+}
+
+NProto::TError THandleTable::GetNodeId(ui64 handle, ui64* nodeId) const
+{
+    ui64 slotNo = 0;
+    THandleSlot slot{};
+    auto error = Handles->Get(0 /* lsn */, handle, &slot, &slotNo);
     if (error.GetCode() == E_FS_NOENT) {
         return ErrorInvalidHandle(handle);
     }
@@ -100,11 +213,33 @@ NProto::TError THandleTable::Get(ui64 handle, ui64* nodeId) const
     return {};
 }
 
+NProto::TError THandleTable::GetNodeHandleCount(
+    ui64 nodeId,
+    ui64* handleCount) const
+{
+    TNodeHandlesSlot nodeHandles{};
+    ui64 slotNo = 0;
+    auto error =
+        NodeId2HandleCount->Get(0 /* lsn */, nodeId, &nodeHandles, &slotNo);
+
+    if (error.GetCode() == E_FS_NOENT) {
+        *handleCount = 0;
+        return {};
+    }
+
+    if (HasError(error)) {
+        return error;
+    }
+
+    *handleCount = nodeHandles.HandleCount;
+    return {};
+}
+
 [[nodiscard]] NProto::TError THandleTable::CollectStats(
     TFileSystemShardStats* stats) const
 {
     TPersistentHashTableStats slotStats;
-    auto e = Slots->CollectStats(&slotStats);
+    auto e = Handles->CollectStats(&slotStats);
     if (HasError(e)) {
         return e;
     }

--- a/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.h
@@ -44,7 +44,10 @@ public:
 
     NProto::TError Put(THandleSlot v, TWriteContext& writeContext);
 
-    NProto::TError Delete(ui64 handle, TWriteContext& writeContext);
+    NProto::TError Delete(
+        ui64 handle,
+        TWriteContext& writeContext,
+        ui64* nodeId);
 
     NProto::TError Get(ui64 handle, ui64* nodeId) const;
 

--- a/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/model/handle_table.h
@@ -21,35 +21,55 @@ struct THandleSlot
 
 static_assert(sizeof(THandleSlot) <= HandleSlotSize);
 
+constexpr ui64 NodeHandlesSlotSize = 16;
+
+struct TNodeHandlesSlot
+{
+    ui64 NodeId;
+    ui64 HandleCount;
+};
+
+static_assert(sizeof(TNodeHandlesSlot) <= NodeHandlesSlotSize);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class THandleTable
 {
 private:
-    static constexpr ui64 SlotsPerPage = 256;
-    static_assert(SlotsPerPage * HandleSlotSize <= PageSize);
+    static constexpr ui64 HandleSlotsPerPage = 256;
+    static_assert(HandleSlotsPerPage * HandleSlotSize <= PageSize);
+    static constexpr ui64 NodeHandlesSlotsPerPage = 256;
+    static_assert(NodeHandlesSlotsPerPage * NodeHandlesSlotSize <= PageSize);
 
-    using THt = TPersistentHashTable<ui64, THandleSlot>;
-    std::unique_ptr<THt> Slots;
+    using THandles = TPersistentHashTable<ui64, THandleSlot>;
+    std::unique_ptr<THandles> Handles;
+    using TNodeId2HandleCount = TPersistentHashTable<ui64, TNodeHandlesSlot>;
+    std::unique_ptr<TNodeId2HandleCount> NodeId2HandleCount;
 
 public:
-    ui64 Init(ui64 handlesPerGroup, ui64 firstPageNo, IPageStorePtr pageStore);
+    ui64 Init(
+        ui64 nodesPerGroup,
+        ui64 handlesPerGroup,
+        ui64 firstPageNo,
+        IPageStorePtr pageStore);
 
     [[nodiscard]] ui64 GetSlotCount() const
     {
-        return Slots->GetSlotCount();
+        return Handles->GetSlotCount() + NodeId2HandleCount->GetSlotCount();
     }
 
     NProto::TError AllocateHandle(ui64* handle) const;
 
-    NProto::TError Put(THandleSlot v, TWriteContext& writeContext);
+    NProto::TError Put(THandleSlot handle, TWriteContext& writeContext);
 
     NProto::TError Delete(
         ui64 handle,
         TWriteContext& writeContext,
-        ui64* nodeId);
+        TNodeHandlesSlot* nodeHandles);
 
-    NProto::TError Get(ui64 handle, ui64* nodeId) const;
+    NProto::TError Get(ui64 handle, TNodeHandlesSlot* nodeHandles) const;
+    NProto::TError GetNodeId(ui64 handle, ui64* nodeId) const;
+    NProto::TError GetNodeHandleCount(ui64 nodeId, ui64* handleCount) const;
 
     [[nodiscard]] NProto::TError CollectStats(
         TFileSystemShardStats* stats) const;

--- a/cloud/filestore/libs/storage/fastshard/impl/model/node_table.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/model/node_table.cpp
@@ -109,6 +109,18 @@ NProto::TError TNodeTable::ResizeNode(
 }
 
 NProto::TError TNodeTable::UpdateNode(
+    const TNodeTableSlot& slot,
+    ui64 slotNo,
+    TWriteContext& writeContext)
+{
+    return Slots->Update(
+        writeContext.Lsn,
+        slot,
+        slotNo,
+        writeContext.PageGroups);
+}
+
+NProto::TError TNodeTable::UpdateNode(
     ui64 nodeId,
     ui32 flags,
     const NProto::TSetNodeAttrRequest::TUpdate& update,
@@ -182,6 +194,22 @@ NProto::TError TNodeTable::DeleteNode(
 {
     return Slots
         ->Delete(writeContext.Lsn, nodeId, slot, writeContext.PageGroups);
+}
+
+NProto::TError TNodeTable::GetNode(
+    ui64 nodeId,
+    TWriteContext& writeContext,
+    TNodeTableSlot* slot,
+    ui64* slotNo,
+    NProto::TNodeAttr* attr) const
+{
+    auto error = Slots->Get(writeContext.Lsn, nodeId, slot, slotNo);
+    if (HasError(error)) {
+        return error;
+    }
+
+    *attr = Convert(*slot);
+    return {};
 }
 
 NProto::TError TNodeTable::GetNode(ui64 nodeId, NProto::TNodeAttr* attr) const

--- a/cloud/filestore/libs/storage/fastshard/impl/model/node_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/model/node_table.h
@@ -67,6 +67,11 @@ public:
         TWriteContext& writeContext);
 
     NProto::TError UpdateNode(
+        const TNodeTableSlot& slot,
+        ui64 slotNo,
+        TWriteContext& writeContext);
+
+    NProto::TError UpdateNode(
         ui64 nodeId,
         ui32 flags,
         const NProto::TSetNodeAttrRequest::TUpdate& update,
@@ -82,6 +87,13 @@ public:
         ui64 nodeId,
         TWriteContext& writeContext,
         TNodeTableSlot* slot);
+
+    NProto::TError GetNode(
+        ui64 nodeId,
+        TWriteContext& writeContext,
+        TNodeTableSlot* slot,
+        ui64* slotNo,
+        NProto::TNodeAttr* attr) const;
 
     NProto::TError GetNode(ui64 nodeId, NProto::TNodeAttr* attr) const;
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -410,7 +410,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-auto CreateAttrs(ui64 id, ui32 mode, ui64 size, ui64 uid, ui64 gid, ui32 links)
+auto CreateAttrs(ui64 id, ui32 mode, ui64 size, ui64 uid, ui64 gid)
 {
     ui64 now = MicroSeconds();
 
@@ -424,7 +424,7 @@ auto CreateAttrs(ui64 id, ui32 mode, ui64 size, ui64 uid, ui64 gid, ui32 links)
     attrs.SetSize(size);
     attrs.SetUid(uid);
     attrs.SetGid(gid);
-    attrs.SetLinks(links);
+    attrs.SetLinks(1);
 
     return attrs;
 }
@@ -626,8 +626,11 @@ public:
         SILK_INFO("handle table offset=%lu", handleTableOffset);
         const ui64 handlesPerFile = 10;
         const ui64 handlesPerGroup = handlesPerFile * Config.GetNodesPerGroup();
-        const ui64 handleTablePageCount =
-            Handles.Init(handlesPerGroup, firstPageNo, PageStore);
+        const ui64 handleTablePageCount = Handles.Init(
+            Config.GetNodesPerGroup(),
+            handlesPerGroup,
+            firstPageNo,
+            PageStore);
         firstPageNo += handleTablePageCount;
 
         const ui64 pageIndexOffset = firstPageNo * PageSize;
@@ -943,7 +946,6 @@ public:
         ui32 mode,
         ui64 uid,
         ui64 gid,
-        ui32 links,
         TWriteContext& writeContext,
         NProto::TNodeAttr* attr)
     {
@@ -958,7 +960,7 @@ public:
         }
 
         nodeId = ShardedId(nodeId, ShardNo);
-        *attr = CreateAttrs(nodeId, mode, 0 /* size */, uid, gid, links);
+        *attr = CreateAttrs(nodeId, mode, 0 /* size */, uid, gid);
 
         error = Nodes.PutNode(*attr, writeContext);
         if (HasError(error)) {
@@ -1025,7 +1027,6 @@ public:
                 request.GetFile().GetMode(),
                 request.GetUid(),
                 request.GetGid(),
-                1 /* links */,
                 writeContext,
                 &attr);
         }
@@ -1152,7 +1153,20 @@ public:
             return error;
         }
 
-        if (slot.Links > 1) {
+        ui64 handleCount = 0;
+        if (slot.Links == 1) {
+            error = Handles.GetNodeHandleCount(nodeId, &handleCount);
+            if (HasError(error)) {
+                SILK_LOG(
+                    LogLevel(error),
+                    "[%s] UnrefNode::Handles.GetNodeHandleCount error=%s",
+                    lc.Describe().c_str(),
+                    FormatError(error).c_str());
+                return error;
+            }
+        }
+
+        if (slot.Links > 1 || handleCount > 0) {
             slot.Links -= 1;
             attr.SetLinks(slot.Links);
             error = Nodes.UpdateNode(slot, slotNo, writeContext);
@@ -1290,10 +1304,7 @@ public:
         ui64 nodeId = request.GetNodeId();
         NProto::TNodeAttr attr;
         if (request.GetName().empty()) {
-            TNodeTableSlot slot{};
-            ui64 slotNo = 0;
-            auto error =
-                Nodes.GetNode(nodeId, writeContext, &slot, &slotNo, &attr);
+            auto error = Nodes.GetNode(nodeId, &attr);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
@@ -1301,18 +1312,6 @@ public:
                     lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
-            } else {
-                slot.Links += 1;
-                attr.SetLinks(slot.Links);
-                error = Nodes.UpdateNode(slot, slotNo, writeContext);
-                if (HasError(error)) {
-                    SILK_LOG(
-                        LogLevel(error),
-                        "[%s] CreateHandle::Nodes.UpdateNode error=%s",
-                        lc.Describe().c_str(),
-                        FormatError(error).c_str());
-                    *response.MutableError() = std::move(error);
-                }
             }
         } else {
             auto error = Names.Get(request.GetName(), &nodeId);
@@ -1324,7 +1323,6 @@ public:
                         request.GetMode(),
                         request.GetUid(),
                         request.GetGid(),
-                        2 /* links */,
                         writeContext,
                         &attr);
                     if (HasError(error)) {
@@ -1354,10 +1352,7 @@ public:
                     ErrorAlreadyExists(request.GetName());
             } else {
                 lc.NodeId = nodeId;
-                TNodeTableSlot slot{};
-                ui64 slotNo = 0;
-                auto error =
-                    Nodes.GetNode(nodeId, writeContext, &slot, &slotNo, &attr);
+                auto error = Nodes.GetNode(nodeId, &attr);
                 if (HasError(error)) {
                     SILK_LOG(
                         LogLevel(error),
@@ -1365,18 +1360,6 @@ public:
                         lc.Describe().c_str(),
                         FormatError(error).c_str());
                     *response.MutableError() = std::move(error);
-                } else {
-                    slot.Links += 1;
-                    attr.SetLinks(slot.Links);
-                    error = Nodes.UpdateNode(slot, slotNo, writeContext);
-                    if (HasError(error)) {
-                        SILK_LOG(
-                            LogLevel(error),
-                            "[%s] CreateHandle::Nodes.UpdateNode error=%s",
-                            lc.Describe().c_str(),
-                            FormatError(error).c_str());
-                        *response.MutableError() = std::move(error);
-                    }
                 }
             }
         }
@@ -1461,9 +1444,9 @@ public:
             std::lock_guard g(Mutex);
             wcg.Init();
 
-            ui64 nodeId = 0;
+            TNodeHandlesSlot nodeHandles{};
             auto error =
-                Handles.Delete(request.GetHandle(), writeContext, &nodeId);
+                Handles.Delete(request.GetHandle(), writeContext, &nodeHandles);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
@@ -1471,17 +1454,35 @@ public:
                     lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
-            } else {
-                lc.NodeId = nodeId;
+            } else if (nodeHandles.HandleCount == 0) {
+                lc.NodeId = nodeHandles.NodeId;
 
-                error = UnrefNode(lc, nodeId, writeContext);
+                TNodeTableSlot slot{};
+                ui64 slotNo = 0;
+                NProto::TNodeAttr attr;
+                auto error = Nodes.GetNode(
+                    nodeHandles.NodeId,
+                    writeContext,
+                    &slot,
+                    &slotNo,
+                    &attr);
                 if (HasError(error)) {
                     SILK_LOG(
                         LogLevel(error),
-                        "[%s] DestroyHandle::UnrefNode error=%s",
+                        "[%s] DestroyHandle::Nodes.GetNode error=%s",
                         lc.Describe().c_str(),
                         FormatError(error).c_str());
                     *response.MutableError() = std::move(error);
+                } else if (slot.Links == 0) {
+                    error = DestroyNode(lc, nodeHandles.NodeId, writeContext);
+                    if (HasError(error)) {
+                        SILK_LOG(
+                            LogLevel(error),
+                            "[%s] DestroyHandle::DestroyNode error=%s",
+                            lc.Describe().c_str(),
+                            FormatError(error).c_str());
+                        *response.MutableError() = std::move(error);
+                    }
                 }
             }
         }
@@ -1531,7 +1532,7 @@ public:
         std::unique_lock l(Mutex);
 
         ui64 nodeId = 0;
-        auto error = Handles.Get(request.GetHandle(), &nodeId);
+        auto error = Handles.GetNodeId(request.GetHandle(), &nodeId);
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),
@@ -1842,7 +1843,7 @@ public:
         std::lock_guard l(Mutex);
 
         ui64 nodeId = 0;
-        auto error = Handles.Get(request.GetHandle(), &nodeId);
+        auto error = Handles.GetNodeId(request.GetHandle(), &nodeId);
         if (HasError(error)) {
             SILK_LOG(
                 LogLevel(error),

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -410,7 +410,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-auto CreateAttrs(ui64 id, ui32 mode, ui64 size, ui64 uid, ui64 gid)
+auto CreateAttrs(ui64 id, ui32 mode, ui64 size, ui64 uid, ui64 gid, ui32 links)
 {
     ui64 now = MicroSeconds();
 
@@ -421,10 +421,10 @@ auto CreateAttrs(ui64 id, ui32 mode, ui64 size, ui64 uid, ui64 gid)
     attrs.SetATime(now);
     attrs.SetMTime(now);
     attrs.SetCTime(now);
-    attrs.SetLinks(1);
     attrs.SetSize(size);
     attrs.SetUid(uid);
     attrs.SetGid(gid);
+    attrs.SetLinks(links);
 
     return attrs;
 }
@@ -943,6 +943,7 @@ public:
         ui32 mode,
         ui64 uid,
         ui64 gid,
+        ui32 links,
         TWriteContext& writeContext,
         NProto::TNodeAttr* attr)
     {
@@ -957,7 +958,7 @@ public:
         }
 
         nodeId = ShardedId(nodeId, ShardNo);
-        *attr = CreateAttrs(nodeId, mode, 0 /* size */, uid, gid);
+        *attr = CreateAttrs(nodeId, mode, 0 /* size */, uid, gid, links);
 
         error = Nodes.PutNode(*attr, writeContext);
         if (HasError(error)) {
@@ -1024,6 +1025,7 @@ public:
                 request.GetFile().GetMode(),
                 request.GetUid(),
                 request.GetGid(),
+                1 /* links */,
                 writeContext,
                 &attr);
         }
@@ -1061,6 +1063,122 @@ public:
         return response;
     }
 
+    NProto::TError DestroyNode(
+        TLoggingContext& lc,
+        ui64 nodeId,
+        TWriteContext& writeContext)
+    {
+        TNodeTableSlot slot{};
+        auto error = Nodes.DeleteNode(nodeId, writeContext, &slot);
+        if (HasError(error)) {
+            SILK_LOG(
+                LogLevel(error),
+                "[%s] DestroyNode::Nodes.DeleteNode error=%s",
+                lc.Describe().c_str(),
+                FormatError(error).c_str());
+            return error;
+        }
+
+        TVector<ui64> storagePageClusterIds;
+        for (ui64 offset = 0; offset < slot.Size;
+                offset += PageClusterSize)
+        {
+            const ui64 pageClusterId = offset / PageClusterSize;
+            lc.PageClusterIds.push_back(pageClusterId);
+
+            TNodePageClusterSlot slot{};
+            error = PageIndex.Delete(
+                {
+                    .NodeId = nodeId,
+                    .PageClusterId = pageClusterId,
+                },
+                writeContext,
+                &slot);
+
+            if (error.GetCode() == E_FS_NOENT) {
+                //
+                // This page cluster is not allocated.
+                //
+
+                lc.StoragePageClusterIds.push_back(
+                    InvalidStoragePageClusterId);
+                continue;
+            }
+
+            if (HasError(error)) {
+                SILK_LOG(
+                    LogLevel(error),
+                    "[%s] DestroyNode::PageIndex.Delete error=%s",
+                    lc.Describe().c_str(),
+                    FormatError(error).c_str());
+                return error;
+            }
+
+            storagePageClusterIds.push_back(slot.StoragePageClusterId);
+            lc.StoragePageClusterIds.push_back(slot.StoragePageClusterId);
+        }
+
+        error = PageAllocator.Deallocate(
+            lc,
+            storagePageClusterIds,
+            writeContext);
+        if (HasError(error)) {
+            SILK_LOG(
+                LogLevel(error),
+                "[%s] DestroyNode::PageAllocator.Deallocate error=%s",
+                lc.Describe().c_str(),
+                FormatError(error).c_str());
+            return error;
+        }
+
+        return {};
+    }
+
+    NProto::TError UnrefNode(
+        TLoggingContext& lc,
+        ui64 nodeId,
+        TWriteContext& writeContext)
+    {
+        TNodeTableSlot slot{};
+        ui64 slotNo = 0;
+        NProto::TNodeAttr attr;
+        auto error = Nodes.GetNode(nodeId, writeContext, &slot, &slotNo, &attr);
+        if (HasError(error)) {
+            SILK_LOG(
+                LogLevel(error),
+                "[%s] UnrefNode::Nodes.GetNode error=%s",
+                lc.Describe().c_str(),
+                FormatError(error).c_str());
+            return error;
+        }
+
+        if (slot.Links > 1) {
+            slot.Links -= 1;
+            attr.SetLinks(slot.Links);
+            error = Nodes.UpdateNode(slot, slotNo, writeContext);
+            if (HasError(error)) {
+                SILK_LOG(
+                    LogLevel(error),
+                    "[%s] UnrefNode::Nodes.UpdateNode error=%s",
+                    lc.Describe().c_str(),
+                    FormatError(error).c_str());
+                return error;
+            }
+        } else {
+            error = DestroyNode(lc, nodeId, writeContext);
+            if (HasError(error)) {
+                SILK_LOG(
+                    LogLevel(error),
+                    "[%s] UnrefNode::DestroyNode error=%s",
+                    lc.Describe().c_str(),
+                    FormatError(error).c_str());
+                return error;
+            }
+        }
+
+        return {};
+    }
+
     NProto::TUnlinkNodeResponse UnlinkNode(NProto::TUnlinkNodeRequest request)
     {
         NProto::TUnlinkNodeResponse response;
@@ -1078,10 +1196,6 @@ public:
 
         TWriteContext writeContext;
         TWriteContextGuard wcg(writeContext, *PageStore);
-
-        //
-        // TODO(#5894): take Links into account.
-        //
 
         ui64 nodeId = 0;
         {
@@ -1112,66 +1226,11 @@ public:
                 return response;
             }
 
-            TNodeTableSlot slot{};
-            error = Nodes.DeleteNode(nodeId, writeContext, &slot);
+            error = UnrefNode(lc, nodeId, writeContext);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
-                    "[%s] UnlinkNode::Nodes.DeleteNode error=%s",
-                    lc.Describe().c_str(),
-                    FormatError(error).c_str());
-                *response.MutableError() = std::move(error);
-                return response;
-            }
-
-            TVector<ui64> storagePageClusterIds;
-            for (ui64 offset = 0; offset < slot.Size;
-                    offset += PageClusterSize)
-            {
-                const ui64 pageClusterId = offset / PageClusterSize;
-                lc.PageClusterIds.push_back(pageClusterId);
-
-                TNodePageClusterSlot slot{};
-                error = PageIndex.Delete(
-                    {
-                        .NodeId = nodeId,
-                        .PageClusterId = pageClusterId,
-                    },
-                    writeContext,
-                    &slot);
-
-                if (error.GetCode() == E_FS_NOENT) {
-                    //
-                    // This page cluster is not allocated.
-                    //
-
-                    lc.StoragePageClusterIds.push_back(
-                        InvalidStoragePageClusterId);
-                    continue;
-                }
-
-                if (HasError(error)) {
-                    SILK_LOG(
-                        LogLevel(error),
-                        "[%s] UnlinkNode::PageIndex.Delete error=%s",
-                        lc.Describe().c_str(),
-                        FormatError(error).c_str());
-                    *response.MutableError() = std::move(error);
-                    return response;
-                }
-
-                storagePageClusterIds.push_back(slot.StoragePageClusterId);
-                lc.StoragePageClusterIds.push_back(slot.StoragePageClusterId);
-            }
-
-            error = PageAllocator.Deallocate(
-                lc,
-                storagePageClusterIds,
-                writeContext);
-            if (HasError(error)) {
-                SILK_LOG(
-                    LogLevel(error),
-                    "[%s] UnlinkNode::PageAllocator.Deallocate error=%s",
+                    "[%s] UnlinkNode::UnrefNode error=%s",
                     lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
@@ -1231,11 +1290,26 @@ public:
         ui64 nodeId = request.GetNodeId();
         NProto::TNodeAttr attr;
         if (request.GetName().empty()) {
-            auto error = Nodes.GetNode(nodeId, &attr);
+            TNodeTableSlot slot{};
+            ui64 slotNo = 0;
+            auto error =
+                Nodes.GetNode(nodeId, writeContext, &slot, &slotNo, &attr);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
                     "[%s] CreateHandle::Nodes.GetNode error=%s",
+                    lc.Describe().c_str(),
+                    FormatError(error).c_str());
+                *response.MutableError() = std::move(error);
+            }
+
+            slot.Links += 1;
+            attr.SetLinks(slot.Links);
+            error = Nodes.UpdateNode(slot, slotNo, writeContext);
+            if (HasError(error)) {
+                SILK_LOG(
+                    LogLevel(error),
+                    "[%s] CreateHandle::Nodes.UpdateNode error=%s",
                     lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
@@ -1250,6 +1324,7 @@ public:
                         request.GetMode(),
                         request.GetUid(),
                         request.GetGid(),
+                        2 /* links */,
                         writeContext,
                         &attr);
                     if (HasError(error)) {
@@ -1279,11 +1354,26 @@ public:
                     ErrorAlreadyExists(request.GetName());
             } else {
                 lc.NodeId = nodeId;
-                auto error = Nodes.GetNode(nodeId, &attr);
+                TNodeTableSlot slot{};
+                ui64 slotNo = 0;
+                auto error =
+                    Nodes.GetNode(nodeId, writeContext, &slot, &slotNo, &attr);
                 if (HasError(error)) {
                     SILK_LOG(
                         LogLevel(error),
                         "[%s] CreateHandle::Nodes.GetNode error=%s",
+                        lc.Describe().c_str(),
+                        FormatError(error).c_str());
+                    *response.MutableError() = std::move(error);
+                }
+
+                slot.Links += 1;
+                attr.SetLinks(slot.Links);
+                error = Nodes.UpdateNode(slot, slotNo, writeContext);
+                if (HasError(error)) {
+                    SILK_LOG(
+                        LogLevel(error),
+                        "[%s] CreateHandle::Nodes.UpdateNode error=%s",
                         lc.Describe().c_str(),
                         FormatError(error).c_str());
                     *response.MutableError() = std::move(error);
@@ -1300,7 +1390,6 @@ public:
             return response;
         }
 
-        attr.SetLinks(attr.GetLinks() + 1);
         ui64 handle = 0;
         auto error = Handles.AllocateHandle(&handle);
         if (HasError(error)) {
@@ -1372,7 +1461,9 @@ public:
             std::lock_guard g(Mutex);
             wcg.Init();
 
-            auto error = Handles.Delete(request.GetHandle(), writeContext);
+            ui64 nodeId = 0;
+            auto error =
+                Handles.Delete(request.GetHandle(), writeContext, &nodeId);
             if (HasError(error)) {
                 SILK_LOG(
                     LogLevel(error),
@@ -1380,11 +1471,19 @@ public:
                     lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
-            }
+            } else {
+                lc.NodeId = nodeId;
 
-            //
-            // TODO(#5894): update Links.
-            //
+                error = UnrefNode(lc, nodeId, writeContext);
+                if (HasError(error)) {
+                    SILK_LOG(
+                        LogLevel(error),
+                        "[%s] DestroyHandle::UnrefNode error=%s",
+                        lc.Describe().c_str(),
+                        FormatError(error).c_str());
+                    *response.MutableError() = std::move(error);
+                }
+            }
         }
 
         if (HasError(response.GetError())) {

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -1301,18 +1301,18 @@ public:
                     lc.Describe().c_str(),
                     FormatError(error).c_str());
                 *response.MutableError() = std::move(error);
-            }
-
-            slot.Links += 1;
-            attr.SetLinks(slot.Links);
-            error = Nodes.UpdateNode(slot, slotNo, writeContext);
-            if (HasError(error)) {
-                SILK_LOG(
-                    LogLevel(error),
-                    "[%s] CreateHandle::Nodes.UpdateNode error=%s",
-                    lc.Describe().c_str(),
-                    FormatError(error).c_str());
-                *response.MutableError() = std::move(error);
+            } else {
+                slot.Links += 1;
+                attr.SetLinks(slot.Links);
+                error = Nodes.UpdateNode(slot, slotNo, writeContext);
+                if (HasError(error)) {
+                    SILK_LOG(
+                        LogLevel(error),
+                        "[%s] CreateHandle::Nodes.UpdateNode error=%s",
+                        lc.Describe().c_str(),
+                        FormatError(error).c_str());
+                    *response.MutableError() = std::move(error);
+                }
             }
         } else {
             auto error = Names.Get(request.GetName(), &nodeId);
@@ -1365,18 +1365,18 @@ public:
                         lc.Describe().c_str(),
                         FormatError(error).c_str());
                     *response.MutableError() = std::move(error);
-                }
-
-                slot.Links += 1;
-                attr.SetLinks(slot.Links);
-                error = Nodes.UpdateNode(slot, slotNo, writeContext);
-                if (HasError(error)) {
-                    SILK_LOG(
-                        LogLevel(error),
-                        "[%s] CreateHandle::Nodes.UpdateNode error=%s",
-                        lc.Describe().c_str(),
-                        FormatError(error).c_str());
-                    *response.MutableError() = std::move(error);
+                } else {
+                    slot.Links += 1;
+                    attr.SetLinks(slot.Links);
+                    error = Nodes.UpdateNode(slot, slotNo, writeContext);
+                    if (HasError(error)) {
+                        SILK_LOG(
+                            LogLevel(error),
+                            "[%s] CreateHandle::Nodes.UpdateNode error=%s",
+                            lc.Describe().c_str(),
+                            FormatError(error).c_str());
+                        *response.MutableError() = std::move(error);
+                    }
                 }
             }
         }

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
@@ -298,7 +298,7 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNodeAttr().GetType());
         EXPECT_EQ(expectedMode, response.GetNodeAttr().GetMode());
-        EXPECT_EQ(2U, response.GetNodeAttr().GetLinks());
+        EXPECT_EQ(1U, response.GetNodeAttr().GetLinks());
         nodeId = response.GetNodeAttr().GetId();
         handle1 = response.GetHandle();
     }
@@ -317,7 +317,7 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNode().GetType());
         EXPECT_EQ(expectedMode, response.GetNode().GetMode());
-        EXPECT_EQ(2U, response.GetNode().GetLinks());
+        EXPECT_EQ(1U, response.GetNode().GetLinks());
     }
 
     ui64 handle2 = 0;
@@ -340,7 +340,12 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNodeAttr().GetType());
         EXPECT_EQ(expectedMode, response.GetNodeAttr().GetMode());
-        EXPECT_EQ(3U, response.GetNodeAttr().GetLinks());
+
+        //
+        // Links still equal to 1, handles are tracked separately.
+        //
+
+        EXPECT_EQ(1U, response.GetNodeAttr().GetLinks());
         handle2 = response.GetHandle();
         EXPECT_NE(handle2, handle1);
     }
@@ -359,7 +364,12 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNode().GetType());
         EXPECT_EQ(expectedMode, response.GetNode().GetMode());
-        EXPECT_EQ(3U, response.GetNode().GetLinks());
+
+        //
+        // Links still equal to 1, handles are tracked separately.
+        //
+
+        EXPECT_EQ(1U, response.GetNode().GetLinks());
     }
 
     {
@@ -386,7 +396,12 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNode().GetType());
         EXPECT_EQ(expectedMode, response.GetNode().GetMode());
-        EXPECT_EQ(2U, response.GetNode().GetLinks());
+
+        //
+        // Links equal to 0, the node is alive because there're open handles.
+        //
+
+        EXPECT_EQ(0U, response.GetNode().GetLinks());
     }
 
     {
@@ -412,7 +427,12 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNode().GetType());
         EXPECT_EQ(expectedMode, response.GetNode().GetMode());
-        EXPECT_EQ(1U, response.GetNode().GetLinks());
+
+        //
+        // Links equal to 0, the node is alive because there're open handles.
+        //
+
+        EXPECT_EQ(0U, response.GetNode().GetLinks());
     }
 
     {

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
@@ -298,6 +298,7 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNodeAttr().GetType());
         EXPECT_EQ(expectedMode, response.GetNodeAttr().GetMode());
+        EXPECT_EQ(2U, response.GetNodeAttr().GetLinks());
         nodeId = response.GetNodeAttr().GetId();
         handle1 = response.GetHandle();
     }
@@ -316,6 +317,7 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNode().GetType());
         EXPECT_EQ(expectedMode, response.GetNode().GetMode());
+        EXPECT_EQ(2U, response.GetNode().GetLinks());
     }
 
     ui64 handle2 = 0;
@@ -338,8 +340,53 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
             static_cast<ui32>(E_REGULAR_NODE),
             response.GetNodeAttr().GetType());
         EXPECT_EQ(expectedMode, response.GetNodeAttr().GetMode());
+        EXPECT_EQ(3U, response.GetNodeAttr().GetLinks());
         handle2 = response.GetHandle();
         EXPECT_NE(handle2, handle1);
+    }
+
+    {
+        TGetNodeAttrRequest request;
+        request.SetNodeId(nodeId);
+        auto f = shard->GetNodeAttr(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        EXPECT_EQ(nodeId, response.GetNode().GetId());
+        EXPECT_EQ(uid, response.GetNode().GetUid());
+        EXPECT_EQ(gid, response.GetNode().GetGid());
+        EXPECT_EQ(
+            static_cast<ui32>(E_REGULAR_NODE),
+            response.GetNode().GetType());
+        EXPECT_EQ(expectedMode, response.GetNode().GetMode());
+        EXPECT_EQ(3U, response.GetNode().GetLinks());
+    }
+
+    {
+        TUnlinkNodeRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        auto f = shard->UnlinkNode(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        TGetNodeAttrRequest request;
+        request.SetNodeId(nodeId);
+        auto f = shard->GetNodeAttr(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        EXPECT_EQ(nodeId, response.GetNode().GetId());
+        EXPECT_EQ(uid, response.GetNode().GetUid());
+        EXPECT_EQ(gid, response.GetNode().GetGid());
+        EXPECT_EQ(
+            static_cast<ui32>(E_REGULAR_NODE),
+            response.GetNode().GetType());
+        EXPECT_EQ(expectedMode, response.GetNode().GetMode());
+        EXPECT_EQ(2U, response.GetNode().GetLinks());
     }
 
     {
@@ -349,6 +396,23 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
         auto response = f.GetValueSync();
         EXPECT_EQ(S_OK, response.GetError().GetCode())
             << FormatError(response.GetError());
+    }
+
+    {
+        TGetNodeAttrRequest request;
+        request.SetNodeId(nodeId);
+        auto f = shard->GetNodeAttr(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        EXPECT_EQ(nodeId, response.GetNode().GetId());
+        EXPECT_EQ(uid, response.GetNode().GetUid());
+        EXPECT_EQ(gid, response.GetNode().GetGid());
+        EXPECT_EQ(
+            static_cast<ui32>(E_REGULAR_NODE),
+            response.GetNode().GetType());
+        EXPECT_EQ(expectedMode, response.GetNode().GetMode());
+        EXPECT_EQ(1U, response.GetNode().GetLinks());
     }
 
     {
@@ -366,6 +430,15 @@ TEST(NaiveMirroredShardTest, CreatesHandles)
         auto f = shard->DestroyHandle(request);
         auto response = f.GetValueSync();
         EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        TGetNodeAttrRequest request;
+        request.SetNodeId(nodeId);
+        auto f = shard->GetNodeAttr(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(NCloud::E_FS_NOENT, response.GetError().GetCode())
             << FormatError(response.GetError());
     }
 }

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_layout.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut_layout.cpp
@@ -152,14 +152,14 @@ TEST(NaiveMirroredShardLayoutTest, DumpsLayout)
         const auto& c = components[2];
         EXPECT_EQ("HandleTable", c["name"].GetString());
         EXPECT_EQ(12_KB, c["offsetBytes"].GetUInteger());
-        EXPECT_EQ(12_KB, c["sizeBytes"].GetUInteger());
-        EXPECT_EQ(768ULL, c["slotCount"].GetUInteger());
+        EXPECT_EQ(16_KB, c["sizeBytes"].GetUInteger());
+        EXPECT_EQ(1024ULL, c["slotCount"].GetUInteger());
     }
 
     {
         const auto& c = components[3];
         EXPECT_EQ("PageIndex", c["name"].GetString());
-        EXPECT_EQ(24_KB, c["offsetBytes"].GetUInteger());
+        EXPECT_EQ(28_KB, c["offsetBytes"].GetUInteger());
         EXPECT_EQ(52_KB, c["sizeBytes"].GetUInteger());
         EXPECT_EQ(2210ULL, c["slotCount"].GetUInteger());
     }
@@ -167,7 +167,7 @@ TEST(NaiveMirroredShardLayoutTest, DumpsLayout)
     {
         const auto& c = components[4];
         EXPECT_EQ("PageAllocatorBitmap", c["name"].GetString());
-        EXPECT_EQ(76_KB, c["offsetBytes"].GetUInteger());
+        EXPECT_EQ(80_KB, c["offsetBytes"].GetUInteger());
         EXPECT_EQ(4_KB, c["sizeBytes"].GetUInteger());
         EXPECT_EQ(2048ULL, c["slotCount"].GetUInteger());
     }

--- a/cloud/filestore/tests/fastshard/fmdtest/qemu-kikimr-naive-mirrored-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
+++ b/cloud/filestore/tests/fastshard/fmdtest/qemu-kikimr-naive-mirrored-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
@@ -32,27 +32,27 @@
         {
             "name": "HandleTable",
             "offsetBytes": 14573568,
-            "sizeBytes": 16003072,
+            "sizeBytes": 17604608,
             "slotSize": 16,
-            "slotCount": 1000192
+            "slotCount": 1100288
         },
         {
             "name": "PageIndex",
-            "offsetBytes": 30576640,
+            "offsetBytes": 32178176,
             "sizeBytes": 757760,
             "slotSize": 24,
             "slotCount": 31450
         },
         {
             "name": "PageAllocatorBitmap",
-            "offsetBytes": 31334400,
+            "offsetBytes": 32935936,
             "sizeBytes": 4096,
             "slotSize": 0,
             "slotCount": 29492
         },
         {
             "name": "DataPages",
-            "offsetBytes": 31358976,
+            "offsetBytes": 32964608,
             "sizeBytes": 966393856,
             "slotSize": 32768,
             "slotCount": 29492


### PR DESCRIPTION
### Notes
* tracking open handle count per node id in handle table
* a node is destroyed only when it has 0 links and 0 open handles
* implemented proper links tracking upon `UnlinkNode` (but hardlinks are currently not supported anyway so it's not really impactful) 

### Issue
https://github.com/ydb-platform/nbs/issues/6958
