### PR TITLE
Stable-read and chain validation for periodic TLS certificate provider

### DIFF
--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -362,7 +362,8 @@ void TBootstrapBase::Init()
             serverGroup,
             Configs->ServerConfig->GetRootCertsFile(),
             std::move(certPathList),
-            Configs->ServerConfig->GetRefreshCertsPeriod());
+            Configs->ServerConfig->GetRefreshCertsPeriod(),
+            Timer);
     }
 
     for (auto& event: PostponedCriticalEvents) {

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -999,7 +999,8 @@ void TBootstrapYdb::SetupCellManager()
                     ->GetSubgroup("component", "cells"),
                 grpcConfig.GetRootCertsFile(),
                 std::move(certList),
-                Configs->ServerConfig->GetRefreshCertsPeriod());
+                Configs->ServerConfig->GetRefreshCertsPeriod(),
+                Timer);
         }
 
         CellManager = CreateCellManager(

--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -186,7 +186,8 @@ void TBootstrapServer::InitComponents()
             serverCounters,
             Configs->ServerConfig->GetRootCertsFile(),
             std::move(certPathList),
-            Configs->ServerConfig->GetRefreshCertsPeriod());
+            Configs->ServerConfig->GetRefreshCertsPeriod(),
+            Timer);
     }
 
     Server = NServer::CreateServer(

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -91,6 +91,7 @@ struct TClientCertificateProviderFactory
     ILoggingServicePtr Logging;
     TString LogComponent;
     ISchedulerPtr Scheduler;
+    ITimerPtr Timer;
     ITaskQueuePtr LongRunningTaskExecutor;
     NMonitoring::TDynamicCountersPtr ServerGroup;
     TDuration RefreshInterval;
@@ -99,12 +100,14 @@ struct TClientCertificateProviderFactory
             ILoggingServicePtr logging,
             TString logComponent,
             ISchedulerPtr scheduler,
+            ITimerPtr timer,
             ITaskQueuePtr longRunningTaskExecutor,
             NMonitoring::TDynamicCountersPtr serverGroup,
             TDuration refreshInterval)
         : Logging(std::move(logging))
         , LogComponent(std::move(logComponent))
         , Scheduler(std::move(scheduler))
+        , Timer(std::move(timer))
         , LongRunningTaskExecutor(std::move(longRunningTaskExecutor))
         , ServerGroup(std::move(serverGroup))
         , RefreshInterval(refreshInterval)
@@ -124,7 +127,8 @@ struct TClientCertificateProviderFactory
             std::move(endpointGroup),
             std::move(rootCertPath),
             std::move(certificates),
-            RefreshInterval);
+            RefreshInterval,
+            Timer);
     }
 };
 
@@ -500,7 +504,8 @@ void TBootstrapVhost::InitComponents()
             serverCounters,
             Configs->ServerConfig->GetRootCertsFile(),
             std::move(certPathList),
-            Configs->ServerConfig->GetRefreshCertsPeriod());
+            Configs->ServerConfig->GetRefreshCertsPeriod(),
+            Timer);
     }
 
     Server = CreateServer(
@@ -567,6 +572,7 @@ void TBootstrapVhost::InitEndpoints()
         GetComponentName(
             NStorage::TFileStoreComponents::TLS_CERTIFICATE_PROVIDER),
         Scheduler,
+        Timer,
         LongRunningTaskExecutor,
         FilestoreCounters->GetSubgroup("component", VhostMetricsComponent),
         Configs->ServerConfig->GetRefreshCertsPeriod());

--- a/cloud/storage/core/libs/grpc/periodic_tls_certificate_provider.cpp
+++ b/cloud/storage/core/libs/grpc/periodic_tls_certificate_provider.cpp
@@ -1,9 +1,11 @@
 #include "tls_certificate_provider.h"
+#include "stable_read.h"
 #include "tls_utils.h"
 
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
+#include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/common/verify.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
@@ -125,6 +127,7 @@ class TPeriodicCertificateProvider final
     const TDuration RefreshInterval;
     const ISchedulerPtr Scheduler;
     const ITaskQueuePtr TaskQueue;
+    const ITimerPtr Timer;
 
     grpc_core::RefCountedPtr<TGrpcTlsCertificateProvider> TlsProvider;
     std::shared_ptr<grpc::experimental::CertificateProviderInterface>
@@ -132,6 +135,8 @@ class TPeriodicCertificateProvider final
 
     NTlsUtils::TRootCaPair RootCaPair;
     TVector<NTlsUtils::TCertificatePair> Certificates;
+    TStableRead<TString> RootCaStableRead;
+    TVector<TStableRead<NTlsUtils::TIdentityContent>> IdentityStableReads;
     TVector<NMonitoring::TDynamicCountersPtr> CertificateMetrics;
     NMonitoring::TDynamicCountersPtr RootCaMetrics;
 
@@ -151,17 +156,20 @@ public:
             NMonitoring::TDynamicCountersPtr serverGroup,
             TString rootCertPath,
             TVector<TCertificateFiles> certificates,
-            TDuration refreshInterval)
+            TDuration refreshInterval,
+            ITimerPtr timer)
         : Logging(std::move(logging))
         , LogComponent(std::move(logComponent))
         , ServerGroup(std::move(serverGroup))
         , RefreshInterval(refreshInterval)
         , Scheduler(std::move(scheduler))
         , TaskQueue(std::move(taskQueue))
+        , Timer(std::move(timer))
         , TlsProvider(grpc_core::MakeRefCounted<TGrpcTlsCertificateProvider>())
         , GrpcProvider(std::make_shared<TGrpcCertificateProvider>(TlsProvider))
         , RootCaPair(NTlsUtils::LoadRootCaPair(std::move(rootCertPath)))
         , Certificates(NTlsUtils::LoadCertificatePairs(std::move(certificates)))
+        , IdentityStableReads(Certificates.size())
         , CertificateMetrics(Certificates.size())
     {
     }
@@ -171,6 +179,9 @@ public:
         Y_ABORT_UNLESS(Started.load() == false);
     }
 
+    // Completes when the files have been re-read and any new content has
+    // either been applied or rejected, which may take up to half of the
+    // refresh interval, or when the provider is stopped.
     NThreading::TFuture<void> UpdateCertificates() override
     {
         NThreading::TFuture<void> future;
@@ -186,7 +197,7 @@ public:
             future = PendingUpdate.GetFuture();
         }
         if (scheduleUpdate) {
-            ScheduleUpdateAt(TInstant::Now(), /*periodic=*/false);
+            ScheduleUpdateAt(Timer->Now(), /*periodic=*/false);
         }
         return future;
     }
@@ -256,7 +267,7 @@ public:
 
         PublishInitialState();
 
-        ScheduleUpdateAt(TInstant::Now() + RefreshInterval, true);
+        ScheduleUpdateAt(Timer->Now() + RefreshInterval, true);
     }
 
     void Stop() override
@@ -320,11 +331,17 @@ private:
         if (run) {
             pending = RefreshCertificates();
 
+            // The requested update is complete when no content is waiting
+            // for a stable read anymore, or when the provider is stopped.
+            // Until then repeated UpdateCertificates() calls share the same
+            // future instead of triggering extra reads.
             NThreading::TPromise<void> promise;
             {
                 TGuard<TMutex> lock(UpdateMutex);
-                promise = std::exchange(PendingUpdate, {});
                 UpdateInProgress = false;
+                if (!pending || !Started.load()) {
+                    promise = std::exchange(PendingUpdate, {});
+                }
             }
             if (promise.Initialized()) {
                 promise.SetValue();
@@ -345,11 +362,11 @@ private:
         // a half intervals without reading unchanged files more often.
         if (periodic) {
             ScheduleUpdateAt(
-                TInstant::Now() +
+                Timer->Now() +
                     (pending ? RefreshInterval / 2 : RefreshInterval),
                 true);
         } else if (pending) {
-            ScheduleUpdateAt(TInstant::Now() + RefreshInterval / 2, false);
+            ScheduleUpdateAt(Timer->Now() + RefreshInterval / 2, false);
         }
     }
 
@@ -409,33 +426,155 @@ private:
         PublishCerts();
     }
 
-    // Returns true if some content is waiting for a stable read.
+    // Re-reads the certificate files. New content is applied only after it
+    // has stayed unchanged for half of the refresh interval, see TStableRead.
+    // The last successfully loaded content is kept if the files cannot be
+    // read, parsed or validated; new content that fails these checks is
+    // reported on every check until the files change. Every certificate is
+    // refreshed independently. Returns true if some content is waiting for a
+    // stable read.
     bool RefreshCertificates()
     {
-        auto result =
-            NTlsUtils::UpdateCertificates(Certificates, RootCaPair, Log);
+        const TInstant now = Timer->Now();
+        const TDuration holdTime = RefreshInterval / 2;
 
-        if (result.RootCaChanged) {
+        bool pending = false;
+        bool changed = false;
+
+        if (RefreshRootCa(now, holdTime, pending)) {
             PublishRootCaFingerprint();
+            changed = true;
         }
 
-        bool identityChanged = false;
         for (size_t i = 0; i < Certificates.size(); ++i) {
-            const auto& update = result.Certificates[i];
-            if (!update.Changed) {
-                continue;
+            if (RefreshIdentity(i, now, holdTime, pending)) {
+                changed = true;
             }
-            identityChanged = true;
-            PublishExpireTs(i, update.NotValidAfter);
         }
 
         // The distributor notifies gRPC on every publish, which rebuilds the
         // SSL context, so publish only when something has changed.
-        if (result.RootCaChanged || identityChanged) {
+        if (changed) {
             PublishCerts();
         }
 
-        return result.Pending;
+        return pending;
+    }
+
+    // Returns true if the root certificate has been replaced.
+    bool RefreshRootCa(TInstant now, TDuration holdTime, bool& pending)
+    {
+        const auto& path = RootCaPair.RootCaPath;
+        if (path.empty()) {
+            return false;
+        }
+
+        auto content = NTlsUtils::TryReadFile(path);
+        if (HasError(content.GetError())) {
+            RootCaStableRead.Reset();
+            STORAGE_WARN(
+                "Root certificate update is skipped: "
+                << FormatError(content.GetError()));
+            return false;
+        }
+
+        switch (RootCaStableRead.Observe(
+            RootCaPair.RootCa,
+            content.GetResult(),
+            now,
+            holdTime))
+        {
+            case EStableReadDecision::Unchanged:
+                return false;
+            case EStableReadDecision::Wait:
+                pending = true;
+                STORAGE_INFO(
+                    "New root certificate " << path.Quote()
+                    << ", waiting for a stable read");
+                return false;
+            case EStableReadDecision::Apply:
+                break;
+        }
+
+        auto validity = NTlsUtils::IsValidPemCertificate(content.GetResult());
+        if (HasError(validity.GetError())) {
+            STORAGE_WARN(
+                "Root certificate update is skipped: "
+                << FormatError(validity.GetError()));
+            return false;
+        }
+
+        RootCaPair.RootCa = content.ExtractResult();
+        STORAGE_INFO(
+            "Root certificate " << path.Quote() << " has been updated");
+        return true;
+    }
+
+    // Returns true if the certificate has been replaced.
+    bool RefreshIdentity(
+        size_t index,
+        TInstant now,
+        TDuration holdTime,
+        bool& pending)
+    {
+        auto& cert = Certificates[index];
+        auto& stableRead = IdentityStableReads[index];
+        const auto& path = cert.Files.CertChainPath;
+
+        auto content = NTlsUtils::ReadIdentity(cert.Files);
+        if (HasError(content.GetError())) {
+            stableRead.Reset();
+            STORAGE_WARN(
+                "Identity certificate update is skipped for " << path.Quote()
+                << ": " << FormatError(content.GetError()));
+            return false;
+        }
+
+        const NTlsUtils::TIdentityContent current{
+            .PrivateKey = cert.PrivateKey,
+            .CertChain = cert.CertChain,
+        };
+        switch (stableRead.Observe(current, content.GetResult(), now, holdTime))
+        {
+            case EStableReadDecision::Unchanged:
+                return false;
+            case EStableReadDecision::Wait:
+                pending = true;
+                STORAGE_INFO(
+                    "New identity certificate " << path.Quote()
+                    << ", waiting for a stable read");
+                return false;
+            case EStableReadDecision::Apply:
+                break;
+        }
+
+        auto validity = NTlsUtils::ValidateIdentity(content.GetResult());
+        if (HasError(validity.GetError())) {
+            STORAGE_WARN(
+                "Identity certificate update is skipped for " << path.Quote()
+                << ": " << FormatError(validity.GetError()));
+            return false;
+        }
+
+        TInstant notValidAfter;
+        auto notAfterTs = NTlsUtils::GetCertificateNotAfterTimestampSec(
+            content.GetResult().CertChain);
+        if (HasError(notAfterTs)) {
+            STORAGE_WARN(
+                "Unable to parse certificate notAfter date for "
+                << path.Quote() << ": " << FormatError(notAfterTs.GetError()));
+        } else {
+            notValidAfter = TInstant::Seconds(notAfterTs.ExtractResult());
+        }
+
+        auto identity = content.ExtractResult();
+        cert.PrivateKey = std::move(identity.PrivateKey);
+        cert.CertChain = std::move(identity.CertChain);
+        PublishExpireTs(index, notValidAfter);
+        STORAGE_INFO(
+            "Identity certificate " << path.Quote() << " has been updated"
+            << ", expires at " << notValidAfter);
+        return true;
     }
 };
 
@@ -451,9 +590,11 @@ ICertificateProviderPtr CreatePeriodicCertificateProvider(
     NMonitoring::TDynamicCountersPtr serverGroup,
     TString rootCertPath,
     TVector<TCertificateFiles> certificates,
-    TDuration refreshInterval)
+    TDuration refreshInterval,
+    ITimerPtr timer)
 {
-    Y_ENSURE(refreshInterval, "refreshInterval should not be zero");
+    Y_ABORT_UNLESS(refreshInterval, "refreshInterval should not be zero");
+    Y_ABORT_UNLESS(timer, "timer should not be null");
 
     return std::make_shared<TPeriodicCertificateProvider>(
         std::move(logging),
@@ -463,7 +604,8 @@ ICertificateProviderPtr CreatePeriodicCertificateProvider(
         std::move(serverGroup),
         std::move(rootCertPath),
         std::move(certificates),
-        refreshInterval);
+        refreshInterval,
+        std::move(timer));
 }
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/grpc/periodic_tls_certificate_provider.cpp
+++ b/cloud/storage/core/libs/grpc/periodic_tls_certificate_provider.cpp
@@ -179,9 +179,8 @@ public:
         Y_ABORT_UNLESS(Started.load() == false);
     }
 
-    // Completes when the files have been re-read and any new content has
-    // either been applied or rejected, which may take up to half of the
-    // refresh interval, or when the provider is stopped.
+    // See ICertificateProvider. The hold time is the refresh interval,
+    // repeated calls share the same future.
     NThreading::TFuture<void> UpdateCertificates() override
     {
         NThreading::TFuture<void> future;
@@ -357,16 +356,11 @@ private:
             return;
         }
 
-        // Files are checked once per interval. New content is re-checked
-        // after half an interval, so that a change takes effect within one and
-        // a half intervals without reading unchanged files more often.
+        // Files are checked once per interval and new content must stay
+        // unchanged for an interval, so a change takes effect within two
+        // intervals.
         if (periodic) {
-            ScheduleUpdateAt(
-                Timer->Now() +
-                    (pending ? RefreshInterval / 2 : RefreshInterval),
-                true);
-        } else if (pending) {
-            ScheduleUpdateAt(Timer->Now() + RefreshInterval / 2, false);
+            ScheduleUpdateAt(Timer->Now() + RefreshInterval, true);
         }
     }
 
@@ -408,16 +402,33 @@ private:
         }
     }
 
+    // The initial load is lenient so that the service is able to start, and
+    // unchanged files are never re-validated, so this is the only place where
+    // certificates that are already invalid on disk get reported.
     void PublishInitialState()
     {
         PublishRootCaFingerprint();
         for (size_t i = 0; i < Certificates.size(); ++i) {
-            auto notAfterTs = NTlsUtils::GetCertificateNotAfterTimestampSec(
-                Certificates[i].CertChain);
+            const auto& cert = Certificates[i];
+            const auto& path = cert.Files.CertChainPath;
+
+            auto validity = NTlsUtils::ValidateIdentity({
+                .PrivateKey = cert.PrivateKey,
+                .CertChain = cert.CertChain,
+            });
+            if (HasError(validity.GetError())) {
+                STORAGE_WARN(
+                    "Identity certificate " << path.Quote()
+                    << " is loaded but not valid: "
+                    << FormatError(validity.GetError()));
+            }
+
+            auto notAfterTs =
+                NTlsUtils::GetCertificateNotAfterTimestampSec(cert.CertChain);
             if (HasError(notAfterTs)) {
                 STORAGE_WARN(
                     "Unable to parse certificate notAfter date for "
-                    << Certificates[i].Files.CertChainPath.Quote() << ": "
+                    << path.Quote() << ": "
                     << FormatError(notAfterTs.GetError()));
                 continue;
             }
@@ -427,7 +438,7 @@ private:
     }
 
     // Re-reads the certificate files. New content is applied only after it
-    // has stayed unchanged for half of the refresh interval, see TStableRead.
+    // has stayed unchanged for the refresh interval, see TStableRead.
     // The last successfully loaded content is kept if the files cannot be
     // read, parsed or validated; new content that fails these checks is
     // reported on every check until the files change. Every certificate is
@@ -436,7 +447,7 @@ private:
     bool RefreshCertificates()
     {
         const TInstant now = Timer->Now();
-        const TDuration holdTime = RefreshInterval / 2;
+        const TDuration holdTime = RefreshInterval;
 
         bool pending = false;
         bool changed = false;

--- a/cloud/storage/core/libs/grpc/periodic_tls_certificate_provider.cpp
+++ b/cloud/storage/core/libs/grpc/periodic_tls_certificate_provider.cpp
@@ -254,7 +254,7 @@ public:
                 ->GetSubgroup("cert", GetBaseName(RootCaPair.RootCaPath));
         }
 
-        RefreshCertificates();
+        PublishInitialState();
 
         ScheduleUpdateAt(TInstant::Now() + RefreshInterval, true);
     }
@@ -316,8 +316,9 @@ private:
             }
         }
 
+        bool pending = false;
         if (run) {
-            RefreshCertificates();
+            pending = RefreshCertificates();
 
             NThreading::TPromise<void> promise;
             {
@@ -330,69 +331,111 @@ private:
             }
         }
 
+        bool alive = false;
+        {
+            TGuard<TMutex> lock(UpdateMutex);
+            alive = Started;
+        }
+        if (!alive) {
+            return;
+        }
+
+        // Files are checked once per interval. New content is re-checked
+        // after half an interval, so that a change takes effect within one and
+        // a half intervals without reading unchanged files more often.
         if (periodic) {
-            bool alive = false;
-            {
-                TGuard<TMutex> lock(UpdateMutex);
-                alive = Started;
-            }
-            if (alive) {
-                ScheduleUpdateAt(
-                    TInstant::Now() + RefreshInterval,
-                    true);
-            }
+            ScheduleUpdateAt(
+                TInstant::Now() +
+                    (pending ? RefreshInterval / 2 : RefreshInterval),
+                true);
+        } else if (pending) {
+            ScheduleUpdateAt(TInstant::Now() + RefreshInterval / 2, false);
         }
     }
 
-    void RefreshCertificates()
+    void PublishRootCaFingerprint()
     {
-        auto certPairs = Certificates;
-
-        const TString oldRootCa = RootCaPair.RootCa;
-        auto result = NTlsUtils::UpdateCertificates(certPairs, RootCaPair, Log);
-        RootCaPair.RootCa = result.RootCa.GetOrElse(oldRootCa);
-        const bool rootChanged = oldRootCa != RootCaPair.RootCa;
-
         if (RootCaMetrics) {
             const ui64 fingerprint = RootCaFingerprint(RootCaPair.RootCa);
             *RootCaMetrics->GetCounter("Fingerprint", false) = fingerprint;
         }
+    }
 
+    void PublishExpireTs(size_t index, TInstant notValidAfter)
+    {
+        if (CertificateMetrics[index] && notValidAfter) {
+            *CertificateMetrics[index]->GetCounter("ExpireTs", false) =
+                notValidAfter.Seconds();
+        }
+    }
+
+    void PublishCerts()
+    {
         PemKeyCertPairList identityPairs;
-        for (size_t i = 0; i < Certificates.size(); ++i) {
-            auto& certificate = Certificates[i];
-            const auto& newCert = result.Certificates[i];
-
-            if (!newCert.Defined()) {
+        for (const auto& certificate: Certificates) {
+            if (certificate.PrivateKey.empty() ||
+                certificate.CertChain.empty())
+            {
                 continue;
             }
-
-            if (CertificateMetrics[i] && newCert->NotValidAfter) {
-                *CertificateMetrics[i]->GetCounter("ExpireTs", false) =
-                    newCert->NotValidAfter.Seconds();
-            }
-
-            const auto& chain = newCert->CertificatesChain;
-            const bool identityChanged =
-                chain.front().private_key() != certificate.PrivateKey ||
-                chain.front().cert_chain() != certificate.CertChain;
-
-            if (identityChanged || rootChanged) {
-                certificate.PrivateKey = TString(chain.front().private_key());
-                certificate.CertChain = TString(chain.front().cert_chain());
-            }
-
-            identityPairs.insert(identityPairs.end(), chain.begin(), chain.end());
+            identityPairs.emplace_back(
+                certificate.PrivateKey,
+                certificate.CertChain);
         }
 
         TMaybe<TString> rootCert = RootCaPair.RootCa.empty()
             ? Nothing()
             : TMaybe<TString>(RootCaPair.RootCa);
-        const bool hasMaterialsToPublish =
-            rootCert.Defined() || !identityPairs.empty();
-        if (hasMaterialsToPublish) {
+        if (rootCert.Defined() || !identityPairs.empty()) {
             TlsProvider->PublishCerts(rootCert, std::move(identityPairs));
         }
+    }
+
+    void PublishInitialState()
+    {
+        PublishRootCaFingerprint();
+        for (size_t i = 0; i < Certificates.size(); ++i) {
+            auto notAfterTs = NTlsUtils::GetCertificateNotAfterTimestampSec(
+                Certificates[i].CertChain);
+            if (HasError(notAfterTs)) {
+                STORAGE_WARN(
+                    "Unable to parse certificate notAfter date for "
+                    << Certificates[i].Files.CertChainPath.Quote() << ": "
+                    << FormatError(notAfterTs.GetError()));
+                continue;
+            }
+            PublishExpireTs(i, TInstant::Seconds(notAfterTs.ExtractResult()));
+        }
+        PublishCerts();
+    }
+
+    // Returns true if some content is waiting for a stable read.
+    bool RefreshCertificates()
+    {
+        auto result =
+            NTlsUtils::UpdateCertificates(Certificates, RootCaPair, Log);
+
+        if (result.RootCaChanged) {
+            PublishRootCaFingerprint();
+        }
+
+        bool identityChanged = false;
+        for (size_t i = 0; i < Certificates.size(); ++i) {
+            const auto& update = result.Certificates[i];
+            if (!update.Changed) {
+                continue;
+            }
+            identityChanged = true;
+            PublishExpireTs(i, update.NotValidAfter);
+        }
+
+        // The distributor notifies gRPC on every publish, which rebuilds the
+        // SSL context, so publish only when something has changed.
+        if (result.RootCaChanged || identityChanged) {
+            PublishCerts();
+        }
+
+        return result.Pending;
     }
 };
 

--- a/cloud/storage/core/libs/grpc/stable_read.h
+++ b/cloud/storage/core/libs/grpc/stable_read.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <util/datetime/base.h>
+#include <util/generic/maybe.h>
+#include <util/stream/output.h>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class EStableReadDecision
+{
+    // Content equals the current one.
+    Unchanged,
+    // Content has been read for the first time, differs from the content
+    // read previously or has not been stable for long enough yet.
+    Wait,
+    // Content has stayed unchanged for the hold time and can be applied.
+    Apply,
+};
+
+// Files such as certificates are rewritten by external tools, not necessarily
+// atomically, and a partially written file may be syntactically valid, e.g. a
+// certificate chain without its intermediate certificate. TStableRead lets new
+// content be applied only after it has stayed unchanged for the hold time
+// since it was first read. A read is counted by the time it was made, so reads
+// that happen to follow each other closely do not shorten the hold. This is a
+// heuristic that reduces the chance of picking up an intermediate state of a
+// rewrite, not a guarantee: a writer that stalls for longer than the hold time
+// is indistinguishable from a finished one.
+template <typename T>
+class TStableRead
+{
+private:
+    TMaybe<T> Pending;
+    TInstant PendingSince;
+
+public:
+    EStableReadDecision Observe(
+        const T& current,
+        const T& content,
+        TInstant now,
+        TDuration holdTime)
+    {
+        if (content == current) {
+            Pending.Clear();
+            return EStableReadDecision::Unchanged;
+        }
+
+        if (!Pending.Defined() || *Pending != content) {
+            Pending = content;
+            PendingSince = now;
+            return EStableReadDecision::Wait;
+        }
+
+        return now - PendingSince >= holdTime
+            ? EStableReadDecision::Apply
+            : EStableReadDecision::Wait;
+    }
+
+    // Forgets the pending content, e.g. after a read error: the hold starts
+    // over when the content is read again.
+    void Reset()
+    {
+        Pending.Clear();
+    }
+
+    [[nodiscard]] bool IsPending() const
+    {
+        return Pending.Defined();
+    }
+};
+
+}   // namespace NCloud
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_DECLARE_OUT_SPEC(inline, NCloud::EStableReadDecision, out, decision)
+{
+    switch (decision) {
+        case NCloud::EStableReadDecision::Unchanged:
+            out << "Unchanged";
+            break;
+        case NCloud::EStableReadDecision::Wait:
+            out << "Wait";
+            break;
+        case NCloud::EStableReadDecision::Apply:
+            out << "Apply";
+            break;
+    }
+}

--- a/cloud/storage/core/libs/grpc/stable_read_ut.cpp
+++ b/cloud/storage/core/libs/grpc/stable_read_ut.cpp
@@ -1,0 +1,119 @@
+#include "stable_read.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const TInstant StartTime = TInstant::Seconds(1000000);
+const TDuration HoldTime = TDuration::Minutes(30);
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TStableReadTest)
+{
+    Y_UNIT_TEST(ShouldIgnoreUnchangedContent)
+    {
+        TStableRead<TString> stableRead;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Unchanged,
+            stableRead.Observe("a", "a", StartTime, HoldTime));
+        UNIT_ASSERT(!stableRead.IsPending());
+    }
+
+    Y_UNIT_TEST(ShouldApplyContentAfterHoldTime)
+    {
+        TStableRead<TString> stableRead;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Wait,
+            stableRead.Observe("a", "b", StartTime, HoldTime));
+        UNIT_ASSERT(stableRead.IsPending());
+
+        // Reading the same content again does not count until HoldTime has
+        // passed since it was first seen, whoever triggers the read.
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Wait,
+            stableRead.Observe("a", "b", StartTime + HoldTime / 2, HoldTime));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Apply,
+            stableRead.Observe("a", "b", StartTime + HoldTime, HoldTime));
+    }
+
+    Y_UNIT_TEST(ShouldRestartHoldTimeWhenContentChanges)
+    {
+        TStableRead<TString> stableRead;
+
+        stableRead.Observe("a", "b", StartTime, HoldTime);
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Wait,
+            stableRead.Observe("a", "c", StartTime + HoldTime / 2, HoldTime));
+
+        // Only half of HoldTime has passed since "c" was first seen.
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Wait,
+            stableRead.Observe("a", "c", StartTime + HoldTime, HoldTime));
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Apply,
+            stableRead.Observe(
+                "a",
+                "c",
+                StartTime + HoldTime + HoldTime / 2,
+                HoldTime));
+    }
+
+    Y_UNIT_TEST(ShouldForgetPendingContentWhenCurrentIsReadAgain)
+    {
+        TStableRead<TString> stableRead;
+
+        stableRead.Observe("a", "b", StartTime, HoldTime);
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Unchanged,
+            stableRead.Observe("a", "a", StartTime + HoldTime / 2, HoldTime));
+        UNIT_ASSERT(!stableRead.IsPending());
+
+        // "b" is seen for the first time again.
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Wait,
+            stableRead.Observe("a", "b", StartTime + HoldTime, HoldTime));
+    }
+
+    Y_UNIT_TEST(ShouldResetPendingContent)
+    {
+        TStableRead<TString> stableRead;
+
+        stableRead.Observe("a", "b", StartTime, HoldTime);
+        stableRead.Reset();
+        UNIT_ASSERT(!stableRead.IsPending());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Wait,
+            stableRead.Observe("a", "b", StartTime + HoldTime, HoldTime));
+    }
+
+    Y_UNIT_TEST(ShouldKeepPendingContentWhenApplyIsRejected)
+    {
+        TStableRead<TString> stableRead;
+
+        stableRead.Observe("a", "b", StartTime, HoldTime);
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Apply,
+            stableRead.Observe("a", "b", StartTime + HoldTime, HoldTime));
+
+        // The caller failed to apply "b" and keeps "a": "b" stays pending
+        // and is reported again on the next read.
+        UNIT_ASSERT(stableRead.IsPending());
+        UNIT_ASSERT_VALUES_EQUAL(
+            EStableReadDecision::Apply,
+            stableRead.Observe("a", "b", StartTime + 2 * HoldTime, HoldTime));
+    }
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/grpc/tls_certificate_provider.cpp
+++ b/cloud/storage/core/libs/grpc/tls_certificate_provider.cpp
@@ -176,7 +176,8 @@ ICertificateProviderPtr CreateCertificateProvider(
     NMonitoring::TDynamicCountersPtr serverGroup,
     TString rootCertPath,
     TVector<TCertificateFiles> certificates,
-    TDuration refreshInterval)
+    TDuration refreshInterval,
+    ITimerPtr timer)
 {
     if (refreshInterval == TDuration::Zero()) {
         return CreateStaticCertificateProvider(
@@ -198,7 +199,8 @@ ICertificateProviderPtr CreateCertificateProvider(
                 std::move(serverGroup),
                 std::move(rootCertPath),
                 {},
-                refreshInterval);
+                refreshInterval,
+                std::move(timer));
         }
 
         return CreateStaticCertificateProvider({}, {});
@@ -212,7 +214,8 @@ ICertificateProviderPtr CreateCertificateProvider(
         std::move(serverGroup),
         std::move(rootCertPath),
         std::move(certs),
-        refreshInterval);
+        refreshInterval,
+        std::move(timer));
 }
 
 ICertificateProviderPtr CreateStaticCertificateProvider(

--- a/cloud/storage/core/libs/grpc/tls_certificate_provider.h
+++ b/cloud/storage/core/libs/grpc/tls_certificate_provider.h
@@ -61,7 +61,8 @@ ICertificateProviderPtr CreatePeriodicCertificateProvider(
     NMonitoring::TDynamicCountersPtr serverGroup,
     TString rootCertPath,
     TVector<TCertificateFiles> certificates,
-    TDuration refreshInterval);
+    TDuration refreshInterval,
+    ITimerPtr timer);
 
 ICertificateProviderPtr CreateCertificateProvider(
     ILoggingServicePtr logging,
@@ -71,6 +72,7 @@ ICertificateProviderPtr CreateCertificateProvider(
     NMonitoring::TDynamicCountersPtr serverGroup,
     TString rootCertPath,
     TVector<TCertificateFiles> certificates,
-    TDuration refreshInterval);
+    TDuration refreshInterval,
+    ITimerPtr timer);
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/grpc/tls_certificate_provider.h
+++ b/cloud/storage/core/libs/grpc/tls_certificate_provider.h
@@ -31,6 +31,13 @@ struct TCertificateFiles
 struct ICertificateProvider
     : IStartable
 {
+    // Requests a re-read of the certificate files. The future completes when
+    // any new content has been either applied or rejected, or when the
+    // provider is stopped. New content is applied only after it has stayed
+    // unchanged for a while (see TStableRead), so this takes at least that
+    // long, and content that keeps changing keeps the future pending until it
+    // settles or the provider is stopped: wait on it with a timeout.
+    // Providers that do not refresh certificates complete it right away.
     virtual NThreading::TFuture<void> UpdateCertificates() = 0;
     virtual std::shared_ptr<grpc::ChannelCredentials>
         CreateSecureClientCredentials() = 0;

--- a/cloud/storage/core/libs/grpc/tls_certificate_provider_ut.cpp
+++ b/cloud/storage/core/libs/grpc/tls_certificate_provider_ut.cpp
@@ -117,7 +117,7 @@ struct TCertificateProviderTestContext
             ServerGroup,
             RootPath,
             TVector<TCertificateFiles>{ServerPair, ClientPair},
-            TDuration::Seconds(1),
+            TDuration::MilliSeconds(200),
             CreateWallClockTimer());
         UNIT_ASSERT(Provider);
         Provider->Start();
@@ -287,12 +287,12 @@ struct TManualProviderContext
             Timer);
     }
 
-    // New content is applied only after it has stayed unchanged for half of
-    // the refresh interval since it was first read.
+    // New content is applied only after it has stayed unchanged for the
+    // refresh interval since it was first read.
     void RunUntilStable() const
     {
         Scheduler->RunPending();
-        Timer->AdvanceTime(RefreshInterval / 2);
+        Timer->AdvanceTime(RefreshInterval);
         Scheduler->RunPending();
     }
 
@@ -621,7 +621,7 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
 
         // Content changed again, so it is still not stable.
         context.RotateServer("server3.key", "server3.crt");
-        context.Timer->AdvanceTime(context.RefreshInterval / 2);
+        context.Timer->AdvanceTime(context.RefreshInterval);
         context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_EQUAL(
             initial,
@@ -633,14 +633,14 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
 
-        context.Timer->AdvanceTime(context.RefreshInterval / 2);
+        context.Timer->AdvanceTime(context.RefreshInterval);
         context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_UNEQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
     }
 
-    Y_UNIT_TEST(ShouldRecheckNewContentAfterHalfInterval)
+    Y_UNIT_TEST(ShouldCheckFilesOncePerInterval)
     {
         const auto interval = TDuration::Hours(1);
         const auto tolerance = TDuration::Seconds(10);
@@ -665,17 +665,17 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         context.Scheduler->RunPending();
         assertNextDelay(interval);
 
-        // New content is re-checked after half an interval.
+        // New content does not change the schedule either.
         context.RotateServer("server3.key", "server3.crt");
         context.Scheduler->RunPending();
-        assertNextDelay(interval / 2);
+        assertNextDelay(interval);
 
-        context.Timer->AdvanceTime(interval / 2);
+        context.Timer->AdvanceTime(interval);
         context.Scheduler->RunPending();
         assertNextDelay(interval);
     }
 
-    Y_UNIT_TEST(ShouldConfirmNewContentAfterOnDemandUpdate)
+    Y_UNIT_TEST(ShouldConfirmNewContentAfterOnDemandUpdateOnNextCheck)
     {
         const auto interval = TDuration::Hours(1);
         TManualProviderContext context(interval);
@@ -696,13 +696,12 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         // The update is not complete until the new content is applied.
         UNIT_ASSERT(!future.HasValue());
 
-        // The periodic check and a confirmation after half an interval.
-        const auto delays = context.Scheduler->PendingDelays();
-        UNIT_ASSERT_VALUES_EQUAL(2, delays.size());
-        UNIT_ASSERT_C(delays[1] <= interval / 2, delays[1]);
+        // No extra check is scheduled: the next periodic one confirms the
+        // new content once it has stayed unchanged for an interval.
+        UNIT_ASSERT_VALUES_EQUAL(1, context.Scheduler->PendingCount());
 
-        context.Timer->AdvanceTime(interval / 2);
-        context.Scheduler->RunPendingWithin(interval / 2);
+        context.Timer->AdvanceTime(interval);
+        context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_UNEQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
@@ -725,12 +724,12 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         context.RotateServer("server3.key", "server3.crt");
         auto first = context.Provider->UpdateCertificates();
         context.Scheduler->RunPendingWithin(TDuration::Zero());
-        UNIT_ASSERT_VALUES_EQUAL(2, context.Scheduler->PendingCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, context.Scheduler->PendingCount());
 
         // A repeated request joins the pending one instead of reading the
         // files again right away.
         auto second = context.Provider->UpdateCertificates();
-        UNIT_ASSERT_VALUES_EQUAL(2, context.Scheduler->PendingCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, context.Scheduler->PendingCount());
         context.Scheduler->RunPendingWithin(TDuration::Zero());
         UNIT_ASSERT_VALUES_EQUAL(
             initial,
@@ -738,8 +737,8 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         UNIT_ASSERT(!first.HasValue());
         UNIT_ASSERT(!second.HasValue());
 
-        context.Timer->AdvanceTime(interval / 2);
-        context.Scheduler->RunPendingWithin(interval / 2);
+        context.Timer->AdvanceTime(interval);
+        context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_UNEQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
@@ -769,11 +768,9 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         UNIT_ASSERT_VALUES_EQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
-        const auto delays = context.Scheduler->PendingDelays();
-        UNIT_ASSERT_VALUES_EQUAL(1, delays.size());
-        UNIT_ASSERT_C(delays[0] <= interval / 2, delays[0]);
+        UNIT_ASSERT_VALUES_EQUAL(1, context.Scheduler->PendingCount());
 
-        context.Timer->AdvanceTime(interval / 2);
+        context.Timer->AdvanceTime(interval);
         context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_UNEQUAL(
             initial,
@@ -861,13 +858,13 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         WriteTextFile(
             context.ServerPair.PrivateKeyPath,
             ReadCertResource("server3.key"));
-        context.Timer->AdvanceTime(context.RefreshInterval / 2);
+        context.Timer->AdvanceTime(context.RefreshInterval);
         context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_EQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
 
-        context.Timer->AdvanceTime(context.RefreshInterval / 2);
+        context.Timer->AdvanceTime(context.RefreshInterval);
         context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_UNEQUAL(
             initial,
@@ -891,6 +888,50 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         WriteTextFile(context.RootPath, ReadCertResource("server2.crt"));
         context.RunUntilStable();
         UNIT_ASSERT_VALUES_UNEQUAL(initial, context.GetRootCaFingerprint());
+    }
+
+    Y_UNIT_TEST(ShouldStartWithInvalidInitialChain)
+    {
+        TTempDir tempDir;
+        const TString rootPath = TStringBuilder()
+            << tempDir.Name() << "/ca.crt";
+        WriteTextFile(rootPath, ReadCertResource("ca.crt"));
+
+        // The chain cannot be built. It is served as is and only reported,
+        // so that the service is able to start.
+        const auto pair = CreateCertificatePair(
+            tempDir.Name(),
+            "server",
+            ReadCertResource("server1.key"),
+            ReadCertResource("server1.crt") + ReadCertResource("server3.crt"));
+
+        auto timer = std::make_shared<TTestTimer>();
+        auto scheduler = std::make_shared<TManualScheduler>(timer);
+        auto rootCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        auto serverGroup = rootCounters->GetSubgroup("component", "server");
+
+        auto provider = CreatePeriodicCertificateProvider(
+            CreateLoggingService("console"),
+            "TLS_CERTIFICATE_PROVIDER",
+            scheduler,
+            CreateTaskQueueStub(),
+            serverGroup,
+            rootPath,
+            TVector<TCertificateFiles>{pair},
+            TDuration::Seconds(1),
+            timer);
+        provider->Start();
+        Y_DEFER {
+            provider->Stop();
+        };
+
+        const auto expireTs = serverGroup
+            ->GetSubgroup("subsystem", "certificates")
+            ->GetSubgroup("cert", GetBaseName(pair.CertChainPath))
+            ->GetCounter("ExpireTs", false)
+            ->Val();
+        UNIT_ASSERT(expireTs > 0);
+        UNIT_ASSERT(provider->CreateSecureServerCredentials());
     }
 
     Y_UNIT_TEST(ShouldReportExpireTsCountersForStaticProvider)

--- a/cloud/storage/core/libs/grpc/tls_certificate_provider_ut.cpp
+++ b/cloud/storage/core/libs/grpc/tls_certificate_provider_ut.cpp
@@ -3,6 +3,7 @@
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
+#include <cloud/storage/core/libs/common/timer_test.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <library/cpp/logger/log.h>
@@ -116,7 +117,8 @@ struct TCertificateProviderTestContext
             ServerGroup,
             RootPath,
             TVector<TCertificateFiles>{ServerPair, ClientPair},
-            TDuration::Seconds(1));
+            TDuration::Seconds(1),
+            CreateWallClockTimer());
         UNIT_ASSERT(Provider);
         Provider->Start();
     }
@@ -160,10 +162,16 @@ private:
         TCallback Callback;
     };
 
+    const ITimerPtr Timer;
+
     TMutex Lock;
     TDeque<TScheduled> Pending;
 
 public:
+    explicit TManualScheduler(ITimerPtr timer)
+        : Timer(std::move(timer))
+    {}
+
     void Start() override
     {}
 
@@ -174,7 +182,7 @@ public:
     {
         TGuard guard(Lock);
         Pending.push_back({
-            .Delay = deadline - TInstant::Now(),
+            .Delay = deadline - Timer->Now(),
             .Callback = std::move(callback),
         });
     }
@@ -239,6 +247,8 @@ struct TManualProviderContext
     TCertificateFiles ServerPair;
     TCertificateFiles ClientPair;
 
+    const TDuration RefreshInterval;
+    std::shared_ptr<TTestTimer> Timer;
     std::shared_ptr<TManualScheduler> Scheduler;
     NMonitoring::TDynamicCountersPtr RootCounters;
     NMonitoring::TDynamicCountersPtr ServerGroup;
@@ -257,7 +267,9 @@ struct TManualProviderContext
               "client",
               ReadCertResource("server2.key"),
               ReadCertResource("server2.crt")))
-        , Scheduler(std::make_shared<TManualScheduler>())
+        , RefreshInterval(refreshInterval)
+        , Timer(std::make_shared<TTestTimer>())
+        , Scheduler(std::make_shared<TManualScheduler>(Timer))
         , RootCounters(MakeIntrusive<NMonitoring::TDynamicCounters>())
         , ServerGroup(RootCounters->GetSubgroup("component", "server"))
     {
@@ -271,13 +283,16 @@ struct TManualProviderContext
             ServerGroup,
             RootPath,
             TVector<TCertificateFiles>{ServerPair, ClientPair},
-            refreshInterval);
+            refreshInterval,
+            Timer);
     }
 
-    // New content is applied only after it has been read unchanged twice.
+    // New content is applied only after it has stayed unchanged for half of
+    // the refresh interval since it was first read.
     void RunUntilStable() const
     {
         Scheduler->RunPending();
+        Timer->AdvanceTime(RefreshInterval / 2);
         Scheduler->RunPending();
     }
 
@@ -390,7 +405,8 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
                 MakeIntrusive<NMonitoring::TDynamicCounters>(),
                 rootPath,
                 TVector<TCertificateFiles>{pair},
-                TDuration::Seconds(1)),
+                TDuration::Seconds(1),
+                CreateWallClockTimer()),
             yexception);
     }
 
@@ -414,7 +430,8 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
                     .PrivateKeyPath = "/nonexistent/server.key",
                     .CertChainPath = "/nonexistent/server.crt",
                 }},
-                TDuration::Seconds(1)),
+                TDuration::Seconds(1),
+                CreateWallClockTimer()),
             yexception);
     }
 
@@ -515,7 +532,8 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
             << tempDir.Name() << "/ca.crt";
         WriteTextFile(rootPath, ReadCertResource("ca.crt"));
 
-        auto scheduler = std::make_shared<TManualScheduler>();
+        auto scheduler =
+            std::make_shared<TManualScheduler>(CreateWallClockTimer());
         auto provider = CreateCertificateProvider(
             CreateLoggingService("console"),
             "TLS_CERTIFICATE_PROVIDER",
@@ -524,7 +542,8 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
             MakeIntrusive<NMonitoring::TDynamicCounters>(),
             rootPath,
             TVector<TCertificateFiles>{{}},
-            TDuration::Seconds(1));
+            TDuration::Seconds(1),
+            CreateWallClockTimer());
 
         provider->Start();
         Y_DEFER {
@@ -541,7 +560,8 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
             << tempDir.Name() << "/ca.crt";
         WriteTextFile(rootPath, ReadCertResource("ca.crt"));
 
-        auto scheduler = std::make_shared<TManualScheduler>();
+        auto scheduler =
+            std::make_shared<TManualScheduler>(CreateWallClockTimer());
         auto provider = CreateCertificateProvider(
             CreateLoggingService("console"),
             "TLS_CERTIFICATE_PROVIDER",
@@ -550,7 +570,8 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
             MakeIntrusive<NMonitoring::TDynamicCounters>(),
             rootPath,
             TVector<TCertificateFiles>{},
-            TDuration::Seconds(1));
+            TDuration::Seconds(1),
+            CreateWallClockTimer());
 
         provider->Start();
         Y_DEFER {
@@ -600,11 +621,19 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
 
         // Content changed again, so it is still not stable.
         context.RotateServer("server3.key", "server3.crt");
+        context.Timer->AdvanceTime(context.RefreshInterval / 2);
         context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_EQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
 
+        // Reading it again right away does not count.
+        context.Scheduler->RunPending();
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+
+        context.Timer->AdvanceTime(context.RefreshInterval / 2);
         context.Scheduler->RunPending();
         UNIT_ASSERT_VALUES_UNEQUAL(
             initial,
@@ -641,6 +670,7 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         context.Scheduler->RunPending();
         assertNextDelay(interval / 2);
 
+        context.Timer->AdvanceTime(interval / 2);
         context.Scheduler->RunPending();
         assertNextDelay(interval);
     }
@@ -658,22 +688,209 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
             context.GetExpireTs(context.ServerPair.CertChainPath);
 
         context.RotateServer("server3.key", "server3.crt");
-        context.Provider->UpdateCertificates();
+        auto future = context.Provider->UpdateCertificates();
         context.Scheduler->RunPendingWithin(TDuration::Zero());
         UNIT_ASSERT_VALUES_EQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
+        // The update is not complete until the new content is applied.
+        UNIT_ASSERT(!future.HasValue());
 
         // The periodic check and a confirmation after half an interval.
         const auto delays = context.Scheduler->PendingDelays();
         UNIT_ASSERT_VALUES_EQUAL(2, delays.size());
         UNIT_ASSERT_C(delays[1] <= interval / 2, delays[1]);
 
+        context.Timer->AdvanceTime(interval / 2);
         context.Scheduler->RunPendingWithin(interval / 2);
         UNIT_ASSERT_VALUES_UNEQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
+        UNIT_ASSERT(future.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(1, context.Scheduler->PendingCount());
+    }
+
+    Y_UNIT_TEST(ShouldNotApplyNewContentOnRepeatedOnDemandUpdates)
+    {
+        const auto interval = TDuration::Hours(1);
+        TManualProviderContext context(interval);
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        const ui64 initial =
+            context.GetExpireTs(context.ServerPair.CertChainPath);
+
+        context.RotateServer("server3.key", "server3.crt");
+        auto first = context.Provider->UpdateCertificates();
+        context.Scheduler->RunPendingWithin(TDuration::Zero());
+        UNIT_ASSERT_VALUES_EQUAL(2, context.Scheduler->PendingCount());
+
+        // A repeated request joins the pending one instead of reading the
+        // files again right away.
+        auto second = context.Provider->UpdateCertificates();
+        UNIT_ASSERT_VALUES_EQUAL(2, context.Scheduler->PendingCount());
+        context.Scheduler->RunPendingWithin(TDuration::Zero());
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+        UNIT_ASSERT(!first.HasValue());
+        UNIT_ASSERT(!second.HasValue());
+
+        context.Timer->AdvanceTime(interval / 2);
+        context.Scheduler->RunPendingWithin(interval / 2);
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+        UNIT_ASSERT(first.HasValue());
+        UNIT_ASSERT(second.HasValue());
+    }
+
+    Y_UNIT_TEST(ShouldHoldNewContentWhenPeriodicCheckFiresEarly)
+    {
+        const auto interval = TDuration::Hours(1);
+        TManualProviderContext context(interval);
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        const ui64 initial =
+            context.GetExpireTs(context.ServerPair.CertChainPath);
+
+        context.RotateServer("server3.key", "server3.crt");
+        context.Scheduler->RunPending();
+
+        // A check that happens to run right after the first read, e.g. a
+        // periodic one scheduled before an on-demand update, does not count
+        // as a stable read.
+        context.Scheduler->RunPending();
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+        const auto delays = context.Scheduler->PendingDelays();
+        UNIT_ASSERT_VALUES_EQUAL(1, delays.size());
+        UNIT_ASSERT_C(delays[0] <= interval / 2, delays[0]);
+
+        context.Timer->AdvanceTime(interval / 2);
+        context.Scheduler->RunPending();
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+    }
+
+    Y_UNIT_TEST(ShouldCompleteOnDemandUpdateOnStop)
+    {
+        TManualProviderContext context(TDuration::Hours(1));
+        context.Provider->Start();
+
+        context.RotateServer("server3.key", "server3.crt");
+        auto future = context.Provider->UpdateCertificates();
+        context.Scheduler->RunPendingWithin(TDuration::Zero());
+        UNIT_ASSERT(!future.HasValue());
+
+        context.Provider->Stop();
+        UNIT_ASSERT(future.HasValue());
+    }
+
+    Y_UNIT_TEST(ShouldKeepCertificateWhenRefreshedFilesAreInvalid)
+    {
+        TManualProviderContext context;
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        const ui64 initial =
+            context.GetExpireTs(context.ServerPair.CertChainPath);
+
+        // Broken certificate file.
+        WriteTextFile(context.ServerPair.CertChainPath, "broken");
+        context.RunUntilStable();
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+
+        // Private key does not match the certificate.
+        context.RotateServer("server3.key", "server1.crt");
+        context.RunUntilStable();
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+
+        // Chain cannot be built.
+        WriteTextFile(
+            context.ServerPair.PrivateKeyPath,
+            ReadCertResource("server1.key"));
+        WriteTextFile(
+            context.ServerPair.CertChainPath,
+            ReadCertResource("server1.crt") + ReadCertResource("server3.crt"));
+        context.RunUntilStable();
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+
+        // Valid content is applied.
+        context.RotateServer("server3.key", "server3.crt");
+        context.RunUntilStable();
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+    }
+
+    Y_UNIT_TEST(ShouldRestartStableReadOnReadError)
+    {
+        TManualProviderContext context;
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        const ui64 initial =
+            context.GetExpireTs(context.ServerPair.CertChainPath);
+
+        context.RotateServer("server3.key", "server3.crt");
+        context.Scheduler->RunPending();
+
+        // A read error, e.g. in the middle of a non-atomic rotation, restarts
+        // the hold.
+        NFs::Remove(context.ServerPair.PrivateKeyPath);
+        context.Scheduler->RunPending();
+
+        WriteTextFile(
+            context.ServerPair.PrivateKeyPath,
+            ReadCertResource("server3.key"));
+        context.Timer->AdvanceTime(context.RefreshInterval / 2);
+        context.Scheduler->RunPending();
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+
+        context.Timer->AdvanceTime(context.RefreshInterval / 2);
+        context.Scheduler->RunPending();
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+    }
+
+    Y_UNIT_TEST(ShouldKeepRootCaWhenRefreshedFileIsInvalid)
+    {
+        TManualProviderContext context;
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        const auto initial = context.GetRootCaFingerprint();
+
+        WriteTextFile(context.RootPath, "not a certificate");
+        context.RunUntilStable();
+        UNIT_ASSERT_VALUES_EQUAL(initial, context.GetRootCaFingerprint());
+
+        WriteTextFile(context.RootPath, ReadCertResource("server2.crt"));
+        context.RunUntilStable();
+        UNIT_ASSERT_VALUES_UNEQUAL(initial, context.GetRootCaFingerprint());
     }
 
     Y_UNIT_TEST(ShouldReportExpireTsCountersForStaticProvider)

--- a/cloud/storage/core/libs/grpc/tls_certificate_provider_ut.cpp
+++ b/cloud/storage/core/libs/grpc/tls_certificate_provider_ut.cpp
@@ -153,8 +153,15 @@ class TManualScheduler final
     : public IScheduler
 {
 private:
+    struct TScheduled
+    {
+        // How far ahead of the scheduling time the task was scheduled.
+        TDuration Delay;
+        TCallback Callback;
+    };
+
     TMutex Lock;
-    TDeque<TCallback> Pending;
+    TDeque<TScheduled> Pending;
 
 public:
     void Start() override
@@ -163,10 +170,13 @@ public:
     void Stop() override
     {}
 
-    void Schedule(ITaskQueue*, TInstant, TCallback callback) override
+    void Schedule(ITaskQueue*, TInstant deadline, TCallback callback) override
     {
         TGuard guard(Lock);
-        Pending.push_back(std::move(callback));
+        Pending.push_back({
+            .Delay = deadline - TInstant::Now(),
+            .Callback = std::move(callback),
+        });
     }
 
     size_t PendingCount()
@@ -175,15 +185,46 @@ public:
         return Pending.size();
     }
 
+    TVector<TDuration> PendingDelays()
+    {
+        TGuard guard(Lock);
+        TVector<TDuration> delays;
+        for (const auto& scheduled: Pending) {
+            delays.push_back(scheduled.Delay);
+        }
+        return delays;
+    }
+
     void RunPending()
     {
-        TDeque<TCallback> batch;
+        RunPending([](const TDuration&) { return true; });
+    }
+
+    // Runs only the tasks scheduled at most |maxDelay| ahead.
+    void RunPendingWithin(TDuration maxDelay)
+    {
+        RunPending([=](const TDuration& delay) { return delay <= maxDelay; });
+    }
+
+private:
+    template <typename TPredicate>
+    void RunPending(TPredicate shouldRun)
+    {
+        TDeque<TScheduled> batch;
         {
             TGuard guard(Lock);
-            batch.swap(Pending);
+            TDeque<TScheduled> rest;
+            for (auto& scheduled: Pending) {
+                if (shouldRun(scheduled.Delay)) {
+                    batch.push_back(std::move(scheduled));
+                } else {
+                    rest.push_back(std::move(scheduled));
+                }
+            }
+            Pending.swap(rest);
         }
-        for (auto& callback: batch) {
-            callback();
+        for (auto& scheduled: batch) {
+            scheduled.Callback();
         }
     }
 };
@@ -203,7 +244,8 @@ struct TManualProviderContext
     NMonitoring::TDynamicCountersPtr ServerGroup;
     ICertificateProviderPtr Provider;
 
-    TManualProviderContext()
+    explicit TManualProviderContext(
+            TDuration refreshInterval = TDuration::Seconds(1))
         : RootPath(TStringBuilder() << TempDir.Name() << "/ca.crt")
         , ServerPair(CreateCertificatePair(
               TempDir.Name(),
@@ -229,7 +271,14 @@ struct TManualProviderContext
             ServerGroup,
             RootPath,
             TVector<TCertificateFiles>{ServerPair, ClientPair},
-            TDuration::Seconds(1));
+            refreshInterval);
+    }
+
+    // New content is applied only after it has been read unchanged twice.
+    void RunUntilStable() const
+    {
+        Scheduler->RunPending();
+        Scheduler->RunPending();
     }
 
     void RotateServer(const TString& key, const TString& cert) const
@@ -424,7 +473,7 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         UNIT_ASSERT(before > 0);
 
         context.RotateServer("server3.key", "server3.crt");
-        context.Scheduler->RunPending();
+        context.RunUntilStable();
 
         const ui64 after =
             context.GetExpireTs(context.ServerPair.CertChainPath);
@@ -445,13 +494,13 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         UNIT_ASSERT(initial > 0);
 
         WriteTextFile(context.ServerPair.CertChainPath, "broken");
-        context.Scheduler->RunPending();
+        context.RunUntilStable();
         UNIT_ASSERT_VALUES_EQUAL(
             initial,
             context.GetExpireTs(context.ServerPair.CertChainPath));
 
         context.RotateServer("server3.key", "server3.crt");
-        context.Scheduler->RunPending();
+        context.RunUntilStable();
 
         const ui64 recovered =
             context.GetExpireTs(context.ServerPair.CertChainPath);
@@ -524,11 +573,107 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         const auto beforeFingerprint = context.GetRootCaFingerprint();
 
         WriteTextFile(context.RootPath, ReadCertResource("server2.crt"));
-        context.Scheduler->RunPending();
+        context.RunUntilStable();
 
         const auto afterFingerprint = context.GetRootCaFingerprint();
 
         UNIT_ASSERT_VALUES_UNEQUAL(beforeFingerprint, afterFingerprint);
+    }
+
+    Y_UNIT_TEST(ShouldNotApplyRotatedCertificateUntilStableRead)
+    {
+        TManualProviderContext context;
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        const ui64 initial =
+            context.GetExpireTs(context.ServerPair.CertChainPath);
+
+        // Content seen once is not applied yet.
+        context.RotateServer("server2.key", "server2.crt");
+        context.Scheduler->RunPending();
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+
+        // Content changed again, so it is still not stable.
+        context.RotateServer("server3.key", "server3.crt");
+        context.Scheduler->RunPending();
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+
+        context.Scheduler->RunPending();
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+    }
+
+    Y_UNIT_TEST(ShouldRecheckNewContentAfterHalfInterval)
+    {
+        const auto interval = TDuration::Hours(1);
+        const auto tolerance = TDuration::Seconds(10);
+        TManualProviderContext context(interval);
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        auto assertNextDelay = [&](TDuration expected)
+        {
+            const auto delays = context.Scheduler->PendingDelays();
+            UNIT_ASSERT_VALUES_EQUAL(1, delays.size());
+            UNIT_ASSERT_C(
+                delays[0] <= expected && delays[0] + tolerance >= expected,
+                delays[0]);
+        };
+
+        assertNextDelay(interval);
+
+        // Unchanged files are checked once per interval.
+        context.Scheduler->RunPending();
+        assertNextDelay(interval);
+
+        // New content is re-checked after half an interval.
+        context.RotateServer("server3.key", "server3.crt");
+        context.Scheduler->RunPending();
+        assertNextDelay(interval / 2);
+
+        context.Scheduler->RunPending();
+        assertNextDelay(interval);
+    }
+
+    Y_UNIT_TEST(ShouldConfirmNewContentAfterOnDemandUpdate)
+    {
+        const auto interval = TDuration::Hours(1);
+        TManualProviderContext context(interval);
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        const ui64 initial =
+            context.GetExpireTs(context.ServerPair.CertChainPath);
+
+        context.RotateServer("server3.key", "server3.crt");
+        context.Provider->UpdateCertificates();
+        context.Scheduler->RunPendingWithin(TDuration::Zero());
+        UNIT_ASSERT_VALUES_EQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+
+        // The periodic check and a confirmation after half an interval.
+        const auto delays = context.Scheduler->PendingDelays();
+        UNIT_ASSERT_VALUES_EQUAL(2, delays.size());
+        UNIT_ASSERT_C(delays[1] <= interval / 2, delays[1]);
+
+        context.Scheduler->RunPendingWithin(interval / 2);
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            initial,
+            context.GetExpireTs(context.ServerPair.CertChainPath));
+        UNIT_ASSERT_VALUES_EQUAL(1, context.Scheduler->PendingCount());
     }
 
     Y_UNIT_TEST(ShouldReportExpireTsCountersForStaticProvider)

--- a/cloud/storage/core/libs/grpc/tls_utils.cpp
+++ b/cloud/storage/core/libs/grpc/tls_utils.cpp
@@ -8,6 +8,7 @@
 #include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
 
 #include <algorithm>
 #include <ctime>
@@ -24,6 +25,11 @@ namespace {
 using TBioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
 using TX509Ptr = std::unique_ptr<X509, decltype(&X509_free)>;
 using TEvpPkeyPtr = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
+using TX509StorePtr = std::unique_ptr<X509_STORE, decltype(&X509_STORE_free)>;
+using TX509StoreCtxPtr =
+    std::unique_ptr<X509_STORE_CTX, decltype(&X509_STORE_CTX_free)>;
+using TX509StackPtr =
+    std::unique_ptr<STACK_OF(X509), decltype(&sk_X509_free)>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -150,44 +156,173 @@ bool IsEmptyPair(const TCertificateFiles& certPair)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TMaybe<TString> UpdateRootCa(
-    const TRootCaPair& root,
-    TLog& Log)
+enum class EStableRead
 {
-    if (root.RootCaPath.empty()) {
-        return Nothing();
+    // Content equals the current one.
+    Unchanged,
+    // New content has been read for the first time or differs from the
+    // content read previously.
+    Wait,
+    // New content has been read unchanged twice in a row.
+    Apply,
+};
+
+template <typename T>
+EStableRead DecideStableRead(
+    const T& current,
+    TMaybe<T>& pending,
+    const T& content)
+{
+    if (content == current) {
+        pending.Clear();
+        return EStableRead::Unchanged;
     }
 
-    auto result = NTlsUtils::ReadAndValidateRootCertificate(root.RootCaPath);
-    if (HasError(result.GetError())) {
-        STORAGE_WARN(
-            "Root certificate update is skipped: "
-            << FormatError(result.GetError()));
-
-        return root.RootCa.empty()
-            ? Nothing()
-            : TMaybe<TString>(root.RootCa);
-    }
-
-    return result.ExtractResult();
+    const bool stable = pending.Defined() && *pending == content;
+    pending = content;
+    return stable ? EStableRead::Apply : EStableRead::Wait;
 }
 
-TResultOrError<grpc_core::PemKeyCertPairList> ReadAndValidateIdentityCertificate(
-    const TCertificateFiles& files)
+// Returns true if the root certificate has been replaced.
+bool UpdateRootCa(TRootCaPair& root, bool& pending, TLog& Log)
 {
-    auto identityResult = NTlsUtils::ReadAndValidateIdentityPair(files);
-    if (HasError(identityResult)) {
-        return identityResult.GetError();
+    if (root.RootCaPath.empty()) {
+        return false;
     }
 
-    const auto& pair = identityResult.GetResult().front();
-    auto validityResult =
-        NTlsUtils::ValidateIdentityCertificateValidity(pair.cert_chain());
-    if (HasError(validityResult)) {
-        return validityResult.GetError();
+    auto content = TryReadFile(root.RootCaPath);
+    if (HasError(content.GetError())) {
+        root.Pending.Clear();
+        STORAGE_WARN(
+            "Root certificate update is skipped: "
+            << FormatError(content.GetError()));
+        return false;
     }
 
-    return identityResult.ExtractResult();
+    switch (DecideStableRead(root.RootCa, root.Pending, content.GetResult())) {
+        case EStableRead::Unchanged:
+            return false;
+        case EStableRead::Wait:
+            pending = true;
+            STORAGE_INFO(
+                "New root certificate " << root.RootCaPath.Quote()
+                << ", waiting for a stable read");
+            return false;
+        case EStableRead::Apply:
+            break;
+    }
+
+    auto validity = IsValidPemCertificate(content.GetResult());
+    if (HasError(validity.GetError())) {
+        STORAGE_WARN(
+            "Root certificate update is skipped: "
+            << FormatError(validity.GetError()));
+        return false;
+    }
+
+    root.RootCa = content.ExtractResult();
+    root.Pending.Clear();
+    STORAGE_INFO(
+        "Root certificate " << root.RootCaPath.Quote() << " has been updated");
+    return true;
+}
+
+TResultOrError<void> ValidateIdentity(const TPendingIdentity& identity)
+{
+    auto keyMatchesCert = PrivateKeyAndCertificateMatch(
+        identity.PrivateKey,
+        identity.CertChain);
+    if (HasError(keyMatchesCert.GetError())) {
+        return keyMatchesCert.GetError();
+    }
+
+    auto validity = ValidateIdentityCertificateValidity(identity.CertChain);
+    if (HasError(validity.GetError())) {
+        return validity.GetError();
+    }
+
+    return ValidateIdentityCertificateChain(identity.CertChain);
+}
+
+TResultOrError<TPendingIdentity> ReadIdentity(const TCertificateFiles& files)
+{
+    auto privateKey = TryReadFile(files.PrivateKeyPath);
+    if (HasError(privateKey.GetError())) {
+        return privateKey.GetError();
+    }
+
+    auto certChain = TryReadFile(files.CertChainPath);
+    if (HasError(certChain.GetError())) {
+        return certChain.GetError();
+    }
+
+    return TPendingIdentity{
+        .PrivateKey = privateKey.ExtractResult(),
+        .CertChain = certChain.ExtractResult(),
+    };
+}
+
+TCertificateUpdate UpdateIdentity(
+    TCertificatePair& cert,
+    bool& pending,
+    TLog& Log)
+{
+    TCertificateUpdate update;
+    const auto& path = cert.Files.CertChainPath;
+
+    auto content = ReadIdentity(cert.Files);
+    if (HasError(content.GetError())) {
+        cert.Pending.Clear();
+        STORAGE_WARN(
+            "Identity certificate update is skipped for " << path.Quote()
+            << ": " << FormatError(content.GetError()));
+        return update;
+    }
+
+    const TPendingIdentity current{
+        .PrivateKey = cert.PrivateKey,
+        .CertChain = cert.CertChain,
+    };
+    switch (DecideStableRead(current, cert.Pending, content.GetResult())) {
+        case EStableRead::Unchanged:
+            return update;
+        case EStableRead::Wait:
+            pending = true;
+            STORAGE_INFO(
+                "New identity certificate " << path.Quote()
+                << ", waiting for a stable read");
+            return update;
+        case EStableRead::Apply:
+            break;
+    }
+
+    auto validity = ValidateIdentity(content.GetResult());
+    if (HasError(validity.GetError())) {
+        STORAGE_WARN(
+            "Identity certificate update is skipped for " << path.Quote()
+            << ": " << FormatError(validity.GetError()));
+        return update;
+    }
+
+    auto notAfterTs = GetCertificateNotAfterTimestampSec(
+        content.GetResult().CertChain);
+    if (HasError(notAfterTs)) {
+        STORAGE_WARN(
+            "Unable to parse certificate notAfter date for " << path.Quote()
+            << ": " << FormatError(notAfterTs.GetError()));
+    } else {
+        update.NotValidAfter = TInstant::Seconds(notAfterTs.ExtractResult());
+    }
+
+    auto identity = content.ExtractResult();
+    cert.PrivateKey = std::move(identity.PrivateKey);
+    cert.CertChain = std::move(identity.CertChain);
+    cert.Pending.Clear();
+    update.Changed = true;
+    STORAGE_INFO(
+        "Identity certificate " << path.Quote() << " has been updated"
+        << ", expires at " << update.NotValidAfter);
+    return update;
 }
 
 }   // namespace
@@ -302,6 +437,69 @@ TResultOrError<void> ValidateIdentityCertificateValidity(
                     << "Identity certificate #" << i
                     << " has expired");
         }
+    }
+
+    return {};
+}
+
+TResultOrError<void> ValidateIdentityCertificateChain(
+    TStringBuf certChainPem)
+{
+    TSslErrorQueueGuard errorGuard;
+
+    auto chainResult = ParseNonEmptyPemCertificates(
+        certChainPem,
+        "Identity certificate chain");
+    if (HasError(chainResult.GetError())) {
+        return chainResult.GetError();
+    }
+
+    const auto& chain = chainResult.GetResult();
+
+    TX509StorePtr store(X509_STORE_new(), X509_STORE_free);
+    if (!store) {
+        return MakeOpenSslError("Failed to allocate X509 store");
+    }
+    if (X509_STORE_add_cert(store.get(), chain.back().get()) != 1) {
+        return MakeOpenSslError("Failed to add trust anchor to X509 store");
+    }
+
+    // Does not own the certificates.
+    TX509StackPtr intermediates(sk_X509_new_null(), sk_X509_free);
+    if (!intermediates) {
+        return MakeOpenSslError("Failed to allocate X509 stack");
+    }
+    for (size_t i = 1; i + 1 < chain.size(); ++i) {
+        if (sk_X509_push(intermediates.get(), chain[i].get()) <= 0) {
+            return MakeOpenSslError("Failed to add certificate to X509 stack");
+        }
+    }
+
+    TX509StoreCtxPtr ctx(X509_STORE_CTX_new(), X509_STORE_CTX_free);
+    if (!ctx) {
+        return MakeOpenSslError("Failed to allocate X509 store context");
+    }
+    if (X509_STORE_CTX_init(
+            ctx.get(),
+            store.get(),
+            chain.front().get(),
+            intermediates.get()) != 1)
+    {
+        return MakeOpenSslError("Failed to init X509 store context");
+    }
+
+    // The trust anchor is not necessarily self-signed.
+    X509_STORE_CTX_set_flags(ctx.get(), X509_V_FLAG_PARTIAL_CHAIN);
+
+    if (X509_verify_cert(ctx.get()) != 1) {
+        const int error = X509_STORE_CTX_get_error(ctx.get());
+        return TErrorResponse(
+            E_INVALID_STATE,
+            TStringBuilder()
+                << "Identity certificate chain cannot be built: "
+                << X509_verify_cert_error_string(error)
+                << " (certificate #"
+                << X509_STORE_CTX_get_error_depth(ctx.get()) << ")");
     }
 
     return {};
@@ -456,57 +654,20 @@ TVector<TCertificateFiles> PrepareCertificateFilePairs(
 }
 
 TCertificatesUpdateResult UpdateCertificates(
-    const TVector<TCertificatePair>& certificates,
-    const TRootCaPair& root,
+    TVector<TCertificatePair>& certificates,
+    TRootCaPair& root,
     TLog& log)
 {
-    TLog& Log = log;
+    TCertificatesUpdateResult result;
+    result.RootCaChanged = UpdateRootCa(root, result.Pending, log);
 
-    TCertificatesUpdateResult updateResult;
-    updateResult.Certificates.resize(certificates.size());
-    updateResult.RootCa = UpdateRootCa(root, Log);
-
-    for (size_t i = 0; i < certificates.size(); ++i) {
-        const TCertificatePair& cert = certificates[i];
-        auto identityResult = ReadAndValidateIdentityCertificate(cert.Files);
-
-        if (HasError(identityResult)) {
-            STORAGE_WARN(
-                "Identity certificate update is skipped for "
-                << cert.Files.CertChainPath.Quote() << ": "
-                << FormatError(identityResult.GetError()));
-
-            if (!cert.PrivateKey.empty() && !cert.CertChain.empty()) {
-                grpc_core::PemKeyCertPairList fallback;
-                fallback.emplace_back(cert.PrivateKey, cert.CertChain);
-                updateResult.Certificates[i] = TCertificate{
-                    .CertificatesChain = std::move(fallback),
-                };
-            }
-
-            continue;
-        }
-
-        TCertificate newCert;
-        newCert.CertificatesChain = identityResult.ExtractResult();
-
-        const auto& identityPair = newCert.CertificatesChain.front();
-        auto notAfterTs =
-            NTlsUtils::GetCertificateNotAfterTimestampSec(
-                identityPair.cert_chain());
-        if (HasError(notAfterTs)) {
-            STORAGE_WARN(
-                "Unable to parse certificate notAfter date for "
-                << cert.Files.CertChainPath.Quote() << ": "
-                << FormatError(notAfterTs.GetError()));
-        } else {
-            newCert.NotValidAfter = TInstant::Seconds(notAfterTs.ExtractResult());
-        }
-
-        updateResult.Certificates[i] = std::move(newCert);
+    result.Certificates.reserve(certificates.size());
+    for (auto& cert: certificates) {
+        result.Certificates.push_back(
+            UpdateIdentity(cert, result.Pending, log));
     }
 
-    return updateResult;
+    return result;
 }
 
 }   // namespace NCloud::NTlsUtils

--- a/cloud/storage/core/libs/grpc/tls_utils.cpp
+++ b/cloud/storage/core/libs/grpc/tls_utils.cpp
@@ -156,175 +156,6 @@ bool IsEmptyPair(const TCertificateFiles& certPair)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-enum class EStableRead
-{
-    // Content equals the current one.
-    Unchanged,
-    // New content has been read for the first time or differs from the
-    // content read previously.
-    Wait,
-    // New content has been read unchanged twice in a row.
-    Apply,
-};
-
-template <typename T>
-EStableRead DecideStableRead(
-    const T& current,
-    TMaybe<T>& pending,
-    const T& content)
-{
-    if (content == current) {
-        pending.Clear();
-        return EStableRead::Unchanged;
-    }
-
-    const bool stable = pending.Defined() && *pending == content;
-    pending = content;
-    return stable ? EStableRead::Apply : EStableRead::Wait;
-}
-
-// Returns true if the root certificate has been replaced.
-bool UpdateRootCa(TRootCaPair& root, bool& pending, TLog& Log)
-{
-    if (root.RootCaPath.empty()) {
-        return false;
-    }
-
-    auto content = TryReadFile(root.RootCaPath);
-    if (HasError(content.GetError())) {
-        root.Pending.Clear();
-        STORAGE_WARN(
-            "Root certificate update is skipped: "
-            << FormatError(content.GetError()));
-        return false;
-    }
-
-    switch (DecideStableRead(root.RootCa, root.Pending, content.GetResult())) {
-        case EStableRead::Unchanged:
-            return false;
-        case EStableRead::Wait:
-            pending = true;
-            STORAGE_INFO(
-                "New root certificate " << root.RootCaPath.Quote()
-                << ", waiting for a stable read");
-            return false;
-        case EStableRead::Apply:
-            break;
-    }
-
-    auto validity = IsValidPemCertificate(content.GetResult());
-    if (HasError(validity.GetError())) {
-        STORAGE_WARN(
-            "Root certificate update is skipped: "
-            << FormatError(validity.GetError()));
-        return false;
-    }
-
-    root.RootCa = content.ExtractResult();
-    root.Pending.Clear();
-    STORAGE_INFO(
-        "Root certificate " << root.RootCaPath.Quote() << " has been updated");
-    return true;
-}
-
-TResultOrError<void> ValidateIdentity(const TPendingIdentity& identity)
-{
-    auto keyMatchesCert = PrivateKeyAndCertificateMatch(
-        identity.PrivateKey,
-        identity.CertChain);
-    if (HasError(keyMatchesCert.GetError())) {
-        return keyMatchesCert.GetError();
-    }
-
-    auto validity = ValidateIdentityCertificateValidity(identity.CertChain);
-    if (HasError(validity.GetError())) {
-        return validity.GetError();
-    }
-
-    return ValidateIdentityCertificateChain(identity.CertChain);
-}
-
-TResultOrError<TPendingIdentity> ReadIdentity(const TCertificateFiles& files)
-{
-    auto privateKey = TryReadFile(files.PrivateKeyPath);
-    if (HasError(privateKey.GetError())) {
-        return privateKey.GetError();
-    }
-
-    auto certChain = TryReadFile(files.CertChainPath);
-    if (HasError(certChain.GetError())) {
-        return certChain.GetError();
-    }
-
-    return TPendingIdentity{
-        .PrivateKey = privateKey.ExtractResult(),
-        .CertChain = certChain.ExtractResult(),
-    };
-}
-
-TCertificateUpdate UpdateIdentity(
-    TCertificatePair& cert,
-    bool& pending,
-    TLog& Log)
-{
-    TCertificateUpdate update;
-    const auto& path = cert.Files.CertChainPath;
-
-    auto content = ReadIdentity(cert.Files);
-    if (HasError(content.GetError())) {
-        cert.Pending.Clear();
-        STORAGE_WARN(
-            "Identity certificate update is skipped for " << path.Quote()
-            << ": " << FormatError(content.GetError()));
-        return update;
-    }
-
-    const TPendingIdentity current{
-        .PrivateKey = cert.PrivateKey,
-        .CertChain = cert.CertChain,
-    };
-    switch (DecideStableRead(current, cert.Pending, content.GetResult())) {
-        case EStableRead::Unchanged:
-            return update;
-        case EStableRead::Wait:
-            pending = true;
-            STORAGE_INFO(
-                "New identity certificate " << path.Quote()
-                << ", waiting for a stable read");
-            return update;
-        case EStableRead::Apply:
-            break;
-    }
-
-    auto validity = ValidateIdentity(content.GetResult());
-    if (HasError(validity.GetError())) {
-        STORAGE_WARN(
-            "Identity certificate update is skipped for " << path.Quote()
-            << ": " << FormatError(validity.GetError()));
-        return update;
-    }
-
-    auto notAfterTs = GetCertificateNotAfterTimestampSec(
-        content.GetResult().CertChain);
-    if (HasError(notAfterTs)) {
-        STORAGE_WARN(
-            "Unable to parse certificate notAfter date for " << path.Quote()
-            << ": " << FormatError(notAfterTs.GetError()));
-    } else {
-        update.NotValidAfter = TInstant::Seconds(notAfterTs.ExtractResult());
-    }
-
-    auto identity = content.ExtractResult();
-    cert.PrivateKey = std::move(identity.PrivateKey);
-    cert.CertChain = std::move(identity.CertChain);
-    cert.Pending.Clear();
-    update.Changed = true;
-    STORAGE_INFO(
-        "Identity certificate " << path.Quote() << " has been updated"
-        << ", expires at " << update.NotValidAfter);
-    return update;
-}
-
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -589,6 +420,41 @@ TResultOrError<grpc_core::PemKeyCertPairList> ReadAndValidateIdentityPair(
     return result;
 }
 
+TResultOrError<TIdentityContent> ReadIdentity(const TCertificateFiles& files)
+{
+    auto privateKey = TryReadFile(files.PrivateKeyPath);
+    if (HasError(privateKey.GetError())) {
+        return privateKey.GetError();
+    }
+
+    auto certChain = TryReadFile(files.CertChainPath);
+    if (HasError(certChain.GetError())) {
+        return certChain.GetError();
+    }
+
+    return TIdentityContent{
+        .PrivateKey = privateKey.ExtractResult(),
+        .CertChain = certChain.ExtractResult(),
+    };
+}
+
+TResultOrError<void> ValidateIdentity(const TIdentityContent& identity)
+{
+    auto keyMatchesCert = PrivateKeyAndCertificateMatch(
+        identity.PrivateKey,
+        identity.CertChain);
+    if (HasError(keyMatchesCert.GetError())) {
+        return keyMatchesCert.GetError();
+    }
+
+    auto validity = ValidateIdentityCertificateValidity(identity.CertChain);
+    if (HasError(validity.GetError())) {
+        return validity.GetError();
+    }
+
+    return ValidateIdentityCertificateChain(identity.CertChain);
+}
+
 TVector<TCertificatePair> LoadCertificatePairs(
     TVector<TCertificateFiles> certificates)
 {
@@ -651,23 +517,6 @@ TVector<TCertificateFiles> PrepareCertificateFilePairs(
         res.emplace_back(std::move(cert));
     }
     return res;
-}
-
-TCertificatesUpdateResult UpdateCertificates(
-    TVector<TCertificatePair>& certificates,
-    TRootCaPair& root,
-    TLog& log)
-{
-    TCertificatesUpdateResult result;
-    result.RootCaChanged = UpdateRootCa(root, result.Pending, log);
-
-    result.Certificates.reserve(certificates.size());
-    for (auto& cert: certificates) {
-        result.Certificates.push_back(
-            UpdateIdentity(cert, result.Pending, log));
-    }
-
-    return result;
 }
 
 }   // namespace NCloud::NTlsUtils

--- a/cloud/storage/core/libs/grpc/tls_utils.h
+++ b/cloud/storage/core/libs/grpc/tls_utils.h
@@ -13,29 +13,46 @@ namespace NCloud::NTlsUtils {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TPendingIdentity
+{
+    TString PrivateKey;
+    TString CertChain;
+
+    bool operator==(const TPendingIdentity& other) const = default;
+};
+
 struct TCertificatePair
 {
     TCertificateFiles Files;
     TString PrivateKey;
     TString CertChain;
+    // Content that differs from the current one and has been read once, see
+    // UpdateCertificates.
+    TMaybe<TPendingIdentity> Pending;
 };
 
 struct TRootCaPair
 {
     TString RootCaPath;
     TString RootCa;
+    // Content that differs from the current one and has been read once, see
+    // UpdateCertificates.
+    TMaybe<TString> Pending;
 };
 
-struct TCertificate
+struct TCertificateUpdate
 {
-    grpc_core::PemKeyCertPairList CertificatesChain;
+    bool Changed = false;
+    // Earliest notAfter of the chain, set when Changed.
     TInstant NotValidAfter;
 };
 
 struct TCertificatesUpdateResult
 {
-    TVector<TMaybe<TCertificate>> Certificates;
-    TMaybe<TString> RootCa;
+    bool RootCaChanged = false;
+    TVector<TCertificateUpdate> Certificates;
+    // Some content is waiting for a stable read.
+    bool Pending = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,6 +66,14 @@ TResultOrError<void> PrivateKeyAndCertificateMatch(
     TStringBuf certChain);
 
 TResultOrError<void> ValidateIdentityCertificateValidity(
+    TStringBuf certChainPem);
+
+// Checks that the chain can be built from the leaf up to the last certificate
+// the same way clients do it: issuer names, signatures, CA and name
+// constraints. The last certificate serves as the trust anchor: there is no
+// trust store here, and whether the chain ends at a trusted root is the
+// client's job anyway.
+TResultOrError<void> ValidateIdentityCertificateChain(
     TStringBuf certChainPem);
 
 TResultOrError<ui64> GetCertificateNotAfterTimestampSec(
@@ -68,9 +93,21 @@ TVector<TCertificatePair> LoadCertificatePairs(
 
 TRootCaPair LoadRootCaPair(TString rootCaPath);
 
+// Re-reads certificate files and updates |certificates| and |root| in place.
+// Certificate files are rewritten by external tools, not necessarily
+// atomically, and a partially written file may be syntactically valid, e.g. a
+// chain without its intermediate certificate. Therefore new content is applied
+// only after it has been read unchanged twice in a row (stable-read), a read
+// error restarts the count. This is a heuristic that reduces the chance of
+// picking up an intermediate state of a rewrite, not a guarantee: a writer
+// that stalls for longer than the check interval is indistinguishable from a
+// finished one. The last successfully loaded content is kept if the files
+// cannot be read, parsed or validated; new content that fails these checks is
+// reported on every call until the files change. Every certificate is
+// refreshed independently.
 TCertificatesUpdateResult UpdateCertificates(
-    const TVector<TCertificatePair>& certificates,
-    const TRootCaPair& root,
+    TVector<TCertificatePair>& certificates,
+    TRootCaPair& root,
     TLog& log);
 
 }   // namespace NCloud::NTlsUtils

--- a/cloud/storage/core/libs/grpc/tls_utils.h
+++ b/cloud/storage/core/libs/grpc/tls_utils.h
@@ -3,7 +3,6 @@
 #include "tls_certificate_provider.h"
 
 #include <cloud/storage/core/libs/common/error.h>
-#include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h>
 
@@ -13,12 +12,13 @@ namespace NCloud::NTlsUtils {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TPendingIdentity
+// Contents of a private key file and a certificate chain file.
+struct TIdentityContent
 {
     TString PrivateKey;
     TString CertChain;
 
-    bool operator==(const TPendingIdentity& other) const = default;
+    bool operator==(const TIdentityContent& other) const = default;
 };
 
 struct TCertificatePair
@@ -26,33 +26,12 @@ struct TCertificatePair
     TCertificateFiles Files;
     TString PrivateKey;
     TString CertChain;
-    // Content that differs from the current one and has been read once, see
-    // UpdateCertificates.
-    TMaybe<TPendingIdentity> Pending;
 };
 
 struct TRootCaPair
 {
     TString RootCaPath;
     TString RootCa;
-    // Content that differs from the current one and has been read once, see
-    // UpdateCertificates.
-    TMaybe<TString> Pending;
-};
-
-struct TCertificateUpdate
-{
-    bool Changed = false;
-    // Earliest notAfter of the chain, set when Changed.
-    TInstant NotValidAfter;
-};
-
-struct TCertificatesUpdateResult
-{
-    bool RootCaChanged = false;
-    TVector<TCertificateUpdate> Certificates;
-    // Some content is waiting for a stable read.
-    bool Pending = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -85,6 +64,14 @@ TResultOrError<TString> ReadAndValidateRootCertificate(
 TResultOrError<grpc_core::PemKeyCertPairList> ReadAndValidateIdentityPair(
     const TCertificateFiles& files);
 
+TResultOrError<TIdentityContent> ReadIdentity(const TCertificateFiles& files);
+
+// Checks that the private key matches the certificate, that every certificate
+// in the chain is valid now and that the chain can be built. Applied to
+// refreshed certificates; the initial load is lenient so that the service is
+// able to start, see LoadCertificatePairs.
+TResultOrError<void> ValidateIdentity(const TIdentityContent& identity);
+
 TVector<TCertificateFiles> PrepareCertificateFilePairs(
     TVector<TCertificateFiles> certificates);
 
@@ -92,22 +79,5 @@ TVector<TCertificatePair> LoadCertificatePairs(
     TVector<TCertificateFiles> certificates);
 
 TRootCaPair LoadRootCaPair(TString rootCaPath);
-
-// Re-reads certificate files and updates |certificates| and |root| in place.
-// Certificate files are rewritten by external tools, not necessarily
-// atomically, and a partially written file may be syntactically valid, e.g. a
-// chain without its intermediate certificate. Therefore new content is applied
-// only after it has been read unchanged twice in a row (stable-read), a read
-// error restarts the count. This is a heuristic that reduces the chance of
-// picking up an intermediate state of a rewrite, not a guarantee: a writer
-// that stalls for longer than the check interval is indistinguishable from a
-// finished one. The last successfully loaded content is kept if the files
-// cannot be read, parsed or validated; new content that fails these checks is
-// reported on every call until the files change. Every certificate is
-// refreshed independently.
-TCertificatesUpdateResult UpdateCertificates(
-    TVector<TCertificatePair>& certificates,
-    TRootCaPair& root,
-    TLog& log);
 
 }   // namespace NCloud::NTlsUtils

--- a/cloud/storage/core/libs/grpc/tls_utils_ut.cpp
+++ b/cloud/storage/core/libs/grpc/tls_utils_ut.cpp
@@ -7,10 +7,14 @@
 #include <util/generic/yexception.h>
 #include <util/stream/file.h>
 #include <util/string/builder.h>
+#include <util/system/fs.h>
 
 #include <openssl/bio.h>
+#include <openssl/evp.h>
 #include <openssl/pem.h>
+#include <openssl/rsa.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 
 #include <memory>
 
@@ -104,6 +108,135 @@ TString SetCertificateValidity(
     return TString(data, size);
 }
 
+using TEvpPkeyPtr = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
+using TX509Ptr = std::unique_ptr<X509, decltype(&X509_free)>;
+
+TEvpPkeyPtr GeneratePrivateKey()
+{
+    using TCtxPtr =
+        std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>;
+
+    TCtxPtr ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr), EVP_PKEY_CTX_free);
+    UNIT_ASSERT(ctx);
+    UNIT_ASSERT_VALUES_EQUAL(1, EVP_PKEY_keygen_init(ctx.get()));
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        EVP_PKEY_CTX_set_rsa_keygen_bits(ctx.get(), 2048));
+
+    EVP_PKEY* key = nullptr;
+    UNIT_ASSERT_VALUES_EQUAL(1, EVP_PKEY_keygen(ctx.get(), &key));
+    return TEvpPkeyPtr(key, EVP_PKEY_free);
+}
+
+TString CertificateToPem(X509* certificate)
+{
+    using TBioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
+
+    TBioPtr output(BIO_new(BIO_s_mem()), BIO_free);
+    UNIT_ASSERT(output);
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        PEM_write_bio_X509(output.get(), certificate));
+
+    char* data = nullptr;
+    const long size = BIO_get_mem_data(output.get(), &data);
+    UNIT_ASSERT(size > 0);
+    return TString(data, size);
+}
+
+TX509Ptr ParseCertificate(TStringBuf pem)
+{
+    using TBioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
+
+    TBioPtr input(
+        BIO_new_mem_buf(pem.data(), static_cast<int>(pem.size())),
+        BIO_free);
+    UNIT_ASSERT(input);
+
+    TX509Ptr certificate(
+        PEM_read_bio_X509(input.get(), nullptr, nullptr, nullptr),
+        X509_free);
+    UNIT_ASSERT(certificate);
+    return certificate;
+}
+
+void AddExtension(X509* certificate, X509* issuer, int nid, const char* value)
+{
+    X509V3_CTX ctx;
+    X509V3_set_ctx_nodb(&ctx);
+    X509V3_set_ctx(&ctx, issuer, certificate, nullptr, nullptr, 0);
+
+    X509_EXTENSION* extension = X509V3_EXT_conf_nid(
+        nullptr,
+        &ctx,
+        nid,
+        const_cast<char*>(value));
+    UNIT_ASSERT(extension);
+    UNIT_ASSERT_VALUES_EQUAL(1, X509_add_ext(certificate, extension, -1));
+    X509_EXTENSION_free(extension);
+}
+
+// CA certificate for |key|, self-signed if |issuer| is null and signed by
+// |issuerKey| otherwise. Valid from one day ago for one year.
+TString IssueCertificate(
+    const TString& commonName,
+    EVP_PKEY* key,
+    X509* issuer,
+    EVP_PKEY* issuerKey)
+{
+    TX509Ptr certificate(X509_new(), X509_free);
+    UNIT_ASSERT(certificate);
+    UNIT_ASSERT_VALUES_EQUAL(1, X509_set_version(certificate.get(), 2));
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        ASN1_INTEGER_set(
+            X509_get_serialNumber(certificate.get()),
+            static_cast<long>(TInstant::Now().MicroSeconds() & 0x7fffffff)));
+
+    X509_NAME* subject = X509_get_subject_name(certificate.get());
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        X509_NAME_add_entry_by_txt(
+            subject,
+            "CN",
+            MBSTRING_ASC,
+            reinterpret_cast<const unsigned char*>(commonName.c_str()),
+            -1,
+            -1,
+            0));
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        X509_set_issuer_name(
+            certificate.get(),
+            issuer ? X509_get_subject_name(issuer) : subject));
+
+    UNIT_ASSERT(X509_gmtime_adj(
+        X509_getm_notBefore(certificate.get()),
+        -24 * 60 * 60));
+    UNIT_ASSERT(X509_gmtime_adj(
+        X509_getm_notAfter(certificate.get()),
+        YearSeconds));
+    UNIT_ASSERT_VALUES_EQUAL(1, X509_set_pubkey(certificate.get(), key));
+
+    AddExtension(
+        certificate.get(),
+        issuer ? issuer : certificate.get(),
+        NID_basic_constraints,
+        "critical,CA:TRUE");
+    AddExtension(
+        certificate.get(),
+        issuer ? issuer : certificate.get(),
+        NID_key_usage,
+        "critical,keyCertSign,digitalSignature");
+
+    UNIT_ASSERT(X509_sign(
+        certificate.get(),
+        issuerKey ? issuerKey : key,
+        EVP_sha256()));
+
+    return CertificateToPem(certificate.get());
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -162,6 +295,70 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
             ValidateIdentityCertificateValidity(cert + expired).GetError()));
         UNIT_ASSERT(HasError(
             ValidateIdentityCertificateValidity(cert + notYetValid).GetError()));
+    }
+
+    Y_UNIT_TEST(ShouldValidateIdentityCertificateChain)
+    {
+        const auto leaf = ReadCertResource("server1.crt");
+        const auto ca = ReadCertResource("ca.crt");
+        const auto selfSigned = ReadCertResource("server3.crt");
+
+        UNIT_ASSERT(!HasError(
+            ValidateIdentityCertificateChain(leaf).GetError()));
+        UNIT_ASSERT(!HasError(
+            ValidateIdentityCertificateChain(leaf + ca).GetError()));
+        UNIT_ASSERT(!HasError(
+            ValidateIdentityCertificateChain(selfSigned).GetError()));
+    }
+
+    Y_UNIT_TEST(ShouldRejectIdentityCertificateChainThatCannotBeBuilt)
+    {
+        const auto leaf = ReadCertResource("server1.crt");
+        const auto ca = ReadCertResource("ca.crt");
+        const auto unrelated = ReadCertResource("server3.crt");
+
+        // Leaf is not issued by the next certificate.
+        UNIT_ASSERT(HasError(
+            ValidateIdentityCertificateChain(leaf + unrelated).GetError()));
+        // Intermediate certificate is not issued by the next certificate.
+        UNIT_ASSERT(HasError(
+            ValidateIdentityCertificateChain(leaf + ca + unrelated)
+                .GetError()));
+        UNIT_ASSERT(HasError(
+            ValidateIdentityCertificateChain("not a certificate")
+                .GetError()));
+    }
+
+    Y_UNIT_TEST(ShouldRejectIdentityCertificateChainWithRenamedIssuer)
+    {
+        const auto issuerKey = GeneratePrivateKey();
+        const auto leafKey = GeneratePrivateKey();
+
+        const auto issuerPem = IssueCertificate(
+            "intermediate",
+            issuerKey.get(),
+            nullptr,
+            nullptr);
+        const auto issuer = ParseCertificate(issuerPem);
+        const auto leafPem = IssueCertificate(
+            "leaf",
+            leafKey.get(),
+            issuer.get(),
+            issuerKey.get());
+        UNIT_ASSERT(!HasError(
+            ValidateIdentityCertificateChain(leafPem + issuerPem).GetError()));
+
+        // Issuer certificate has been re-issued for the same key with a
+        // different subject: the signature is valid, but the issuer name of
+        // the leaf certificate does not match.
+        const auto renamedIssuerPem = IssueCertificate(
+            "intermediate-renamed",
+            issuerKey.get(),
+            nullptr,
+            nullptr);
+        UNIT_ASSERT(HasError(
+            ValidateIdentityCertificateChain(leafPem + renamedIssuerPem)
+                .GetError()));
     }
 
     Y_UNIT_TEST(ShouldExtractCertificateNotAfterTimestamp)
@@ -276,7 +473,7 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
         UNIT_ASSERT(HasError(result.GetError()));
     }
 
-    Y_UNIT_TEST(ShouldUpdateAllCertificatesWhenValid)
+    Y_UNIT_TEST(ShouldApplyCertificatesAfterStableRead)
     {
         TTempDir tempDir;
         const TString rootPath =
@@ -290,19 +487,131 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
             ReadCertResource("server1.crt"));
 
         TVector<TCertificatePair> certs{TCertificatePair{.Files = files}};
+        TRootCaPair root{.RootCaPath = rootPath};
+        TLog log;
+
+        // New content is not applied until it is read unchanged twice.
+        auto result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(result.Pending);
+        UNIT_ASSERT(!result.RootCaChanged);
+        UNIT_ASSERT_VALUES_EQUAL(1, result.Certificates.size());
+        UNIT_ASSERT(!result.Certificates[0].Changed);
+        UNIT_ASSERT_VALUES_EQUAL("", root.RootCa);
+        UNIT_ASSERT_VALUES_EQUAL("", certs[0].CertChain);
+
+        result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(!result.Pending);
+        UNIT_ASSERT(result.RootCaChanged);
+        UNIT_ASSERT(result.Certificates[0].Changed);
+        UNIT_ASSERT(result.Certificates[0].NotValidAfter != TInstant::Zero());
+        UNIT_ASSERT_VALUES_EQUAL(ReadCertResource("ca.crt"), root.RootCa);
+        UNIT_ASSERT_VALUES_EQUAL(
+            ReadCertResource("server1.key"),
+            certs[0].PrivateKey);
+        UNIT_ASSERT_VALUES_EQUAL(
+            ReadCertResource("server1.crt"),
+            certs[0].CertChain);
+
+        // Unchanged content.
+        result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(!result.Pending);
+        UNIT_ASSERT(!result.RootCaChanged);
+        UNIT_ASSERT(!result.Certificates[0].Changed);
+    }
+
+    Y_UNIT_TEST(ShouldRestartStableReadWhenContentChangesAgain)
+    {
+        TTempDir tempDir;
+        const TString rootPath =
+            TStringBuilder() << tempDir.Name() << "/ca.crt";
+        WriteTextFile(rootPath, ReadCertResource("ca.crt"));
+
+        const auto files = CreateCertificatePair(
+            tempDir.Name(),
+            "server",
+            ReadCertResource("server1.key"),
+            ReadCertResource("server1.crt"));
+
+        TVector<TCertificatePair> certs{TCertificatePair{
+            .Files = files,
+            .PrivateKey = ReadCertResource("server1.key"),
+            .CertChain = ReadCertResource("server1.crt"),
+        }};
         TRootCaPair root{
             .RootCaPath = rootPath,
             .RootCa = ReadCertResource("ca.crt"),
         };
         TLog log;
 
-        const auto result = UpdateCertificates(certs, root, log);
+        WriteTextFile(rootPath, ReadCertResource("server2.crt"));
+        WriteTextFile(files.PrivateKeyPath, ReadCertResource("server2.key"));
+        WriteTextFile(files.CertChainPath, ReadCertResource("server2.crt"));
+        auto result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(result.Pending);
 
-        UNIT_ASSERT(result.RootCa.Defined());
-        UNIT_ASSERT_VALUES_EQUAL(ReadCertResource("ca.crt"), *result.RootCa);
-        UNIT_ASSERT_VALUES_EQUAL(1, result.Certificates.size());
-        UNIT_ASSERT(result.Certificates[0].Defined());
-        UNIT_ASSERT(result.Certificates[0]->NotValidAfter != TInstant::Zero());
+        // Content differs from the previous read, so it is not stable yet.
+        WriteTextFile(rootPath, ReadCertResource("server3.crt"));
+        WriteTextFile(files.PrivateKeyPath, ReadCertResource("server3.key"));
+        WriteTextFile(files.CertChainPath, ReadCertResource("server3.crt"));
+        result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(result.Pending);
+        UNIT_ASSERT(!result.RootCaChanged);
+        UNIT_ASSERT(!result.Certificates[0].Changed);
+        UNIT_ASSERT_VALUES_EQUAL(ReadCertResource("ca.crt"), root.RootCa);
+        UNIT_ASSERT_VALUES_EQUAL(
+            ReadCertResource("server1.crt"),
+            certs[0].CertChain);
+
+        result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(!result.Pending);
+        UNIT_ASSERT(result.RootCaChanged);
+        UNIT_ASSERT(result.Certificates[0].Changed);
+        UNIT_ASSERT_VALUES_EQUAL(ReadCertResource("server3.crt"), root.RootCa);
+        UNIT_ASSERT_VALUES_EQUAL(
+            ReadCertResource("server3.crt"),
+            certs[0].CertChain);
+    }
+
+    Y_UNIT_TEST(ShouldResetPendingContentOnReadError)
+    {
+        TTempDir tempDir;
+        const auto files = CreateCertificatePair(
+            tempDir.Name(),
+            "server",
+            ReadCertResource("server3.key"),
+            ReadCertResource("server3.crt"));
+
+        TVector<TCertificatePair> certs{TCertificatePair{
+            .Files = files,
+            .PrivateKey = ReadCertResource("server1.key"),
+            .CertChain = ReadCertResource("server1.crt"),
+        }};
+        TRootCaPair root;
+        TLog log;
+
+        auto result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(result.Pending);
+
+        // A read error, e.g. in the middle of a non-atomic rotation,
+        // restarts the stable-read.
+        NFs::Remove(files.CertChainPath);
+        result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(!result.Pending);
+        UNIT_ASSERT(!result.Certificates[0].Changed);
+
+        WriteTextFile(files.CertChainPath, ReadCertResource("server3.crt"));
+        result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(result.Pending);
+        UNIT_ASSERT(!result.Certificates[0].Changed);
+        UNIT_ASSERT_VALUES_EQUAL(
+            ReadCertResource("server1.crt"),
+            certs[0].CertChain);
+
+        result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(result.Certificates[0].Changed);
+        UNIT_ASSERT_VALUES_EQUAL(
+            ReadCertResource("server3.crt"),
+            certs[0].CertChain);
     }
 
     Y_UNIT_TEST(ShouldKeepPreviousRootWhenRootBecomesInvalid)
@@ -312,24 +621,19 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
             TStringBuilder() << tempDir.Name() << "/ca.crt";
         WriteTextFile(rootPath, "not a certificate");
 
-        const auto files = CreateCertificatePair(
-            tempDir.Name(),
-            "server",
-            ReadCertResource("server1.key"),
-            ReadCertResource("server1.crt"));
-
         const TString previousRoot = ReadCertResource("ca.crt");
-        TVector<TCertificatePair> certs{TCertificatePair{.Files = files}};
+        TVector<TCertificatePair> certs;
         TRootCaPair root{.RootCaPath = rootPath, .RootCa = previousRoot};
         TLog log;
 
-        const auto result = UpdateCertificates(certs, root, log);
-
-        UNIT_ASSERT(result.RootCa.Defined());
-        UNIT_ASSERT_VALUES_EQUAL(previousRoot, *result.RootCa);
+        for (int i = 0; i < 3; ++i) {
+            const auto result = UpdateCertificates(certs, root, log);
+            UNIT_ASSERT(!result.RootCaChanged);
+            UNIT_ASSERT_VALUES_EQUAL(previousRoot, root.RootCa);
+        }
     }
 
-    Y_UNIT_TEST(ShouldFallBackToPreviousIdentityWhenFileInvalid)
+    Y_UNIT_TEST(ShouldKeepPreviousIdentityWhenFileInvalid)
     {
         TTempDir tempDir;
         const auto files = CreateCertificatePair(
@@ -343,19 +647,19 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
             .PrivateKey = ReadCertResource("server1.key"),
             .CertChain = ReadCertResource("server1.crt"),
         }};
+        TRootCaPair root;
         TLog log;
 
-        const auto result = UpdateCertificates(certs, TRootCaPair{}, log);
-
-        UNIT_ASSERT(result.Certificates[0].Defined());
-        UNIT_ASSERT_VALUES_EQUAL(
-            ReadCertResource("server1.crt"),
-            TString(result.Certificates[0]
-                        ->CertificatesChain.front()
-                        .cert_chain()));
+        for (int i = 0; i < 3; ++i) {
+            const auto result = UpdateCertificates(certs, root, log);
+            UNIT_ASSERT(!result.Certificates[0].Changed);
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadCertResource("server1.crt"),
+                certs[0].CertChain);
+        }
     }
 
-    Y_UNIT_TEST(ShouldFallBackToPreviousIdentityWhenValidityCheckFails)
+    Y_UNIT_TEST(ShouldKeepPreviousIdentityWhenValidityCheckFails)
     {
         TTempDir tempDir;
         const auto validCert = ReadCertResource("server1.crt");
@@ -371,6 +675,7 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
             .PrivateKey = privateKey,
             .CertChain = validCert,
         }};
+        TRootCaPair root;
         TLog log;
 
         for (const auto& invalidCert: {
@@ -384,16 +689,50 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
                      10 * YearSeconds)})
         {
             WriteTextFile(files.CertChainPath, validCert + invalidCert);
-            const auto result =
-                UpdateCertificates(certs, TRootCaPair{}, log);
-
-            UNIT_ASSERT(result.Certificates[0].Defined());
-            UNIT_ASSERT_VALUES_EQUAL(
-                validCert,
-                TString(result.Certificates[0]
-                            ->CertificatesChain.front()
-                            .cert_chain()));
+            for (int i = 0; i < 2; ++i) {
+                const auto result =
+                    UpdateCertificates(certs, root, log);
+                UNIT_ASSERT(!result.Certificates[0].Changed);
+                UNIT_ASSERT_VALUES_EQUAL(validCert, certs[0].CertChain);
+            }
         }
+    }
+
+    Y_UNIT_TEST(ShouldKeepPreviousIdentityWhenChainCannotBeBuilt)
+    {
+        TTempDir tempDir;
+        const auto leaf = ReadCertResource("server1.crt");
+        const auto privateKey = ReadCertResource("server1.key");
+        const auto files = CreateCertificatePair(
+            tempDir.Name(),
+            "server",
+            privateKey,
+            leaf);
+
+        TVector<TCertificatePair> certs{TCertificatePair{
+            .Files = files,
+            .PrivateKey = privateKey,
+            .CertChain = leaf,
+        }};
+        TRootCaPair root;
+        TLog log;
+
+        WriteTextFile(
+            files.CertChainPath,
+            leaf + ReadCertResource("server3.crt"));
+        for (int i = 0; i < 2; ++i) {
+            const auto result = UpdateCertificates(certs, root, log);
+            UNIT_ASSERT(!result.Certificates[0].Changed);
+            UNIT_ASSERT_VALUES_EQUAL(leaf, certs[0].CertChain);
+        }
+
+        WriteTextFile(files.CertChainPath, leaf + ReadCertResource("ca.crt"));
+        UpdateCertificates(certs, root, log);
+        const auto result = UpdateCertificates(certs, root, log);
+        UNIT_ASSERT(result.Certificates[0].Changed);
+        UNIT_ASSERT_VALUES_EQUAL(
+            leaf + ReadCertResource("ca.crt"),
+            certs[0].CertChain);
     }
 
     Y_UNIT_TEST(ShouldAcceptExpiredIdentityDuringInitialLoad)
@@ -416,7 +755,7 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
         UNIT_ASSERT_VALUES_EQUAL(validCert + expiredCert, pairs[0].CertChain);
     }
 
-    Y_UNIT_TEST(ShouldLeaveIdentityUndefinedWhenInvalidAndNoPrevious)
+    Y_UNIT_TEST(ShouldLeaveIdentityEmptyWhenInvalidAndNoPrevious)
     {
         TTempDir tempDir;
         const auto files = CreateCertificatePair(
@@ -426,12 +765,15 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
             "broken certificate");
 
         TVector<TCertificatePair> certs{TCertificatePair{.Files = files}};
+        TRootCaPair root;
         TLog log;
 
-        const auto result = UpdateCertificates(certs, TRootCaPair{}, log);
-
-        UNIT_ASSERT_VALUES_EQUAL(1, result.Certificates.size());
-        UNIT_ASSERT(!result.Certificates[0].Defined());
+        for (int i = 0; i < 2; ++i) {
+            const auto result = UpdateCertificates(certs, root, log);
+            UNIT_ASSERT_VALUES_EQUAL(1, result.Certificates.size());
+            UNIT_ASSERT(!result.Certificates[0].Changed);
+        }
+        UNIT_ASSERT_VALUES_EQUAL("", certs[0].CertChain);
     }
 
     Y_UNIT_TEST(ShouldLoadCertificatePairsAndSkipEmpty)

--- a/cloud/storage/core/libs/grpc/tls_utils_ut.cpp
+++ b/cloud/storage/core/libs/grpc/tls_utils_ut.cpp
@@ -7,7 +7,6 @@
 #include <util/generic/yexception.h>
 #include <util/stream/file.h>
 #include <util/string/builder.h>
-#include <util/system/fs.h>
 
 #include <openssl/bio.h>
 #include <openssl/evp.h>
@@ -473,266 +472,71 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
         UNIT_ASSERT(HasError(result.GetError()));
     }
 
-    Y_UNIT_TEST(ShouldApplyCertificatesAfterStableRead)
+    Y_UNIT_TEST(ShouldReadIdentity)
     {
         TTempDir tempDir;
-        const TString rootPath =
-            TStringBuilder() << tempDir.Name() << "/ca.crt";
-        WriteTextFile(rootPath, ReadCertResource("ca.crt"));
-
         const auto files = CreateCertificatePair(
             tempDir.Name(),
             "server",
             ReadCertResource("server1.key"),
             ReadCertResource("server1.crt"));
 
-        TVector<TCertificatePair> certs{TCertificatePair{.Files = files}};
-        TRootCaPair root{.RootCaPath = rootPath};
-        TLog log;
-
-        // New content is not applied until it is read unchanged twice.
-        auto result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(result.Pending);
-        UNIT_ASSERT(!result.RootCaChanged);
-        UNIT_ASSERT_VALUES_EQUAL(1, result.Certificates.size());
-        UNIT_ASSERT(!result.Certificates[0].Changed);
-        UNIT_ASSERT_VALUES_EQUAL("", root.RootCa);
-        UNIT_ASSERT_VALUES_EQUAL("", certs[0].CertChain);
-
-        result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(!result.Pending);
-        UNIT_ASSERT(result.RootCaChanged);
-        UNIT_ASSERT(result.Certificates[0].Changed);
-        UNIT_ASSERT(result.Certificates[0].NotValidAfter != TInstant::Zero());
-        UNIT_ASSERT_VALUES_EQUAL(ReadCertResource("ca.crt"), root.RootCa);
+        const auto result = ReadIdentity(files);
+        UNIT_ASSERT(!HasError(result.GetError()));
         UNIT_ASSERT_VALUES_EQUAL(
             ReadCertResource("server1.key"),
-            certs[0].PrivateKey);
+            result.GetResult().PrivateKey);
         UNIT_ASSERT_VALUES_EQUAL(
             ReadCertResource("server1.crt"),
-            certs[0].CertChain);
+            result.GetResult().CertChain);
 
-        // Unchanged content.
-        result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(!result.Pending);
-        UNIT_ASSERT(!result.RootCaChanged);
-        UNIT_ASSERT(!result.Certificates[0].Changed);
+        const auto missing = ReadIdentity({
+            .PrivateKeyPath = files.PrivateKeyPath,
+            .CertChainPath = "/nonexistent/server.crt",
+        });
+        UNIT_ASSERT(HasError(missing.GetError()));
     }
 
-    Y_UNIT_TEST(ShouldRestartStableReadWhenContentChangesAgain)
+    Y_UNIT_TEST(ShouldValidateIdentity)
     {
-        TTempDir tempDir;
-        const TString rootPath =
-            TStringBuilder() << tempDir.Name() << "/ca.crt";
-        WriteTextFile(rootPath, ReadCertResource("ca.crt"));
+        const auto key = ReadCertResource("server1.key");
+        const auto cert = ReadCertResource("server1.crt");
+        const auto ca = ReadCertResource("ca.crt");
 
-        const auto files = CreateCertificatePair(
-            tempDir.Name(),
-            "server",
-            ReadCertResource("server1.key"),
-            ReadCertResource("server1.crt"));
+        UNIT_ASSERT(!HasError(
+            ValidateIdentity({.PrivateKey = key, .CertChain = cert})
+                .GetError()));
+        UNIT_ASSERT(!HasError(
+            ValidateIdentity({.PrivateKey = key, .CertChain = cert + ca})
+                .GetError()));
 
-        TVector<TCertificatePair> certs{TCertificatePair{
-            .Files = files,
-            .PrivateKey = ReadCertResource("server1.key"),
-            .CertChain = ReadCertResource("server1.crt"),
-        }};
-        TRootCaPair root{
-            .RootCaPath = rootPath,
-            .RootCa = ReadCertResource("ca.crt"),
-        };
-        TLog log;
+        // Private key does not match the certificate.
+        UNIT_ASSERT(HasError(
+            ValidateIdentity({
+                .PrivateKey = ReadCertResource("server2.key"),
+                .CertChain = cert,
+            }).GetError()));
 
-        WriteTextFile(rootPath, ReadCertResource("server2.crt"));
-        WriteTextFile(files.PrivateKeyPath, ReadCertResource("server2.key"));
-        WriteTextFile(files.CertChainPath, ReadCertResource("server2.crt"));
-        auto result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(result.Pending);
+        // Expired intermediate certificate.
+        UNIT_ASSERT(HasError(
+            ValidateIdentity({
+                .PrivateKey = key,
+                .CertChain = cert + SetCertificateValidity(
+                    ca,
+                    -10 * YearSeconds,
+                    -5 * YearSeconds),
+            }).GetError()));
 
-        // Content differs from the previous read, so it is not stable yet.
-        WriteTextFile(rootPath, ReadCertResource("server3.crt"));
-        WriteTextFile(files.PrivateKeyPath, ReadCertResource("server3.key"));
-        WriteTextFile(files.CertChainPath, ReadCertResource("server3.crt"));
-        result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(result.Pending);
-        UNIT_ASSERT(!result.RootCaChanged);
-        UNIT_ASSERT(!result.Certificates[0].Changed);
-        UNIT_ASSERT_VALUES_EQUAL(ReadCertResource("ca.crt"), root.RootCa);
-        UNIT_ASSERT_VALUES_EQUAL(
-            ReadCertResource("server1.crt"),
-            certs[0].CertChain);
+        // Chain cannot be built.
+        UNIT_ASSERT(HasError(
+            ValidateIdentity({
+                .PrivateKey = key,
+                .CertChain = cert + ReadCertResource("server3.crt"),
+            }).GetError()));
 
-        result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(!result.Pending);
-        UNIT_ASSERT(result.RootCaChanged);
-        UNIT_ASSERT(result.Certificates[0].Changed);
-        UNIT_ASSERT_VALUES_EQUAL(ReadCertResource("server3.crt"), root.RootCa);
-        UNIT_ASSERT_VALUES_EQUAL(
-            ReadCertResource("server3.crt"),
-            certs[0].CertChain);
-    }
-
-    Y_UNIT_TEST(ShouldResetPendingContentOnReadError)
-    {
-        TTempDir tempDir;
-        const auto files = CreateCertificatePair(
-            tempDir.Name(),
-            "server",
-            ReadCertResource("server3.key"),
-            ReadCertResource("server3.crt"));
-
-        TVector<TCertificatePair> certs{TCertificatePair{
-            .Files = files,
-            .PrivateKey = ReadCertResource("server1.key"),
-            .CertChain = ReadCertResource("server1.crt"),
-        }};
-        TRootCaPair root;
-        TLog log;
-
-        auto result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(result.Pending);
-
-        // A read error, e.g. in the middle of a non-atomic rotation,
-        // restarts the stable-read.
-        NFs::Remove(files.CertChainPath);
-        result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(!result.Pending);
-        UNIT_ASSERT(!result.Certificates[0].Changed);
-
-        WriteTextFile(files.CertChainPath, ReadCertResource("server3.crt"));
-        result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(result.Pending);
-        UNIT_ASSERT(!result.Certificates[0].Changed);
-        UNIT_ASSERT_VALUES_EQUAL(
-            ReadCertResource("server1.crt"),
-            certs[0].CertChain);
-
-        result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(result.Certificates[0].Changed);
-        UNIT_ASSERT_VALUES_EQUAL(
-            ReadCertResource("server3.crt"),
-            certs[0].CertChain);
-    }
-
-    Y_UNIT_TEST(ShouldKeepPreviousRootWhenRootBecomesInvalid)
-    {
-        TTempDir tempDir;
-        const TString rootPath =
-            TStringBuilder() << tempDir.Name() << "/ca.crt";
-        WriteTextFile(rootPath, "not a certificate");
-
-        const TString previousRoot = ReadCertResource("ca.crt");
-        TVector<TCertificatePair> certs;
-        TRootCaPair root{.RootCaPath = rootPath, .RootCa = previousRoot};
-        TLog log;
-
-        for (int i = 0; i < 3; ++i) {
-            const auto result = UpdateCertificates(certs, root, log);
-            UNIT_ASSERT(!result.RootCaChanged);
-            UNIT_ASSERT_VALUES_EQUAL(previousRoot, root.RootCa);
-        }
-    }
-
-    Y_UNIT_TEST(ShouldKeepPreviousIdentityWhenFileInvalid)
-    {
-        TTempDir tempDir;
-        const auto files = CreateCertificatePair(
-            tempDir.Name(),
-            "server",
-            ReadCertResource("server1.key"),
-            "broken certificate");
-
-        TVector<TCertificatePair> certs{TCertificatePair{
-            .Files = files,
-            .PrivateKey = ReadCertResource("server1.key"),
-            .CertChain = ReadCertResource("server1.crt"),
-        }};
-        TRootCaPair root;
-        TLog log;
-
-        for (int i = 0; i < 3; ++i) {
-            const auto result = UpdateCertificates(certs, root, log);
-            UNIT_ASSERT(!result.Certificates[0].Changed);
-            UNIT_ASSERT_VALUES_EQUAL(
-                ReadCertResource("server1.crt"),
-                certs[0].CertChain);
-        }
-    }
-
-    Y_UNIT_TEST(ShouldKeepPreviousIdentityWhenValidityCheckFails)
-    {
-        TTempDir tempDir;
-        const auto validCert = ReadCertResource("server1.crt");
-        const auto privateKey = ReadCertResource("server1.key");
-        const auto files = CreateCertificatePair(
-            tempDir.Name(),
-            "server",
-            privateKey,
-            validCert);
-
-        TVector<TCertificatePair> certs{TCertificatePair{
-            .Files = files,
-            .PrivateKey = privateKey,
-            .CertChain = validCert,
-        }};
-        TRootCaPair root;
-        TLog log;
-
-        for (const auto& invalidCert: {
-                 SetCertificateValidity(
-                     validCert,
-                     -10 * YearSeconds,
-                     -5 * YearSeconds),
-                 SetCertificateValidity(
-                     validCert,
-                     5 * YearSeconds,
-                     10 * YearSeconds)})
-        {
-            WriteTextFile(files.CertChainPath, validCert + invalidCert);
-            for (int i = 0; i < 2; ++i) {
-                const auto result =
-                    UpdateCertificates(certs, root, log);
-                UNIT_ASSERT(!result.Certificates[0].Changed);
-                UNIT_ASSERT_VALUES_EQUAL(validCert, certs[0].CertChain);
-            }
-        }
-    }
-
-    Y_UNIT_TEST(ShouldKeepPreviousIdentityWhenChainCannotBeBuilt)
-    {
-        TTempDir tempDir;
-        const auto leaf = ReadCertResource("server1.crt");
-        const auto privateKey = ReadCertResource("server1.key");
-        const auto files = CreateCertificatePair(
-            tempDir.Name(),
-            "server",
-            privateKey,
-            leaf);
-
-        TVector<TCertificatePair> certs{TCertificatePair{
-            .Files = files,
-            .PrivateKey = privateKey,
-            .CertChain = leaf,
-        }};
-        TRootCaPair root;
-        TLog log;
-
-        WriteTextFile(
-            files.CertChainPath,
-            leaf + ReadCertResource("server3.crt"));
-        for (int i = 0; i < 2; ++i) {
-            const auto result = UpdateCertificates(certs, root, log);
-            UNIT_ASSERT(!result.Certificates[0].Changed);
-            UNIT_ASSERT_VALUES_EQUAL(leaf, certs[0].CertChain);
-        }
-
-        WriteTextFile(files.CertChainPath, leaf + ReadCertResource("ca.crt"));
-        UpdateCertificates(certs, root, log);
-        const auto result = UpdateCertificates(certs, root, log);
-        UNIT_ASSERT(result.Certificates[0].Changed);
-        UNIT_ASSERT_VALUES_EQUAL(
-            leaf + ReadCertResource("ca.crt"),
-            certs[0].CertChain);
+        UNIT_ASSERT(HasError(
+            ValidateIdentity({.PrivateKey = key, .CertChain = "broken"})
+                .GetError()));
     }
 
     Y_UNIT_TEST(ShouldAcceptExpiredIdentityDuringInitialLoad)
@@ -753,27 +557,6 @@ Y_UNIT_TEST_SUITE(TTlsUtilsTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1, pairs.size());
         UNIT_ASSERT_VALUES_EQUAL(validCert + expiredCert, pairs[0].CertChain);
-    }
-
-    Y_UNIT_TEST(ShouldLeaveIdentityEmptyWhenInvalidAndNoPrevious)
-    {
-        TTempDir tempDir;
-        const auto files = CreateCertificatePair(
-            tempDir.Name(),
-            "server",
-            ReadCertResource("server1.key"),
-            "broken certificate");
-
-        TVector<TCertificatePair> certs{TCertificatePair{.Files = files}};
-        TRootCaPair root;
-        TLog log;
-
-        for (int i = 0; i < 2; ++i) {
-            const auto result = UpdateCertificates(certs, root, log);
-            UNIT_ASSERT_VALUES_EQUAL(1, result.Certificates.size());
-            UNIT_ASSERT(!result.Certificates[0].Changed);
-        }
-        UNIT_ASSERT_VALUES_EQUAL("", certs[0].CertChain);
     }
 
     Y_UNIT_TEST(ShouldLoadCertificatePairsAndSkipEmpty)

--- a/cloud/storage/core/libs/grpc/ut/ya.make
+++ b/cloud/storage/core/libs/grpc/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(cloud/storage/core/libs/grpc)
 SRCS(
     executor_ut.cpp
     init_ut.cpp
+    stable_read_ut.cpp
     tls_certificate_provider_ut.cpp
     tls_utils_ut.cpp
     utils_ut.cpp


### PR DESCRIPTION
### Problem

The periodic TLS certificate provider used by NBS and Filestore picks up rotated certificate files, but it trusts whatever is on disk at the moment of the check:

- Certificate files are rewritten by external tools, not necessarily atomically. A partially written file can be syntactically valid, e.g. a chain without its intermediate certificate or a root bundle with only some of the roots. Such a file passed all checks and replaced the working last-known-good material until the next refresh.
- The identity chain was validated only for key/certificate match and validity dates. A chain that clients cannot build, e.g. a leaf with an unrelated intermediate or with an issuer re-issued for the same key under a different subject, was accepted and served, after which clients failed the handshake.
- Every refresh read, parsed and validated all files and republished the key materials even when nothing had changed. `grpc_tls_certificate_distributor::SetKeyMaterials` notifies its watchers unconditionally, so gRPC rebuilt the SSL context on every refresh interval.

The same issues were addressed for Disk Manager in its automatic certificate refresh, this PR aligns the C++ provider with it.

### Notes

- Stable-read: New content is applied only after it has stayed unchanged for a full RefreshCertsPeriod since it was first read, whoever triggers the reads, a read error restarts the hold. Files are checked once per period, so a change takes effect within two periods. This is a heuristic that reduces the chance of picking up an intermediate state of a non-atomic rewrite, not a guarantee.
- The stable-read state machine is a standalone `TStableRead<T>` in `cloud/storage/core/libs/grpc/stable_read.h` with its own unit tests; `tls_utils` stays about reading and validating certificates (`ReadIdentity`, `ValidateIdentity`), and the periodic provider orchestrates read, hold, validation, apply, metrics and publishing.
- Raw file contents are compared before any parsing, so an unchanged file costs a read and a comparison per check.
- A refreshed identity chain must be buildable from the leaf up to the last certificate in the file via `X509_verify_cert`: issuer names, signatures, CA and name constraints. The last certificate serves as the trust anchor, whether the chain ends at a trusted root is the client's job. Initial load stays lenient so that the service is able to start.
- Key materials and metrics are published to gRPC at start and then only when the root CA or an identity certificate has actually changed.
- `UpdateCertificates()` completes when the requested update has settled, i.e. new content has been applied or rejected, or when the provider is stopped; repeated calls share the same future instead of triggering extra reads.
- `CreatePeriodicCertificateProvider` and `CreateCertificateProvider` take an `ITimerPtr` so that the hold is testable without sleeping; bootstraps pass the timer they already use for the scheduler.

### Issue
https://github.com/ydb-platform/nbs/issues/5722
