### PR TITLE
fix: remove nested workflow permissions

### DIFF
--- a/.github/workflows/build_and_test_proxy.yaml
+++ b/.github/workflows/build_and_test_proxy.yaml
@@ -75,12 +75,6 @@ on:
         required: true
         type: string
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_demand_build_and_test.yaml
+++ b/.github/workflows/on_demand_build_and_test.yaml
@@ -172,12 +172,6 @@ on:
         default: ""
         description: "Nebius image id to use for VM"
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -116,12 +116,6 @@ on:
         description: "sleep_after_tests"
         value: ${{ jobs.build-and-test.outputs.sleep_after_tests }}
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_hybrid_build_and_test.yaml
+++ b/.github/workflows/on_hybrid_build_and_test.yaml
@@ -164,12 +164,6 @@ on:
         default: ""
         description: "Per ya make test attempt timeout in minutes"
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -116,12 +116,6 @@ on:
         description: "sleep_after_tests"
         value: ${{ jobs.build-and-test.outputs.sleep_after_tests }}
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version

--- a/.github/workflows/on_pooled_build_and_test.yaml
+++ b/.github/workflows/on_pooled_build_and_test.yaml
@@ -156,14 +156,6 @@ on:
         default: ""
         description: "Per ya make test attempt timeout in minutes"
 
-
-
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 jobs:
   build-and-test:
     name: Build and test NBS [build_preset=${{ inputs.build_preset }} component=${{ inputs.component == '' && 'all' || inputs.component }} target_platform=${{ inputs.target_platform == '' && 'native' || inputs.target_platform }}]

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -96,12 +96,6 @@ on:
         default: ""
         description: "Per ya make test attempt timeout in minutes"
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  issues: write
-
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version


### PR DESCRIPTION
Seems like you can't even _ask_ for extended permissions inside nested workflows

https://github.com/ydb-platform/nbs/pull/7044

Tested: https://github.com/ydb-platform/nbs/actions/runs/34219795524/job/102040025060