### PR TITLE
Try fix rmmod nbd test flaps

### DIFF
--- a/cloud/blockstore/tests/e2e-tests/test.py
+++ b/cloud/blockstore/tests/e2e-tests/test.py
@@ -577,6 +577,9 @@ def test_restore_endpoint_when_socket_directory_does_not_exist():
         )
         assert result.returncode == 0
 
+        # Wait for the initial NBD partition probe before restarting NBS.
+        subprocess.check_call(["udevadm", "settle"], timeout=20)
+
         shutil.rmtree(socket_dir)
 
         env.nbs.restart()
@@ -587,6 +590,9 @@ def test_restore_endpoint_when_socket_directory_does_not_exist():
         )
         assert result.returncode == 0
         assert socket_path.exists()
+
+        # Restoring the endpoint reconfigures NBD and starts another probe.
+        subprocess.check_call(["udevadm", "settle"], timeout=20)
 
     except subprocess.CalledProcessError as e:
         log_called_process_error(e)


### PR DESCRIPTION
```
cloud/blockstore/tests/e2e-tests/test.py:601: in test_restore_endpoint_when_socket_directory_does_not_exist
    cleanup_after_test(env)
cloud/blockstore/tests/e2e-tests/test.py:104: in cleanup_after_test
    subprocess.check_call(["rmmod", "nbd"], timeout=20)
contrib/tools/python3/Lib/subprocess.py:415: in check_call
    raise CalledProcessError(retcode, cmd)
E   subprocess.CalledProcessError: Command '['rmmod', 'nbd']' returned non-zero exit status 1.

logsdir:
/var/www/build/logs/run_26_09_07__11_30_01/cloud/blockstore/tests/e2e-tests/test-results/py3test/testing_out_stuff
log:
/var/www/build/logs/run_26_09_07__11_30_01/cloud/blockstore/tests/e2e-tests/test-results/py3test/testing_out_stuff/test.py.test_restore_endpoint_when_socket_directory_does_not_exist.log
```

Found the problem: `rmmod` is correctly detecting an active NBD partition probe. It is not an endpoint leak or the previous 10-minute deadlock.

The sequence is:

- NBS restarts about 1 ms after the initial endpoint starts, before its partition probe finishes.
- Restoring the endpoint reconfigures NBD and starts another probe.
- The test immediately stops the endpoint.
- [[dmesg](http://release.nbs.kubevirt-testing.man.nbcloud.net/ci/logs/run_26_09_07__11_30_01/cloud/blockstore/tests/e2e-tests/test-results/py3test/testing_out_stuff/test.py__test_restore_endpoint_when_socket_directory_does_not_exist/dmesg.txt)](http://release.nbs.kubevirt-testing.man.nbcloud.net/ci/logs/run_26_09_07__11_30_01/cloud/blockstore/tests/e2e-tests/test-results/py3test/testing_out_stuff/test.py__test_restore_endpoint_when_socket_directory_does_not_exist/dmesg.txt) shows partition-read errors continuing for approximately 132 ms after `NBD_DISCONNECT`, so the subsequent `rmmod nbd` gets `EBUSY`.

This shares the trigger described in [[#6791](https://github.com/ydb-platform/nbs/pull/6791#issuecomment-5411674177)](https://github.com/ydb-platform/nbs/pull/6791#issuecomment-5411674177), but endpoint restoration and `StopEndpoint` both complete successfully in this run.

I fixed [test.py](https://github.com/ydb-platform/nbs/blob/9c455b698e828745e4ca1d38df79caf1c8196ff6/cloud/blockstore/tests/e2e-tests/test.py#L580) by waiting for udev to settle:

- After initial `startendpoint`, before restarting NBS.
- After endpoint restoration, before `stopendpoint`.

The strict `rmmod` check remains unchanged—no retry, sleep, or ignored error.

Validation passed:

- `./ya make --style cloud/blockstore/tests/e2e-tests`
- Python compilation
- `git diff --check`

The full VM test was not run locally because `/dev/kvm` is unavailable. The change is currently uncommitted.