### PR TITLE
[Blockstore] Allow COW build support in lightweight server

### DIFF
--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
 )
 
 CHECK_DEPENDENT_DIRS(ALLOW_ONLY PEERDIRS
+    build/cow
     build/internal/platform
     build/platform
     certs


### PR DESCRIPTION
### Notes

Allow `build/cow` in the lightweight server's dependency allowlist. The build system automatically adds `build/cow/on` or `build/cow/off`; without this entry, configuration fails with a `CHECK_DEPENDENT_DIRS` violation.

### Issue

NBS CI fails during build graph configuration for `cloud/blockstore/apps/server_lightweight`:

```text
cloud/blockstore/apps/server_lightweight  < configure >
Error: forbids direct or indirect PEERDIR dependency to module  $B/build/cow/on/libbuild-cow-on.a  via  CHECK_DEPENDENT_DIRS
------  FAIL cloud/blockstore/apps/server_lightweight
```
