### PR TITLE
switch between rdma and grpc based on link state

### DIFF
--- a/cloud/blockstore/config/cells.proto
+++ b/cloud/blockstore/config/cells.proto
@@ -56,10 +56,8 @@ message TCellConfig
     optional bool GrpcDataFallbackEnabled = 11;
 
     // How long an RDMA connection that has dropped once has to stay up again
-    // before data is moved back onto it. The first connect never waits - the
-    // wait guards against a link that has already proved it flaps. Zero moves
-    // the data over as soon as it reconnects. Defaults to 30 seconds.
-    optional uint32 RdmaSettleTimeMs = 12;
+    // before data is moved back onto it, in milliseconds.
+    optional uint32 RdmaSettleTime = 12;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/config/cells.proto
+++ b/cloud/blockstore/config/cells.proto
@@ -51,10 +51,15 @@ message TCellConfig
     // Minimum number of hosts in a cell to have connections to.
     optional uint32 MinCellConnections = 10;
 
-    // While the Transport data endpoint is being set up, serve data over gRPC
-    // instead of waiting for it. The switch to Transport happens as soon as it is
-    // ready and is never undone.
+    // While the RDMA data endpoint is unavailable - either because it has not
+    // been set up yet or because the connection broke - serve data over gRPC.
     optional bool GrpcDataFallbackEnabled = 11;
+
+    // How long an RDMA connection that has dropped once has to stay up again
+    // before data is moved back onto it. The first connect never waits - the
+    // wait guards against a link that has already proved it flaps. Zero moves
+    // the data over as soon as it reconnects. Defaults to 30 seconds.
+    optional uint32 RdmaSettleTimeMs = 12;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/cells/iface/config.cpp
+++ b/cloud/blockstore/libs/cells/iface/config.cpp
@@ -23,7 +23,7 @@ namespace {
         NProto::ECellDataTransport,                                            \
         NProto::CELL_DATA_TRANSPORT_GRPC                                      )\
     xxx(GrpcDataFallbackEnabled,     bool,                   false            )\
-    xxx(RdmaSettleTimeMs,            ui32,                   30000            )\
+    xxx(RdmaSettleTime,              TDuration,   TDuration::Seconds(10)     )\
 // BLOCKSTORE_CELL_DEFAULT_CONFIG
 
 #define BLOCKSTORE_CELL_DECLARE_CONFIG(name, type, value)                      \
@@ -139,7 +139,7 @@ TCellHostConfig::TCellHostConfig(
         hostConfig.GetTransport():
         cellConfig.GetTransport())
     , GrpcDataFallbackEnabled(cellConfig.GetGrpcDataFallbackEnabled())
-    , RdmaSettleTime(TDuration::MilliSeconds(cellConfig.GetRdmaSettleTimeMs()))
+    , RdmaSettleTime(cellConfig.GetRdmaSettleTime())
 {
 }
 

--- a/cloud/blockstore/libs/cells/iface/config.cpp
+++ b/cloud/blockstore/libs/cells/iface/config.cpp
@@ -23,6 +23,7 @@ namespace {
         NProto::ECellDataTransport,                                            \
         NProto::CELL_DATA_TRANSPORT_GRPC                                      )\
     xxx(GrpcDataFallbackEnabled,     bool,                   false            )\
+    xxx(RdmaSettleTimeMs,            ui32,                   30000            )\
 // BLOCKSTORE_CELL_DEFAULT_CONFIG
 
 #define BLOCKSTORE_CELL_DECLARE_CONFIG(name, type, value)                      \
@@ -138,6 +139,7 @@ TCellHostConfig::TCellHostConfig(
         hostConfig.GetTransport():
         cellConfig.GetTransport())
     , GrpcDataFallbackEnabled(cellConfig.GetGrpcDataFallbackEnabled())
+    , RdmaSettleTime(TDuration::MilliSeconds(cellConfig.GetRdmaSettleTimeMs()))
 {
 }
 

--- a/cloud/blockstore/libs/cells/iface/config.h
+++ b/cloud/blockstore/libs/cells/iface/config.h
@@ -28,6 +28,7 @@ private:
     TString Fqdn;
     NProto::ECellDataTransport Transport = NProto::CELL_DATA_TRANSPORT_UNSET;
     bool GrpcDataFallbackEnabled = false;
+    TDuration RdmaSettleTime;
 
 public:
     TCellHostConfig(
@@ -59,6 +60,11 @@ public:
     bool GetGrpcDataFallbackEnabled() const
     {
         return GrpcDataFallbackEnabled;
+    }
+
+    TDuration GetRdmaSettleTime() const
+    {
+        return RdmaSettleTime;
     }
 
     TString GetFqdn() const
@@ -95,6 +101,7 @@ public:
     [[nodiscard]] ui32 GetNbdPort() const;
     [[nodiscard]] NProto::ECellDataTransport GetTransport() const;
     [[nodiscard]] bool GetGrpcDataFallbackEnabled() const;
+    [[nodiscard]] ui32 GetRdmaSettleTimeMs() const;
     [[nodiscard]] const TConfiguredHostsByFqdn& GetHosts() const;
     [[nodiscard]] ui32 GetDescribeVolumeHostCount() const;
     [[nodiscard]] ui32 GetMinCellConnections() const;

--- a/cloud/blockstore/libs/cells/iface/config.h
+++ b/cloud/blockstore/libs/cells/iface/config.h
@@ -101,7 +101,7 @@ public:
     [[nodiscard]] ui32 GetNbdPort() const;
     [[nodiscard]] NProto::ECellDataTransport GetTransport() const;
     [[nodiscard]] bool GetGrpcDataFallbackEnabled() const;
-    [[nodiscard]] ui32 GetRdmaSettleTimeMs() const;
+    [[nodiscard]] TDuration GetRdmaSettleTime() const;
     [[nodiscard]] const TConfiguredHostsByFqdn& GetHosts() const;
     [[nodiscard]] ui32 GetDescribeVolumeHostCount() const;
     [[nodiscard]] ui32 GetMinCellConnections() const;

--- a/cloud/blockstore/libs/cells/impl/connection.cpp
+++ b/cloud/blockstore/libs/cells/impl/connection.cpp
@@ -234,8 +234,7 @@ NThreading::TFuture<TResultOrError<TSwitchingDataEndpoint>> SetupDataEndpoint(
                 // report the endpoint state to
                 auto future = bootstrap.EndpointsSetup->SetupHostRdmaEndpoint(
                     bootstrap,
-                    hostConfig,
-                    nullptr);
+                    hostConfig);
 
                 using TResult = TResultOrError<TSwitchingDataEndpoint>;
                 return future.Apply(

--- a/cloud/blockstore/libs/cells/impl/connection.cpp
+++ b/cloud/blockstore/libs/cells/impl/connection.cpp
@@ -25,8 +25,6 @@ using TCellConnectionPtr = std::shared_ptr<TCellConnection>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// The data endpoint together with the switcher that decides what it points at.
-// The switcher is empty for transports that never switch.
 struct TSwitchingDataEndpoint
 {
     IBlockStorePtr Router;
@@ -81,8 +79,6 @@ private:
 
     const IBlockStorePtr ControlService;
     const IBlockStorePtr DataEndpoint;
-    // keeps switching alive for as long as the connection is: the endpoint
-    // holds the handler only weakly
     const ITransportSwitcherPtr Switcher;
 
 public:
@@ -111,8 +107,6 @@ public:
         return HostConfig.GetFqdn();
     }
 
-    // Built on demand rather than cached: the wrapper owns the connection, so
-    // storing it here would close a reference cycle.
     IBlockStorePtr GetService() override
     {
         return std::make_shared<TControlService>(
@@ -120,8 +114,6 @@ public:
             shared_from_this());
     }
 
-    // Built on demand for the same reason as GetService() above: the storage
-    // holds the connection, so caching it here would close a reference cycle.
     IStoragePtr GetStorage() override
     {
         return CreateRemoteStorage(DataEndpoint, shared_from_this());
@@ -198,8 +190,6 @@ TSwitchingDataEndpoint CreateSwitchingDataEndpoint(
         CreateGrpcDataEndpoint(bootstrap, hostConfig, controlService);
     auto router = CreateEndpointRouter(fallback);
 
-    // the switcher has to exist before the factory runs: the factory hands the
-    // handler it is given down to the rdma client
     auto switcher = StartTransportSwitching(
         router,
         fallback,
@@ -230,8 +220,6 @@ NThreading::TFuture<TResultOrError<TSwitchingDataEndpoint>> SetupDataEndpoint(
     switch (hostConfig.GetTransport()) {
         case NProto::CELL_DATA_TRANSPORT_RDMA:
             if (!hostConfig.GetGrpcDataFallbackEnabled()) {
-                // nothing switches here, so the rdma client has nobody to
-                // report the endpoint state to
                 auto future = bootstrap.EndpointsSetup->SetupHostRdmaEndpoint(
                     bootstrap,
                     hostConfig);
@@ -259,11 +247,11 @@ NThreading::TFuture<TResultOrError<TSwitchingDataEndpoint>> SetupDataEndpoint(
         case NProto::CELL_DATA_TRANSPORT_GRPC:
             return MakeFuture(TResultOrError<TSwitchingDataEndpoint>(
                 TSwitchingDataEndpoint{
-                    CreateGrpcDataEndpoint(
+                    .Router = CreateGrpcDataEndpoint(
                         bootstrap,
                         hostConfig,
                         controlService),
-                    nullptr}));
+                    .Switcher = nullptr}));
 
         default:
             return MakeFuture(TResultOrError<TSwitchingDataEndpoint>(MakeError(

--- a/cloud/blockstore/libs/cells/impl/connection.cpp
+++ b/cloud/blockstore/libs/cells/impl/connection.cpp
@@ -25,6 +25,16 @@ using TCellConnectionPtr = std::shared_ptr<TCellConnection>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// The data endpoint together with the switcher that decides what it points at.
+// The switcher is empty for transports that never switch.
+struct TSwitchingDataEndpoint
+{
+    IBlockStorePtr Router;
+    ITransportSwitcherPtr Switcher;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 // Wraps the per-client control service so that mount responses can be read on
 // their way back. Holds the connection alive: the endpoint above may release
 // its handle while requests are still in flight.
@@ -71,6 +81,9 @@ private:
 
     const IBlockStorePtr ControlService;
     const IBlockStorePtr DataEndpoint;
+    // keeps switching alive for as long as the connection is: the endpoint
+    // holds the handler only weakly
+    const ITransportSwitcherPtr Switcher;
 
 public:
     TCellConnection(
@@ -78,12 +91,14 @@ public:
             TCellHostConfig hostConfig,
             ICellConnectionObserverPtr observer,
             IBlockStorePtr controlService,
-            IBlockStorePtr dataEndpoint)
+            IBlockStorePtr dataEndpoint,
+            ITransportSwitcherPtr switcher)
         : Pool(std::move(pool))
         , HostConfig(std::move(hostConfig))
         , Observer(std::move(observer))
         , ControlService(std::move(controlService))
         , DataEndpoint(std::move(dataEndpoint))
+        , Switcher(std::move(switcher))
     {}
 
     ~TCellConnection() override
@@ -105,9 +120,11 @@ public:
             shared_from_this());
     }
 
+    // Built on demand for the same reason as GetService() above: the storage
+    // holds the connection, so caching it here would close a reference cycle.
     IStoragePtr GetStorage() override
     {
-        return CreateRemoteStorage(DataEndpoint);
+        return CreateRemoteStorage(DataEndpoint, shared_from_this());
     }
 
     void OnMountResponse(
@@ -172,32 +189,40 @@ IBlockStorePtr CreateGrpcDataEndpoint(
 
 // Serves data over gRPC right away and switches over to RDMA as soon as it is
 // up, so that setting up RDMA does not hold the connection back.
-IBlockStorePtr CreateSwitchingDataEndpoint(
+TSwitchingDataEndpoint CreateSwitchingDataEndpoint(
     const TBootstrap& bootstrap,
     const TCellHostConfig& hostConfig,
     const IBlockStorePtr& controlService)
 {
-    auto router = CreateEndpointRouter(
-        CreateGrpcDataEndpoint(bootstrap, hostConfig, controlService));
+    auto fallback =
+        CreateGrpcDataEndpoint(bootstrap, hostConfig, controlService);
+    auto router = CreateEndpointRouter(fallback);
 
-    StartTransportSwitching(
+    // the switcher has to exist before the factory runs: the factory hands the
+    // handler it is given down to the rdma client
+    auto switcher = StartTransportSwitching(
         router,
-        [bootstrap, hostConfig]
+        fallback,
+        [bootstrap, hostConfig](
+            NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
         {
             return bootstrap.EndpointsSetup->SetupHostRdmaEndpoint(
                 bootstrap,
-                hostConfig);
+                hostConfig,
+                std::move(handler));
         },
         bootstrap.Timer,
         bootstrap.Scheduler,
         bootstrap.Logging,
         hostConfig.GetFqdn(),
-        TTransportSwitcherConfig{});
+        TTransportSwitcherConfig{
+            .SettleTime = hostConfig.GetRdmaSettleTime(),
+        });
 
-    return router;
+    return {std::move(router), std::move(switcher)};
 }
 
-NThreading::TFuture<TResultOrError<IBlockStorePtr>> SetupDataEndpoint(
+NThreading::TFuture<TResultOrError<TSwitchingDataEndpoint>> SetupDataEndpoint(
     const TBootstrap& bootstrap,
     const TCellHostConfig& hostConfig,
     const IBlockStorePtr& controlService)
@@ -205,23 +230,44 @@ NThreading::TFuture<TResultOrError<IBlockStorePtr>> SetupDataEndpoint(
     switch (hostConfig.GetTransport()) {
         case NProto::CELL_DATA_TRANSPORT_RDMA:
             if (!hostConfig.GetGrpcDataFallbackEnabled()) {
-                return bootstrap.EndpointsSetup->SetupHostRdmaEndpoint(
+                // nothing switches here, so the rdma client has nobody to
+                // report the endpoint state to
+                auto future = bootstrap.EndpointsSetup->SetupHostRdmaEndpoint(
                     bootstrap,
-                    hostConfig);
+                    hostConfig,
+                    nullptr);
+
+                using TResult = TResultOrError<TSwitchingDataEndpoint>;
+                return future.Apply(
+                    [](const auto& f) -> TResult
+                    {
+                        const auto& result = f.GetValue();
+                        if (HasError(result)) {
+                            return result.GetError();
+                        }
+                        return TSwitchingDataEndpoint{
+                            result.GetResult(),
+                            nullptr};
+                    });
             }
 
-            return MakeFuture(TResultOrError<IBlockStorePtr>(
+            return MakeFuture(TResultOrError<TSwitchingDataEndpoint>(
                 CreateSwitchingDataEndpoint(
                     bootstrap,
                     hostConfig,
                     controlService)));
 
         case NProto::CELL_DATA_TRANSPORT_GRPC:
-            return MakeFuture(TResultOrError<IBlockStorePtr>(
-                CreateGrpcDataEndpoint(bootstrap, hostConfig, controlService)));
+            return MakeFuture(TResultOrError<TSwitchingDataEndpoint>(
+                TSwitchingDataEndpoint{
+                    CreateGrpcDataEndpoint(
+                        bootstrap,
+                        hostConfig,
+                        controlService),
+                    nullptr}));
 
         default:
-            return MakeFuture(TResultOrError<IBlockStorePtr>(MakeError(
+            return MakeFuture(TResultOrError<TSwitchingDataEndpoint>(MakeError(
                 E_ARGUMENT,
                 TStringBuilder()
                     << "Unsupported cell data transport "
@@ -281,13 +327,15 @@ TCellConnectionFuture CreateCellConnection(
                             return result.GetError();
                         }
 
+                        const auto& endpoint = result.GetResult();
                         return ICellConnectionPtr(
                             std::make_shared<TCellConnection>(
                                 std::move(pool),
                                 std::move(hostConfig),
                                 std::move(observer),
                                 std::move(controlService),
-                                result.GetResult()));
+                                endpoint.Router,
+                                endpoint.Switcher));
                     });
         });
 }

--- a/cloud/blockstore/libs/cells/impl/connection_ut.cpp
+++ b/cloud/blockstore/libs/cells/impl/connection_ut.cpp
@@ -45,25 +45,33 @@ struct TTestEndpointBootstrap: public ICellHostEndpointBootstrap
     TPromise<TResultOrError<IBlockStorePtr>> RdmaSetupPromise =
         NewPromise<TResultOrError<IBlockStorePtr>>();
 
+    // what the synchronous form hands back; the test decides when the endpoint
+    // reports itself connected
+    TResultOrError<IBlockStorePtr> RdmaSetupResult =
+        MakeError(E_REJECTED, "no rdma endpoint in this test");
+
     NCloud::NStorage::NRdma::IClientEndpointHandlerPtr RdmaHandler;
 
     TRdmaEndpointBootstrapFuture SetupHostRdmaEndpoint(
+        const TBootstrap& bootstrap,
+        const TCellHostConfig& config) override
+    {
+        Y_UNUSED(bootstrap);
+        Y_UNUSED(config);
+
+        return RdmaSetupPromise.GetFuture();
+    }
+
+    TRdmaEndpointBootstrapResult SetupHostRdmaEndpoint(
         const TBootstrap& bootstrap,
         const TCellHostConfig& config,
         NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler) override
     {
         Y_UNUSED(bootstrap);
+        Y_UNUSED(config);
 
         RdmaHandler = std::move(handler);
-        if (RdmaHandler) {
-            // the real rdma client reports the state as soon as the endpoint
-            // is up, which is what lets the data move over
-            RdmaHandler->HandleConnected(
-                config.GetFqdn(),
-                config.GetRdmaPort());
-        }
-
-        return RdmaSetupPromise.GetFuture();
+        return RdmaSetupResult;
     }
 };
 
@@ -186,6 +194,9 @@ struct TTestEnv
         proto.AddHosts()->SetFqdn("host-a");
         CellConfig = std::make_shared<TCellConfig>(std::move(proto));
 
+        // the synchronous form hands the endpoint back before it connects
+        EndpointsSetup->RdmaSetupResult = IBlockStorePtr(RdmaService);
+
         Bootstrap.EndpointsSetup = EndpointsSetup;
         Bootstrap.GrpcClient = GrpcClient;
         Bootstrap.Logging = CreateLoggingService("console");
@@ -302,8 +313,8 @@ Y_UNIT_TEST_SUITE(TCellConnectionTest)
             env.GrpcClient->Service->RequestCount);
         UNIT_ASSERT_VALUES_EQUAL(0, env.RdmaService->RequestCount);
 
-        env.EndpointsSetup->RdmaSetupPromise.SetValue(
-            TResultOrError<IBlockStorePtr>(env.RdmaService));
+        UNIT_ASSERT(env.EndpointsSetup->RdmaHandler);
+        env.EndpointsSetup->RdmaHandler->HandleConnected();
 
         TTestEnv::Read(connection);
         UNIT_ASSERT_VALUES_EQUAL(1, env.RdmaService->RequestCount);
@@ -333,15 +344,13 @@ Y_UNIT_TEST_SUITE(TCellConnectionTest)
 
         auto connection = env.Connect("host-a");
 
-        env.EndpointsSetup->RdmaSetupPromise.SetValue(
-            TResultOrError<IBlockStorePtr>(env.RdmaService));
-
         UNIT_ASSERT(env.EndpointsSetup->RdmaHandler);
+        env.EndpointsSetup->RdmaHandler->HandleConnected();
 
         TTestEnv::Read(connection);
         UNIT_ASSERT_VALUES_EQUAL(1, env.RdmaService->RequestCount);
 
-        env.EndpointsSetup->RdmaHandler->HandleDisconnected("host-a", 10020);
+        env.EndpointsSetup->RdmaHandler->HandleDisconnected();
 
         const auto grpcRequests = env.GrpcClient->Service->RequestCount;
         TTestEnv::Read(connection);
@@ -359,15 +368,13 @@ Y_UNIT_TEST_SUITE(TCellConnectionTest)
 
         auto connection = env.Connect("host-a");
 
-        env.EndpointsSetup->RdmaSetupPromise.SetValue(
-            TResultOrError<IBlockStorePtr>(env.RdmaService));
-
         UNIT_ASSERT(env.EndpointsSetup->RdmaHandler);
+        env.EndpointsSetup->RdmaHandler->HandleConnected();
 
         // the first connect moves the data over at once, so make the link drop
         // and come back - only then does the settle time apply
-        env.EndpointsSetup->RdmaHandler->HandleDisconnected("host-a", 10020);
-        env.EndpointsSetup->RdmaHandler->HandleConnected("host-a", 10020);
+        env.EndpointsSetup->RdmaHandler->HandleDisconnected();
+        env.EndpointsSetup->RdmaHandler->HandleConnected();
 
         auto grpcRequests = env.GrpcClient->Service->RequestCount;
         TTestEnv::Read(connection);

--- a/cloud/blockstore/libs/cells/impl/connection_ut.cpp
+++ b/cloud/blockstore/libs/cells/impl/connection_ut.cpp
@@ -16,6 +16,7 @@
 #include <cloud/storage/core/libs/common/scheduler_test.h>
 #include <cloud/storage/core/libs/common/timer_test.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/rdma/iface/client.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -44,12 +45,24 @@ struct TTestEndpointBootstrap: public ICellHostEndpointBootstrap
     TPromise<TResultOrError<IBlockStorePtr>> RdmaSetupPromise =
         NewPromise<TResultOrError<IBlockStorePtr>>();
 
+    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr RdmaHandler;
+
     TRdmaEndpointBootstrapFuture SetupHostRdmaEndpoint(
         const TBootstrap& bootstrap,
-        const TCellHostConfig& config) override
+        const TCellHostConfig& config,
+        NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler) override
     {
         Y_UNUSED(bootstrap);
-        Y_UNUSED(config);
+
+        RdmaHandler = std::move(handler);
+        if (RdmaHandler) {
+            // the real rdma client reports the state as soon as the endpoint
+            // is up, which is what lets the data move over
+            RdmaHandler->HandleConnected(
+                config.GetFqdn(),
+                config.GetRdmaPort());
+        }
+
         return RdmaSetupPromise.GetFuture();
     }
 };
@@ -150,6 +163,10 @@ struct TTestEnv
     std::shared_ptr<TTestBlockStore> RdmaService =
         std::make_shared<TTestBlockStore>();
 
+    std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
+    std::shared_ptr<TTestScheduler> Scheduler =
+        std::make_shared<TTestScheduler>(TInstant::Zero());
+
     TCellConfigPtr CellConfig;
     TCellHostPoolPtr Pool;
     TBootstrap Bootstrap;
@@ -157,22 +174,23 @@ struct TTestEnv
     explicit TTestEnv(
         NProto::ECellDataTransport transport =
             NProto::CELL_DATA_TRANSPORT_GRPC,
-        bool grpcDataFallback = false)
+        bool grpcDataFallback = false,
+        ui32 rdmaSettleTimeMs = 0)
     {
         NProto::TCellConfig proto;
         proto.SetCellId("cell-1");
         proto.SetGrpcPort(9766);
         proto.SetTransport(transport);
         proto.SetGrpcDataFallbackEnabled(grpcDataFallback);
+        proto.SetRdmaSettleTimeMs(rdmaSettleTimeMs);
         proto.AddHosts()->SetFqdn("host-a");
         CellConfig = std::make_shared<TCellConfig>(std::move(proto));
 
         Bootstrap.EndpointsSetup = EndpointsSetup;
         Bootstrap.GrpcClient = GrpcClient;
         Bootstrap.Logging = CreateLoggingService("console");
-        Bootstrap.Timer = std::make_shared<TTestTimer>();
-        Bootstrap.Scheduler =
-            std::make_shared<TTestScheduler>(TInstant::Zero());
+        Bootstrap.Timer = Timer;
+        Bootstrap.Scheduler = Scheduler;
 
         Pool = std::make_shared<TCellHostPool>(CellConfig, Bootstrap);
     }
@@ -307,6 +325,67 @@ Y_UNIT_TEST_SUITE(TCellConnectionTest)
 
         TTestEnv::Read(result.GetResult());
         UNIT_ASSERT_VALUES_EQUAL(1, env.RdmaService->RequestCount);
+    }
+
+    Y_UNIT_TEST(ShouldMoveDataBackToGrpcWhenRdmaBreaks)
+    {
+        TTestEnv env(NProto::CELL_DATA_TRANSPORT_RDMA, true);
+
+        auto connection = env.Connect("host-a");
+
+        env.EndpointsSetup->RdmaSetupPromise.SetValue(
+            TResultOrError<IBlockStorePtr>(env.RdmaService));
+
+        UNIT_ASSERT(env.EndpointsSetup->RdmaHandler);
+
+        TTestEnv::Read(connection);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.RdmaService->RequestCount);
+
+        env.EndpointsSetup->RdmaHandler->HandleDisconnected("host-a", 10020);
+
+        const auto grpcRequests = env.GrpcClient->Service->RequestCount;
+        TTestEnv::Read(connection);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.RdmaService->RequestCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            grpcRequests + 1,
+            env.GrpcClient->Service->RequestCount);
+    }
+
+    Y_UNIT_TEST(ShouldHoldDataOnGrpcUntilRdmaSettles)
+    {
+        // the settle time has to travel from the proto all the way into the
+        // switcher, so drive it through a real connection
+        TTestEnv env(NProto::CELL_DATA_TRANSPORT_RDMA, true, 10000);
+
+        auto connection = env.Connect("host-a");
+
+        env.EndpointsSetup->RdmaSetupPromise.SetValue(
+            TResultOrError<IBlockStorePtr>(env.RdmaService));
+
+        UNIT_ASSERT(env.EndpointsSetup->RdmaHandler);
+
+        // the first connect moves the data over at once, so make the link drop
+        // and come back - only then does the settle time apply
+        env.EndpointsSetup->RdmaHandler->HandleDisconnected("host-a", 10020);
+        env.EndpointsSetup->RdmaHandler->HandleConnected("host-a", 10020);
+
+        auto grpcRequests = env.GrpcClient->Service->RequestCount;
+        TTestEnv::Read(connection);
+        UNIT_ASSERT_VALUES_EQUAL(0, env.RdmaService->RequestCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            grpcRequests + 1,
+            env.GrpcClient->Service->RequestCount);
+
+        env.Timer->AdvanceTime(TDuration::Seconds(10));
+        env.Scheduler->AdvanceTime(TDuration::Seconds(10));
+        env.Scheduler->RunAllScheduledTasks();
+
+        grpcRequests = env.GrpcClient->Service->RequestCount;
+        TTestEnv::Read(connection);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.RdmaService->RequestCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            grpcRequests,
+            env.GrpcClient->Service->RequestCount);
     }
 }
 

--- a/cloud/blockstore/libs/cells/impl/connection_ut.cpp
+++ b/cloud/blockstore/libs/cells/impl/connection_ut.cpp
@@ -45,8 +45,6 @@ struct TTestEndpointBootstrap: public ICellHostEndpointBootstrap
     TPromise<TResultOrError<IBlockStorePtr>> RdmaSetupPromise =
         NewPromise<TResultOrError<IBlockStorePtr>>();
 
-    // what the synchronous form hands back; the test decides when the endpoint
-    // reports itself connected
     TResultOrError<IBlockStorePtr> RdmaSetupResult =
         MakeError(E_REJECTED, "no rdma endpoint in this test");
 
@@ -190,7 +188,7 @@ struct TTestEnv
         proto.SetGrpcPort(9766);
         proto.SetTransport(transport);
         proto.SetGrpcDataFallbackEnabled(grpcDataFallback);
-        proto.SetRdmaSettleTimeMs(rdmaSettleTimeMs);
+        proto.SetRdmaSettleTime(rdmaSettleTimeMs);
         proto.AddHosts()->SetFqdn("host-a");
         CellConfig = std::make_shared<TCellConfig>(std::move(proto));
 

--- a/cloud/blockstore/libs/cells/impl/describe_volume_ut.cpp
+++ b/cloud/blockstore/libs/cells/impl/describe_volume_ut.cpp
@@ -106,7 +106,7 @@ std::shared_ptr<TTestServiceClient> CreateCellEndpoint(
         clientAppConfig,
         host,
         service,
-        CreateRemoteStorage(service));
+        CreateRemoteStorage(service, nullptr));
     return service;
 }
 

--- a/cloud/blockstore/libs/cells/impl/endpoint_bootstrap.h
+++ b/cloud/blockstore/libs/cells/impl/endpoint_bootstrap.h
@@ -28,15 +28,10 @@ struct ICellHostEndpointBootstrap
         const TBootstrap& bootstrap,
         const TCellHostConfig& config) = 0;
 
-    // Waits for the endpoint to connect, and fails if it does not. For callers
-    // that have nothing to serve data with in the meantime.
     virtual TRdmaEndpointBootstrapFuture SetupHostRdmaEndpoint(
         const TBootstrap& bootstrap,
         const TCellHostConfig& config) = 0;
 
-    // Hands the endpoint back before it has connected and reports its state
-    // through the handler. For callers that have a fallback transport and want
-    // to move over once the endpoint is usable.
     virtual TRdmaEndpointBootstrapResult SetupHostRdmaEndpoint(
         const TBootstrap& bootstrap,
         const TCellHostConfig& config,

--- a/cloud/blockstore/libs/cells/impl/endpoint_bootstrap.h
+++ b/cloud/blockstore/libs/cells/impl/endpoint_bootstrap.h
@@ -21,15 +21,23 @@ struct ICellHostEndpointBootstrap
         NThreading::TFuture<NClient::IMultiClientEndpointPtr>;
     using TRdmaEndpointBootstrapFuture =
         NThreading::TFuture<TResultOrError<IBlockStorePtr>>;
+    using TRdmaEndpointBootstrapResult = TResultOrError<IBlockStorePtr>;
     using TShutdownEndpointFuture = NThreading::TFuture<void>;
 
     virtual TGrpcEndpointBootstrapFuture SetupHostGrpcEndpoint(
         const TBootstrap& bootstrap,
         const TCellHostConfig& config) = 0;
 
-    // The handler is how the rdma client reports the endpoint state back to
-    // whoever asked for the endpoint; it may be empty when nobody listens.
+    // Waits for the endpoint to connect, and fails if it does not. For callers
+    // that have nothing to serve data with in the meantime.
     virtual TRdmaEndpointBootstrapFuture SetupHostRdmaEndpoint(
+        const TBootstrap& bootstrap,
+        const TCellHostConfig& config) = 0;
+
+    // Hands the endpoint back before it has connected and reports its state
+    // through the handler. For callers that have a fallback transport and want
+    // to move over once the endpoint is usable.
+    virtual TRdmaEndpointBootstrapResult SetupHostRdmaEndpoint(
         const TBootstrap& bootstrap,
         const TCellHostConfig& config,
         NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler) = 0;

--- a/cloud/blockstore/libs/cells/impl/endpoint_bootstrap.h
+++ b/cloud/blockstore/libs/cells/impl/endpoint_bootstrap.h
@@ -27,9 +27,12 @@ struct ICellHostEndpointBootstrap
         const TBootstrap& bootstrap,
         const TCellHostConfig& config) = 0;
 
+    // The handler is how the rdma client reports the endpoint state back to
+    // whoever asked for the endpoint; it may be empty when nobody listens.
     virtual TRdmaEndpointBootstrapFuture SetupHostRdmaEndpoint(
         const TBootstrap& bootstrap,
-        const TCellHostConfig& config) = 0;
+        const TCellHostConfig& config,
+        NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler) = 0;
 
     virtual ~ICellHostEndpointBootstrap() = default;
 };

--- a/cloud/blockstore/libs/cells/impl/endpoint_bootstrap_impl.cpp
+++ b/cloud/blockstore/libs/cells/impl/endpoint_bootstrap_impl.cpp
@@ -26,9 +26,7 @@ auto TCellCellHostEndpointBootstrap::SetupHostGrpcEndpoint(
 
 auto TCellCellHostEndpointBootstrap::SetupHostRdmaEndpoint(
     const TBootstrap& bootstrap,
-    const TCellHostConfig& config,
-    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
-    -> TRdmaEndpointBootstrapFuture
+    const TCellHostConfig& config) -> TRdmaEndpointBootstrapFuture
 {
     NClient::TRdmaEndpointConfig rdmaEndpoint{
         .Address = config.GetFqdn(),
@@ -36,6 +34,25 @@ auto TCellCellHostEndpointBootstrap::SetupHostRdmaEndpoint(
     };
 
     return CreateRdmaDataEndpointAsync(
+        bootstrap.Logging,
+        bootstrap.RdmaClient,
+        bootstrap.TraceSerializer,
+        bootstrap.RdmaTaskQueue,
+        rdmaEndpoint);
+}
+
+auto TCellCellHostEndpointBootstrap::SetupHostRdmaEndpoint(
+    const TBootstrap& bootstrap,
+    const TCellHostConfig& config,
+    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
+    -> TRdmaEndpointBootstrapResult
+{
+    NClient::TRdmaEndpointConfig rdmaEndpoint{
+        .Address = config.GetFqdn(),
+        .Port = config.GetRdmaPort(),
+    };
+
+    return CreateRdmaDataEndpoint(
         bootstrap.Logging,
         bootstrap.RdmaClient,
         bootstrap.TraceSerializer,

--- a/cloud/blockstore/libs/cells/impl/endpoint_bootstrap_impl.cpp
+++ b/cloud/blockstore/libs/cells/impl/endpoint_bootstrap_impl.cpp
@@ -26,7 +26,9 @@ auto TCellCellHostEndpointBootstrap::SetupHostGrpcEndpoint(
 
 auto TCellCellHostEndpointBootstrap::SetupHostRdmaEndpoint(
     const TBootstrap& bootstrap,
-    const TCellHostConfig& config) -> TRdmaEndpointBootstrapFuture
+    const TCellHostConfig& config,
+    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
+    -> TRdmaEndpointBootstrapFuture
 {
     NClient::TRdmaEndpointConfig rdmaEndpoint{
         .Address = config.GetFqdn(),
@@ -38,7 +40,8 @@ auto TCellCellHostEndpointBootstrap::SetupHostRdmaEndpoint(
         bootstrap.RdmaClient,
         bootstrap.TraceSerializer,
         bootstrap.RdmaTaskQueue,
-        rdmaEndpoint);
+        rdmaEndpoint,
+        std::move(handler));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/cells/impl/endpoint_bootstrap_impl.h
+++ b/cloud/blockstore/libs/cells/impl/endpoint_bootstrap_impl.h
@@ -17,6 +17,7 @@ struct TCellCellHostEndpointBootstrap: public ICellHostEndpointBootstrap
 {
     using ICellHostEndpointBootstrap::TGrpcEndpointBootstrapFuture;
     using ICellHostEndpointBootstrap::TRdmaEndpointBootstrapFuture;
+    using ICellHostEndpointBootstrap::TRdmaEndpointBootstrapResult;
 
     auto SetupHostGrpcEndpoint(
         const TBootstrap& bootstrap,
@@ -24,9 +25,14 @@ struct TCellCellHostEndpointBootstrap: public ICellHostEndpointBootstrap
 
     auto SetupHostRdmaEndpoint(
         const TBootstrap& bootstrap,
+        const TCellHostConfig& config)
+        -> TRdmaEndpointBootstrapFuture override;
+
+    auto SetupHostRdmaEndpoint(
+        const TBootstrap& bootstrap,
         const TCellHostConfig& config,
         NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
-        -> TRdmaEndpointBootstrapFuture override;
+        -> TRdmaEndpointBootstrapResult override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/cells/impl/endpoint_bootstrap_impl.h
+++ b/cloud/blockstore/libs/cells/impl/endpoint_bootstrap_impl.h
@@ -24,7 +24,9 @@ struct TCellCellHostEndpointBootstrap: public ICellHostEndpointBootstrap
 
     auto SetupHostRdmaEndpoint(
         const TBootstrap& bootstrap,
-        const TCellHostConfig& config) -> TRdmaEndpointBootstrapFuture override;
+        const TCellHostConfig& config,
+        NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
+        -> TRdmaEndpointBootstrapFuture override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/cells/impl/remote_storage.cpp
+++ b/cloud/blockstore/libs/cells/impl/remote_storage.cpp
@@ -18,9 +18,11 @@ namespace {
 struct TRemoteStorage: public IStorage
 {
     const IBlockStorePtr Endpoint;
+    const ICellConnectionPtr Connection;
 
-    explicit TRemoteStorage(IBlockStorePtr endpoint)
+    TRemoteStorage(IBlockStorePtr endpoint, ICellConnectionPtr connection)
         : Endpoint(std::move(endpoint))
+        , Connection(std::move(connection))
     {}
 
     TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
@@ -69,9 +71,13 @@ struct TRemoteStorage: public IStorage
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IStoragePtr CreateRemoteStorage(IBlockStorePtr endpoint)
+IStoragePtr CreateRemoteStorage(
+    IBlockStorePtr endpoint,
+    ICellConnectionPtr connection)
 {
-    return std::make_shared<TRemoteStorage>(std::move(endpoint));
+    return std::make_shared<TRemoteStorage>(
+        std::move(endpoint),
+        std::move(connection));
 }
 
 }   // namespace NCloud::NBlockStore::NCells

--- a/cloud/blockstore/libs/cells/impl/remote_storage.h
+++ b/cloud/blockstore/libs/cells/impl/remote_storage.h
@@ -1,11 +1,16 @@
 #pragma once
 
+#include <cloud/blockstore/libs/cells/iface/connection.h>
 #include <cloud/blockstore/libs/service/public.h>
 
 namespace NCloud::NBlockStore::NCells {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IStoragePtr CreateRemoteStorage(IBlockStorePtr endpoint);
+// Holds the connection alive: the caller may keep the storage handle alone,
+// and dropping the connection would take the transport switcher with it.
+IStoragePtr CreateRemoteStorage(
+    IBlockStorePtr endpoint,
+    ICellConnectionPtr connection);
 
 }   // namespace NCloud::NBlockStore::NCells

--- a/cloud/blockstore/libs/cells/impl/remote_storage.h
+++ b/cloud/blockstore/libs/cells/impl/remote_storage.h
@@ -7,8 +7,6 @@ namespace NCloud::NBlockStore::NCells {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Holds the connection alive: the caller may keep the storage handle alone,
-// and dropping the connection would take the transport switcher with it.
 IStoragePtr CreateRemoteStorage(
     IBlockStorePtr endpoint,
     ICellConnectionPtr connection);

--- a/cloud/blockstore/libs/cells/impl/transport_switcher.cpp
+++ b/cloud/blockstore/libs/cells/impl/transport_switcher.cpp
@@ -6,6 +6,7 @@
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <util/string/builder.h>
+#include <util/system/spinlock.h>
 
 namespace NCloud::NBlockStore::NCells {
 
@@ -13,25 +14,39 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Owns itself for as long as an attempt is pending: every scheduled retry
-// holds a strong reference, and once the router is gone nothing schedules any
-// more.
+// Keeps the router pointing at the transport that can serve data right now: the
+// fallback until the preferred endpoint is acquired and settled, and back onto
+// the fallback the moment that endpoint breaks.
+//
+// Owns itself for as long as an attempt is pending: every scheduled retry holds
+// a strong reference, and once the router is gone nothing schedules any more.
 class TTransportSwitcher final
-    : public std::enable_shared_from_this<TTransportSwitcher>
+    : public ITransportSwitcher
+    , public std::enable_shared_from_this<TTransportSwitcher>
 {
 private:
     const std::weak_ptr<IEndpointRouter> Router;
+    const IBlockStorePtr Fallback;   // the endpoint the router started with
     const TEndpointFactory Factory;
     const ITimerPtr Timer;
     const ISchedulerPtr Scheduler;
     const TString Host;
+    const TDuration SettleTime;
 
     TLog Log;
     TBackoffDelayProvider RetryDelay;
 
+    TAdaptiveLock Lock;
+    IBlockStorePtr Preferred;       // the rdma endpoint, once acquired
+    bool PreferredActive = false;   // is the router pointing at it
+    bool Connected = false;
+    bool EverActive = false;
+    ui64 SettleGeneration = 0;
+
 public:
     TTransportSwitcher(
             IEndpointRouterPtr router,
+            IBlockStorePtr fallback,
             TEndpointFactory factory,
             ITimerPtr timer,
             ISchedulerPtr scheduler,
@@ -39,13 +54,18 @@ public:
             TString host,
             const TTransportSwitcherConfig& config)
         : Router(std::move(router))
+        , Fallback(std::move(fallback))
         , Factory(std::move(factory))
         , Timer(std::move(timer))
         , Scheduler(std::move(scheduler))
         , Host(std::move(host))
+        , SettleTime(config.SettleTime)
         , Log(logging->CreateLog("BLOCKSTORE_CELLS"))
         , RetryDelay(config.InitialRetryDelay, config.MaxRetryDelay)
     {}
+
+    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr GetEndpointHandler()
+        override;
 
     void Attempt()
     {
@@ -53,9 +73,50 @@ public:
             return;
         }
 
-        Factory().Subscribe(
-            [self = shared_from_this()](const auto& future)
-            { self->OnAttemptCompleted(future.GetValue()); });
+        // a failed attempt destroys the endpoint it was building, and with it
+        // the handler handed out here, so no stale handler can ever drive the
+        // endpoint a later attempt produces
+        Factory(GetEndpointHandler())
+            .Subscribe(
+                [self = shared_from_this()](const auto& future)
+                { self->OnAttemptCompleted(future.GetValue()); });
+    }
+
+    void OnConnected()
+    {
+        ui64 generation = 0;
+
+        with_lock (Lock) {
+            Connected = true;
+            generation = ++SettleGeneration;
+        }
+
+        StartSettling(generation);
+    }
+
+    void OnDisconnected()
+    {
+        auto router = Router.lock();
+        if (!router) {
+            return;
+        }
+
+        with_lock (Lock) {
+            Connected = false;
+            // invalidates a settle in flight
+            ++SettleGeneration;
+
+            if (!PreferredActive) {
+                return;
+            }
+            PreferredActive = false;
+
+            // under the lock, so that a settle racing this break cannot store
+            // its target after ours; the store is a wait-free swap
+            router->SetTarget(Fallback);
+        }
+
+        STORAGE_INFO("[" << Host << "] moving data back onto the fallback");
     }
 
 private:
@@ -67,9 +128,22 @@ private:
         }
 
         if (!HasError(result) && result.GetResult()) {
-            STORAGE_INFO(
-                "[" << Host << "] switched over to the preferred transport");
-            router->SetTarget(result.GetResult());
+            ui64 generation = 0;
+            bool connected = false;
+
+            with_lock (Lock) {
+                Preferred = result.GetResult();
+                connected = Connected;
+                if (connected) {
+                    generation = ++SettleGeneration;
+                }
+            }
+
+            if (connected) {
+                // the endpoint reported itself connected before we got hold of
+                // it, so nothing else is going to start the wait
+                StartSettling(generation);
+            }
             return;
         }
 
@@ -83,14 +157,123 @@ private:
             Timer->Now() + delay,
             [self = shared_from_this()] { self->Attempt(); });
     }
+
+    // Starts the wait after which the data may move onto the preferred
+    // transport. The generation lets a break invalidate a wait in flight.
+    void StartSettling(ui64 generation)
+    {
+        bool everActive = false;
+
+        with_lock (Lock) {
+            everActive = EverActive;
+        }
+
+        // The wait guards a return to a link that has already proved it can
+        // drop. A link that has never carried our data has proved nothing, so
+        // making it wait would only keep the data on the slower transport.
+        if (!SettleTime || !everActive) {
+            Settle(generation);
+            return;
+        }
+
+        Scheduler->Schedule(
+            Timer->Now() + SettleTime,
+            [weakSelf = weak_from_this(), generation]
+            {
+                if (auto self = weakSelf.lock()) {
+                    self->Settle(generation);
+                }
+            });
+    }
+
+    void Settle(ui64 generation)
+    {
+        auto router = Router.lock();
+        if (!router) {
+            return;
+        }
+
+        with_lock (Lock) {
+            if (generation != SettleGeneration || !Connected ||
+                PreferredActive || !Preferred)
+            {
+                return;
+            }
+            PreferredActive = true;
+            EverActive = true;
+
+            // under the lock, so that a break racing this settle cannot store
+            // its target before ours; the store is a wait-free swap
+            router->SetTarget(Preferred);
+        }
+
+        STORAGE_INFO(
+            "[" << Host << "] switched over to the preferred transport");
+    }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Turns the endpoint state reported by the rdma client into switching
+// decisions. Holds the switcher weakly: the endpoint holds the handler, and the
+// switcher holds the endpoint, so a strong reference here would keep both alive
+// forever.
+class TEndpointHandler final
+    : public NCloud::NStorage::NRdma::IClientEndpointHandler
+{
+private:
+    const std::weak_ptr<TTransportSwitcher> Switcher;
+
+    TLog Log;
+
+public:
+    TEndpointHandler(std::weak_ptr<TTransportSwitcher> switcher, TLog log)
+        : Switcher(std::move(switcher))
+        , Log(std::move(log))
+    {}
+
+    void HandleConnected(const TString& host, ui32 port) override
+    {
+        Y_UNUSED(host);
+        Y_UNUSED(port);
+        if (auto self = Switcher.lock()) {
+            self->OnConnected();
+        }
+    }
+
+    void HandleDisconnected(const TString& host, ui32 port) override
+    {
+        Y_UNUSED(host);
+        Y_UNUSED(port);
+        if (auto self = Switcher.lock()) {
+            self->OnDisconnected();
+        }
+    }
+
+    void HandleUnavailable(const TString& host, ui32 port) override
+    {
+        Y_UNUSED(port);
+        // nothing to do: by now the data is already on the fallback. The signal
+        // belongs to host liveness, which is a separate concern.
+        STORAGE_WARN("[" << host << "] rdma endpoint is unavailable");
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+NCloud::NStorage::NRdma::IClientEndpointHandlerPtr
+TTransportSwitcher::GetEndpointHandler()
+{
+    return std::make_shared<TEndpointHandler>(weak_from_this(), Log);
+}
 
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void StartTransportSwitching(
+ITransportSwitcherPtr StartTransportSwitching(
     IEndpointRouterPtr router,
+    IBlockStorePtr fallback,
     TEndpointFactory factory,
     ITimerPtr timer,
     ISchedulerPtr scheduler,
@@ -100,6 +283,7 @@ void StartTransportSwitching(
 {
     auto switcher = std::make_shared<TTransportSwitcher>(
         std::move(router),
+        std::move(fallback),
         std::move(factory),
         std::move(timer),
         std::move(scheduler),
@@ -108,6 +292,8 @@ void StartTransportSwitching(
         config);
 
     switcher->Attempt();
+
+    return switcher;
 }
 
 }   // namespace NCloud::NBlockStore::NCells

--- a/cloud/blockstore/libs/cells/impl/transport_switcher.cpp
+++ b/cloud/blockstore/libs/cells/impl/transport_switcher.cpp
@@ -61,10 +61,6 @@ public:
     NCloud::NStorage::NRdma::IClientEndpointHandlerPtr GetEndpointHandler()
         override;
 
-    // Asks for the preferred endpoint once. There is nothing to retry: the
-    // endpoint is handed back before it has connected and reconnects on its
-    // own from then on, so a failure here means the rdma client itself cannot
-    // give us one, and we stay on the fallback.
     void Start()
     {
         auto result = Factory(GetEndpointHandler());
@@ -89,8 +85,6 @@ public:
         }
 
         if (connected) {
-            // the endpoint reported itself connected before we got hold of it,
-            // so nothing else is going to start the wait
             StartSettling(generation);
         }
     }
@@ -124,8 +118,8 @@ public:
             }
             PreferredActive = false;
 
-            // under the lock, so that a settle racing this break cannot store
-            // its target after ours; the store is a wait-free swap
+            // inside the lock: a settle racing this break must not store its
+            // target after ours
             router->SetTarget(Fallback);
         }
 
@@ -177,8 +171,8 @@ private:
             PreferredActive = true;
             EverActive = true;
 
-            // under the lock, so that a break racing this settle cannot store
-            // its target before ours; the store is a wait-free swap
+            // inside the lock: a break racing this settle must not store its
+            // target before ours
             router->SetTarget(Preferred);
         }
 
@@ -228,9 +222,6 @@ public:
 
     void HandleUnavailable() override
     {
-        // nothing to do: by now the data is already on the fallback. The signal
-        // belongs to host liveness, which is a separate concern. It repeats on
-        // every reconnect attempt for as long as the endpoint stays down.
         STORAGE_WARN("[" << Host << "] rdma endpoint is unavailable");
     }
 };

--- a/cloud/blockstore/libs/cells/impl/transport_switcher.cpp
+++ b/cloud/blockstore/libs/cells/impl/transport_switcher.cpp
@@ -1,6 +1,5 @@
 #include "transport_switcher.h"
 
-#include <cloud/storage/core/libs/common/backoff_delay_provider.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -15,11 +14,8 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 // Keeps the router pointing at the transport that can serve data right now: the
-// fallback until the preferred endpoint is acquired and settled, and back onto
-// the fallback the moment that endpoint breaks.
-//
-// Owns itself for as long as an attempt is pending: every scheduled retry holds
-// a strong reference, and once the router is gone nothing schedules any more.
+// fallback until the preferred endpoint has connected and settled, and back
+// onto the fallback the moment that endpoint breaks.
 class TTransportSwitcher final
     : public ITransportSwitcher
     , public std::enable_shared_from_this<TTransportSwitcher>
@@ -34,7 +30,6 @@ private:
     const TDuration SettleTime;
 
     TLog Log;
-    TBackoffDelayProvider RetryDelay;
 
     TAdaptiveLock Lock;
     IBlockStorePtr Preferred;       // the rdma endpoint, once acquired
@@ -61,25 +56,43 @@ public:
         , Host(std::move(host))
         , SettleTime(config.SettleTime)
         , Log(logging->CreateLog("BLOCKSTORE_CELLS"))
-        , RetryDelay(config.InitialRetryDelay, config.MaxRetryDelay)
     {}
 
     NCloud::NStorage::NRdma::IClientEndpointHandlerPtr GetEndpointHandler()
         override;
 
-    void Attempt()
+    // Asks for the preferred endpoint once. There is nothing to retry: the
+    // endpoint is handed back before it has connected and reconnects on its
+    // own from then on, so a failure here means the rdma client itself cannot
+    // give us one, and we stay on the fallback.
+    void Start()
     {
-        if (Router.expired()) {
+        auto result = Factory(GetEndpointHandler());
+
+        if (HasError(result) || !result.GetResult()) {
+            STORAGE_WARN(
+                "[" << Host << "] can't set up the preferred transport: "
+                    << FormatError(result.GetError())
+                    << ", staying on the fallback");
             return;
         }
 
-        // a failed attempt destroys the endpoint it was building, and with it
-        // the handler handed out here, so no stale handler can ever drive the
-        // endpoint a later attempt produces
-        Factory(GetEndpointHandler())
-            .Subscribe(
-                [self = shared_from_this()](const auto& future)
-                { self->OnAttemptCompleted(future.GetValue()); });
+        ui64 generation = 0;
+        bool connected = false;
+
+        with_lock (Lock) {
+            Preferred = result.GetResult();
+            connected = Connected;
+            if (connected) {
+                generation = ++SettleGeneration;
+            }
+        }
+
+        if (connected) {
+            // the endpoint reported itself connected before we got hold of it,
+            // so nothing else is going to start the wait
+            StartSettling(generation);
+        }
     }
 
     void OnConnected()
@@ -120,44 +133,6 @@ public:
     }
 
 private:
-    void OnAttemptCompleted(const TResultOrError<IBlockStorePtr>& result)
-    {
-        auto router = Router.lock();
-        if (!router) {
-            return;
-        }
-
-        if (!HasError(result) && result.GetResult()) {
-            ui64 generation = 0;
-            bool connected = false;
-
-            with_lock (Lock) {
-                Preferred = result.GetResult();
-                connected = Connected;
-                if (connected) {
-                    generation = ++SettleGeneration;
-                }
-            }
-
-            if (connected) {
-                // the endpoint reported itself connected before we got hold of
-                // it, so nothing else is going to start the wait
-                StartSettling(generation);
-            }
-            return;
-        }
-
-        const auto delay = RetryDelay.GetDelayAndIncrease();
-
-        STORAGE_WARN(
-            "[" << Host << "] can't set up the preferred transport: "
-                << FormatError(result.GetError()) << ", retrying in " << delay);
-
-        Scheduler->Schedule(
-            Timer->Now() + delay,
-            [self = shared_from_this()] { self->Attempt(); });
-    }
-
     // Starts the wait after which the data may move onto the preferred
     // transport. The generation lets a break invalidate a wait in flight.
     void StartSettling(ui64 generation)
@@ -223,39 +198,40 @@ class TEndpointHandler final
 {
 private:
     const std::weak_ptr<TTransportSwitcher> Switcher;
+    const TString Host;   // only for logging: the calls carry no host
 
     TLog Log;
 
 public:
-    TEndpointHandler(std::weak_ptr<TTransportSwitcher> switcher, TLog log)
+    TEndpointHandler(
+            std::weak_ptr<TTransportSwitcher> switcher,
+            TString host,
+            TLog log)
         : Switcher(std::move(switcher))
+        , Host(std::move(host))
         , Log(std::move(log))
     {}
 
-    void HandleConnected(const TString& host, ui32 port) override
+    void HandleConnected() override
     {
-        Y_UNUSED(host);
-        Y_UNUSED(port);
         if (auto self = Switcher.lock()) {
             self->OnConnected();
         }
     }
 
-    void HandleDisconnected(const TString& host, ui32 port) override
+    void HandleDisconnected() override
     {
-        Y_UNUSED(host);
-        Y_UNUSED(port);
         if (auto self = Switcher.lock()) {
             self->OnDisconnected();
         }
     }
 
-    void HandleUnavailable(const TString& host, ui32 port) override
+    void HandleUnavailable() override
     {
-        Y_UNUSED(port);
         // nothing to do: by now the data is already on the fallback. The signal
-        // belongs to host liveness, which is a separate concern.
-        STORAGE_WARN("[" << host << "] rdma endpoint is unavailable");
+        // belongs to host liveness, which is a separate concern. It repeats on
+        // every reconnect attempt for as long as the endpoint stays down.
+        STORAGE_WARN("[" << Host << "] rdma endpoint is unavailable");
     }
 };
 
@@ -264,7 +240,7 @@ public:
 NCloud::NStorage::NRdma::IClientEndpointHandlerPtr
 TTransportSwitcher::GetEndpointHandler()
 {
-    return std::make_shared<TEndpointHandler>(weak_from_this(), Log);
+    return std::make_shared<TEndpointHandler>(weak_from_this(), Host, Log);
 }
 
 }   // namespace
@@ -291,7 +267,7 @@ ITransportSwitcherPtr StartTransportSwitching(
         std::move(host),
         config);
 
-    switcher->Attempt();
+    switcher->Start();
 
     return switcher;
 }

--- a/cloud/blockstore/libs/cells/impl/transport_switcher.h
+++ b/cloud/blockstore/libs/cells/impl/transport_switcher.h
@@ -22,23 +22,21 @@ namespace NCloud::NBlockStore::NCells {
 
 struct TTransportSwitcherConfig
 {
-    TDuration InitialRetryDelay = TDuration::Seconds(1);
-    TDuration MaxRetryDelay = TDuration::Seconds(30);
     TDuration SettleTime = TDuration::Seconds(30);
 };
 
 // The handler has to reach the rdma client, and only the switcher can make it,
-// so the factory is handed one rather than capturing it.
-using TEndpointFactory = std::function<NThreading::TFuture<
-    TResultOrError<IBlockStorePtr>>(
+// so the factory is handed one rather than capturing it. It returns the
+// endpoint before it has connected; the handler says when it can carry data.
+using TEndpointFactory = std::function<TResultOrError<IBlockStorePtr>(
     NCloud::NStorage::NRdma::IClientEndpointHandlerPtr)>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
 // Decides which transport the router points at, for as long as the connection
 // lives. Data starts on the endpoint the router was created with and moves onto
-// the preferred transport once the factory has produced it and it has stayed
-// connected for SettleTime; a break moves the data straight back.
+// the preferred transport once it has connected and stayed connected for
+// SettleTime; a break moves the data straight back.
 //
 // Immediate on the way down and deliberate on the way up: at a break there is
 // nothing to wait for since the requests are already aborted, while returning

--- a/cloud/blockstore/libs/cells/impl/transport_switcher.h
+++ b/cloud/blockstore/libs/cells/impl/transport_switcher.h
@@ -22,12 +22,9 @@ namespace NCloud::NBlockStore::NCells {
 
 struct TTransportSwitcherConfig
 {
-    TDuration SettleTime = TDuration::Seconds(30);
+    TDuration SettleTime = TDuration::Seconds(10);
 };
 
-// The handler has to reach the rdma client, and only the switcher can make it,
-// so the factory is handed one rather than capturing it. It returns the
-// endpoint before it has connected; the handler says when it can carry data.
 using TEndpointFactory = std::function<TResultOrError<IBlockStorePtr>(
     NCloud::NStorage::NRdma::IClientEndpointHandlerPtr)>;
 
@@ -37,14 +34,6 @@ using TEndpointFactory = std::function<TResultOrError<IBlockStorePtr>(
 // lives. Data starts on the endpoint the router was created with and moves onto
 // the preferred transport once it has connected and stayed connected for
 // SettleTime; a break moves the data straight back.
-//
-// Immediate on the way down and deliberate on the way up: at a break there is
-// nothing to wait for since the requests are already aborted, while returning
-// on the first reconnect would keep feeding a flapping link.
-//
-// The handler from GetEndpointHandler() must be given to the rdma client so it
-// reports the endpoint state. It holds the switcher weakly, so the switcher's
-// life is bound by whoever owns it and not by the endpoint.
 struct ITransportSwitcher
 {
     virtual ~ITransportSwitcher() = default;

--- a/cloud/blockstore/libs/cells/impl/transport_switcher.h
+++ b/cloud/blockstore/libs/cells/impl/transport_switcher.h
@@ -7,6 +7,7 @@
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
+#include <cloud/storage/core/libs/rdma/iface/client.h>
 
 #include <library/cpp/threading/future/future.h>
 
@@ -23,25 +24,42 @@ struct TTransportSwitcherConfig
 {
     TDuration InitialRetryDelay = TDuration::Seconds(1);
     TDuration MaxRetryDelay = TDuration::Seconds(30);
+    TDuration SettleTime = TDuration::Seconds(30);
 };
 
-using TEndpointFactory =
-    std::function<NThreading::TFuture<TResultOrError<IBlockStorePtr>>()>;
+// The handler has to reach the rdma client, and only the switcher can make it,
+// so the factory is handed one rather than capturing it.
+using TEndpointFactory = std::function<NThreading::TFuture<
+    TResultOrError<IBlockStorePtr>>(
+    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr)>;
 
-// Asks the factory for the endpoint of the preferred transport and switches
-// the router over to it as soon as one is ready, retrying with a growing delay
-// until it succeeds.
+////////////////////////////////////////////////////////////////////////////////
+
+// Decides which transport the router points at, for as long as the connection
+// lives. Data starts on the endpoint the router was created with and moves onto
+// the preferred transport once the factory has produced it and it has stayed
+// connected for SettleTime; a break moves the data straight back.
 //
-// Once the router is gone nothing further is attempted, so a released
-// connection stops the retries by itself - though an attempt already in flight
-// is not cancelled, so the factory's future has to complete eventually.
+// Immediate on the way down and deliberate on the way up: at a break there is
+// nothing to wait for since the requests are already aborted, while returning
+// on the first reconnect would keep feeding a flapping link.
 //
-// Switching is currently one-way and happens once: nothing here watches the
-// transport afterwards. Health driven switching in both directions is meant to
-// replace this driver, which is why the router itself carries no such
-// assumption.
-void StartTransportSwitching(
+// The handler from GetEndpointHandler() must be given to the rdma client so it
+// reports the endpoint state. It holds the switcher weakly, so the switcher's
+// life is bound by whoever owns it and not by the endpoint.
+struct ITransportSwitcher
+{
+    virtual ~ITransportSwitcher() = default;
+
+    virtual NCloud::NStorage::NRdma::IClientEndpointHandlerPtr
+        GetEndpointHandler() = 0;
+};
+
+using ITransportSwitcherPtr = std::shared_ptr<ITransportSwitcher>;
+
+ITransportSwitcherPtr StartTransportSwitching(
     IEndpointRouterPtr router,
+    IBlockStorePtr fallback,
     TEndpointFactory factory,
     ITimerPtr timer,
     ISchedulerPtr scheduler,

--- a/cloud/blockstore/libs/cells/impl/transport_switcher_ut.cpp
+++ b/cloud/blockstore/libs/cells/impl/transport_switcher_ut.cpp
@@ -86,31 +86,32 @@ struct TTestEnv
             Logging,
             "test-host",
             TTransportSwitcherConfig{
-                .InitialRetryDelay = TDuration::Seconds(1),
-                .MaxRetryDelay = TDuration::Seconds(4),
                 .SettleTime = SettleTime,
             });
     }
 
     TEndpointFactory AlwaysSucceeds()
     {
-        return FailsThenSucceeds(0);
-    }
-
-    TEndpointFactory FailsThenSucceeds(ui32 failures)
-    {
-        return [this, failures](
+        return [this](
                    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
         {
             Y_UNUSED(handler);
             ++FactoryCalls;
 
-            if (FactoryCalls <= failures) {
-                return MakeFuture(TResultOrError<IBlockStorePtr>(
-                    MakeError(E_REJECTED, "endpoint is not up yet")));
-            }
+            return TResultOrError<IBlockStorePtr>(Better);
+        };
+    }
 
-            return MakeFuture(TResultOrError<IBlockStorePtr>(Better));
+    TEndpointFactory AlwaysFails()
+    {
+        return [this](
+                   NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
+        {
+            Y_UNUSED(handler);
+            ++FactoryCalls;
+
+            return TResultOrError<IBlockStorePtr>(
+                MakeError(E_REJECTED, "rdma client is down"));
         };
     }
 };
@@ -127,7 +128,7 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         env.SettleTime = TDuration::Zero();
         env.StartSwitching(env.AlwaysSucceeds());
 
-        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
+        env.Switcher->GetEndpointHandler()->HandleConnected();
 
         Read(env.Router);
 
@@ -136,103 +137,23 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
     }
 
-    Y_UNIT_TEST(ShouldRetryAfterFailedAttempt)
+    Y_UNIT_TEST(ShouldStayOnFallbackWhenTheEndpointCannotBeCreated)
     {
         TTestEnv env;
         env.SettleTime = TDuration::Zero();
-        env.StartSwitching(env.FailsThenSucceeds(1));
+        env.StartSwitching(env.AlwaysFails());
 
+        // asked once and not again: an endpoint that was handed back would
+        // reconnect on its own, so a failure here is the rdma client itself
+        // refusing, and nothing about it changes on a timer
+        UNIT_ASSERT_VALUES_EQUAL(1, env.FactoryCalls);
+
+        env.AdvanceTime(TDuration::Seconds(30));
         UNIT_ASSERT_VALUES_EQUAL(1, env.FactoryCalls);
 
         Read(env.Router);
         UNIT_ASSERT_VALUES_EQUAL(1, env.Initial->ReadCount);
-
-        env.AdvanceTime(TDuration::Seconds(1));
-        UNIT_ASSERT_VALUES_EQUAL(2, env.FactoryCalls);
-
-        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
-
-        Read(env.Router);
-        UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
-    }
-
-    Y_UNIT_TEST(ShouldNotRetryBeforeDelayElapses)
-    {
-        TTestEnv env;
-        env.StartSwitching(env.FailsThenSucceeds(1));
-
-        env.Scheduler->RunAllScheduledTasksUntilNow();
-        UNIT_ASSERT_VALUES_EQUAL(1, env.FactoryCalls);
-
-        env.AdvanceTime(TDuration::MilliSeconds(999));
-        UNIT_ASSERT_VALUES_EQUAL(1, env.FactoryCalls);
-
-        env.AdvanceTime(TDuration::MilliSeconds(1));
-        UNIT_ASSERT_VALUES_EQUAL(2, env.FactoryCalls);
-    }
-
-    Y_UNIT_TEST(ShouldGrowDelayBetweenAttempts)
-    {
-        TTestEnv env;
-        env.StartSwitching(env.FailsThenSucceeds(2));
-
-        env.AdvanceTime(TDuration::Seconds(1));
-        UNIT_ASSERT_VALUES_EQUAL(2, env.FactoryCalls);
-
-        // the second delay is twice the first one, so one second is no longer
-        // enough to trigger the next attempt
-        env.AdvanceTime(TDuration::Seconds(1));
-        UNIT_ASSERT_VALUES_EQUAL(2, env.FactoryCalls);
-
-        env.AdvanceTime(TDuration::Seconds(1));
-        UNIT_ASSERT_VALUES_EQUAL(3, env.FactoryCalls);
-    }
-
-    // The switcher cannot cancel an attempt that is already in flight, so it
-    // outlives the router until that attempt completes. Observed through the
-    // factory, which the switcher owns and releases along with itself.
-    Y_UNIT_TEST(ShouldOutliveRouterUntilPendingAttemptCompletes)
-    {
-        auto sentinel = std::make_shared<int>(0);
-        std::weak_ptr<int> weakSentinel = sentinel;
-
-        auto promise = NewPromise<TResultOrError<IBlockStorePtr>>();
-
-        TTestEnv env;
-        env.StartSwitching(
-            [sentinel = std::move(sentinel), promise](
-                NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
-            {
-                Y_UNUSED(handler);
-                return promise.GetFuture();
-            });
-
-        env.Router.reset();
-        env.Switcher.reset();
-
-        UNIT_ASSERT_C(
-            weakSentinel.lock(),
-            "switcher was released while its attempt was still in flight");
-
-        promise.SetValue(TResultOrError<IBlockStorePtr>(
-            MakeError(E_REJECTED, "endpoint is not up yet")));
-
-        UNIT_ASSERT_C(
-            !weakSentinel.lock(),
-            "switcher was not released once the pending attempt completed");
-    }
-
-    Y_UNIT_TEST(ShouldStopRetryingOnceRouterIsGone)
-    {
-        TTestEnv env;
-        env.StartSwitching(env.FailsThenSucceeds(10));
-
-        UNIT_ASSERT_VALUES_EQUAL(1, env.FactoryCalls);
-
-        env.Router.reset();
-
-        env.AdvanceTime(TDuration::Seconds(1));
-        UNIT_ASSERT_VALUES_EQUAL(1, env.FactoryCalls);
+        UNIT_ASSERT_VALUES_EQUAL(0, env.Better->ReadCount);
     }
 
     Y_UNIT_TEST(ShouldReturnToRdmaOnlyAfterItSettles)
@@ -244,9 +165,9 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
 
         // the first connect moves the data over at once; only a link that has
         // dropped once has to serve out the wait
-        handler->HandleConnected("test-host", 10020);
-        handler->HandleDisconnected("test-host", 10020);
-        handler->HandleConnected("test-host", 10020);
+        handler->HandleConnected();
+        handler->HandleDisconnected();
+        handler->HandleConnected();
 
         Read(env.Router);
         UNIT_ASSERT_VALUES_EQUAL(1, env.Initial->ReadCount);
@@ -264,7 +185,7 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         env.SettleTime = TDuration::Zero();
         env.StartSwitching(env.AlwaysSucceeds());
 
-        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
+        env.Switcher->GetEndpointHandler()->HandleConnected();
 
         Read(env.Router);
         UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
@@ -276,10 +197,10 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         env.StartSwitching(env.AlwaysSucceeds());
 
         auto handler = env.Switcher->GetEndpointHandler();
-        handler->HandleConnected("test-host", 10020);
+        handler->HandleConnected();
 
         env.AdvanceTime(TDuration::Seconds(5));
-        handler->HandleDisconnected("test-host", 10020);
+        handler->HandleDisconnected();
         env.AdvanceTime(TDuration::Seconds(10));
 
         Read(env.Router);
@@ -294,8 +215,8 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         env.StartSwitching(env.AlwaysSucceeds());
 
         auto handler = env.Switcher->GetEndpointHandler();
-        handler->HandleConnected("test-host", 10020);
-        handler->HandleDisconnected("test-host", 10020);
+        handler->HandleConnected();
+        handler->HandleDisconnected();
 
         Read(env.Router);
         UNIT_ASSERT_VALUES_EQUAL(1, env.Initial->ReadCount);
@@ -309,9 +230,9 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         env.StartSwitching(env.AlwaysSucceeds());
 
         auto handler = env.Switcher->GetEndpointHandler();
-        handler->HandleConnected("test-host", 10020);
-        handler->HandleDisconnected("test-host", 10020);
-        handler->HandleConnected("test-host", 10020);
+        handler->HandleConnected();
+        handler->HandleDisconnected();
+        handler->HandleConnected();
 
         Read(env.Router);
         UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
@@ -324,8 +245,8 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         env.StartSwitching(env.AlwaysSucceeds());
 
         auto handler = env.Switcher->GetEndpointHandler();
-        handler->HandleConnected("test-host", 10020);
-        handler->HandleUnavailable("test-host", 10020);
+        handler->HandleConnected();
+        handler->HandleUnavailable();
 
         Read(env.Router);
         UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
@@ -338,8 +259,8 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         env.StartSwitching(env.AlwaysSucceeds());
 
         auto handler = env.Switcher->GetEndpointHandler();
-        handler->HandleConnected("test-host", 10020);
-        handler->HandleConnected("test-host", 10020);
+        handler->HandleConnected();
+        handler->HandleConnected();
 
         Read(env.Router);
         UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
@@ -350,7 +271,7 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         TTestEnv env;
         env.StartSwitching(env.AlwaysSucceeds());
 
-        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
+        env.Switcher->GetEndpointHandler()->HandleConnected();
         env.Router.reset();
 
         // the settle timer must find the router gone and do nothing
@@ -362,7 +283,7 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         TTestEnv env;
         env.StartSwitching(env.AlwaysSucceeds());
 
-        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
+        env.Switcher->GetEndpointHandler()->HandleConnected();
 
         // the settle time guards a return to a link that has already proved it
         // can drop; a link that has never dropped has nothing to prove
@@ -377,11 +298,11 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
         env.StartSwitching(env.AlwaysSucceeds());
 
         auto handler = env.Switcher->GetEndpointHandler();
-        handler->HandleConnected("test-host", 10020);
+        handler->HandleConnected();
 
         env.AdvanceTime(TDuration::Seconds(5));
-        handler->HandleDisconnected("test-host", 10020);
-        handler->HandleConnected("test-host", 10020);
+        handler->HandleDisconnected();
+        handler->HandleConnected();
 
         // the first timer is due now, but its generation is stale
         env.AdvanceTime(TDuration::Seconds(5));

--- a/cloud/blockstore/libs/cells/impl/transport_switcher_ut.cpp
+++ b/cloud/blockstore/libs/cells/impl/transport_switcher_ut.cpp
@@ -64,6 +64,9 @@ struct TTestEnv
 
     ui32 FactoryCalls = 0;
 
+    TDuration SettleTime = TDuration::Seconds(10);
+    ITransportSwitcherPtr Switcher;
+
     // moves both clocks forward and lets everything due by now run
     void AdvanceTime(TDuration duration)
     {
@@ -74,8 +77,9 @@ struct TTestEnv
 
     void StartSwitching(TEndpointFactory factory)
     {
-        StartTransportSwitching(
+        Switcher = StartTransportSwitching(
             Router,
+            Initial,   // the endpoint the router starts on
             std::move(factory),
             Timer,
             Scheduler,
@@ -84,6 +88,7 @@ struct TTestEnv
             TTransportSwitcherConfig{
                 .InitialRetryDelay = TDuration::Seconds(1),
                 .MaxRetryDelay = TDuration::Seconds(4),
+                .SettleTime = SettleTime,
             });
     }
 
@@ -94,8 +99,10 @@ struct TTestEnv
 
     TEndpointFactory FailsThenSucceeds(ui32 failures)
     {
-        return [this, failures]
+        return [this, failures](
+                   NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
         {
+            Y_UNUSED(handler);
             ++FactoryCalls;
 
             if (FactoryCalls <= failures) {
@@ -117,7 +124,10 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
     Y_UNIT_TEST(ShouldInstallEndpointIntoRouterWhenItIsReady)
     {
         TTestEnv env;
+        env.SettleTime = TDuration::Zero();
         env.StartSwitching(env.AlwaysSucceeds());
+
+        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
 
         Read(env.Router);
 
@@ -129,6 +139,7 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
     Y_UNIT_TEST(ShouldRetryAfterFailedAttempt)
     {
         TTestEnv env;
+        env.SettleTime = TDuration::Zero();
         env.StartSwitching(env.FailsThenSucceeds(1));
 
         UNIT_ASSERT_VALUES_EQUAL(1, env.FactoryCalls);
@@ -138,6 +149,8 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
 
         env.AdvanceTime(TDuration::Seconds(1));
         UNIT_ASSERT_VALUES_EQUAL(2, env.FactoryCalls);
+
+        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
 
         Read(env.Router);
         UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
@@ -187,10 +200,15 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
 
         TTestEnv env;
         env.StartSwitching(
-            [sentinel = std::move(sentinel), promise]
-            { return promise.GetFuture(); });
+            [sentinel = std::move(sentinel), promise](
+                NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
+            {
+                Y_UNUSED(handler);
+                return promise.GetFuture();
+            });
 
         env.Router.reset();
+        env.Switcher.reset();
 
         UNIT_ASSERT_C(
             weakSentinel.lock(),
@@ -215,6 +233,165 @@ Y_UNIT_TEST_SUITE(TTransportSwitcherTest)
 
         env.AdvanceTime(TDuration::Seconds(1));
         UNIT_ASSERT_VALUES_EQUAL(1, env.FactoryCalls);
+    }
+
+    Y_UNIT_TEST(ShouldReturnToRdmaOnlyAfterItSettles)
+    {
+        TTestEnv env;
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        auto handler = env.Switcher->GetEndpointHandler();
+
+        // the first connect moves the data over at once; only a link that has
+        // dropped once has to serve out the wait
+        handler->HandleConnected("test-host", 10020);
+        handler->HandleDisconnected("test-host", 10020);
+        handler->HandleConnected("test-host", 10020);
+
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Initial->ReadCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, env.Better->ReadCount);
+
+        env.AdvanceTime(TDuration::Seconds(10));
+
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
+    }
+
+    Y_UNIT_TEST(ShouldSwitchToRdmaAtOnceWhenSettleTimeIsZero)
+    {
+        TTestEnv env;
+        env.SettleTime = TDuration::Zero();
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
+
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
+    }
+
+    Y_UNIT_TEST(ShouldNotSwitchWhenRdmaBreaksWhileSettling)
+    {
+        TTestEnv env;
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        auto handler = env.Switcher->GetEndpointHandler();
+        handler->HandleConnected("test-host", 10020);
+
+        env.AdvanceTime(TDuration::Seconds(5));
+        handler->HandleDisconnected("test-host", 10020);
+        env.AdvanceTime(TDuration::Seconds(10));
+
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Initial->ReadCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, env.Better->ReadCount);
+    }
+
+    Y_UNIT_TEST(ShouldFallBackToGrpcWhenRdmaBreaks)
+    {
+        TTestEnv env;
+        env.SettleTime = TDuration::Zero();
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        auto handler = env.Switcher->GetEndpointHandler();
+        handler->HandleConnected("test-host", 10020);
+        handler->HandleDisconnected("test-host", 10020);
+
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Initial->ReadCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, env.Better->ReadCount);
+    }
+
+    Y_UNIT_TEST(ShouldReturnToRdmaAfterItComesBack)
+    {
+        TTestEnv env;
+        env.SettleTime = TDuration::Zero();
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        auto handler = env.Switcher->GetEndpointHandler();
+        handler->HandleConnected("test-host", 10020);
+        handler->HandleDisconnected("test-host", 10020);
+        handler->HandleConnected("test-host", 10020);
+
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreUnavailable)
+    {
+        TTestEnv env;
+        env.SettleTime = TDuration::Zero();
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        auto handler = env.Switcher->GetEndpointHandler();
+        handler->HandleConnected("test-host", 10020);
+        handler->HandleUnavailable("test-host", 10020);
+
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
+    }
+
+    Y_UNIT_TEST(ShouldTolerateRepeatedConnected)
+    {
+        TTestEnv env;
+        env.SettleTime = TDuration::Zero();
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        auto handler = env.Switcher->GetEndpointHandler();
+        handler->HandleConnected("test-host", 10020);
+        handler->HandleConnected("test-host", 10020);
+
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
+    }
+
+    Y_UNIT_TEST(ShouldNotSettleOntoAReleasedRouter)
+    {
+        TTestEnv env;
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
+        env.Router.reset();
+
+        // the settle timer must find the router gone and do nothing
+        env.AdvanceTime(TDuration::Seconds(10));
+    }
+
+    Y_UNIT_TEST(ShouldSwitchToRdmaAtOnceOnTheFirstConnect)
+    {
+        TTestEnv env;
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        env.Switcher->GetEndpointHandler()->HandleConnected("test-host", 10020);
+
+        // the settle time guards a return to a link that has already proved it
+        // can drop; a link that has never dropped has nothing to prove
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(0, env.Initial->ReadCount);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
+    }
+
+    Y_UNIT_TEST(ShouldRestartTheSettleTimeOnReconnect)
+    {
+        TTestEnv env;
+        env.StartSwitching(env.AlwaysSucceeds());
+
+        auto handler = env.Switcher->GetEndpointHandler();
+        handler->HandleConnected("test-host", 10020);
+
+        env.AdvanceTime(TDuration::Seconds(5));
+        handler->HandleDisconnected("test-host", 10020);
+        handler->HandleConnected("test-host", 10020);
+
+        // the first timer is due now, but its generation is stale
+        env.AdvanceTime(TDuration::Seconds(5));
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Initial->ReadCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, env.Better->ReadCount);
+
+        env.AdvanceTime(TDuration::Seconds(5));
+        Read(env.Router);
+        UNIT_ASSERT_VALUES_EQUAL(1, env.Better->ReadCount);
     }
 }
 

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -929,7 +929,7 @@ CreateRdmaEndpointClientAsync(
     });
 }
 
-IBlockStorePtr CreateRdmaDataEndpoint(
+NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaDataEndpointAsync(
     ILoggingServicePtr logging,
     NRdma::IClientPtr client,
     ITraceSerializerPtr traceSerializer,
@@ -942,13 +942,18 @@ IBlockStorePtr CreateRdmaDataEndpoint(
         std::move(taskQueue),
         client->IsAlignedDataEnabled());
 
-    auto startEndpoint = client->StartEndpoint(config.Address, config.Port);
-
-    endpoint->Init(startEndpoint.GetValue(WAIT_TIMEOUT));
-    return endpoint;
+    auto future = client->StartEndpoint(config.Address, config.Port);
+    return future.Apply([endpoint = std::move(endpoint)] (const auto& future) mutable {
+        auto result = SafeExecute<TResultOrError<IBlockStorePtr>>(
+            [&] {
+                endpoint->Init(future.GetValue());
+                return TResultOrError<IBlockStorePtr>(endpoint);
+            });
+        return result;
+    });
 }
 
-NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaDataEndpointAsync(
+TResultOrError<IBlockStorePtr> CreateRdmaDataEndpoint(
     ILoggingServicePtr logging,
     NRdma::IClientPtr client,
     ITraceSerializerPtr traceSerializer,
@@ -962,18 +967,19 @@ NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaDataEndpointAsync(
         std::move(taskQueue),
         client->IsAlignedDataEnabled());
 
-    auto future = client->StartEndpoint(
+    // hands the endpoint back before it has connected; the handler is how the
+    // caller learns when it is usable
+    auto [clientEndpoint, error] = client->StartEndpoint(
         config.Address,
         config.Port,
         std::move(handler));
-    return future.Apply([endpoint = std::move(endpoint)] (const auto& future) mutable {
-        auto result = SafeExecute<TResultOrError<IBlockStorePtr>>(
-            [&] {
-                endpoint->Init(future.GetValue());
-                return TResultOrError<IBlockStorePtr>(endpoint);
-            });
-        return result;
-    });
+
+    if (HasError(error)) {
+        return error;
+    }
+
+    endpoint->Init(std::move(clientEndpoint));
+    return IBlockStorePtr(std::move(endpoint));
 }
 
 }   // namespace NCloud::NBlockStore::NClient

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -953,7 +953,8 @@ NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaDataEndpointAsync(
     NRdma::IClientPtr client,
     ITraceSerializerPtr traceSerializer,
     ITaskQueuePtr taskQueue,
-    const TRdmaEndpointConfig& config)
+    const TRdmaEndpointConfig& config,
+    NRdma::IClientEndpointHandlerPtr handler)
 {
     auto endpoint = std::make_shared<TRdmaDataEndpoint>(
         std::move(logging),
@@ -961,7 +962,10 @@ NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaDataEndpointAsync(
         std::move(taskQueue),
         client->IsAlignedDataEnabled());
 
-    auto future = client->StartEndpoint(config.Address, config.Port);
+    auto future = client->StartEndpoint(
+        config.Address,
+        config.Port,
+        std::move(handler));
     return future.Apply([endpoint = std::move(endpoint)] (const auto& future) mutable {
         auto result = SafeExecute<TResultOrError<IBlockStorePtr>>(
             [&] {

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -967,8 +967,6 @@ TResultOrError<IBlockStorePtr> CreateRdmaDataEndpoint(
         std::move(taskQueue),
         client->IsAlignedDataEnabled());
 
-    // hands the endpoint back before it has connected; the handler is how the
-    // caller learns when it is usable
     auto [clientEndpoint, error] = client->StartEndpoint(
         config.Address,
         config.Port,

--- a/cloud/blockstore/libs/client_rdma/rdma_client.h
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.h
@@ -53,6 +53,7 @@ NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaDataEndpointAsync(
     NCloud::NStorage::NRdma::IClientPtr client,
     ITraceSerializerPtr traceSerializer,
     ITaskQueuePtr taskQueue,
-    const TRdmaEndpointConfig& config);
+    const TRdmaEndpointConfig& config,
+    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler = nullptr);
 
 }   // namespace NCloud::NBlockStore::NClient

--- a/cloud/blockstore/libs/client_rdma/rdma_client.h
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.h
@@ -41,14 +41,19 @@ NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaEndpointClientAsyn
     ITaskQueuePtr taskQueue,
     const TRdmaEndpointConfig& config);
 
-IBlockStorePtr CreateRdmaDataEndpoint(
+// Waits for the first connect: the future fails, and the endpoint is torn
+// down, if it does not come up.
+NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaDataEndpointAsync(
     ILoggingServicePtr logging,
     NCloud::NStorage::NRdma::IClientPtr client,
-    NCloud::NStorage::NRdma::IClientEndpointPtr clientEndpoint,
     ITraceSerializerPtr traceSerializer,
-    ITaskQueuePtr taskQueue);
+    ITaskQueuePtr taskQueue,
+    const TRdmaEndpointConfig& config);
 
-NThreading::TFuture<TResultOrError<IBlockStorePtr>> CreateRdmaDataEndpointAsync(
+// The handler is how the rdma client reports the endpoint state back; it may
+// be empty when nobody listens. The endpoint is returned before it has
+// connected, so a caller that has no handler cannot tell when it is usable.
+TResultOrError<IBlockStorePtr> CreateRdmaDataEndpoint(
     ILoggingServicePtr logging,
     NCloud::NStorage::NRdma::IClientPtr client,
     ITraceSerializerPtr traceSerializer,

--- a/cloud/blockstore/libs/client_rdma/rdma_client_ut.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client_ut.cpp
@@ -253,15 +253,15 @@ struct TTestEnv
 
     IBlockStorePtr CreateDataEndpoint()
     {
-        auto future = CreateRdmaDataEndpointAsync(
+        auto result = CreateRdmaDataEndpoint(
             Logging,
             Client,
             TraceSerializer,
             TaskQueue,
             Config);
-        UNIT_ASSERT_C(future.HasValue(), "Value not set");
-        auto result = future.GetValue();
-        UNIT_ASSERT_C(!HasError(result.GetError()), result.GetError().GetMessage());
+        UNIT_ASSERT_C(
+            !HasError(result.GetError()),
+            result.GetError().GetMessage());
         return result.GetResult();
     }
 };


### PR DESCRIPTION
### Notes

[Cells] Move data back to gRPC while RDMA is down

Setting up RDMA stopped holding a cell connection back in #7035, but the
switch was one-way: once data moved onto RDMA nobody looked at it again.
A break then cost the whole reconnect window, because every retry went
into the transport that had just died while a healthy gRPC path sat
unused beside it.

Building on the endpoint state handler that landed with the synchronous
StartEndpoint, the switcher now owns the transport choice for as long as
the connection lives. A break moves data straight back onto gRPC; a
reconnect moves it onto RDMA again only once it has stayed up for
RdmaSettleTime, so a flapping link does not keep pulling traffic onto a
transport about to drop. The default settle time is 10 seconds and zero
switches over immediately.

The first connect never waits. The settle time guards a return to a link
that has already proved it can drop; a link that has never carried our
data has proved nothing, and making it wait would only keep the data on
the slower transport.

Taking the endpoint is synchronous now: it is handed back before it has
connected and reconnects on its own from then on, so the switcher asks
for it once and has nothing to retry. A failure there means the rdma
client itself cannot give us an endpoint, and the connection stays on
gRPC.

The win is in the retries rather than in the failing requests: the ones
already in flight are aborted by the rdma client itself, and what this
buys is that TDurableClient's next attempt lands somewhere that works.

Gated by the existing GrpcDataFallbackEnabled, off by default. The path
with the flag off is untouched and still waits for the first connect
through the asynchronous form: without a fallback transport, handing out
a connection early would trade a failed mount for IO that fails
retriably forever.


### Issue
Put links to the related issues here
