### PR TITLE
[Storage] Run file-backed container tests as medium in all modes

### DIFF
--- a/cloud/storage/core/libs/file_backed_containers/ut/ya.make
+++ b/cloud/storage/core/libs/file_backed_containers/ut/ya.make
@@ -1,12 +1,8 @@
 UNITTEST_FOR(cloud/storage/core/libs/file_backed_containers)
 
-# TFileRingBufferTest::RandomizedPushPopRestore tests may need more time
-# under sanitizers
-IF (SANITIZER_TYPE OR WITH_VALGRIND)
-    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
-ELSE()
-    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
-ENDIF()
+# Randomized ring-buffer tests exercise both V5 and V6 and can exceed
+# the small-test chunk timeout even without sanitizers.
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
 SRCDIR(cloud/storage/core/libs/file_backed_containers)
 


### PR DESCRIPTION
### Notes

Run `file_backed_containers/ut` with the shared medium-test recipe in every build mode. The randomized ring-buffer tests exceed the 60-second small-test chunk limit in ordinary builds. The suite already uses the medium recipe under sanitizers and Valgrind.

For ordinary builds, this changes the chunk timeout from 60 to 600 seconds, the chunk count from 15 to 10, and the resource requirements from 2 CPU / 8 GB to 4 CPU / 16 GB. Test workloads remain unchanged. Run the suite with `-tt` or `-A`; small-only `-t` runs no longer select it.

### Issue

The tests in Arcadia hit the 60-second chunk timeout in `cloud/storage/core/libs/file_backed_containers/ut` (`default-linux-x86_64-relwithdebinfo`, chunk 8/15):

```text
13 tests:  3 - GOOD ,  9 - NOT_LAUNCHED ,  1 - TIMEOUT Chunk exceeded  60s  timeout and was killed
 List of the tests involved in the launch:
 TFileRingBufferTest::RandomizedPushPopRestoreSmallV5 ( good ) duration:  28.13s
 TFileRingBufferTest::RandomizedPushPopRestoreV6 ( good ) duration:  18.02s
 TFileRingBufferTest::RandomizedPushPopRestoreV5 ( good ) duration:  9.74s
 TFileRingBufferTest::RandomizedPushPopRestoreSmallV6 ( timeout ) duration:  8.98s
 9  tests were not launched inside chunk.
```

The three successful tests consumed 55.89 seconds in total; the next test was killed when the chunk exhausted its time budget, leaving nine tests unstarted.
