### PR TITLE
Reduce per-byte assertion overhead in io_uring tests

### DIFF
--- a/cloud/storage/core/libs/io_uring/service_ut.cpp
+++ b/cloud/storage/core/libs/io_uring/service_ut.cpp
@@ -219,7 +219,7 @@ Y_UNIT_TEST_SUITE(TIoUringTest)
             }
 
             for (char val: buffer) {
-                UNIT_ASSERT_VALUES_EQUAL(expectedData, val);
+                UNIT_ASSERT(expectedData == val);
             }
         }
     }
@@ -270,7 +270,7 @@ Y_UNIT_TEST_SUITE(TIoUringTest)
 
             for (auto& buffer: buffers) {
                 for (char val: buffer) {
-                    UNIT_ASSERT_VALUES_EQUAL(expectedData, val);
+                    UNIT_ASSERT(expectedData == val);
                 }
             }
         }


### PR DESCRIPTION
### Notes

Replace `UNIT_ASSERT_VALUES_EQUAL(expectedData, val)` with `UNIT_ASSERT(expectedData == val)` in `ShouldReadWrite` and `ShouldReadWriteV`. This avoids comparing integer values through string representations while retaining verification of every byte. The simpler assertion reports the failed expression rather than printing both values.

On a Linux dev host with release + ASan and QEMU/KVM, median runtimes across three runs per variant improved as follows:

| Test | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `ShouldReadWrite` | 2.89 s | 0.93 s | 3.1x |
| `ShouldReadWriteV` | 2.29 s | 0.38 s | 5.9x |

All six tests passed with the original `small` configuration after the change. The original variant also passed on dev, so the timeout was not reproduced there. No timeout change is included in this PR.

### Issue

The tests in Arcadia hit the 60-second chunk timeout in `cloud/storage/core/libs/io_uring/ut` (`default-linux-x86_64-release-asan`):

```text
6 tests:  2 - GOOD ,  3 - NOT_LAUNCHED ,  1 - TIMEOUT Chunk exceeded  60s  timeout and was killed
 List of the tests involved in the launch:
 TIoUringTest::ShouldReadWriteV ( timeout ) duration:  29.73s
 TIoUringTest::ShouldReadWrite ( good ) duration:  27.58s
 TIoUringNullTest::ShouldInvokeCompletions ( good ) duration:  0.05s
 3  tests were not launched inside chunk.
```

`ShouldReadWrite` completed, but `ShouldReadWriteV` was killed when the chunk exhausted its time budget, leaving three tests unstarted.
