### PR TITLE
[NBS]: Split filestore sharding tests into a separate target

### DIFF
--- a/cloud/filestore/libs/storage/service/ut_sharding/ya.make
+++ b/cloud/filestore/libs/storage/service/ut_sharding/ya.make
@@ -2,15 +2,13 @@ UNITTEST_FOR(cloud/filestore/libs/storage/service)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
 
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    SPLIT_FACTOR(14)
+ENDIF()
+
 SRCS(
-    helpers_ut.cpp
-    protobuf_utils_ut.cpp
-    service_ut.cpp
-    service_ut_helpers.cpp
-    service_ut_parentless.cpp
-    service_ut_quotas.cpp
-    service_ut_writedata_unconfirmed.cpp
-    service_actor_actions_ut.cpp
+    ../service_ut_helpers.cpp
+    ../service_ut_sharding.cpp
 )
 
 PEERDIR(

--- a/cloud/filestore/libs/storage/service/ya.make
+++ b/cloud/filestore/libs/storage/service/ya.make
@@ -74,4 +74,5 @@ END()
 
 RECURSE_FOR_TESTS(
     ut
+    ut_sharding
 )


### PR DESCRIPTION
Move filestore sharding unit tests to a dedicated test target.

The new target retains the medium test recipe and increases the split factor for sanitizer and Valgrind builds.

Testing:
- [ ] cloud/filestore/libs/storage/service/ut_sharding
- [ ] cloud/filestore/libs/storage/service/ut

Log with test timeouts:
```
38 tests: 37 - GOOD, 1 - TIMEOUT

Chunk exceeded 600s timeout and was killed
List of the tests involved in the launch:
TStorageServiceShardingTest::ShouldCreateALotOfShards (good) duration: 187.12s
TStorageServiceShardingTest::ShouldBalanceShardsByWeightedDeterministic (good) duration: 139.34s
TStorageServiceShardingTest::ShouldBalanceShardsWithDirectoryRestrictionByWeightedDeterministic (good) duration: 77.61s
TStorageServiceShardingTest::ShouldCreateALotOfShardsThrottled (timeout) duration: 38.64s
TStorageServiceShardingTest::ShouldCheckAttrForNodeCreatedInShardViaLeader (good) duration: 12.04s
TStorageServiceShardingTest::ShouldDeleteShardsBeThrottled (good) duration: 6.32s
TStorageServiceShardingTest::ShouldDeleteShardsAutomatically (good) duration: 5.88s
TStorageServiceShardingTest::ShouldHandleErrorsDuringShardedFileSystemResize (good) duration: 5.69s
TStorageServiceShardingTest::ShouldAddShardsAutomaticallyUponResize (good) duration: 5.68s
TStorageServiceShardingTest::ShouldAddShardsAutomaticallyUponResizeThrottled (good) duration: 5.42s
28 more tests with 117.43s total duration are not listed.
```