### PR TITLE
introduce endpoint event listener interface & sync StartEndpoint

### DIFF
--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -615,7 +615,7 @@ public:
 
 class TRdmaDataEndpoint
     : public TEndpointBase
-    , public NRdma::IClientHandler
+    , public NRdma::IClientRequestHandler
     , public std::enable_shared_from_this<TRdmaDataEndpoint>
 {
     const ITraceSerializerPtr TraceSerializer;

--- a/cloud/blockstore/libs/client_rdma/rdma_client_ut.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client_ut.cpp
@@ -40,7 +40,7 @@ class TRequest: public NRdma::TClientRequest
 {
 public:
     TRequest(
-            NRdma::IClientHandlerPtr handler,
+            NRdma::IClientRequestHandlerPtr handler,
             std::unique_ptr<NRdma::TNullContext> context)
         : NRdma::TClientRequest(std::move(handler), std::move(context))
     {}
@@ -68,7 +68,7 @@ struct TTestClientEndpoint: public NRdma::IClientEndpoint
     ui64 NextRequestId = 0;
 
     TResultOrError<NRdma::TClientRequestPtr> AllocateRequest(
-        NRdma::IClientHandlerPtr handler,
+        NRdma::IClientRequestHandlerPtr handler,
         std::unique_ptr<NRdma::TNullContext> context,
         size_t requestBytes,
         size_t responseBytes) override
@@ -195,6 +195,18 @@ struct TTestRdmaClient: public NRdma::IClient
         Y_UNUSED(port);
 
         return MakeFuture<NRdma::IClientEndpointPtr>(Endpoint);
+    }
+
+    TResultOrError<NRdma::IClientEndpointPtr> StartEndpoint(
+        TString host,
+        ui32 port,
+        NRdma::IClientEndpointHandlerPtr handler) override
+    {
+        Y_UNUSED(host);
+        Y_UNUSED(port);
+        Y_UNUSED(handler);
+
+        return NRdma::IClientEndpointPtr(Endpoint);
     }
 
     void Start() override

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -140,10 +140,20 @@ public:
         Impl.reset();
     }
 
-    auto StartEndpoint(TString host, ui32 port) -> NThreading::TFuture<
-        NCloud::NStorage::NRdma::IClientEndpointPtr> override
+    auto StartEndpoint(TString host, ui32 port)
+        -> NThreading::TFuture<NCloud::NStorage::NRdma::IClientEndpointPtr>
+        override
     {
         return Impl->StartEndpoint(std::move(host), port);
+    }
+
+    auto StartEndpoint(
+        TString host,
+        ui32 port,
+        NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
+        -> TResultOrError<NCloud::NStorage::NRdma::IClientEndpointPtr> override
+    {
+        return Impl->StartEndpoint(std::move(host), port, std::move(handler));
     }
 
     void DumpHtml(IOutputStream& out) const override

--- a/cloud/blockstore/libs/rdma/fake/client.cpp
+++ b/cloud/blockstore/libs/rdma/fake/client.cpp
@@ -123,7 +123,7 @@ struct TClientRequest: public NRdma::TClientRequest
 public:
     TClientRequest(
         const TActorId& rdmaActorId,
-        NRdma::IClientHandlerPtr handler,
+        NRdma::IClientRequestHandlerPtr handler,
         std::unique_ptr<NRdma::TNullContext> context,
         ui32 requestSize,
         ui32 responseSize)
@@ -169,7 +169,7 @@ public:
         TEndpointId endpointId);
 
     auto AllocateRequest(
-        NRdma::IClientHandlerPtr handler,
+        NRdma::IClientRequestHandlerPtr handler,
         std::unique_ptr<NRdma::TNullContext> context,
         size_t requestBytes,
         size_t responseBytes)
@@ -203,7 +203,7 @@ TClientEndpoint::TClientEndpoint(
 {}
 
 auto TClientEndpoint::AllocateRequest(
-    NRdma::IClientHandlerPtr handler,
+    NRdma::IClientRequestHandlerPtr handler,
     std::unique_ptr<NRdma::TNullContext> context,
     size_t requestBytes,
     size_t responseBytes) -> TResultOrError<NRdma::TClientRequestPtr>
@@ -1087,6 +1087,12 @@ public:
     auto StartEndpoint(TString host, ui32 port)
         -> TFuture<NRdma::IClientEndpointPtr> override;
 
+    auto StartEndpoint(
+        TString host,
+        ui32 port,
+        NRdma::IClientEndpointHandlerPtr handler)
+        -> TResultOrError<NRdma::IClientEndpointPtr> override;
+
     void DumpHtml(IOutputStream& out) const override;
 
     [[nodiscard]] bool IsAlignedDataEnabled() const override;
@@ -1125,6 +1131,22 @@ auto TFakeRdmaClient::StartEndpoint(TString host, ui32 port)
     ActorSystem->Send(RdmaActorId, std::move(request));
 
     return future;
+}
+
+auto TFakeRdmaClient::StartEndpoint(
+    TString host,
+    ui32 port,
+    NRdma::IClientEndpointHandlerPtr handler)
+    -> TResultOrError<NRdma::IClientEndpointPtr>
+{
+    Y_UNUSED(handler);
+
+    // the fake sets endpoints up through the actor system, so it has no way to
+    // hand one back before that has happened
+    return MakeError(
+        E_NOT_IMPLEMENTED,
+        TStringBuilder() << "fake rdma client cannot create an endpoint to "
+                         << host << ":" << port << " synchronously");
 }
 
 void TFakeRdmaClient::DumpHtml(IOutputStream& out) const

--- a/cloud/blockstore/libs/rdma/fake/client_ut.cpp
+++ b/cloud/blockstore/libs/rdma/fake/client_ut.cpp
@@ -252,7 +252,7 @@ struct TFixture
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TTestClientHandler
-    : public NCloud::NStorage::NRdma::IClientHandler
+    : public NCloud::NStorage::NRdma::IClientRequestHandler
 {
     std::function<
         void(NCloud::NStorage::NRdma::TClientRequestPtr, ui32, size_t)>
@@ -274,7 +274,7 @@ public:
 };
 
 template <typename TFn>
-NCloud::NStorage::NRdma::IClientHandlerPtr Handler(TFn&& fn)
+NCloud::NStorage::NRdma::IClientRequestHandlerPtr Handler(TFn&& fn)
 {
     return std::make_shared<TTestClientHandler>(std::forward<TFn>(fn));
 }

--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -24,7 +24,7 @@ class TRequest: public NCloud::NStorage::NRdma::TClientRequest
 {
 public:
     TRequest(
-        NCloud::NStorage::NRdma::IClientHandlerPtr handler,
+        NCloud::NStorage::NRdma::IClientRequestHandlerPtr handler,
         std::unique_ptr<NCloud::NStorage::NRdma::TNullContext> context)
         : NCloud::NStorage::NRdma::TClientRequest(
               std::move(handler),
@@ -70,7 +70,7 @@ struct TRdmaClientTest::TRdmaEndpointImpl
     {}
 
     TResultOrError<NCloud::NStorage::NRdma::TClientRequestPtr> AllocateRequest(
-        NCloud::NStorage::NRdma::IClientHandlerPtr handler,
+        NCloud::NStorage::NRdma::IClientRequestHandlerPtr handler,
         std::unique_ptr<NCloud::NStorage::NRdma::TNullContext> context,
         size_t requestBytes,
         size_t responseBytes) override

--- a/cloud/blockstore/libs/rdma_test/client_test.cpp
+++ b/cloud/blockstore/libs/rdma_test/client_test.cpp
@@ -376,6 +376,19 @@ TRdmaClientTest::StartEndpoint(TString host, ui32 port)
     return ep.Promise;
 }
 
+TResultOrError<NCloud::NStorage::NRdma::IClientEndpointPtr>
+TRdmaClientTest::StartEndpoint(
+    TString host,
+    ui32 port,
+    NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler)
+{
+    Y_UNUSED(host);
+    Y_UNUSED(port);
+    Y_UNUSED(handler);
+
+    return MakeError(E_NOT_IMPLEMENTED);
+}
+
 void TRdmaClientTest::InjectErrors(
     NProto::TError allocationError,
     NProto::TError rdmaResponseError,

--- a/cloud/blockstore/libs/rdma_test/client_test.h
+++ b/cloud/blockstore/libs/rdma_test/client_test.h
@@ -33,6 +33,11 @@ struct TRdmaClientTest: NCloud::NStorage::NRdma::IClient
     NThreading::TFuture<NCloud::NStorage::NRdma::IClientEndpointPtr>
     StartEndpoint(TString host, ui32 port) override;
 
+    TResultOrError<NCloud::NStorage::NRdma::IClientEndpointPtr> StartEndpoint(
+        TString host,
+        ui32 port,
+        NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler) override;
+
     void Start() override
     {
     }

--- a/cloud/blockstore/libs/service_local/storage_rdma.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma.cpp
@@ -336,7 +336,7 @@ public:
 
 class TRdmaStorage final
     : public IStorage
-    , public NCloud::NStorage::NRdma::IClientHandler
+    , public NCloud::NStorage::NRdma::IClientRequestHandler
     , public std::enable_shared_from_this<TRdmaStorage>
 {
 private:

--- a/cloud/blockstore/libs/service_local/storage_rdma_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma_ut.cpp
@@ -22,7 +22,7 @@ namespace {
 class TDummyClientEndpoint: public NCloud::NStorage::NRdma::IClientEndpoint
 {
     TResultOrError<NCloud::NStorage::NRdma::TClientRequestPtr> AllocateRequest(
-        NCloud::NStorage::NRdma::IClientHandlerPtr handler,
+        NCloud::NStorage::NRdma::IClientRequestHandlerPtr handler,
         std::unique_ptr<NCloud::NStorage::NRdma::TNullContext> context,
         size_t requestBytes,
         size_t responseBytes) override
@@ -71,6 +71,20 @@ public:
         StartedEndpoints.emplace_back(host, port);
 
         return MakeFuture<NCloud::NStorage::NRdma::IClientEndpointPtr>(
+            std::make_shared<TDummyClientEndpoint>());
+    }
+
+    TResultOrError<NCloud::NStorage::NRdma::IClientEndpointPtr> StartEndpoint(
+        TString host,
+        ui32 port,
+        NCloud::NStorage::NRdma::IClientEndpointHandlerPtr handler) noexcept
+        override
+    {
+        Y_UNUSED(handler);
+
+        StartedEndpoints.emplace_back(host, port);
+
+        return NCloud::NStorage::NRdma::IClientEndpointPtr(
             std::make_shared<TDummyClientEndpoint>());
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h
@@ -30,7 +30,7 @@ struct TDeviceRequestRdmaContext: public NCloud::NStorage::NRdma::TNullContext
 };
 
 struct IClientHandlerWithTracking
-    : public NCloud::NStorage::NRdma::IClientHandler
+    : public NCloud::NStorage::NRdma::IClientRequestHandler
 {
     virtual void OnRequestStarted(
         ui32 deviceIdx,

--- a/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/storage_rdma.cpp
@@ -65,7 +65,7 @@ public:
 
     TResultOrError<NRdma::TClientRequestPtr> PrepareRequest(
         NRdma::IClientEndpoint& endpoint,
-        NRdma::IClientHandlerPtr handler)
+        NRdma::IClientRequestHandlerPtr handler)
     {
         LWTRACK(
             RdmaPrepareRequest,
@@ -157,7 +157,7 @@ public:
 
     TResultOrError<NRdma::TClientRequestPtr> PrepareRequest(
         NRdma::IClientEndpoint& endpoint,
-        NRdma::IClientHandlerPtr handler)
+        NRdma::IClientRequestHandlerPtr handler)
     {
         size_t dataSize = Request->GetBlockSize() * Request->GetBlocksCount();
 
@@ -214,7 +214,7 @@ public:
 
 class TRdmaStorage final
     : public IStorage
-    , public NRdma::IClientHandler
+    , public NRdma::IClientRequestHandler
     , public std::enable_shared_from_this<TRdmaStorage>
 {
 private:

--- a/cloud/storage/core/libs/rdma/iface/client.h
+++ b/cloud/storage/core/libs/rdma/iface/client.h
@@ -70,10 +70,11 @@ public:
 
 // TClientRequest encapsulates all information for executing the request:
 // input and output buffers, response handler, user context.
-// Do not create TClientRequest directly, use IClientHandler::AllocateRequest().
+// Do not create TClientRequest directly, use
+// IClientRequestHandler::AllocateRequest().
 struct TClientRequest
 {
-    IClientHandlerPtr Handler;
+    IClientRequestHandlerPtr Handler;
     std::unique_ptr<TNullContext> Context;
 
     TStringBuf RequestBuffer;
@@ -83,7 +84,7 @@ struct TClientRequest
 
 protected:
     TClientRequest(
-            IClientHandlerPtr handler,
+            IClientRequestHandlerPtr handler,
             std::unique_ptr<TNullContext> context)
         : Handler(std::move(handler))
         , Context(std::move(context))
@@ -92,15 +93,28 @@ protected:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// IClientHandler interface is used to process the response on the user side.
-struct IClientHandler
+// IClientRequestHandler interface is used to process the response on the user
+// side.
+struct IClientRequestHandler
 {
-    virtual ~IClientHandler() = default;
+    virtual ~IClientRequestHandler() = default;
 
     virtual void HandleResponse(
         TClientRequestPtr req,
         ui32 status,
         size_t responseBytes) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Used to notify user about changes in the endpoint state
+struct IClientEndpointHandler
+{
+    virtual ~IClientEndpointHandler() = default;
+
+    virtual void HandleConnected() = 0;
+    virtual void HandleDisconnected() = 0;
+    virtual void HandleUnavailable() = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -111,7 +125,7 @@ struct IClientEndpoint
     virtual ~IClientEndpoint() = default;
 
     virtual TResultOrError<TClientRequestPtr> AllocateRequest(
-        IClientHandlerPtr handler,
+        IClientRequestHandlerPtr handler,
         std::unique_ptr<TNullContext> context,
         size_t requestBytes,
         size_t responseBytes) = 0;
@@ -141,6 +155,11 @@ struct IClient
     virtual NThreading::TFuture<IClientEndpointPtr> StartEndpoint(
         TString host,
         ui32 port) = 0;
+
+    virtual TResultOrError<IClientEndpointPtr> StartEndpoint(
+        TString host,
+        ui32 port,
+        IClientEndpointHandlerPtr handler) = 0;
 
     virtual void DumpHtml(IOutputStream& out) const = 0;
 

--- a/cloud/storage/core/libs/rdma/iface/public.h
+++ b/cloud/storage/core/libs/rdma/iface/public.h
@@ -30,8 +30,11 @@ using TClientRequestPtr = std::unique_ptr<TClientRequest>;
 struct IClientEndpoint;
 using IClientEndpointPtr = std::shared_ptr<IClientEndpoint>;
 
-struct IClientHandler;
-using IClientHandlerPtr = std::shared_ptr<IClientHandler>;
+struct IClientRequestHandler;
+using IClientRequestHandlerPtr = std::shared_ptr<IClientRequestHandler>;
+
+struct IClientEndpointHandler;
+using IClientEndpointHandlerPtr = std::shared_ptr<IClientEndpointHandler>;
 
 struct TClientConfig;
 using TClientConfigPtr = std::shared_ptr<TClientConfig>;

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -176,7 +176,7 @@ struct TRequest
 
     TRequest(
             std::weak_ptr<TClientEndpoint> endpoint,
-            IClientHandlerPtr handler,
+            IClientRequestHandlerPtr handler,
             std::unique_ptr<TNullContext> context)
         : TClientRequest(std::move(handler), std::move(context))
         , StartedCycles(GetCycleCount())
@@ -579,7 +579,7 @@ private:
     NVerbs::TConnectionPtr Connection;
     TString Host;
     ui32 Port;
-    IClientHandlerPtr Handler;
+    IClientRequestHandlerPtr Handler;
     TEndpointCountersPtr Counters;
     TLog Log;
     TReconnect Reconnect;
@@ -598,8 +598,10 @@ private:
     NVerbs::TCompletionChannelPtr CompletionChannel = NVerbs::NullPtr;
     NVerbs::TCompletionQueuePtr CompletionQueue = NVerbs::NullPtr;
 
-    TPromise<IClientEndpointPtr> StartResult = NewPromise<IClientEndpointPtr>();
+    TPromise<IClientEndpointPtr> StartResult;
     TPromise<void> StopResult = NewPromise<void>();
+
+    const IClientEndpointHandlerPtr EndpointHandler;
 
     std::atomic<ui64> FlushStartCycles = 0;
 
@@ -657,7 +659,8 @@ public:
         ui32 port,
         TClientConfigPtr config,
         TEndpointCountersPtr stats,
-        TLog log);
+        TLog log,
+        IClientEndpointHandlerPtr handler);
     ~TClientEndpoint() override;
 
     // called from CM and CQ threads
@@ -679,7 +682,7 @@ public:
 
     // called from external thread
     TResultOrError<TClientRequestPtr> AllocateRequest(
-        IClientHandlerPtr handler,
+        IClientRequestHandlerPtr handler,
         std::unique_ptr<TNullContext> context,
         size_t requestBytes,
         size_t responseBytes) noexcept override;
@@ -748,7 +751,8 @@ TClientEndpoint::TClientEndpoint(
         ui32 port,
         TClientConfigPtr config,
         TEndpointCountersPtr stats,
-        TLog log)
+        TLog log,
+        IClientEndpointHandlerPtr handler)
     : Verbs(std::move(verbs))
     , Connection(std::move(connection))
     , Host(std::move(host))
@@ -759,6 +763,7 @@ TClientEndpoint::TClientEndpoint(
     , OriginalConfig(std::move(config))
     , Config(*OriginalConfig)
     , WaitMode(Config.WaitMode)
+    , EndpointHandler(std::move(handler))
     , SendBuffers(Config.BufferPool)
     , RecvBuffers(Config.BufferPool)
 {
@@ -970,7 +975,7 @@ void TClientEndpoint::StartReceive() noexcept
 
 // implements IClientEndpoint
 TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
-    IClientHandlerPtr handler,
+    IClientRequestHandlerPtr handler,
     std::unique_ptr<TNullContext> context,
     size_t requestBytes,
     size_t responseBytes) noexcept
@@ -2518,6 +2523,10 @@ public:
     TFuture<IClientEndpointPtr> StartEndpoint(
         TString host,
         ui32 port) noexcept override;
+    TResultOrError<IClientEndpointPtr> StartEndpoint(
+        TString host,
+        ui32 port,
+        IClientEndpointHandlerPtr handler) noexcept override;
     void DumpHtml(IOutputStream& out) const override;
     bool IsAlignedDataEnabled() const override;
 
@@ -2605,6 +2614,37 @@ void TClient::Stop() noexcept
 }
 
 // implements IClient
+TResultOrError<IClientEndpointPtr> TClient::StartEndpoint(
+    TString host,
+    ui32 port,
+    IClientEndpointHandlerPtr handler) noexcept
+{
+    if (ConnectionPoller == nullptr) {
+        return MakeError(E_RDMA_UNAVAILABLE, "rdma client is down");
+    }
+
+    try {
+        auto endpoint = std::make_shared<TClientEndpoint>(
+            Verbs,
+            ConnectionPoller->CreateConnection(Config->IpTypeOfService),
+            std::move(host),
+            port,
+            Config,
+            Counters,
+            Log,
+            std::move(handler));
+
+        ConnectionPoller->Attach(endpoint.get());
+        PickPoller().Acquire(endpoint);
+        BeginResolveAddress(endpoint.get());
+
+        return IClientEndpointPtr(std::move(endpoint));
+
+    } catch (const TServiceError& e) {
+        return MakeError(E_RDMA_UNAVAILABLE, "unable to start rdma endpoint");
+    }
+}
+
 TFuture<IClientEndpointPtr> TClient::StartEndpoint(
     TString host,
     ui32 port) noexcept
@@ -2627,10 +2667,12 @@ TFuture<IClientEndpointPtr> TClient::StartEndpoint(
             port,
             Config,
             Counters,
-            Log);
+            Log,
+            nullptr);   // this path reports through the future instead
+
+        endpoint->StartResult = NewPromise<IClientEndpointPtr>();
 
         auto future = endpoint->StartResult.GetFuture();
-
         ConnectionPoller->Attach(endpoint.get());
         PickPoller().Acquire(endpoint);
         BeginResolveAddress(endpoint.get());
@@ -2757,6 +2799,10 @@ void TClient::Reconnect(TClientEndpoint* endpoint) noexcept
             return;
         }
         // otherwise keep trying
+
+        if (endpoint->EndpointHandler) {
+            endpoint->EndpointHandler->HandleUnavailable();
+        }
     }
 
     RDMA_DEBUG(
@@ -2825,6 +2871,10 @@ void TClient::Disconnect(TClientEndpoint* endpoint) noexcept
 
     if (endpoint->WaitMode == EWaitMode::Poll) {
         endpoint->AbortRequestsEvent.Set();
+    }
+
+    if (endpoint->EndpointHandler) {
+        endpoint->EndpointHandler->HandleDisconnected();
     }
 }
 
@@ -2983,6 +3033,10 @@ void TClient::HandleConnected(
     if (endpoint->StartResult.Initialized()) {
         auto startResult = std::move(endpoint->StartResult);
         startResult.SetValue(endpoint->shared_from_this());
+    }
+
+    if (endpoint->EndpointHandler) {
+        endpoint->EndpointHandler->HandleConnected();
     }
 }
 

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -15,6 +15,8 @@
 
 #include <util/generic/scope.h>
 #include <util/stream/printf.h>
+#include <util/system/mutex.h>
+#include <util/system/spinlock.h>
 
 #include <thread>
 
@@ -61,7 +63,7 @@ struct TRequestContext: public NRdma::TNullContext
 };
 
 struct TClientHandler
-    : IClientHandler
+    : IClientRequestHandler
 {
     void HandleResponse(
         TClientRequestPtr req,
@@ -77,6 +79,43 @@ struct TClientHandler
                 status,
                 responseBytes);
         }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestEndpointHandler: public IClientEndpointHandler
+{
+    TMutex Lock;
+    TVector<TString> Events;
+
+    void Add(TString event)
+    {
+        with_lock (Lock) {
+            Events.push_back(std::move(event));
+        }
+    }
+
+    TVector<TString> GetEvents()
+    {
+        with_lock (Lock) {
+            return Events;
+        }
+    }
+
+    void HandleConnected() override
+    {
+        Add("connected");
+    }
+
+    void HandleDisconnected() override
+    {
+        Add("disconnected");
+    }
+
+    void HandleUnavailable() override
+    {
+        Add("unavailable");
     }
 };
 
@@ -311,7 +350,7 @@ TEST(TRdmaClientTest, ShouldNotTriggerCompletionAfterFlushTimeout)
 
     auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
-    struct TClientHandler: IClientHandler
+    struct TClientHandler: IClientRequestHandler
     {
         void HandleResponse(
             TClientRequestPtr req,
@@ -691,7 +730,7 @@ TEST(TRdmaClientTest, ShouldAbortRequests)
 
     auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
-    struct TClientHandler: IClientHandler
+    struct TClientHandler: IClientRequestHandler
     {
         TManualEvent Done;
 
@@ -1438,7 +1477,7 @@ TEST(TRdmaClientTest, ShouldBindAndInvalidateBuffers)
 
     auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
-    struct TResponse: IClientHandler
+    struct TResponse: IClientRequestHandler
     {
         ui32 Status = 0;
         TManualEvent Received;
@@ -1703,7 +1742,7 @@ TEST(TRdmaClientTest, ShouldEagerlyDestroyBothMemoryWindowsOnAbortRequest)
 
     auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
-    struct THoldingHandler: IClientHandler
+    struct THoldingHandler: IClientRequestHandler
     {
         TClientRequestPtr Held;
         TManualEvent Received;
@@ -1790,6 +1829,84 @@ TEST(TRdmaClientTest, ShouldNotReleaseBuffersFromStaleBufferPoolGeneration)
     // dropping the request must not touch the torn down pool
     auto req = request.ExtractResult();
     req.reset();
+}
+
+TEST(TRdmaClientTest, ShouldReportEndpointStateToHandler)
+{
+    auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+    testContext->AllowConnect = true;
+
+    auto verbs = NVerbs::CreateTestVerbs(testContext);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto clientConfig = std::make_shared<TClientConfig>();
+
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+
+    auto client = CreateTestClient(verbs, logging, monitoring, clientConfig);
+    client->Start();
+    Y_DEFER
+    {
+        client->Stop();
+    };
+
+    auto handler = std::make_shared<TTestEndpointHandler>();
+
+    auto result = client->StartEndpoint("::", 10020, handler);
+    ASSERT_FALSE(HasError(result));
+
+    // the endpoint is handed back before it has connected, so wait for the
+    // callback rather than for the call to return
+    while (handler->GetEvents().empty()) {
+        SpinLockPause();
+    }
+
+    ASSERT_EQ("connected", handler->GetEvents()[0]);
+
+    Disconnect(testContext);
+
+    while (handler->GetEvents().size() < 2) {
+        SpinLockPause();
+    }
+
+    ASSERT_EQ("disconnected", handler->GetEvents()[1]);
+}
+
+TEST(TRdmaClientTest, ShouldKeepRetryingAnEndpointCreatedSynchronously)
+{
+    auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+    // never let the connect through, so the endpoint stays in the reconnect
+    // loop for the whole test
+    testContext->AllowConnect = false;
+
+    auto verbs = NVerbs::CreateTestVerbs(testContext);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto clientConfig = std::make_shared<TClientConfig>();
+    clientConfig->MaxReconnectDelay = TDuration::MilliSeconds(100);
+
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+
+    auto client = CreateTestClient(verbs, logging, monitoring, clientConfig);
+    client->Start();
+    Y_DEFER
+    {
+        client->Stop();
+    };
+
+    auto handler = std::make_shared<TTestEndpointHandler>();
+
+    auto result = client->StartEndpoint("::", 10020, handler);
+    ASSERT_FALSE(HasError(result));
+
+    // StartEndpoint would have given up by now and torn the endpoint down;
+    // this one has to keep trying and keep saying so
+    while (handler->GetEvents().empty()) {
+        SpinLockPause();
+    }
+
+    ASSERT_EQ("unavailable", handler->GetEvents()[0]);
+    ASSERT_TRUE(result.GetResult());
 }
 
 }   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/server_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server_ut.cpp
@@ -51,7 +51,7 @@ IServerPtr CreateTestServer(
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TClientHandler
-    : IClientHandler
+    : IClientRequestHandler
 {
     void HandleResponse(
         TClientRequestPtr req,


### PR DESCRIPTION
## [RDMA] Report client endpoint state through a handler, add a synchronous StartEndpoint

Extracted from #5842. RDMA layer only — no consumers
of the new API yet.

### Why

The existing `StartEndpoint` returns a future, which gives up: if the first
connect does not succeed within roughly a minute, the future fails and the
endpoint is torn down. A caller with a working fallback transport wants neither
half of that — it wants the endpoint straight away, and it wants to be told
whenever RDMA becomes usable, breaks, and comes back. A future says each of
those things once.

### What

`IClientEndpointHandler` reports the state of one endpoint — `HandleConnected`,
`HandleDisconnected`, `HandleUnavailable`, no arguments: a handler belongs to
the single endpoint it was given to.

`IClient::StartEndpoint` gains a synchronous overload taking that handler. It
returns `TResultOrError<IClientEndpointPtr>` before the endpoint has connected
and never gives up: an endpoint that cannot connect keeps retrying. The overload
is safe against `-Woverloaded-virtual` — both forms are pure virtual, so every
implementation defines both.

`IClientHandler` becomes `IClientRequestHandler`: with two handler interfaces in
one header the old name distinguished nothing. Mechanical, twelve files.

Callbacks run on the connection manager thread, which drives reconnects for
  every endpoint of the client, so a handler must not block there.

### Issue
Put links to the related issues here
