### PR TITLE
[NBS] Skip only blocks from skipped blobs in AffectedBlocks deletion

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -678,7 +678,7 @@ void ApplyBlobsSkipping(
         }
     }
 
-    THashSet<ui32> skippedBlockIndices;
+    THashSet<TAffectedBlock, TAffectedBlockHash> skippedBlocks;
 
     for (const auto& x: blobsToSkip) {
         auto ab = args.AffectedBlobs.find(x.first);
@@ -688,7 +688,7 @@ void ApplyBlobsSkipping(
             // but it does not cause data corruption - the important thing
             // is to ensure that all skipped indices are added, not that
             // all non-skipped are preserved
-            skippedBlockIndices.insert(affectedBlock.BlockIndex);
+            skippedBlocks.insert(affectedBlock);
         }
         args.AffectedBlobs.erase(ab);
     }
@@ -696,7 +696,7 @@ void ApplyBlobsSkipping(
     if (blobsToSkip.size()) {
         TAffectedBlocks affectedBlocks;
         for (const auto& b: args.AffectedBlocks) {
-            if (!skippedBlockIndices.contains(b.BlockIndex)) {
+            if (!skippedBlocks.contains(b)) {
                 affectedBlocks.push_back(b);
             }
         }

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -206,6 +206,53 @@ TPrepareCompleteResult RunPrepareAndComplete(
 
 Y_UNIT_TEST_SUITE(TApplyBlobsSkippingTest)
 {
+    Y_UNIT_TEST(ShouldRemoveOnlyAffectedBlocksFromSkippedBlobs)
+    {
+        auto state = MakeState(
+            2048,   // blockCount
+            true    // mixedBlocksFilterEnabled
+        );
+
+        auto config = MakeStorageConfig(
+            0,    // diskPrefixLength
+            0);   // targetCompactionBytesPerOp
+
+        const TPartialBlobId mixedBlobId(1, 1, 3, 2 * DefaultBlockSize, 1, 0);
+        const TPartialBlobId mergedBlobId(1, 2, 3, 2 * DefaultBlockSize, 2, 0);
+
+        TTxPartition::TRangeCompaction args(
+            0, TBlockRange32::MakeClosedInterval(0, 2));
+
+        // Keep the older version of block 0 and a different block with the
+        // same commit ID as the skipped blocks.
+        args.MarkBlock(0, CommitId, mixedBlobId, 0, true);
+        args.MarkBlock(2, CommitId + 1, mixedBlobId, 1, true);
+        args.MarkBlock(0, CommitId + 1, mergedBlobId, 0, true);
+        args.MarkBlock(1, CommitId + 1, mergedBlobId, 1, true);
+
+        args.AffectedBlobs[mixedBlobId].IndexKind = EChannelDataKind::Mixed;
+        args.AffectedBlobs[mergedBlobId].IndexKind = EChannelDataKind::Merged;
+
+        ApplyBlobsSkipping(*config, 2, state, args);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, args.BlobsSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(2, args.BlocksSkipped);
+        UNIT_ASSERT_VALUES_EQUAL(1, args.AffectedBlobs.size());
+        UNIT_ASSERT(args.AffectedBlobs.contains(mixedBlobId));
+        UNIT_ASSERT(!args.AffectedBlobs.contains(mergedBlobId));
+
+        UNIT_ASSERT_VALUES_EQUAL(2, args.AffectedBlocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, args.AffectedBlocks[0].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(CommitId, args.AffectedBlocks[0].CommitId);
+        UNIT_ASSERT_VALUES_EQUAL(2, args.AffectedBlocks[1].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(CommitId + 1, args.AffectedBlocks[1].CommitId);
+
+        UNIT_ASSERT(!args.BlockMarks[0].CommitId);
+        UNIT_ASSERT(!args.BlockMarks[1].CommitId);
+        UNIT_ASSERT_VALUES_EQUAL(mixedBlobId, args.BlockMarks[2].BlobId);
+        UNIT_ASSERT_VALUES_EQUAL(CommitId + 1, args.BlockMarks[2].CommitId);
+    }
+
     Y_UNIT_TEST(ShouldNotSkipMixedBlobs)
     {
         auto state = MakeState(

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -128,6 +128,16 @@ struct TAffectedBlock
 {
     ui32 BlockIndex = 0;
     ui64 CommitId = 0;
+
+    auto operator<=>(const TAffectedBlock&) const = default;
+};
+
+struct TAffectedBlockHash
+{
+    size_t operator()(const TAffectedBlock& block) const
+    {
+        return MultiHash(block.BlockIndex, block.CommitId);
+    }
 };
 
 using TAffectedBlocks = TVector<TAffectedBlock>;


### PR DESCRIPTION
AffectedBlocks are candidates for early deletion from the mixed index. If there are no concurrent reads and the block is not under any snapshot, we will delete such a block. Before my changes, we were deleting all blocks from the affected ones that intersected with the skipped ones and blocks from skipped blocks. This was redundant because all the blocks from blobs that were compacted were not visible to reads after compaction and could be safely deleted. So now, I delete only the blocks that were skipped from the AffectedBlocks list.
