### PR TITLE
[NBS]: Fix vhost server shutdown race

### DIFF
--- a/cloud/blockstore/vhost-server/server.cpp
+++ b/cloud/blockstore/vhost-server/server.cpp
@@ -178,10 +178,18 @@ void TServer::Start(const TOptions& options)
 
 void TServer::Stop()
 {
+    // Make consecutive repeated Stop() calls safe
+    if (!Handler) {
+        return;
+    }
+
+    auto* handler = Handler;
+    Handler = nullptr;
+
     STORAGE_INFO("Stopping the server");
 
     auto promise = NewPromise();
-    vhd_unregister_blockdev(Handler, [] (void* opaque) {
+    vhd_unregister_blockdev(handler, [] (void* opaque) {
         static_cast<TPromise<void>*>(opaque)->SetValue();
     }, &promise);
 

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -1513,10 +1513,15 @@ TEST_P(TSlowEncryptorServerTest, ShouldWaitForAllThreadPoolTasksBeforeStop)
     Sleep(TDuration::MilliSeconds(200));
 
     Server->Stop();
+    Server.reset();
 
     EXPECT_EQ(
         TDuration::MilliSeconds(requestCount * 100),
         GetTotalSleepTime());
+
+    ASSERT_TRUE(
+        NThreading::WaitAll(futures).Wait(TDuration::Seconds(5)))
+        << "client did not observe all completed requests";
 
     for (size_t i = 0; i < futures.size(); ++i) {
         ASSERT_TRUE(futures[i].HasValue())
@@ -1529,7 +1534,6 @@ TEST_P(TSlowEncryptorServerTest, ShouldWaitForAllThreadPoolTasksBeforeStop)
     }
 
     Client.DeInit();
-    Server.reset();
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### Notes

Make `TServer::Stop()` safe to call more than once. A failed test assertion can trigger cleanup after the server has already been stopped; the second call must not use the stopped vhost event loop.

The slow encryptor test now destroys the explicitly stopped server and waits for the client futures before checking their values. Server-side worker completion does not guarantee that the client event loop has already published every completion to its future.

The race was exposed by MemorySanitizer in `TSlowEncryptorServerTest.ShouldWaitForAllThreadPoolTasksBeforeStop`.