### PR TITLE
[Blockstore] Run fake root KMS alongside load tests in QEMU

### DIFF
--- a/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/test.py
@@ -16,6 +16,10 @@ from cloud.blockstore.config.disk_pb2 import DEVICE_ERASE_METHOD_NONE,  \
     DISK_AGENT_BACKEND_IO_URING
 
 from cloud.blockstore.tests.python.lib.disk_agent_runner import LocalDiskAgent
+from cloud.blockstore.tests.python.lib.fake_root_kms import (
+    start_fake_root_kms,
+    wait_for_fake_root_kms,
+)
 from cloud.blockstore.tests.python.lib.nbs_runner import LocalNbs
 from cloud.blockstore.tests.python.lib.test_base import thread_count, \
     wait_for_nbs_server, wait_for_disk_agent, run_test, wait_for_secure_erase, \
@@ -30,6 +34,7 @@ from contrib.ydb.tests.library.harness.kikimr_runner import ensure_path_exists, 
     get_unique_path_for_current_test
 
 import yatest.common as yatest_common
+from yatest.common.network import PortManager
 
 DEFAULT_BLOCK_SIZE = 4096
 DEFAULT_DEVICE_COUNT = 8
@@ -395,9 +400,32 @@ if SELECTED_BACKEND:
     BACKENDS = [backend for backend in BACKENDS if backend.id == SELECTED_BACKEND]
 
 
+@pytest.fixture
+def root_kms(test_case, monkeypatch):
+    if not test_case.root_kms_encryption:
+        yield
+        return
+
+    # Run alongside NBS, including when pytest executes inside QEMU.
+    working_dir = get_unique_path_for_current_test(
+        output_path=yatest_common.output_path(),
+        sub_folder="root_kms")
+    with PortManager() as pm:
+        port = pm.get_port()
+        process, environment = start_fake_root_kms(working_dir, port)
+        try:
+            wait_for_fake_root_kms(process, port)
+            for name, value in environment.items():
+                monkeypatch.setenv(name, value)
+            yield
+        finally:
+            process.terminate()
+            process.wait(check_exit_code=False, timeout=10)
+
+
 @pytest.mark.parametrize("test_case", TESTS, ids=[x.name for x in TESTS])
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_load(test_case, backend):
+def test_load(test_case, backend, root_kms):
     test_case.config_path = yatest_common.source_path(test_case.config_path)
     if test_case.lwtrace_query_path:
         test_case.lwtrace_query_path = yatest_common.source_path(test_case.lwtrace_query_path)

--- a/cloud/blockstore/tests/loadtest/local-nonrepl/ya.make.inc
+++ b/cloud/blockstore/tests/loadtest/local-nonrepl/ya.make.inc
@@ -45,4 +45,4 @@ REQUIREMENTS(
 FORK_SUBTESTS()
 SPLIT_FACTOR(4)
 
-INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/fake-root-kms/recipe.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/fake-root-kms/dependencies.inc)

--- a/cloud/blockstore/tests/python/lib/fake_root_kms.py
+++ b/cloud/blockstore/tests/python/lib/fake_root_kms.py
@@ -1,0 +1,61 @@
+import json
+import os
+import socket
+
+import yatest.common as common
+
+
+def start_fake_root_kms(working_dir, port):
+    binary_path = common.binary_path(
+        "cloud/blockstore/tools/testing/fake-root-kms/fake-root-kms")
+    os.makedirs(working_dir, exist_ok=True)
+
+    certs_dir = common.source_path(
+        'cloud/blockstore/tests/recipes/fake-root-kms/certs')
+
+    ca = os.path.join(certs_dir, 'ca.crt')
+
+    config = {
+        'port': port,
+        'ca': ca,
+        'server_cert': os.path.join(certs_dir, 'server.crt'),
+        'server_key': os.path.join(certs_dir, 'server.key'),
+        'keys': {
+            'nbs': os.path.join(certs_dir, 'nbs.key')
+        }
+    }
+
+    config_path = os.path.join(working_dir, "config.txt")
+
+    with open(config_path, "w") as f:
+        json.dump(config, f)
+
+    root_kms = common.execute(
+        command=[binary_path, '--config-path', config_path],
+        cwd=working_dir,
+        stdout=os.path.join(working_dir, "out.txt"),
+        stderr=os.path.join(working_dir, "err.txt"),
+        wait=False,
+    )
+
+    environment = {
+        "FAKE_ROOT_KMS_PORT": str(port),
+        "FAKE_ROOT_KMS_CA": ca,
+        "FAKE_ROOT_KMS_CLIENT_CRT": os.path.join(certs_dir, 'client.crt'),
+        "FAKE_ROOT_KMS_CLIENT_KEY": os.path.join(certs_dir, 'client.key'),
+    }
+    return root_kms, environment
+
+
+def wait_for_fake_root_kms(process, port):
+    def ready():
+        if not process.running:
+            process.wait()
+            raise RuntimeError("fake-root-kms exited before becoming ready")
+        try:
+            with socket.create_connection(("localhost", port), timeout=1):
+                return True
+        except OSError:
+            return False
+
+    common.wait_for(ready, timeout=30)

--- a/cloud/blockstore/tests/python/lib/ya.make
+++ b/cloud/blockstore/tests/python/lib/ya.make
@@ -26,6 +26,7 @@ PY_SRCS(
     daemon.py
     disk_agent_runner.py
     endpoints.py
+    fake_root_kms.py
     loadtest_env.py
     nbs_http_proxy.py
     nbs_runner.py

--- a/cloud/blockstore/tests/recipes/fake-root-kms/__main__.py
+++ b/cloud/blockstore/tests/recipes/fake-root-kms/__main__.py
@@ -1,9 +1,9 @@
-import json
 import os
 
 import yatest.common as common
 import yatest.common.network as network
 
+from cloud.blockstore.tests.python.lib.fake_root_kms import start_fake_root_kms
 from cloud.tasks.test.common.processes import register_process, kill_processes
 
 from library.python.testing.recipe import declare_recipe, set_env
@@ -17,9 +17,6 @@ def start(argv):
     pm = network.PortManager()
     port = pm.get_port()
 
-    binary_path = common.binary_path(
-        "cloud/blockstore/tools/testing/fake-root-kms/fake-root-kms")
-
     try:
         test_name = common.context.test_name or ''
         test_name = test_name.translate(str.maketrans({':': '_', '/': '_'}))
@@ -29,40 +26,11 @@ def start(argv):
     working_dir = os.path.join(common.output_path(), test_name, "root_kms")
     os.makedirs(working_dir, exist_ok=True)
 
-    certs_dir = common.source_path(
-        'cloud/blockstore/tests/recipes/fake-root-kms/certs')
-
-    ca = os.path.join(certs_dir, 'ca.crt')
-
-    config = {
-        'port': port,
-        'ca': ca,
-        'server_cert': os.path.join(certs_dir, 'server.crt'),
-        'server_key': os.path.join(certs_dir, 'server.key'),
-        'keys': {
-            'nbs': os.path.join(certs_dir, 'nbs.key')
-        }
-    }
-
-    config_path = os.path.join(working_dir, "config.txt")
-
-    with open(config_path, "w") as f:
-        json.dump(config, f)
-
-    root_kms = common.execute(
-        command=[binary_path, '--config-path', config_path],
-        cwd=working_dir,
-        stdout=os.path.join(working_dir, "out.txt"),
-        stderr=os.path.join(working_dir, "err.txt"),
-        wait=False,
-    )
-
+    root_kms, environment = start_fake_root_kms(working_dir, port)
     register_process(SERVICE_NAME, root_kms.process.pid)
 
-    set_env("FAKE_ROOT_KMS_PORT", str(port))
-    set_env("FAKE_ROOT_KMS_CA", ca)
-    set_env("FAKE_ROOT_KMS_CLIENT_CRT", os.path.join(certs_dir, 'client.crt'))
-    set_env("FAKE_ROOT_KMS_CLIENT_KEY", os.path.join(certs_dir, 'client.key'))
+    for name, value in environment.items():
+        set_env(name, value)
 
 
 def stop(argv):

--- a/cloud/blockstore/tests/recipes/fake-root-kms/dependencies.inc
+++ b/cloud/blockstore/tests/recipes/fake-root-kms/dependencies.inc
@@ -1,0 +1,15 @@
+DEPENDS(
+    cloud/blockstore/tools/testing/fake-root-kms
+)
+
+PEERDIR(
+)
+
+DATA(
+    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/ca.crt
+    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/server.crt
+    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/server.key
+    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/client.crt
+    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/client.key
+    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/nbs.key
+)

--- a/cloud/blockstore/tests/recipes/fake-root-kms/recipe.inc
+++ b/cloud/blockstore/tests/recipes/fake-root-kms/recipe.inc
@@ -1,18 +1,7 @@
 DEPENDS(
     cloud/blockstore/tests/recipes/fake-root-kms
-    cloud/blockstore/tools/testing/fake-root-kms
 )
 
-PEERDIR(
-)
-
-DATA(
-    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/ca.crt
-    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/server.crt
-    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/server.key
-    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/client.crt
-    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/client.key
-    arcadia/cloud/blockstore/tests/recipes/fake-root-kms/certs/nbs.key
-)
+INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/fake-root-kms/dependencies.inc)
 
 USE_RECIPE(cloud/blockstore/tests/recipes/fake-root-kms/fake-root-kms ${RECIPE_ARGS})


### PR DESCRIPTION
### Notes

Start fake-root-kms from a pytest fixture before creating NBS in the local nonreplicated load tests. When pytest runs inside QEMU (in arcadia sandbox  for example), the mock now runs in the same VM and is reachable through localhost.

The fixture starts the mock only for Root KMS encryption scenarios, waits for its listening port, supplies its address and certificate paths through the existing environment variables, and stops the process during teardown.

### Issue

Test `embedded-io-uring` with load-root-kms-encryption scenario starts the mock through a host-side recipe, while NBS runs inside QEMU and connects to localhost:24041 inside the guest. CreateVolume fails after five minutes of retries:

```text
E_RETRY_TIMEOUT Retry timeout: E_GRPC_UNAVAILABLE connections to all backends failing; last error: UNKNOWN: ipv6:%5B::1%5D:24041: Failed to connect to remote host: Connection refused
(retries: 2886, duration: 5m 0s)
```