### PR TITLE
[NBS]: do not report retriable GC errors as critical

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
@@ -247,10 +247,12 @@ void TCollectGarbageActor::NotifyCompleted(
 void TCollectGarbageActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
-        ReportCollectGarbageError(
-            VolumeLabels,
-            TStringBuilder()
-                << "Garbage collection error: " << FormatError(error));
+        if (GetErrorKind(error) != EErrorKind::ErrorRetriable) {
+            ReportCollectGarbageError(
+                VolumeLabels,
+                TStringBuilder()
+                    << "Garbage collection error: " << FormatError(error));
+        }
 
         Error = std::move(error);
     }
@@ -498,10 +500,13 @@ void TCollectGarbageHardActor::NotifyCompleted(
 void TCollectGarbageHardActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
-        ReportCollectGarbageError(
-            VolumeLabels,
-            TStringBuilder()
-                << "Hard garbage collection error: " << FormatError(error));
+        if (GetErrorKind(error) != EErrorKind::ErrorRetriable) {
+            ReportCollectGarbageError(
+                VolumeLabels,
+                TStringBuilder()
+                    << "Hard garbage collection error: " << FormatError(error));
+        }
+
         Error = std::move(error);
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -8582,89 +8582,90 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT(deleteGarbageObserved);
     }
 
-    void DoShouldNotReportCriticalEventForRetriableCollectGarbageError(
-        bool isHardGarbageCollection)
+    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableCollectGarbageError)
     {
+        const auto channelCount = 6;
+        const auto groupCount = channelCount - DataChannelOffset;
+
         auto config = DefaultConfig();
         config.SetDontEnqueueCollectGarbageUponPartitionStartup(true);
 
-        if (!isHardGarbageCollection) {
-            const auto channelCount = 6;
-            const auto groupCount = channelCount - DataChannelOffset;
+        TTestEnv env(0, 1, channelCount, groupCount);
+        auto& runtime = env.GetRuntime();
+        const auto tabletId =
+            InitTestActorRuntime(env, runtime, channelCount, channelCount, config);
 
-            TTestEnv env(0, 1, channelCount, groupCount);
-            auto& runtime = env.GetRuntime();
-            const auto tabletId =
-                InitTestActorRuntime(env, runtime, channelCount, channelCount, config);
+        TPartitionClient partition(runtime, 0, tabletId);
+        partition.WaitReady();
 
-            TPartitionClient partition(runtime, 0, tabletId);
-            partition.WaitReady();
+        // Explicitly complete the initial whole-history GC.
+        // After this, the usual CollectGarbageThreshold logic becomes active.
+        partition.CollectGarbage();
 
-            // Explicitly complete the initial whole-history GC.
-            // After this, the usual CollectGarbageThreshold logic becomes active.
-            partition.CollectGarbage();
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
 
-            NMonitoring::TDynamicCountersPtr counters =
-                new NMonitoring::TDynamicCounters();
-            InitCriticalEventsCounter(counters);
+        const auto collectGarbageError = counters->GetCounter(
+            "AppCriticalEvents/CollectGarbageError",
+            true);
 
-            const auto collectGarbageError = counters->GetCounter(
-                "AppCriticalEvents/CollectGarbageError",
-                true);
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
 
-            UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+        bool retriableErrorSent = false;
 
-            bool retriableErrorSent = false;
-
-            runtime.SetObserverFunc(
-                [&](TAutoPtr<IEventHandle>& event)
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionPrivate::EvDeleteGarbageRequest &&
+                    !retriableErrorSent)
                 {
-                    if (event->GetTypeRewrite() ==
-                            TEvPartitionPrivate::EvDeleteGarbageRequest &&
-                        !retriableErrorSent)
-                    {
-                        retriableErrorSent = true;
+                    retriableErrorSent = true;
 
-                        auto response = std::make_unique<
-                            TEvPartitionPrivate::TEvDeleteGarbageResponse>(
-                            MakeError(E_REJECTED, "tablet is shutting down"));
+                    auto response = std::make_unique<
+                        TEvPartitionPrivate::TEvDeleteGarbageResponse>(
+                        MakeError(E_REJECTED, "tablet is shutting down"));
 
-                        runtime.Send(
-                            new IEventHandle(
-                                event->Sender,
-                                event->Recipient,
-                                response.release(),
-                                0,   // flags
-                                event->Cookie),
-                            0);
+                    runtime.Send(
+                        new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0,   // flags
+                            event->Cookie),
+                        0);
 
-                        return TTestActorRuntime::EEventAction::DROP;
-                    }
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
 
-                    return TTestActorRuntime::DefaultObserverFunc(event);
-                });
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
 
-            // One pending blob is below the default automatic GC threshold.
-            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        // One pending blob is below the default automatic GC threshold.
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
 
-            partition.SendCollectGarbageRequest();
-            const auto response = partition.RecvCollectGarbageResponse();
+        partition.SendCollectGarbageRequest();
+        const auto response = partition.RecvCollectGarbageResponse();
 
-            UNIT_ASSERT_C(
-                retriableErrorSent,
-                "EvDeleteGarbageRequest was not intercepted");
+        UNIT_ASSERT_C(
+            retriableErrorSent,
+            "EvDeleteGarbageRequest was not intercepted");
 
-            // The error must still be returned to the caller.
-            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
-            UNIT_ASSERT_VALUES_EQUAL(
-                "tablet is shutting down",
-                response->GetErrorReason());
+        // The error must still be returned to the caller.
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "tablet is shutting down",
+            response->GetErrorReason());
 
-            // But a retriable error must not produce a critical event.
-            UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+        // But a retriable error must not produce a critical event.
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+    }
 
-            return;
-        }
+    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableHardCollectGarbageError)
+    {
+        auto config = DefaultConfig();
+        config.SetDontEnqueueCollectGarbageUponPartitionStartup(true);
 
         auto runtime = PrepareTestActorRuntime(config);
 
@@ -8738,26 +8739,13 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             HTTP_METHOD::HTTP_METHOD_POST);
 
         // Check that the simulated error reached the caller.
-        UNIT_ASSERT_C(
-            retriableErrorSent,
-            "EvCollectGarbage was not intercepted");
-
+        UNIT_ASSERT(retriableErrorSent);
         UNIT_ASSERT_C(
             httpResponse->Html.Contains("NOTREADY"),
             httpResponse->Html);
 
         // Hard GC must not report a retriable failure as critical either.
         UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
-    }
-
-    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableCollectGarbageError)
-    {
-        DoShouldNotReportCriticalEventForRetriableCollectGarbageError(false);
-    }
-
-    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableHardCollectGarbageError)
-    {
-        DoShouldNotReportCriticalEventForRetriableCollectGarbageError(true);
     }
 
     Y_UNIT_TEST(ShouldExecuteCollectGarbageAtStartup)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -8582,90 +8582,89 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT(deleteGarbageObserved);
     }
 
-    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableCollectGarbageError)
+    void DoShouldNotReportCriticalEventForRetriableCollectGarbageError(
+        bool isHardGarbageCollection)
     {
-        const auto channelCount = 6;
-        const auto groupCount = channelCount - DataChannelOffset;
-
         auto config = DefaultConfig();
         config.SetDontEnqueueCollectGarbageUponPartitionStartup(true);
 
-        TTestEnv env(0, 1, channelCount, groupCount);
-        auto& runtime = env.GetRuntime();
-        const auto tabletId =
-            InitTestActorRuntime(env, runtime, channelCount, channelCount, config);
+        if (!isHardGarbageCollection) {
+            const auto channelCount = 6;
+            const auto groupCount = channelCount - DataChannelOffset;
 
-        TPartitionClient partition(runtime, 0, tabletId);
-        partition.WaitReady();
+            TTestEnv env(0, 1, channelCount, groupCount);
+            auto& runtime = env.GetRuntime();
+            const auto tabletId =
+                InitTestActorRuntime(env, runtime, channelCount, channelCount, config);
 
-        // Explicitly complete the initial whole-history GC.
-        // After this, the usual CollectGarbageThreshold logic becomes active.
-        partition.CollectGarbage();
+            TPartitionClient partition(runtime, 0, tabletId);
+            partition.WaitReady();
 
-        NMonitoring::TDynamicCountersPtr counters =
-            new NMonitoring::TDynamicCounters();
-        InitCriticalEventsCounter(counters);
+            // Explicitly complete the initial whole-history GC.
+            // After this, the usual CollectGarbageThreshold logic becomes active.
+            partition.CollectGarbage();
 
-        const auto collectGarbageError = counters->GetCounter(
-            "AppCriticalEvents/CollectGarbageError",
-            true);
+            NMonitoring::TDynamicCountersPtr counters =
+                new NMonitoring::TDynamicCounters();
+            InitCriticalEventsCounter(counters);
 
-        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+            const auto collectGarbageError = counters->GetCounter(
+                "AppCriticalEvents/CollectGarbageError",
+                true);
 
-        bool retriableErrorSent = false;
+            UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
 
-        runtime.SetObserverFunc(
-            [&](TAutoPtr<IEventHandle>& event)
-            {
-                if (event->GetTypeRewrite() ==
-                        TEvPartitionPrivate::EvDeleteGarbageRequest &&
-                    !retriableErrorSent)
+            bool retriableErrorSent = false;
+
+            runtime.SetObserverFunc(
+                [&](TAutoPtr<IEventHandle>& event)
                 {
-                    retriableErrorSent = true;
+                    if (event->GetTypeRewrite() ==
+                            TEvPartitionPrivate::EvDeleteGarbageRequest &&
+                        !retriableErrorSent)
+                    {
+                        retriableErrorSent = true;
 
-                    auto response = std::make_unique<
-                        TEvPartitionPrivate::TEvDeleteGarbageResponse>(
-                        MakeError(E_REJECTED, "tablet is shutting down"));
+                        auto response = std::make_unique<
+                            TEvPartitionPrivate::TEvDeleteGarbageResponse>(
+                            MakeError(E_REJECTED, "tablet is shutting down"));
 
-                    runtime.Send(
-                        new IEventHandle(
-                            event->Sender,
-                            event->Recipient,
-                            response.release(),
-                            0,   // flags
-                            event->Cookie),
-                        0);
+                        runtime.Send(
+                            new IEventHandle(
+                                event->Sender,
+                                event->Recipient,
+                                response.release(),
+                                0,   // flags
+                                event->Cookie),
+                            0);
 
-                    return TTestActorRuntime::EEventAction::DROP;
-                }
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
 
-                return TTestActorRuntime::DefaultObserverFunc(event);
-            });
+                    return TTestActorRuntime::DefaultObserverFunc(event);
+                });
 
-        // One pending blob is below the default automatic GC threshold.
-        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+            // One pending blob is below the default automatic GC threshold.
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
 
-        partition.SendCollectGarbageRequest();
-        const auto response = partition.RecvCollectGarbageResponse();
+            partition.SendCollectGarbageRequest();
+            const auto response = partition.RecvCollectGarbageResponse();
 
-        UNIT_ASSERT_C(
-            retriableErrorSent,
-            "EvDeleteGarbageRequest was not intercepted");
+            UNIT_ASSERT_C(
+                retriableErrorSent,
+                "EvDeleteGarbageRequest was not intercepted");
 
-        // The error must still be returned to the caller.
-        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
-        UNIT_ASSERT_VALUES_EQUAL(
-            "tablet is shutting down",
-            response->GetErrorReason());
+            // The error must still be returned to the caller.
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "tablet is shutting down",
+                response->GetErrorReason());
 
-        // But a retriable error must not produce a critical event.
-        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
-    }
+            // But a retriable error must not produce a critical event.
+            UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
 
-    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableHardCollectGarbageError)
-    {
-        auto config = DefaultConfig();
-        config.SetDontEnqueueCollectGarbageUponPartitionStartup(true);
+            return;
+        }
 
         auto runtime = PrepareTestActorRuntime(config);
 
@@ -8739,13 +8738,26 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             HTTP_METHOD::HTTP_METHOD_POST);
 
         // Check that the simulated error reached the caller.
-        UNIT_ASSERT(retriableErrorSent);
+        UNIT_ASSERT_C(
+            retriableErrorSent,
+            "EvCollectGarbage was not intercepted");
+
         UNIT_ASSERT_C(
             httpResponse->Html.Contains("NOTREADY"),
             httpResponse->Html);
 
         // Hard GC must not report a retriable failure as critical either.
         UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+    }
+
+    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableCollectGarbageError)
+    {
+        DoShouldNotReportCriticalEventForRetriableCollectGarbageError(false);
+    }
+
+    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableHardCollectGarbageError)
+    {
+        DoShouldNotReportCriticalEventForRetriableCollectGarbageError(true);
     }
 
     Y_UNIT_TEST(ShouldExecuteCollectGarbageAtStartup)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -8582,6 +8582,172 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT(deleteGarbageObserved);
     }
 
+    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableCollectGarbageError)
+    {
+        const auto channelCount = 6;
+        const auto groupCount = channelCount - DataChannelOffset;
+
+        auto config = DefaultConfig();
+        config.SetDontEnqueueCollectGarbageUponPartitionStartup(true);
+
+        TTestEnv env(0, 1, channelCount, groupCount);
+        auto& runtime = env.GetRuntime();
+        const auto tabletId =
+            InitTestActorRuntime(env, runtime, channelCount, channelCount, config);
+
+        TPartitionClient partition(runtime, 0, tabletId);
+        partition.WaitReady();
+
+        // Explicitly complete the initial whole-history GC.
+        // After this, the usual CollectGarbageThreshold logic becomes active.
+        partition.CollectGarbage();
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+
+        const auto collectGarbageError = counters->GetCounter(
+            "AppCriticalEvents/CollectGarbageError",
+            true);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+
+        bool retriableErrorSent = false;
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionPrivate::EvDeleteGarbageRequest &&
+                    !retriableErrorSent)
+                {
+                    retriableErrorSent = true;
+
+                    auto response = std::make_unique<
+                        TEvPartitionPrivate::TEvDeleteGarbageResponse>(
+                        MakeError(E_REJECTED, "tablet is shutting down"));
+
+                    runtime.Send(
+                        new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0,   // flags
+                            event->Cookie),
+                        0);
+
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        // One pending blob is below the default automatic GC threshold.
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+
+        partition.SendCollectGarbageRequest();
+        const auto response = partition.RecvCollectGarbageResponse();
+
+        UNIT_ASSERT_C(
+            retriableErrorSent,
+            "EvDeleteGarbageRequest was not intercepted");
+
+        // The error must still be returned to the caller.
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "tablet is shutting down",
+            response->GetErrorReason());
+
+        // But a retriable error must not produce a critical event.
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+    }
+
+    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableHardCollectGarbageError)
+    {
+        auto config = DefaultConfig();
+        config.SetDontEnqueueCollectGarbageUponPartitionStartup(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // Finish any startup work before installing the observer. This is
+        // particularly relevant for partition v1, where startup GC is enabled.
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+
+        const auto collectGarbageError = counters->GetCounter(
+            "AppCriticalEvents/CollectGarbageError",
+            true);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+
+        bool retriableErrorSent = false;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvBlobStorage::EvCollectGarbage &&
+                    !retriableErrorSent)
+                {
+                    const auto* request =
+                        event->Get<TEvBlobStorage::TEvCollectGarbage>();
+
+                    if (request->Hard &&
+                        request->Channel == DataChannelOffset)
+                    {
+                        retriableErrorSent = true;
+
+                        // NKikimrProto::NOTREADY is classified by GetErrorKind()
+                        // as EErrorKind::ErrorRetriable.
+                        auto response = std::make_unique<
+                            TEvBlobStorage::TEvCollectGarbageResult>(
+                            NKikimrProto::NOTREADY,
+                            0,   // tablet id doesn't matter
+                            0,   // record generation doesn't matter
+                            0,   // per-generation counter doesn't matter
+                            request->Channel);
+
+                        runtime->Send(
+                            new IEventHandle(
+                                event->Sender,
+                                event->Recipient,
+                                response.release(),
+                                0,   // flags
+                                event->Cookie),
+                            0);
+
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        const auto httpResponse = partition.RemoteHttpInfo(
+            BuildRemoteHttpQuery(
+                TestTabletId,
+                {
+                    {"action", "collectGarbage"},
+                    {"type", "hard"},
+                }),
+            HTTP_METHOD::HTTP_METHOD_POST);
+
+        // Check that the simulated error reached the caller.
+        UNIT_ASSERT(retriableErrorSent);
+        UNIT_ASSERT_C(
+            httpResponse->Html.Contains("NOTREADY"),
+            httpResponse->Html);
+
+        // Hard GC must not report a retriable failure as critical either.
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+    }
+
     Y_UNIT_TEST(ShouldExecuteCollectGarbageAtStartup)
     {
         const auto channelCount = 7;

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
@@ -226,10 +226,13 @@ void TCollectGarbageActor::NotifyCompleted(
 void TCollectGarbageActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
-        ReportCollectGarbageError(
-            VolumeLabels,
-            TStringBuilder()
-            << "Garbage collection failed: " << FormatError(error));
+        if (GetErrorKind(error) != EErrorKind::ErrorRetriable) {
+            ReportCollectGarbageError(
+                VolumeLabels,
+                TStringBuilder()
+                    << "Garbage collection failed: " << FormatError(error));
+        }
+
         Error = std::move(error);
     }
 }
@@ -469,10 +472,13 @@ void TCollectGarbageHardActor::NotifyCompleted(
 void TCollectGarbageHardActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
-        ReportCollectGarbageError(
-            VolumeLabels,
-            TStringBuilder()
-            << "Hard garbage collection failed: " << FormatError(error));
+        if (GetErrorKind(error) != EErrorKind::ErrorRetriable) {
+            ReportCollectGarbageError(
+                VolumeLabels,
+                TStringBuilder()
+                    << "Hard garbage collection failed: " << FormatError(error));
+        }
+
         Error = std::move(error);
     }
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -5360,6 +5360,169 @@ Y_UNIT_TEST_SUITE(TPartition2Test)
         UNIT_ASSERT(deleteGarbageObserved);
     }
 
+    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableCollectGarbageError)
+    {
+        const auto channelCount = 6;
+        const auto groupCount = channelCount - DataChannelOffset;
+
+        auto config = DefaultConfig();
+        config.SetDontEnqueueCollectGarbageUponPartitionStartup(true);
+
+        TTestEnv env(0, 1, channelCount, groupCount);
+        auto& runtime = env.GetRuntime();
+        const auto tabletId =
+            InitTestActorRuntime(env, runtime, channelCount, channelCount, config);
+
+        TPartitionClient partition(runtime, 0, tabletId);
+        partition.WaitReady();
+
+        // Explicitly complete the initial whole-history GC.
+        // After this, the usual CollectGarbageThreshold logic becomes active.
+        partition.CollectGarbage();
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+
+        const auto collectGarbageError = counters->GetCounter(
+            "AppCriticalEvents/CollectGarbageError",
+            true);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+
+        bool retriableErrorSent = false;
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionPrivate::EvDeleteGarbageRequest &&
+                    !retriableErrorSent)
+                {
+                    retriableErrorSent = true;
+
+                    auto response = std::make_unique<
+                        TEvPartitionPrivate::TEvDeleteGarbageResponse>(
+                        MakeError(E_REJECTED, "tablet is shutting down"));
+
+                    runtime.Send(
+                        new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0,   // flags
+                            event->Cookie),
+                        0);
+
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        // One pending blob is below the default automatic GC threshold.
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+
+        partition.SendCollectGarbageRequest();
+        const auto response = partition.RecvCollectGarbageResponse();
+
+        UNIT_ASSERT_C(
+            retriableErrorSent,
+            "EvDeleteGarbageRequest was not intercepted");
+
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "tablet is shutting down",
+            response->GetErrorReason());
+
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+    }
+
+    Y_UNIT_TEST(ShouldNotReportCriticalEventForRetriableHardCollectGarbageError)
+    {
+        auto config = DefaultConfig();
+        config.SetDontEnqueueCollectGarbageUponPartitionStartup(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // Finish any startup work before installing the observer. This is
+        // particularly relevant for partition v1, where startup GC is enabled.
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+
+        const auto collectGarbageError = counters->GetCounter(
+            "AppCriticalEvents/CollectGarbageError",
+            true);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+
+        bool retriableErrorSent = false;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvBlobStorage::EvCollectGarbage && !retriableErrorSent)
+                {
+                    const auto* request =
+                        event->Get<TEvBlobStorage::TEvCollectGarbage>();
+
+                    if (request->Hard &&
+                        request->Channel == DataChannelOffset)
+                    {
+                        retriableErrorSent = true;
+
+                        // NKikimrProto::NOTREADY is classified by GetErrorKind()
+                        // as EErrorKind::ErrorRetriable.
+                        auto response = std::make_unique<
+                            TEvBlobStorage::TEvCollectGarbageResult>(
+                            NKikimrProto::NOTREADY,
+                            0,   // tablet id doesn't matter
+                            0,   // record generation doesn't matter
+                            0,   // per-generation counter doesn't matter
+                            request->Channel);
+
+                        runtime->Send(
+                            new IEventHandle(
+                                event->Sender,
+                                event->Recipient,
+                                response.release(),
+                                0,   // flags
+                                event->Cookie),
+                            0);
+
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        const auto httpResponse = partition.RemoteHttpInfo(
+            BuildRemoteHttpQuery(
+                TestTabletId,
+                {
+                    {"action", "collectGarbage"},
+                    {"type", "hard"},
+                }),
+            HTTP_METHOD::HTTP_METHOD_POST);
+
+        // Check that the simulated error reached the caller.
+        UNIT_ASSERT(retriableErrorSent);
+        UNIT_ASSERT_C(
+            httpResponse->Html.Contains("NOTREADY"),
+            httpResponse->Html);
+
+        // Hard GC must not report a retriable failure as critical either.
+        UNIT_ASSERT_VALUES_EQUAL(0, collectGarbageError->Val());
+    }
+
     Y_UNIT_TEST(ShouldExecuteCollectGarbageAtStartup)
     {
         const auto channelCount = 7;


### PR DESCRIPTION
### Notes
Do not report CollectGarbageError as a critical event for retriable errors during regular and hard garbage collection in partition v1 and v2.

Retriable errors are still returned to callers. Unit tests cover E_REJECTED during regular GC and NOTREADY during hard GC.
