### PR TITLE
Keep the volume alive while local allocation waits for secure erase

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_allocate.cpp
@@ -3,8 +3,6 @@
 #include <cloud/blockstore/libs/common/safe_debug_print.h>
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
 
-#include <cloud/storage/core/libs/common/media.h>
-
 #include <util/string/join.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -135,11 +133,7 @@ void TDiskRegistryActor::ExecuteAddDisk(
         &result);
 
     if (args.Error.GetCode() == E_BS_DISK_ALLOCATION_FAILED &&
-        IsDiskRegistryLocalMediaKind(args.MediaKind) &&
-        State->CanAllocateLocalDiskAfterSecureErase(
-            args.AgentIds,
-            args.PoolName,
-            args.BlocksCount * args.BlockSize))
+        result.CanAllocateLocalAfterSecureErase)
     {
         // Note: DM and NBS uses this specific error message to identify this
         // case. Update "createEmptyDiskTask()" and "GetDiagnosticsErrorKind()"

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_destroy.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_destroy.cpp
@@ -198,13 +198,12 @@ void TDiskRegistryActor::HandleListBrokenDisks(
     BLOCKSTORE_DISK_REGISTRY_COUNTER(ListBrokenDisks);
 
     TVector<TString> diskIds;
-    for (const auto& bdi: State->GetBrokenDisks()) {
-        diskIds.push_back(bdi.DiskId);
+    for (const auto& [diskId, tsToDestroy]: State->GetBrokenDisks()) {
+        diskIds.push_back(diskId);
     }
-    auto response = std::make_unique<TEvDiskRegistryPrivate::TEvListBrokenDisksResponse>(
-        std::move(diskIds)
-    );
-    Sort(response->DiskIds.begin(), response->DiskIds.end());
+    auto response =
+        std::make_unique<TEvDiskRegistryPrivate::TEvListBrokenDisksResponse>(
+            std::move(diskIds));
 
     NCloud::Send(ctx, ev->Sender, std::move(response));
 }
@@ -243,9 +242,9 @@ void TDiskRegistryActor::HandleDestroyBrokenDisks(
 
     BrokenDisksDestructionStartTs = ctx.Now();
 
-    for (const auto& info: State->GetBrokenDisks()) {
-        if (info.TsToDestroy < BrokenDisksDestructionStartTs) {
-            DisksBeingDestroyed.push_back(info.DiskId);
+    for (const auto& [diskId, tsToDestroy]: State->GetBrokenDisks()) {
+        if (tsToDestroy < BrokenDisksDestructionStartTs) {
+            DisksBeingDestroyed.push_back(diskId);
         }
     }
 
@@ -259,14 +258,9 @@ void TDiskRegistryActor::HandleDestroyBrokenDisks(
         ctx,
         SelfId(),
         LogTitle,
-        CreateRequestInfo(
-            SelfId(),
-            0,
-            MakeIntrusive<TCallContext>()
-        ),
+        CreateRequestInfo(SelfId(), 0, MakeIntrusive<TCallContext>()),
         Config,
-        DisksBeingDestroyed
-    );
+        DisksBeingDestroyed);
     Actors.insert(actor);
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -1407,11 +1407,11 @@ void TDiskRegistryActor::RenderBrokenDiskList(IOutputStream& out) const
                 }
             }
 
-            for (const auto& x: State->GetBrokenDisks()) {
+            for (const auto& [diskId, tsToDestroy]: State->GetBrokenDisks()) {
                 TABLER() {
-                    TABLED() { DumpDiskLink(out, TabletID(), x.DiskId); }
-                    TABLED() { out << x.TsToDestroy; }
-                    auto it = Find(DisksBeingDestroyed, x.DiskId);
+                    TABLED() { DumpDiskLink(out, TabletID(), diskId); }
+                    TABLED() { out << tsToDestroy; }
+                    auto it = Find(DisksBeingDestroyed, diskId);
 
                     if (it != DisksBeingDestroyed.end()) {
                         TABLED() { out << BrokenDisksDestructionStartTs; }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -18,7 +18,6 @@
 
 #include <util/generic/algorithm.h>
 #include <util/generic/iterator_range.h>
-#include <util/generic/overloaded.h>
 #include <util/generic/size_literals.h>
 #include <util/string/builder.h>
 #include <util/string/join.h>
@@ -267,6 +266,17 @@ auto CollectDirtyDeviceUUIDs(const TVector<TDirtyDevice>& dirtyDevices)
     return uuids;
 }
 
+auto CollectBrokenDisks(const TVector<TBrokenDiskInfo>& brokenDisks)
+{
+    TMap<TString, TInstant> r;
+
+    for (const auto& [diskId, tsToDestroy]: brokenDisks) {
+        r[diskId] = tsToDestroy;
+    }
+
+    return r;
+}
+
 auto CollectAllocatedDevices(const TVector<NProto::TDiskConfig>& disks)
 {
     TVector<std::pair<TString, TString>> r;
@@ -418,7 +428,7 @@ TDiskRegistryState::TDiskRegistryState(
         CollectAllocatedDevices(disks),
         StorageConfig->GetDiskRegistryAlwaysAllocatesLocalDisks(),
         StorageConfig->GetAttachDetachPathsEnabled())
-    , BrokenDisks(std::move(brokenDisks))
+    , BrokenDisks(CollectBrokenDisks(brokenDisks))
     , AutomaticallyReplacedDevices(std::move(automaticallyReplacedDevices))
     , CurrentConfig(std::move(config))
     , NotificationSystem {
@@ -2975,16 +2985,26 @@ NProto::TError TDiskRegistryState::AllocateSimpleDisk(
     const bool isShadowDiskAllocation =
         !checkpointParams.GetCheckpointId().empty();
 
-    auto onError = [&] {
+    auto onError = [&]
+    {
         const bool isNewDisk = disk.Devices.empty();
 
         if (isNewDisk) {
             Disks.erase(params.DiskId);
 
             if (!params.MasterDiskId && !isShadowDiskAllocation) {
-                // failed to allocate storage for the new volume, need to
-                // destroy this volume
-                AddToBrokenDisks(now, db, params.DiskId);
+                if (result->CanAllocateLocalAfterSecureErase) {
+                    // Keep the volume while a local allocation is only waiting
+                    // for secure erase: the volume will retry the allocation.
+                    // Drop the broken marker left by an earlier attempt.
+                    if (BrokenDisks.contains(params.DiskId)) {
+                        DeleteBrokenDisks(db, {params.DiskId});
+                    }
+                } else {
+                    // failed to allocate storage for the new volume, need to
+                    // destroy this volume
+                    AddToBrokenDisks(now, db, params.DiskId);
+                }
             }
         }
     };
@@ -2999,7 +3019,8 @@ NProto::TError TDiskRegistryState::AllocateSimpleDisk(
     result->MuteIOErrors =
         disk.State >= NProto::DISK_STATE_TEMPORARILY_UNAVAILABLE;
 
-    const TDiskPlacementInfo placementInfo = CreateDiskPlacementInfo(disk, params);
+    const TDiskPlacementInfo placementInfo =
+        CreateDiskPlacementInfo(disk, params);
 
     if (placementInfo.PlacementGroupId) {
         auto error = CheckDiskPlacementInfo(placementInfo);
@@ -3073,6 +3094,14 @@ NProto::TError TDiskRegistryState::AllocateSimpleDisk(
     auto allocatedDevices = DeviceList.AllocateDevices(params.DiskId, query);
 
     if (!allocatedDevices) {
+        result->CanAllocateLocalAfterSecureErase =
+            StorageConfig->GetLocalDiskAsyncDeallocationEnabled() &&
+            IsDiskRegistryLocalMediaKind(params.MediaKind) &&
+            CanAllocateLocalDiskAfterSecureErase(
+                params.AgentIds,
+                params.PoolName,
+                requestedSize);
+
         onError();
 
         return MakeError(E_BS_DISK_ALLOCATION_FAILED, TStringBuilder() <<
@@ -3394,7 +3423,7 @@ void TDiskRegistryState::AddToBrokenDisks(
         now + StorageConfig->GetBrokenDiskDestructionDelay()
     };
     db.AddBrokenDisk(brokenDiskInfo);
-    BrokenDisks.push_back(brokenDiskInfo);
+    BrokenDisks[diskId] = brokenDiskInfo.TsToDestroy;
 }
 
 NProto::TDeviceConfig TDiskRegistryState::GetDevice(const TString& id) const
@@ -5099,34 +5128,12 @@ const NProto::TPlacementGroupConfig* TDiskRegistryState::FindPlacementGroup(
 
 void TDiskRegistryState::DeleteBrokenDisks(
     TDiskRegistryDatabase& db,
-    TVector<TDiskId> ids)
+    const TVector<TDiskId>& ids)
 {
     for (const auto& id: ids) {
         db.DeleteBrokenDisk(id);
+        BrokenDisks.erase(id);
     }
-
-    Sort(ids);
-    SortBy(BrokenDisks, [] (const auto& d) {
-        return d.DiskId;
-    });
-
-    TVector<TBrokenDiskInfo> newList;
-
-    std::set_difference(
-        BrokenDisks.begin(),
-        BrokenDisks.end(),
-        ids.begin(),
-        ids.end(),
-        std::back_inserter(newList),
-        TOverloaded {
-            [] (const TBrokenDiskInfo& lhs, const auto& rhs) {
-                return lhs.DiskId < rhs;
-            },
-            [] (const auto& lhs, const auto& rhs) {
-                return lhs < rhs.DiskId;
-            }});
-
-    BrokenDisks.swap(newList);
 }
 
 ui64 TDiskRegistryState::UpdateAndReallocateDisk(
@@ -7236,10 +7243,10 @@ NProto::TDiskRegistryStateBackup TDiskRegistryState::BackupState() const
         return dd;
     });
 
-    transform(BrokenDisks, backup.MutableBrokenDisks(), [] (auto& x) {
+    transform(BrokenDisks, backup.MutableBrokenDisks(), [] (auto& kv) {
         NProto::TDiskRegistryStateBackup::TBrokenDiskInfo info;
-        info.SetDiskId(x.DiskId);
-        info.SetTsToDestroy(x.TsToDestroy.MicroSeconds());
+        info.SetDiskId(kv.first);
+        info.SetTsToDestroy(kv.second.MicroSeconds());
 
         return info;
     });

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -300,6 +300,7 @@ class TDiskRegistryState
 
     using TCheckpoints = THashMap<TCheckpointId, TCheckpointInfo>;
     using TPlacementGroups = THashMap<TString, TPlacementGroupInfo>;
+    using TBrokenDisks = TMap<TDiskId, TInstant>;
 
 private:
     TLog Log;
@@ -318,7 +319,7 @@ private:
     TDeviceOverrides DeviceOverrides;
     TCheckpoints Checkpoints;
     TPlacementGroups PlacementGroups;
-    TVector<TBrokenDiskInfo> BrokenDisks;
+    TBrokenDisks BrokenDisks;
 
     TDeque<TAutomaticallyReplacedDeviceInfo> AutomaticallyReplacedDevices;
     THashSet<TDeviceId> AutomaticallyReplacedDeviceIds;
@@ -426,6 +427,11 @@ public:
         NProto::EVolumeIOMode IOMode = {};
         TInstant IOModeTs;
         bool MuteIOErrors = false;
+
+        // Only meaningful when the allocation failed with
+        // E_BS_DISK_ALLOCATION_FAILED: set when it is a local disk allocation
+        // that can succeed once the dirty devices are securely erased.
+        bool CanAllocateLocalAfterSecureErase = false;
     };
 
     struct TAllocateCheckpointResult: public TAllocateDiskResult
@@ -574,14 +580,14 @@ public:
     }
     const NProto::TPlacementGroupConfig* FindPlacementGroup(const TString& groupId) const;
 
-    const TVector<TBrokenDiskInfo>& GetBrokenDisks() const
+    const TBrokenDisks& GetBrokenDisks() const
     {
         return BrokenDisks;
     }
 
     void DeleteBrokenDisks(
         TDiskRegistryDatabase& db,
-        TVector<TDiskId> ids);
+        const TVector<TDiskId>& ids);
 
     const THashMap<TString, ui64>& GetDisksToReallocate() const;
     ui64 AddReallocateRequest(TDiskRegistryDatabase& db, const TString& diskId);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -3217,10 +3217,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
                 error.GetMessage());
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetBrokenDisks().size());
-            UNIT_ASSERT_VALUES_EQUAL("disk-4", state.GetBrokenDisks()[0].DiskId);
+            UNIT_ASSERT(state.GetBrokenDisks().contains("disk-4"));
             UNIT_ASSERT_VALUES_EQUAL(
                 TInstant::Seconds(105),
-                state.GetBrokenDisks()[0].TsToDestroy
+                state.GetBrokenDisks().at("disk-4")
             );
 
             error = AllocateDisk(
@@ -3238,22 +3238,48 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
                 error.GetMessage());
 
-            auto brokenDisks = state.GetBrokenDisks();
-            SortBy(brokenDisks, [] (const auto& info) {
-                return info.DiskId;
-            });
+            const auto& brokenDisks = state.GetBrokenDisks();
 
             UNIT_ASSERT_VALUES_EQUAL(2, brokenDisks.size());
-            UNIT_ASSERT_VALUES_EQUAL("disk-4", brokenDisks[0].DiskId);
+            UNIT_ASSERT(brokenDisks.contains("disk-4"));
             UNIT_ASSERT_VALUES_EQUAL(
                 TInstant::Seconds(105),
-                brokenDisks[0].TsToDestroy
+                brokenDisks.at("disk-4")
             );
-            UNIT_ASSERT_VALUES_EQUAL("disk-5", brokenDisks[1].DiskId);
+            UNIT_ASSERT(brokenDisks.contains("disk-5"));
             UNIT_ASSERT_VALUES_EQUAL(
                 TInstant::Seconds(106),
-                brokenDisks[1].TsToDestroy
+                brokenDisks.at("disk-5")
             );
+
+            // Marking a disk broken twice must not duplicate it: the
+            // BrokenDisks table is keyed by DiskId, so the in-memory list has
+            // to be keyed the same way. The destruction deadline moves
+            // forward, just like db.AddBrokenDisk does.
+            error = AllocateDisk(
+                db,
+                state,
+                "disk-5",
+                "group-1",
+                0,
+                10_GB,
+                devices,
+                TInstant::Seconds(110)
+            );
+            UNIT_ASSERT_VALUES_EQUAL(E_BS_RESOURCE_EXHAUSTED, error.GetCode());
+
+            UNIT_ASSERT_VALUES_EQUAL(2, brokenDisks.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                TInstant::Seconds(115),
+                brokenDisks.at("disk-5")
+            );
+        });
+
+        executor.ReadTx([&] (TDiskRegistryDatabase db) {
+            // ... and the LocalDB agrees.
+            TVector<TBrokenDiskInfo> diskInfos;
+            UNIT_ASSERT(db.ReadBrokenDisks(diskInfos));
+            UNIT_ASSERT_VALUES_EQUAL(2, diskInfos.size());
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -3265,7 +3291,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
             state.DeleteBrokenDisks(db, {"disk-4"});
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetBrokenDisks().size());
-            UNIT_ASSERT_VALUES_EQUAL("disk-5", state.GetBrokenDisks()[0].DiskId);
+            UNIT_ASSERT(state.GetBrokenDisks().contains("disk-5"));
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -3276,7 +3302,12 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
 
             state.DeleteBrokenDisks(db, {"unknown-1", "unknown-2"});
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetBrokenDisks().size());
-            UNIT_ASSERT_VALUES_EQUAL("disk-5", state.GetBrokenDisks()[0].DiskId);
+            UNIT_ASSERT(state.GetBrokenDisks().contains("disk-5"));
+
+            // Duplicate ids are tolerated.
+            state.DeleteBrokenDisks(db, {"unknown-1", "unknown-1"});
+            UNIT_ASSERT_VALUES_EQUAL(1, state.GetBrokenDisks().size());
+            UNIT_ASSERT(state.GetBrokenDisks().contains("disk-5"));
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
@@ -3351,10 +3382,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
                 error.GetMessage());
             UNIT_ASSERT_VALUES_EQUAL(1, state.GetBrokenDisks().size());
-            UNIT_ASSERT_VALUES_EQUAL("disk-5", state.GetBrokenDisks()[0].DiskId);
+            UNIT_ASSERT(state.GetBrokenDisks().contains("disk-5"));
             UNIT_ASSERT_VALUES_EQUAL(
                 TInstant::Seconds(108),
-                state.GetBrokenDisks()[0].TsToDestroy
+                state.GetBrokenDisks().at("disk-5")
             );
         });
 
@@ -12793,6 +12824,117 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 // Cannot allocate disk of 1 device
                 UNIT_ASSERT(!canAllocateLater(1));
             });
+    }
+
+    void DoTestBrokenLocalDiskWaitingForSecureErase(bool asyncDeallocation)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        constexpr ui64 LocalDeviceSize = 99999997952;   // ~ 93.13 GiB
+        constexpr ui64 LocalDeviceDefaultLogicalBlockSize = 512;   // 512 B
+
+        auto makeLocalDevice = [](const auto* name, const auto* uuid)
+        {
+            return Device(name, uuid) |
+                   WithPool("local-ssd", NProto::DEVICE_POOL_KIND_LOCAL) |
+                   WithTotalSize(
+                       LocalDeviceSize,
+                       LocalDeviceDefaultLogicalBlockSize);
+        };
+
+        auto agentConfig = AgentConfig(
+            1,
+            {
+                makeLocalDevice("NVMELOCAL01", "uuid-1"),
+                makeLocalDevice("NVMELOCAL02", "uuid-2"),
+                makeLocalDevice("NVMELOCAL03", "uuid-3"),
+            });
+        const TVector agents{agentConfig};
+
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithConfig(
+                    [&]
+                    {
+                        auto config = MakeConfig(0, agents);
+
+                        auto* pool = config.AddDevicePoolConfigs();
+                        pool->SetName("local-ssd");
+                        pool->SetKind(NProto::DEVICE_POOL_KIND_LOCAL);
+                        pool->SetAllocationUnit(LocalDeviceSize);
+
+                        return config;
+                    }())
+                .WithStorageConfig(
+                    [&]
+                    {
+                        auto config = CreateDefaultStorageConfigProto();
+                        config.SetNonReplicatedDontSuspendDevices(true);
+                        config.SetLocalDiskAsyncDeallocationEnabled(
+                            asyncDeallocation);
+                        return config;
+                    }())
+                .WithAgents(agents)
+                // One dirty device: allocating all three fails now, but will
+                // succeed once the secure erase finishes.
+                .WithDirtyDevices({TDirtyDevice{"uuid-2", {}}})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                UNIT_ASSERT_SUCCESS(
+                    RegisterAgent(state, db, agentConfig, Now()));
+            });
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                TDiskRegistryState::TAllocateDiskResult result;
+
+                const auto error = state.AllocateDisk(
+                    TInstant::Seconds(100),
+                    db,
+                    TDiskRegistryState::TAllocateDiskParams{
+                        .DiskId = "local0",
+                        .BlockSize = LocalDeviceDefaultLogicalBlockSize,
+                        .BlocksCount = 3 * LocalDeviceSize /
+                                       LocalDeviceDefaultLogicalBlockSize,
+                        .AgentIds = {"agent-1"},
+                        .PoolName = "local-ssd",
+                        .MediaKind = NProto::STORAGE_MEDIA_SSD_LOCAL,
+                    },
+                    &result);
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    E_BS_DISK_ALLOCATION_FAILED,
+                    error.GetCode());
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    asyncDeallocation,
+                    result.CanAllocateLocalAfterSecureErase);
+
+                // Only keeping the volume alive is gated on the flag. With the
+                // feature off we fall back to destroying it.
+                UNIT_ASSERT_VALUES_EQUAL(
+                    asyncDeallocation ? 0 : 1,
+                    state.GetBrokenDisks().size());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    !asyncDeallocation,
+                    state.GetBrokenDisks().contains("local0"));
+            });
+    }
+
+    Y_UNIT_TEST(ShouldNotBreakLocalDiskWaitingForSecureErase)
+    {
+        DoTestBrokenLocalDiskWaitingForSecureErase(true);
+    }
+
+    Y_UNIT_TEST(ShouldBreakLocalDiskWhenAsyncDeallocationIsDisabled)
+    {
+        DoTestBrokenLocalDiskWaitingForSecureErase(false);
     }
 
     Y_UNIT_TEST(ShouldPreserveDeviceModelAfterRegisterAgent)

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -259,7 +259,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
         }
 
         UNIT_ASSERT_VALUES_EQUAL(1, state.GetBrokenDisks().size());
-        UNIT_ASSERT_VALUES_EQUAL("disk-1", state.GetBrokenDisks()[0].DiskId);
+        UNIT_ASSERT(state.GetBrokenDisks().contains("disk-1"));
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) {
             auto dd = state.GetDirtyDevices();

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_allocation.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_allocation.cpp
@@ -1941,8 +1941,10 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                         auto config = CreateDefaultStorageConfig();
                         config.SetNonReplicatedSecureEraseTimeout(Max<ui32>());
                         config.SetNonReplicatedDontSuspendDevices(false);
-                        config.SetQueryAvailableStorageForResumingDevicesEnabled(
-                            true);
+                        config
+                            .SetQueryAvailableStorageForResumingDevicesEnabled(
+                                true);
+                        config.SetLocalDiskAsyncDeallocationEnabled(true);
 
                         return config;
                     }())
@@ -2147,6 +2149,19 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         // Intercept all secure erase requests to keep devices dirty
         TVector<std::unique_ptr<IEventHandle>> secureEraseDeviceRequests;
+        ui32 destroyVolumeRequests = 0;
+        auto countDestroyVolumeRequests =
+            [&](TAutoPtr<IEventHandle>& event)
+        {
+            if (event->GetTypeRewrite() ==
+                    TEvService::EvDestroyVolumeRequest &&
+                event->Recipient == MakeStorageServiceId())
+            {
+                ++destroyVolumeRequests;
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
         runtime->SetObserverFunc(
             [&](TAutoPtr<IEventHandle>& event)
             {
@@ -2160,7 +2175,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                     return TTestActorRuntime::EEventAction::DROP;
                 }
 
-                return TTestActorRuntime::DefaultObserverFunc(event);
+                return countDestroyVolumeRequests(event);
             });
 
         // Disk deallocation to mark all devices as dirty
@@ -2178,6 +2193,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         // Try to allocate disk with dirty devices. We'll get a E_TRY_AGAIN
         const TString diskId = "local0";
+        auto assertNoBrokenDisks = [&]
+        {
+            auto response = diskRegistry.ListBrokenDisks();
+            UNIT_ASSERT_VALUES_EQUAL(0, response->DiskIds.size());
+        };
         auto tryAllocateDisk = [&](bool shouldFail)
         {
             auto request =
@@ -2191,15 +2211,20 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             auto response = diskRegistry.RecvAllocateDiskResponse();
             if (shouldFail) {
                 UNIT_ASSERT(HasError(response->GetError()));
-                UNIT_ASSERT_EQUAL(E_TRY_AGAIN, response->GetStatus());
+                UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
                 return;
             }
             UNIT_ASSERT(!HasError(response->GetError()));
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
         };
-        {
-            auto request =
-                diskRegistry.CreateAllocateDiskRequest(diskId, diskSize);
+
+        // An allocation that no secure erase can satisfy is still broken, even
+        // with async local deallocation enabled. Repeating it must not
+        // duplicate the marker.
+        for (ui32 i = 0; i < 2; ++i) {
+            auto request = diskRegistry.CreateAllocateDiskRequest(
+                diskId,
+                diskSize + LocalDeviceSize);
             request->Record.SetStorageMediaKind(
                 NProto::STORAGE_MEDIA_SSD_LOCAL);
             *request->Record.AddAgentIds() = agents[0].GetAgentId();
@@ -2207,9 +2232,24 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             diskRegistry.SendRequest(std::move(request));
 
             auto response = diskRegistry.RecvAllocateDiskResponse();
-            UNIT_ASSERT(HasError(response->GetError()));
-            UNIT_ASSERT_EQUAL(E_TRY_AGAIN, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_BS_DISK_ALLOCATION_FAILED,
+                response->GetStatus());
+
+            auto brokenDisks = diskRegistry.ListBrokenDisks();
+            UNIT_ASSERT_VALUES_EQUAL(1, brokenDisks->DiskIds.size());
+            UNIT_ASSERT_VALUES_EQUAL(diskId, brokenDisks->DiskIds[0]);
         }
+
+        // Once the request is recoverable after secure erase, its stale broken
+        // marker must be removed before the destruction timer fires.
+        tryAllocateDisk(true);
+        assertNoBrokenDisks();
+
+        runtime->AdvanceCurrentTime(10s);
+        runtime->DispatchEvents({}, 10ms);
+        assertNoBrokenDisks();
+        UNIT_ASSERT_VALUES_EQUAL(0, destroyVolumeRequests);
 
         // Secure erase all devices except one
         runtime->DispatchEvents(
@@ -2223,7 +2263,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                 return options;
             }());
 
-        runtime->SetObserverFunc(TTestActorRuntime::DefaultObserverFunc);
+        runtime->SetObserverFunc(countDestroyVolumeRequests);
 
         UNIT_ASSERT_EQUAL(secureEraseDeviceRequests.size(), 3UL);
         while (secureEraseDeviceRequests.size() != 1) {
@@ -2249,6 +2289,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         // When the last dirty device is clean, we can allocate disk
         tryAllocateDisk(false);
+        assertNoBrokenDisks();
+        UNIT_ASSERT_VALUES_EQUAL(0, destroyVolumeRequests);
     }
 
     Y_UNIT_TEST(ShouldReturnCorrectCapacity)

--- a/cloud/blockstore/tests/local_ssd/test_allocation_retry.py
+++ b/cloud/blockstore/tests/local_ssd/test_allocation_retry.py
@@ -1,0 +1,222 @@
+import os
+import pytest
+import time
+
+from cloud.blockstore.tests.python.lib.test_client import CreateTestClient
+
+from cloud.blockstore.public.sdk.python.client.error import ClientError
+from cloud.blockstore.public.sdk.python.client.error_codes import EResult
+from cloud.blockstore.public.sdk.python.protos import \
+    STORAGE_MEDIA_SSD_LOCAL, STORAGE_MEDIA_SSD_NONREPLICATED
+
+from cloud.blockstore.tests.python.lib.config import NbsConfigurator, \
+    generate_disk_agent_txt
+from cloud.blockstore.tests.python.lib.daemon import start_ydb, start_nbs, \
+    start_disk_agent, get_fqdn
+
+from contrib.ydb.tests.library.harness.kikimr_runner import \
+    get_unique_path_for_current_test, ensure_path_exists
+
+
+BLOCK_SIZE = 4096
+
+# A nonreplicated disk is allocated in units of AllocationUnitNonReplicatedSSD
+# gigabytes, so its devices can't be as small as the local ones.
+NRD_DEVICE_SIZE = 1024**3                   # 1 GiB
+NRD_DEVICE_RAW_SIZE = NRD_DEVICE_SIZE + 4096
+NRD_DEVICE_COUNT = 2
+
+# A local disk has no allocation unit of its own, its pool can be any size.
+LOCAL_POOL_NAME = "local-ssd"
+LOCAL_DEVICE_SIZE = 9 * 1024**2             # 9 MiB
+LOCAL_DEVICE_RAW_SIZE = LOCAL_DEVICE_SIZE + 4096
+LOCAL_DEVICE_COUNT = 2
+
+# Longer than this test can possibly run: the devices reported by the agent are
+# dirty, and postponing their secure erase keeps them that way, so that every
+# allocation below deterministically fails to find a clean device.
+SECURE_ERASE_COOL_DOWN_MS = 10 * 60 * 1000
+
+BROKEN_DISK_DESTRUCTION_DELAY_MS = 2000
+
+NRD_DISK_ID = "nrd0"
+LOCAL_DISK_ID = "local0"
+
+KNOWN_DEVICE_POOLS = {
+    "KnownDevicePools": [
+        {"Kind": "DEVICE_POOL_KIND_DEFAULT",
+            "AllocationUnit": NRD_DEVICE_SIZE},
+        {"Name": LOCAL_POOL_NAME, "Kind": "DEVICE_POOL_KIND_LOCAL",
+            "AllocationUnit": LOCAL_DEVICE_SIZE},
+    ]}
+
+
+@pytest.fixture(name='ydb')
+def start_ydb_cluster():
+
+    ydb_cluster = start_ydb()
+
+    yield ydb_cluster
+
+    ydb_cluster.stop()
+
+
+@pytest.fixture(name='agent_id')
+def get_agent_id():
+    return get_fqdn()
+
+
+@pytest.fixture(name='data_path')
+def create_data_path(tmp_path):
+
+    p = get_unique_path_for_current_test(
+        output_path=tmp_path,
+        sub_folder="data")
+
+    p = os.path.join(p, "dev", "disk", "by-partlabel")
+    ensure_path_exists(p)
+
+    return p
+
+
+@pytest.fixture(name='disk_agent_config')
+def create_disk_agent_config(ydb, data_path):
+    cfg = NbsConfigurator(ydb, 'disk-agent')
+    cfg.generate_default_nbs_configs()
+    cfg.files["disk-agent"] = generate_disk_agent_txt(
+        agent_id='',
+        device_erase_method='DEVICE_ERASE_METHOD_NONE',  # speed up tests
+        storage_discovery_config={
+            "PathConfigs": [{
+                "PathRegExp": f"{data_path}/NVMENBS([0-9]+)",
+                "BlockSize": BLOCK_SIZE,
+                "PoolConfigs": [{
+                    "MinSize": NRD_DEVICE_RAW_SIZE,
+                    "MaxSize": NRD_DEVICE_RAW_SIZE
+                }]}, {
+                "PathRegExp": f"{data_path}/NVMECOMPUTE([0-9]+)",
+                "BlockSize": BLOCK_SIZE,
+                "PoolConfigs": [{
+                    "PoolName": LOCAL_POOL_NAME,
+                    "HashSuffix": "-local",
+                    "MinSize": LOCAL_DEVICE_RAW_SIZE,
+                    "MaxSize": LOCAL_DEVICE_RAW_SIZE
+                }]}
+            ]})
+
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def create_device_files(data_path):
+
+    def create_file(name, size):
+        with open(os.path.join(data_path, name), 'wb') as f:
+            os.truncate(f.fileno(), size)
+
+    for i in range(NRD_DEVICE_COUNT):
+        create_file(f"NVMENBS{i + 1:02}", NRD_DEVICE_RAW_SIZE)
+
+    for i in range(LOCAL_DEVICE_COUNT):
+        create_file(f"NVMECOMPUTE{i + 1:02}", LOCAL_DEVICE_RAW_SIZE)
+
+
+def _wait_for(predicate, description, timeout_sec=60, poll_interval=1):
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(poll_interval)
+
+    assert False, f"timed out waiting for {description}"
+
+
+def _create_nrd_volume(client):
+    client.create_volume(
+        disk_id=NRD_DISK_ID,
+        block_size=BLOCK_SIZE,
+        blocks_count=NRD_DEVICE_SIZE // BLOCK_SIZE,
+        storage_media_kind=STORAGE_MEDIA_SSD_NONREPLICATED)
+
+
+def _create_local_volume(client, agent_id):
+    client.create_volume(
+        disk_id=LOCAL_DISK_ID,
+        block_size=BLOCK_SIZE,
+        blocks_count=LOCAL_DEVICE_COUNT * LOCAL_DEVICE_SIZE // BLOCK_SIZE,
+        storage_media_kind=STORAGE_MEDIA_SSD_LOCAL,
+        storage_pool_name=LOCAL_POOL_NAME,
+        agent_ids=[agent_id])
+
+
+def test_local_disk_allocation_is_retriable(
+        ydb,
+        agent_id,
+        data_path,
+        disk_agent_config):
+
+    nbs_config = NbsConfigurator(ydb)
+    nbs_config.generate_default_nbs_configs()
+
+    nbs_config.files["storage"].NonReplicatedDontSuspendDevices = True
+    nbs_config.files["storage"].AllocationUnitNonReplicatedSSD = \
+        NRD_DEVICE_SIZE // 1024**3
+    nbs_config.files["storage"].LocalDiskAsyncDeallocationEnabled = True
+    nbs_config.files["storage"].CoolDownTimeoutBeforeSecureErase = \
+        SECURE_ERASE_COOL_DOWN_MS
+    nbs_config.files["storage"].BrokenDiskDestructionDelay = \
+        BROKEN_DISK_DESTRUCTION_DELAY_MS
+
+    nbs = start_nbs(nbs_config)
+
+    client = CreateTestClient(f"localhost:{nbs.port}")
+    client.execute_DiskRegistrySetWritableState(State=True)
+    client.update_disk_registry_config(KNOWN_DEVICE_POOLS)
+
+    disk_agent = start_disk_agent(disk_agent_config)
+    assert disk_agent.wait_for_registration()
+
+    client.add_host(agent_id)
+
+    # Every device is dirty and its secure erase won't happen while this test
+    # is running, so nothing can be allocated - neither now nor after a retry
+    # that DR is willing to wait for.
+    client.wait_for_devices_to_be_cleared(
+        expected_dirty_count=NRD_DEVICE_COUNT + LOCAL_DEVICE_COUNT)
+
+    # A nonreplicated disk gets no second chance: DR reports the allocation
+    # failure as is and marks the volume as broken.
+    with pytest.raises(ClientError) as e:
+        _create_nrd_volume(client)
+
+    assert e.value.code == EResult.E_DISK_ALLOCATION_FAILED.value, \
+        str(e.value)
+
+    # ... and the broken volume is destroyed shortly after.
+    _wait_for(
+        lambda: NRD_DISK_ID not in client.list_volumes(),
+        f"{NRD_DISK_ID} to be destroyed")
+
+    # A local disk whose devices are merely waiting for a secure erase is a
+    # different story: the allocation will succeed once the erase is done, so
+    # the client is told to try again instead of being told that the disk is
+    # dead. Repeating the request must not change that.
+    for _ in range(2):
+        with pytest.raises(ClientError) as e:
+            _create_local_volume(client, agent_id)
+
+        assert e.value.code == EResult.E_TRY_AGAIN.value, str(e.value)
+
+        bkp = client.backup_disk_registry_state()
+        assert bkp.get("BrokenDisks", []) == []
+
+    # The volume must survive the broken disk destruction that DR would have
+    # scheduled had it marked the disk as broken.
+    time.sleep(3 * BROKEN_DISK_DESTRUCTION_DELAY_MS / 1000)
+
+    bkp = client.backup_disk_registry_state()
+    assert bkp.get("BrokenDisks", []) == []
+    assert LOCAL_DISK_ID in client.list_volumes()
+
+    disk_agent.kill()
+    nbs.kill()

--- a/cloud/blockstore/tests/local_ssd/ya.make
+++ b/cloud/blockstore/tests/local_ssd/ya.make
@@ -2,7 +2,10 @@ PY3TEST()
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
-TEST_SRCS(test.py)
+TEST_SRCS(
+    test.py
+    test_allocation_retry.py
+)
 
 DEPENDS(
     cloud/blockstore/apps/client


### PR DESCRIPTION
### Notes
Follow-up to #7010.

1) `BrokenDisks` is now a `TMap<TDiskId, TInstant>` instead of a `TVector<TBrokenDiskInfo>`. The LocalDB `BrokenDisks` table is keyed by `DiskId`, so a disk marked broken twice produced two in-memory entries but one row `DeleteBrokenDisks` loses its `set_difference` over a sorted copy and becomes a loop of `erase`, and is now idempotent w.r.t. duplicate ids. 

2) When the `CanAllocateLocalAfterSecureErase` is set, `onError()` keeps the volume instead of marking it broken, and drops a broken marker left by an earlier attempt. Guarded by `LocalDiskAsyncDeallocationEnabled`; with the feature off the old destroy-the-volume behaviour is unchanged.


### Issue
#2945
