### PR TITLE
Filestore: calculate compression only for compaction + zero calculations

### DIFF
--- a/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
@@ -61,8 +61,8 @@ void TWriteDataActor::Bootstrap(const TActorContext& ctx)
 void TWriteDataActor::WriteBlob(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvIndexTabletPrivate::TEvWriteBlobRequest>(
-        RequestInfo->CallContext
-    );
+        RequestInfo->CallContext);
+    request->Mode = TEvIndexTabletPrivate::EWriteBlobMode::Write;
 
     for (auto& blob: Blobs) {
         request->Blobs.emplace_back(blob.BlobId, std::move(blob.BlobContent));

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -308,9 +308,18 @@ struct TEvIndexTabletPrivate
     // WriteBlob
     //
 
+    enum class EWriteBlobMode
+    {
+        Write,
+        Flush,
+        FlushBytes,
+        Compaction,
+    };
+
     struct TWriteBlobRequest
     {
         TVector<TWriteBlob> Blobs;
+        EWriteBlobMode Mode = EWriteBlobMode::Write;
     };
 
     struct TWriteBlobResponse

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -193,8 +193,8 @@ void TCompactionActor::HandleReadBlobResponse(
 void TCompactionActor::WriteBlob(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvIndexTabletPrivate::TEvWriteBlobRequest>(
-        RequestInfo->CallContext
-    );
+        RequestInfo->CallContext);
+    request->Mode = TEvIndexTabletPrivate::EWriteBlobMode::Compaction;
 
     for (const auto& blob: DstBlobs) {
         TString blobContent(Reserve(BlockSize * blob.Blocks.size()));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush.cpp
@@ -110,8 +110,8 @@ void TFlushActor::Bootstrap(const TActorContext& ctx)
 void TFlushActor::WriteBlob(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvIndexTabletPrivate::TEvWriteBlobRequest>(
-        RequestInfo->CallContext
-    );
+        RequestInfo->CallContext);
+    request->Mode = TEvIndexTabletPrivate::EWriteBlobMode::Flush;
 
     for (auto& blob: Blobs) {
         request->Blobs.emplace_back(blob.BlobId, std::move(blob.BlobContent));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -336,8 +336,8 @@ void TFlushBytesActor::HandleReadBlobResponse(
 void TFlushBytesActor::WriteBlob(const TActorContext& ctx)
 {
     auto request = std::make_unique<TEvIndexTabletPrivate::TEvWriteBlobRequest>(
-        RequestInfo->CallContext
-    );
+        RequestInfo->CallContext);
+    request->Mode = TEvIndexTabletPrivate::EWriteBlobMode::FlushBytes;
 
     for (const auto& blob: DstBlobs) {
         TString blobContent(Reserve(BlockSize * blob.Blocks.size()));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writeblob.cpp
@@ -311,7 +311,9 @@ void TIndexTabletActor::HandleWriteBlob(
         }
 
         const auto compRate = Config->GetBlobCompressionRate();
-        if (BlobCodec && compRate && blob.BlobId.GetHash() % compRate == 0) {
+        if (msg->Mode == TEvIndexTabletPrivate::EWriteBlobMode::Compaction &&
+            BlobCodec && compRate && blob.BlobId.GetHash() % compRate == 0)
+        {
             size_t compressedSize = 0;
 
             const auto chunkSize = Config->GetBlobCompressionChunkSize();
@@ -334,6 +336,9 @@ void TIndexTabletActor::HandleWriteBlob(
                 std::memory_order_relaxed);
             Metrics->CompressedBytesWritten.fetch_add(
                 compressedSize,
+                std::memory_order_relaxed);
+            Metrics->ZeroBytesWritten.fetch_add(
+                Count(data, '\0'),
                 std::memory_order_relaxed);
         }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -372,6 +372,9 @@ void TTabletMetrics::Register(
     REGISTER_AGGREGATABLE_SUM(
         CompressedBytesWritten,
         EMetricType::MT_DERIVATIVE);
+    REGISTER_AGGREGATABLE_SUM(
+        ZeroBytesWritten,
+        EMetricType::MT_DERIVATIVE);
 
 #define FILESTORE_TABLET_METRICS_REGISTER_REQUEST(name, ...)                   \
     AggregatableFsRegistry->Register(                                          \

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -252,6 +252,7 @@ struct TTabletMetrics: TAtomicRefCount<TTabletMetrics>
     // Blob compression stats
     std::atomic<i64> UncompressedBytesWritten{0};
     std::atomic<i64> CompressedBytesWritten{0};
+    std::atomic<i64> ZeroBytesWritten{0};
 
     // HandleStatsByNode size stats
     std::atomic<i64> HandleStatsByNodeMaxSize{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -748,7 +748,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
         UNIT_ASSERT_DOUBLES_EQUAL(sz, (network * reportInterval), sz / 100);
     }
 
-    Y_UNIT_TEST(ShouldReportCompressionMetrics)
+    Y_UNIT_TEST(ShouldReportCompressionMetricsForCompaction)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetBlobCompressionRate(1);
@@ -768,31 +768,69 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
 
         tablet.WriteData(handle, 0, 100_KB, 'a');
 
-        TTestRegistryVisitor visitor;
-        registry->Visit(TInstant::Zero(), visitor);
-        visitor.ValidateExpectedCounters({
-            {
+        {
+            TTestRegistryVisitor visitor;
+            registry->Visit(TInstant::Zero(), visitor);
+            visitor.ValidateExpectedCounters({
                 {
-                    {"sensor", "UncompressedBytesWritten"},
-                    {"filesystem", "test"}
+                    {
+                        {"sensor", "UncompressedBytesWritten"},
+                        {"filesystem", "test"}
+                    },
+                    0 // expected
                 },
-                100_KB // expected
-            },
-            {
                 {
-                    {"sensor", "CompressedBytesWritten"},
-                    {"filesystem", "test"}
+                    {
+                        {"sensor", "CompressedBytesWritten"},
+                        {"filesystem", "test"}
+                    },
+                    0 // expected
                 },
-                439 // expected
-            },
-        });
+                {
+                    {
+                        {"sensor", "ZeroBytesWritten"},
+                        {"filesystem", "test"}
+                    },
+                    0 // expected
+                },
+            });
+        }
+
+        tablet.Compaction(GetMixedRangeIndex(nodeId, 0));
+
+        {
+            TTestRegistryVisitor visitor;
+            registry->Visit(TInstant::Zero(), visitor);
+            visitor.ValidateExpectedCounters({
+                {
+                    {
+                        {"sensor", "UncompressedBytesWritten"},
+                        {"filesystem", "test"}
+                    },
+                    100_KB // expected
+                },
+                {
+                    {
+                        {"sensor", "CompressedBytesWritten"},
+                        {"filesystem", "test"}
+                    },
+                    439 // expected
+                },
+                {
+                    {
+                        {"sensor", "ZeroBytesWritten"},
+                        {"filesystem", "test"}
+                    },
+                    0 // expected
+                },
+            });
+        }
     }
 
-    Y_UNIT_TEST(ShouldNotReportCompressionMetricsForAllBlobs)
+    Y_UNIT_TEST(ShouldNotReportCompressionMetricsForNonCompactionBlobs)
     {
         NProto::TStorageConfig storageConfig;
-        storageConfig.SetBlobCompressionRate(2);
-        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetBlobCompressionRate(1);
 
         TTestEnv env({}, std::move(storageConfig));
         auto registry = env.GetRegistry();
@@ -806,25 +844,35 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
             CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
         const auto handle = CreateHandle(tablet, nodeId);
 
-        for (int i = 0; i < 10; i++)
-            tablet.WriteData(handle, 0, 4_KB, 'a');
+        // direct blob path
+        tablet.WriteData(handle, 0, 256_KB, 'a');
+        // fresh blocks + flush path
+        tablet.WriteData(handle, 256_KB, 4_KB, 'a');
+        tablet.Flush();
 
         TTestRegistryVisitor visitor;
         registry->Visit(TInstant::Zero(), visitor);
-        visitor.ValidateExpectedCountersWithPredicate({
+        visitor.ValidateExpectedCounters({
             {
                 {
                     {"sensor", "UncompressedBytesWritten"},
                     {"filesystem", "test"}
                 },
-                [](i64 val) { return val > 0 && val < 40960; } // expected
+                0 // expected
             },
             {
                 {
                     {"sensor", "CompressedBytesWritten"},
-                    {"filesystem", "test"},
+                    {"filesystem", "test"}
                 },
-                [](i64 val) { return val > 0 && val < 370; } // expected
+                0 // expected
+            },
+            {
+                {
+                    {"sensor", "ZeroBytesWritten"},
+                    {"filesystem", "test"}
+                },
+                0 // expected
             },
         });
     }
@@ -854,6 +902,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
         }
 
         tablet.WriteData(handle, 0, data.size(), data.data());
+        tablet.Compaction(GetMixedRangeIndex(nodeId, 0));
 
         TTestRegistryVisitor visitor;
         registry->Visit(TInstant::Zero(), visitor);
@@ -871,6 +920,65 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
                     {"filesystem", "test"},
                 },
                 [](i64 val) { return val >= static_cast<i64>(100_KB); }
+            },
+            {
+                {
+                    {"sensor", "ZeroBytesWritten"},
+                    {"filesystem", "test"},
+                },
+                // random data contains ~0.4% of zero bytes
+                [](i64 val) { return val >= 0 && val < 4096; }
+            },
+        });
+    }
+
+    Y_UNIT_TEST(ShouldReportZeroBytesWrittenForCompactedBlobs)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetBlobCompressionRate(1);
+        storageConfig.SetWriteBlobThreshold(1);
+
+        TTestEnv env({}, std::move(storageConfig));
+        auto registry = env.GetRegistry();
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+        const auto nodeId =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        const auto handle = CreateHandle(tablet, nodeId);
+
+        const TString data = TString(40_KB, '\0') + TString(60_KB, 'a');
+        tablet.WriteData(handle, 0, data.size(), data.data());
+        tablet.Compaction(GetMixedRangeIndex(nodeId, 0));
+
+        TTestRegistryVisitor visitor;
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCounters({
+            {
+                {
+                    {"sensor", "UncompressedBytesWritten"},
+                    {"filesystem", "test"}
+                },
+                100_KB // expected
+            },
+            {
+                {
+                    {"sensor", "ZeroBytesWritten"},
+                    {"filesystem", "test"}
+                },
+                40_KB // expected
+            },
+        });
+        visitor.ValidateExpectedCountersWithPredicate({
+            {
+                {
+                    {"sensor", "CompressedBytesWritten"},
+                    {"filesystem", "test"},
+                },
+                [](i64 val) { return val > 0 && val < 4096; }
             },
         });
     }


### PR DESCRIPTION
### Notes
calculate compression only for compaction
add zero calculation metrics
add ai assisted UTs

### Issue
#7107
