### PR TITLE
issue-2667: add LinkNodeInShard tablet op

### DIFF
--- a/cloud/filestore/libs/diagnostics/profile_log_events.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.cpp
@@ -456,6 +456,14 @@ void InitProfileLogRequestInfo(
 template <>
 void InitProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
+    const NProtoPrivate::TLinkNodeInShardRequest& request)
+{
+    profileLogRequest.MutableNodeInfo()->SetNodeId(request.GetNodeId());
+}
+
+template <>
+void InitProfileLogRequestInfo(
+    NProto::TProfileLogRequestInfo& profileLogRequest,
     const NProto::TAccessNodeRequest& request)
 {
     auto* nodeInfo = profileLogRequest.MutableNodeInfo();

--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -57,6 +57,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(RenameNodeInDestination,            __VA_ARGS__)                       \
     xxx(PrepareUnlinkDirectoryNodeInShard,  __VA_ARGS__)                       \
     xxx(AbortUnlinkDirectoryNodeInShard,    __VA_ARGS__)                       \
+    xxx(LinkNodeInShard,                    __VA_ARGS__)                       \
     xxx(DeleteResponseLogEntry,             __VA_ARGS__)                       \
     xxx(GetResponseLogEntry,                __VA_ARGS__)                       \
     xxx(WriteResponseLogEntry,              __VA_ARGS__)                       \
@@ -243,6 +244,9 @@ struct TEvIndexTablet
 
         EvGetDiagnosticStatsRequest = EvBegin + 91,
         EvGetDiagnosticStatsResponse,
+
+        EvLinkNodeInShardRequest = EvBegin + 93,
+        EvLinkNodeInShardResponse,
 
         // After the TABLET sub-namespace we have TABLET_WORKER and TABLET_PROXY
         // sub-namespaces which don't have any non-local events so if we run out

--- a/cloud/filestore/libs/storage/tablet/model/profile_log_events.h
+++ b/cloud/filestore/libs/storage/tablet/model/profile_log_events.h
@@ -33,6 +33,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(AbortUnlinkDirectoryNodeInShard,    __VA_ARGS__)                       \
     xxx(AddDataUnconfirmed,                 __VA_ARGS__)                       \
     xxx(RecoverUnconfirmedData,             __VA_ARGS__)                       \
+    xxx(LinkNodeInShard,                    __VA_ARGS__)                       \
 // FILESTORE_SYSTEM_REQUESTS
 
 #define FILESTORE_MATERIALIZE_REQUEST(name, ...) name,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_linknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_linknode.cpp
@@ -1,0 +1,211 @@
+#include "tablet_actor.h"
+
+#include "helpers.h"
+
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleLinkNodeInShard(
+    const TEvIndexTablet::TEvLinkNodeInShardRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    using TMethod = TEvIndexTablet::TLinkNodeInShardMethod;
+
+    auto* msg = ev->Get();
+
+    NProto::TProfileLogRequestInfo profileLogRequest;
+    InitTabletProfileLogRequestInfo(
+        profileLogRequest,
+        EFileStoreSystemRequest::LinkNodeInShard,
+        msg->Record,
+        ctx.Now());
+    auto onReply = [&] (const NProto::TError& error) {
+        FinalizeProfileLogRequestInfo(
+            std::move(profileLogRequest),
+            ctx.Now(),
+            GetFileSystemId(),
+            error,
+            ProfileLog);
+    };
+
+    const ui64 clientTabletId =
+        msg->Record.GetHeaders().GetInternal().GetClientTabletId();
+    const ui64 requestId = msg->Record.GetHeaders().GetRequestId();
+
+    if (!clientTabletId || !requestId) {
+        auto error = MakeError(E_ARGUMENT, TStringBuilder()
+            << "both ClientTabletId and RequestId should be nonzero: "
+            << clientTabletId << ", " << requestId);
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TMethod::TResponse>(error));
+        onReply(error);
+        return;
+    }
+
+    if (const auto* e = LookupResponseLogEntry(clientTabletId, requestId)) {
+        auto response = std::make_unique<TMethod::TResponse>();
+        if (e->HasLinkNodeInShardResponse()) {
+            response->Record = e->GetLinkNodeInShardResponse();
+        } else {
+            auto message = ReportInvalidResponseLogEntry(TStringBuilder()
+                << TMethod::Name << ": " << msg->Record.ShortUtf8DebugString()
+                << ", entry: " << e->ShortUtf8DebugString());
+            *response->Record.MutableError() =
+                MakeError(E_INVALID_STATE, std::move(message));
+        }
+        auto error = response->GetError();
+        NCloud::Reply(ctx, *ev, std::move(response));
+        onReply(error);
+        return;
+    }
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
+
+    AddInFlightRequest<TMethod>(*requestInfo);
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s LinkNodeInShard: %s",
+        LogTag.c_str(),
+        msg->Record.ShortUtf8DebugString().Quote().c_str());
+
+    ExecuteTx<TLinkNodeInShard>(
+        ctx,
+        std::move(requestInfo),
+        std::move(msg->Record),
+        std::move(profileLogRequest));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_LinkNodeInShard(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TLinkNodeInShard& args)
+{
+    Y_UNUSED(ctx);
+
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+
+    args.CommitId = GetCurrentCommitId();
+
+    if (!ReadNode(*db, args.Request.GetNodeId(), args.CommitId, args.Node)) {
+        return false;   // not ready
+    }
+
+    if (!args.Node) {
+        args.Error = ErrorInvalidTarget(args.Request.GetNodeId());
+        return true;
+    }
+
+    if (args.Node->Attrs.GetType() == NProto::E_DIRECTORY_NODE) {
+        args.Error = ErrorIsDirectory(args.Request.GetNodeId());
+        return true;
+    }
+
+    if (args.Node->Attrs.GetLinks() + 1 > MaxLink) {
+        args.Error = ErrorMaxLink(args.Request.GetNodeId());
+        return true;
+    }
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_LinkNodeInShard(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TLinkNodeInShard& args)
+{
+    FILESTORE_VALIDATE_TX_ERROR(LinkNodeInShard, args);
+
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+
+    args.CommitId = GenerateCommitId();
+    if (args.CommitId == InvalidCommitId) {
+        args.OnCommitIdOverflow();
+        return;
+    }
+
+    auto attrs = CopyAttrs(args.Node->Attrs, E_CM_CMTIME | E_CM_REF);
+    UpdateNode(
+        *db,
+        args.Request.GetNodeId(),
+        args.Node->MinCommitId,
+        args.CommitId,
+        attrs,
+        args.Node->Attrs);
+
+    ConvertNodeFromAttrs(
+        *args.Response.MutableNode(),
+        args.Request.GetNodeId(),
+        attrs);
+
+    args.Node->Attrs = std::move(attrs);
+
+    // Persist the response so a resend of this (ClientTabletId, RequestId)
+    // returns it without bumping the link count again. Only written on success -
+    // an errored attempt made no durable change and can safely be re-run.
+    args.ResponseLogEntry.SetClientTabletId(
+        args.Request.GetHeaders().GetInternal().GetClientTabletId());
+    args.ResponseLogEntry.SetRequestId(
+        args.Request.GetHeaders().GetRequestId());
+    args.ResponseLogEntry.SetTimestampMs(ctx.Now().MilliSeconds());
+    *args.ResponseLogEntry.MutableLinkNodeInShardResponse() = args.Response;
+    WriteResponseLogEntry(*db, args.ResponseLogEntry);
+}
+
+void TIndexTabletActor::CompleteTx_LinkNodeInShard(
+    const TActorContext& ctx,
+    TTxIndexTablet::TLinkNodeInShard& args)
+{
+    InvalidateReadAheadCache(args.Request.GetNodeId());
+
+    if (!HasError(args.Error)) {
+        CommitResponseLogEntry(std::move(args.ResponseLogEntry));
+    }
+
+    RemoveInFlightRequest(*args.RequestInfo);
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s LinkNodeInShard completed (%s): node %lu, links %u",
+        LogTag.c_str(),
+        FormatError(args.Error).c_str(),
+        args.Request.GetNodeId(),
+        args.Response.GetNode().GetLinks());
+
+    using TMethod = TEvIndexTablet::TLinkNodeInShardMethod;
+
+    auto response = std::make_unique<TMethod::TResponse>(args.Error);
+    if (!HasError(args.Error)) {
+        response->Record = std::move(args.Response);
+    }
+
+    CompleteResponse<TMethod>(
+        response->Record,
+        args.RequestInfo->CallContext,
+        ctx);
+
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+
+    FinalizeProfileLogRequestInfo(
+        std::move(args.ProfileLogRequest),
+        ctx.Now(),
+        GetFileSystemId(),
+        args.Error,
+        ProfileLog);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_linknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_linknode.cpp
@@ -171,20 +171,23 @@ void TIndexTabletActor::CompleteTx_LinkNodeInShard(
     const TActorContext& ctx,
     TTxIndexTablet::TLinkNodeInShard& args)
 {
-    InvalidateReadAheadCache(args.Request.GetNodeId());
+    RemoveInFlightRequest(*args.RequestInfo);
 
     if (!HasError(args.Error)) {
         CommitResponseLogEntry(std::move(args.ResponseLogEntry));
+
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+            "%s LinkNodeInShard completed: node %lu, links %u",
+            LogTag.c_str(),
+            args.Request.GetNodeId(),
+            args.Response.GetNode().GetLinks());
+    } else {
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+            "%s LinkNodeInShard failed: node %lu, error %s",
+            LogTag.c_str(),
+            args.Request.GetNodeId(),
+            FormatError(args.Error).Quote().c_str());
     }
-
-    RemoveInFlightRequest(*args.RequestInfo);
-
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s LinkNodeInShard completed (%s): node %lu, links %u",
-        LogTag.c_str(),
-        FormatError(args.Error).c_str(),
-        args.Request.GetNodeId(),
-        args.Response.GetNode().GetLinks());
 
     using TMethod = TEvIndexTablet::TLinkNodeInShardMethod;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -199,6 +199,7 @@ FILESTORE_GENERATE_IMPL(GetNodeAttrBatch, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(RenameNodeInDestination, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(PrepareUnlinkDirectoryNodeInShard, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(AbortUnlinkDirectoryNodeInShard, TEvIndexTablet)
+FILESTORE_GENERATE_IMPL(LinkNodeInShard, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(ListNodesInternal, TEvIndexTablet)
 
 #undef FILESTORE_GENERATE_IMPL

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -459,6 +459,11 @@ void TIndexTabletState::WriteResponseLogEntry(
             *incompleteEntry.MutableRenameNodeInDestinationResponse();
         *incompleteResponse.MutableError() =
             MakeError(E_REJECTED, "incomplete response");
+    } else if (e.HasLinkNodeInShardResponse()) {
+        auto& incompleteResponse =
+            *incompleteEntry.MutableLinkNodeInShardResponse();
+        *incompleteResponse.MutableError() =
+            MakeError(E_REJECTED, "incomplete response");
     } else {
         TABLET_VERIFY_C(
             0,

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -113,6 +113,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CompleteUnlinkNode,                 __VA_ARGS__)                       \
     xxx(PrepareUnlinkDirectoryNode,         __VA_ARGS__)                       \
     xxx(AbortUnlinkDirectoryNode,           __VA_ARGS__)                       \
+    xxx(LinkNodeInShard,                    __VA_ARGS__)                       \
     xxx(RenameNode,                         __VA_ARGS__)                       \
     xxx(PrepareRenameNodeInSource,          __VA_ARGS__)                       \
     xxx(RenameNodeInDestination,            __VA_ARGS__)                       \
@@ -982,6 +983,50 @@ struct TTxIndexTablet
             ChildNode.Clear();
             ChildRef.Clear();
             OpLogEntry.Clear();
+
+            // deliberately not calling TProfileAware::Clear()
+        }
+    };
+
+    //
+    // LinkNodeInShard
+    //
+
+    struct TLinkNodeInShard
+        : TTxIndexTabletBase
+        , TErrorAware
+        , TSessionAware
+        , TProfileAware
+        , TIndexStateNodeUpdates
+    {
+        const TRequestInfoPtr RequestInfo;
+        const NProtoPrivate::TLinkNodeInShardRequest Request;
+        NProto::TProfileLogRequestInfo ProfileLogRequest;
+        NProtoPrivate::TLinkNodeInShardResponse Response;
+        NProtoPrivate::TResponseLogEntry ResponseLogEntry;
+
+        ui64 CommitId = InvalidCommitId;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
+
+        TLinkNodeInShard(
+                TRequestInfoPtr requestInfo,
+                NProtoPrivate::TLinkNodeInShardRequest request,
+                NProto::TProfileLogRequestInfo profileLogRequest)
+            : TSessionAware(request)
+            , TProfileAware(std::move(profileLogRequest))
+            , RequestInfo(std::move(requestInfo))
+            , Request(std::move(request))
+        {}
+
+        void Clear() override
+        {
+            TErrorAware::Clear();
+            TIndexStateNodeUpdates::Clear();
+
+            CommitId = InvalidCommitId;
+            Node.Clear();
+            Response.Clear();
+            ResponseLogEntry.Clear();
 
             // deliberately not calling TProfileAware::Clear()
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -200,6 +200,159 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         }
     }
 
+    TABLET_TEST_4K_ONLY(ShouldLinkNodeInShard)
+    {
+        TTestEnv env(testEnvConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        const ui64 fileId =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "file"));
+        UNIT_ASSERT_VALUES_EQUAL(1, GetNodeAttrs(tablet, fileId).GetLinks());
+
+        // first call bumps the link count 1 -> 2
+        {
+            auto response = tablet.SendAndRecvLinkNodeInShard(
+                fileId,
+                1 /* clientTabletId */,
+                100 /* requestId */);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_VALUES_EQUAL(fileId, response->Record.GetNode().GetId());
+            UNIT_ASSERT_VALUES_EQUAL(2, response->Record.GetNode().GetLinks());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(2, GetNodeAttrs(tablet, fileId).GetLinks());
+
+        // a resend with the same (clientTabletId, requestId) is served from the
+        // ResponseLog and does NOT bump the link count again
+        {
+            auto response = tablet.SendAndRecvLinkNodeInShard(fileId, 1, 100);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_VALUES_EQUAL(2, response->Record.GetNode().GetLinks());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(2, GetNodeAttrs(tablet, fileId).GetLinks());
+
+        // a different requestId is a different logical op -> bumps again 2 -> 3
+        {
+            auto response = tablet.SendAndRecvLinkNodeInShard(fileId, 1, 101);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_VALUES_EQUAL(3, response->Record.GetNode().GetLinks());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(3, GetNodeAttrs(tablet, fileId).GetLinks());
+    }
+
+    TABLET_TEST_4K_ONLY(ShouldValidateLinkNodeInShardTarget)
+    {
+        TTestEnv env(testEnvConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        const ui64 fileId =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "file"));
+        const ui64 dirId =
+            CreateNode(tablet, TCreateNodeArgs::Directory(RootNodeId, "dir"));
+
+        // missing idempotency key
+        {
+            auto response = tablet.SendAndRecvLinkNodeInShard(
+                fileId,
+                0 /* clientTabletId */);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+        }
+
+        // target does not exist
+        {
+            auto response =
+                tablet.SendAndRecvLinkNodeInShard(fileId + 100500, 1, 200);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FS_NOENT,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+        }
+
+        // target is a directory - hard links to dirs are not allowed
+        {
+            auto response = tablet.SendAndRecvLinkNodeInShard(dirId, 1, 201);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FS_ISDIR,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+        }
+
+        // none of the above touched the file's link count
+        UNIT_ASSERT_VALUES_EQUAL(1, GetNodeAttrs(tablet, fileId).GetLinks());
+    }
+
+    TABLET_TEST_4K_ONLY(ShouldKeepLinkNodeInShardIdempotentAfterReboot)
+    {
+        TTestEnv env(testEnvConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        const ui64 fileId =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "file"));
+
+        {
+            auto response = tablet.SendAndRecvLinkNodeInShard(fileId, 7, 42);
+            UNIT_ASSERT_VALUES_EQUAL(2, response->Record.GetNode().GetLinks());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(2, GetNodeAttrs(tablet, fileId).GetLinks());
+
+        tablet.RebootTablet();
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+        tablet.InitSession("client", "session");
+
+        // the ResponseLog entry survived the reboot -> resend is still a no-op
+        {
+            auto response = tablet.SendAndRecvLinkNodeInShard(fileId, 7, 42);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_VALUES_EQUAL(2, response->Record.GetNode().GetLinks());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(2, GetNodeAttrs(tablet, fileId).GetLinks());
+    }
+
     TABLET_TEST_4K_ONLY(ShouldAbortUnlinkDirectoryNodeInShard)
     {
         TTestEnv env(testEnvConfig);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -310,6 +310,19 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
         // none of the above touched the file's link count
         UNIT_ASSERT_VALUES_EQUAL(1, GetNodeAttrs(tablet, fileId).GetLinks());
+
+        // target already at MaxLink -> E_FS_MLINK
+        tablet.UnsafeUpdateNode(fileId, 0 /* size */, MaxLink /* links */);
+        {
+            auto response = tablet.SendAndRecvLinkNodeInShard(fileId, 1, 202);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FS_MLINK,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+        }
+        UNIT_ASSERT_VALUES_EQUAL(
+            MaxLink,
+            GetNodeAttrs(tablet, fileId).GetLinks());
     }
 
     TABLET_TEST_4K_ONLY(ShouldKeepLinkNodeInShardIdempotentAfterReboot)

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -50,6 +50,7 @@ SRCS(
     tablet_actor_getnodexattr.cpp
     tablet_actor_initschema.cpp
     tablet_actor_listnodes.cpp
+    tablet_actor_linknode.cpp
     tablet_actor_listnodexattr.cpp
     tablet_actor_loadstate.cpp
     tablet_actor_loadstate_noderefs.cpp

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -426,6 +426,20 @@ public:
         return request;
     }
 
+    auto CreateLinkNodeInShardRequest(
+        ui64 nodeId,
+        ui64 clientTabletId = 1,
+        ui64 requestId = 0)
+    {
+        using TRequestEvent = TEvIndexTablet::TEvLinkNodeInShardRequest;
+        auto request = CreateSessionRequest<TRequestEvent>();
+        auto& headers = *request->Record.MutableHeaders();
+        headers.MutableInternal()->SetClientTabletId(clientTabletId);
+        headers.SetRequestId(requestId ? requestId : ++AutoRequestId);
+        request->Record.SetNodeId(nodeId);
+        return request;
+    }
+
     auto CreateRenameNodeInDestinationRequest(
         ui64 newParent,
         const TString& newName,

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -512,7 +512,10 @@ public:
         return request;
     }
 
-    auto CreateUnsafeUpdateNodeRequest(ui64 nodeId, ui64 newSize)
+    auto CreateUnsafeUpdateNodeRequest(
+        ui64 nodeId,
+        ui64 newSize,
+        ui32 links = 1)
     {
         using TRequestEvent = TEvIndexTablet::TEvUnsafeUpdateNodeRequest;
         auto request = std::make_unique<TRequestEvent>();
@@ -522,7 +525,7 @@ public:
         node->SetSize(newSize);
         node->SetType(NProto::E_REGULAR_NODE);
         node->SetMTime(Now().MicroSeconds());
-        node->SetLinks(1);
+        node->SetLinks(links);
         return request;
     }
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -1048,6 +1048,7 @@ message TResponseLogEntry
 
     oneof Response {
         TRenameNodeInDestinationResponse RenameNodeInDestinationResponse = 101;
+        TLinkNodeInShardResponse LinkNodeInShardResponse = 102;
     }
 }
 
@@ -1147,6 +1148,36 @@ message TUnlinkNodeInShardRequest
 
     // Original request that caused this unlink.
     NProto.TUnlinkNodeRequest OriginalRequest = 6;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// LinkNodeInShard request/response
+//
+// Sent by the tablet that owns a directory to the shard that owns a node, to
+// bump that node's hard link count by one
+
+message TLinkNodeInShardRequest
+{
+    // Optional request headers.
+    NProto.THeaders Headers = 1;
+
+    // Shard that owns the target node.
+    string FileSystemId = 2;
+
+    // Node whose link count should be incremented (shard-scoped id).
+    uint64 NodeId = 3;
+}
+
+message TLinkNodeInShardResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    // The target node's attributes after the link count was incremented.
+    NProto.TNodeAttr Node = 2;
+
+    // Optional response headers.
+    NProto.TResponseHeaders Headers = 1000;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
@@ -102,7 +102,7 @@ Y_UNIT_TEST_SUITE(TDumpTest)
     {
         const auto requests = GetRequestTypes();
 
-        UNIT_ASSERT_VALUES_EQUAL(85, requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(86, requests.size());
 
         ui32 index = 0;
 #define TEST_REQUEST_TYPE(id, name)                                            \
@@ -202,6 +202,7 @@ Y_UNIT_TEST_SUITE(TDumpTest)
         TEST_REQUEST_TYPE(10015, AbortUnlinkDirectoryNodeInShard);
         TEST_REQUEST_TYPE(10016, AddDataUnconfirmed);
         TEST_REQUEST_TYPE(10017, RecoverUnconfirmedData);
+        TEST_REQUEST_TYPE(10018, LinkNodeInShard);
 
 #undef TEST_REQUEST_TYPE
     }


### PR DESCRIPTION
### Notes
Shard-side step of a cross-shard hard link: given a node id, bump that node's hard link count by one. It creates no NodeRef in the shard.

Exactly-once is guaranteed by the `ResponseLog` (same mechanism as `RenameNodeInDestination`)

Nothing calls this yet - the directory tablet's OpLog entry and worker actor will come in follow-up changes.

### Issue
#2667
