### PR TITLE
issue-6956: add the log record, chain and page index

### DIFF
--- a/cloud/storage/core/libs/journalled_device/device_page_store.h
+++ b/cloud/storage/core/libs/journalled_device/device_page_store.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include "log_record.h"
+
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <library/cpp/threading/future/future.h>
@@ -12,14 +14,6 @@
 #include <memory>
 
 namespace NCloud::NJournalled {
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TPageRange
-{
-    ui64 FirstPageNo = 0;
-    ui64 PageCount = 0;
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/storage/core/libs/journalled_device/log_chain.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_chain.cpp
@@ -1,0 +1,139 @@
+#include "log_chain.h"
+
+#include <util/generic/utility.h>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TLogRecordChain::InitLastErasedLsn(ui64 lsn)
+{
+    with_lock (Lock) {
+        LastErasedLsn = lsn;
+    }
+}
+
+TResultOrError<TLogRecordPtr> TLogRecordChain::Insert(TLogRecordPtr record)
+{
+    if (record->PrevLsn >= record->Lsn) {
+        return MakeError(E_ARGUMENT);
+    }
+
+    with_lock (Lock) {
+        if (record->Lsn <= LastErasedLsn) {
+            auto erasedStub = std::make_shared<TLogRecord>();
+            erasedStub->Lsn = record->Lsn;
+            erasedStub->PrevLsn = record->PrevLsn;
+            erasedStub->Ready.store(true);
+            erasedStub->Promise =
+                NThreading::NewPromise<NCloud::NProto::TError>();
+            erasedStub->Promise.SetValue(MakeError(S_ALREADY));
+            return erasedStub;
+        }
+
+        auto nextIt = Records.upper_bound(record->Lsn);
+        if (nextIt != Records.end()) {
+            const auto& next = *nextIt->second;
+            if (record->Lsn > next.PrevLsn) {
+                return MakeError(E_INVALID_STATE);
+            }
+        }
+
+        if (nextIt != Records.begin()) {
+            auto prevIt = std::prev(nextIt);
+            const auto& prev = *prevIt->second;
+
+            if (prev.Lsn == record->Lsn && prev.PrevLsn == record->PrevLsn) {
+                return prevIt->second;
+            }
+
+            if (prev.Lsn > record->PrevLsn) {
+                return MakeError(E_INVALID_STATE);
+            }
+        }
+
+        Records.emplace_hint(nextIt, record->Lsn, record);
+    }
+
+    return record;
+}
+
+TLogRecordPtr TLogRecordChain::Extract(ui64 lsn)
+{
+    with_lock (Lock) {
+        auto it = Records.find(lsn);
+        if (it == Records.end()) {
+            return nullptr;
+        }
+
+        auto record = std::move(it->second);
+        Records.erase(it);
+        return record;
+    }
+}
+
+TVector<TLogRecordPtr> TLogRecordChain::EraseUpTo(ui64 lsn)
+{
+    TVector<TLogRecordPtr> records;
+
+    with_lock (Lock) {
+        auto it = Records.begin();
+        while (it != Records.end() && it->second->Lsn <= lsn) {
+            records.push_back(std::move(it->second));
+            it = Records.erase(it);
+        }
+        LastErasedLsn = Max(LastErasedLsn, lsn);
+    }
+
+    return records;
+}
+
+TLogRecordPtr TLogRecordChain::GetOldest() const
+{
+    with_lock (Lock) {
+        return Records.empty() ? nullptr : Records.begin()->second;
+    }
+}
+
+TLogRecordPtr TLogRecordChain::GetChainedNext(ui64 lsn) const
+{
+    with_lock (Lock) {
+        auto nextIt = Records.upper_bound(lsn);
+        if (nextIt == Records.end() || nextIt->second->PrevLsn != lsn) {
+            return nullptr;
+        }
+
+        return nextIt->second;
+    }
+}
+
+TVector<TLogRecordPtr> TLogRecordChain::GetReadyRun(
+    ui64 afterLsn,
+    ui64 maxRecordCount) const
+{
+    TVector<TLogRecordPtr> records;
+
+    with_lock (Lock) {
+        auto recordCount = maxRecordCount > 0
+                             ? Min<size_t>(maxRecordCount, Records.size())
+                             : Records.size();
+
+        records.reserve(recordCount);
+
+        ui64 tailLsn = afterLsn;
+        auto it = Records.upper_bound(tailLsn);
+        for (; it != Records.end() && records.size() < recordCount; ++it) {
+            const auto& record = it->second;
+            if (record->PrevLsn != tailLsn || !record->Ready.load()) {
+                break;
+            }
+
+            records.push_back(record);
+            tailLsn = record->Lsn;
+        }
+    }
+
+    return records;
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/log_chain.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_chain.cpp
@@ -1,6 +1,7 @@
 #include "log_chain.h"
 
 #include <util/generic/utility.h>
+#include <util/string/builder.h>
 
 namespace NCloud::NJournalled {
 
@@ -10,6 +11,7 @@ void TLogRecordChain::InitLastErasedLsn(ui64 lsn)
 {
     with_lock (Lock) {
         LastErasedLsn = lsn;
+        LastChainedLsn = lsn;
     }
 }
 
@@ -21,68 +23,103 @@ TResultOrError<TLogRecordPtr> TLogRecordChain::Insert(TLogRecordPtr record)
 
     with_lock (Lock) {
         if (record->Lsn <= LastErasedLsn) {
-            auto erasedStub = std::make_shared<TLogRecord>();
-            erasedStub->Lsn = record->Lsn;
-            erasedStub->PrevLsn = record->PrevLsn;
-            erasedStub->Ready.store(true);
-            erasedStub->Promise =
-                NThreading::NewPromise<NCloud::NProto::TError>();
-            erasedStub->Promise.SetValue(MakeError(S_ALREADY));
-            return erasedStub;
+            return MakeError(E_INVALID_STATE);
         }
 
-        auto nextIt = Records.upper_bound(record->Lsn);
-        if (nextIt != Records.end()) {
-            const auto& next = *nextIt->second;
-            if (record->Lsn > next.PrevLsn) {
-                return MakeError(E_INVALID_STATE);
+        if (auto it = Records.find(record->PrevLsn); it != Records.end()) {
+            const auto& held = it->second.Record;
+            if (held->Lsn == record->Lsn) {
+                return held;
             }
+            // another record already continues from the same lsn
+            return MakeError(E_INVALID_STATE);
         }
 
-        if (nextIt != Records.begin()) {
-            auto prevIt = std::prev(nextIt);
-            const auto& prev = *prevIt->second;
-
-            if (prev.Lsn == record->Lsn && prev.PrevLsn == record->PrevLsn) {
-                return prevIt->second;
-            }
-
-            if (prev.Lsn > record->PrevLsn) {
-                return MakeError(E_INVALID_STATE);
-            }
+        // the boundaries of the chained run are all held, so a record
+        // starting below LastChainedLsn starts inside another record
+        if (record->PrevLsn < LastChainedLsn) {
+            return MakeError(E_INVALID_STATE);
         }
 
-        Records.emplace_hint(nextIt, record->Lsn, record);
+        Records.emplace(record->PrevLsn, TEntry{.Record = record});
     }
 
     return record;
 }
 
-TLogRecordPtr TLogRecordChain::Extract(ui64 lsn)
+bool TLogRecordChain::MarkAsReady(ui64 prevLsn)
 {
     with_lock (Lock) {
-        auto it = Records.find(lsn);
+        auto it = Records.find(prevLsn);
         if (it == Records.end()) {
-            return nullptr;
+            return false;
         }
 
-        auto record = std::move(it->second);
-        Records.erase(it);
-        return record;
+        it->second.Ready = true;
+
+        for (;;) {
+            auto next = Records.find(LastChainedLsn);
+            if (next == Records.end() || !next->second.Ready) {
+                break;
+            }
+            LastChainedLsn = next->second.Record->Lsn;
+        }
     }
+
+    return true;
 }
 
-TVector<TLogRecordPtr> TLogRecordChain::EraseUpTo(ui64 lsn)
+bool TLogRecordChain::Remove(ui64 prevLsn)
+{
+    with_lock (Lock) {
+        auto it = Records.find(prevLsn);
+        if (it == Records.end()) {
+            return false;
+        }
+
+        if (it->second.Ready) {
+            return false;
+        }
+
+        Records.erase(it);
+    }
+
+    return true;
+}
+
+TResultOrError<TVector<TLogRecordPtr>> TLogRecordChain::EraseUpTo(ui64 lsn)
 {
     TVector<TLogRecordPtr> records;
 
     with_lock (Lock) {
-        auto it = Records.begin();
-        while (it != Records.end() && it->second->Lsn <= lsn) {
-            records.push_back(std::move(it->second));
-            it = Records.erase(it);
+        if (lsn > LastChainedLsn) {
+            return MakeError(
+                E_INVALID_STATE,
+                TStringBuilder() << "lsn " << lsn
+                                 << " reaches past the chained run ending at "
+                                 << LastChainedLsn);
         }
-        LastErasedLsn = Max(LastErasedLsn, lsn);
+
+        for (;;) {
+            auto it = Records.find(LastErasedLsn);
+            if (it == Records.end() || it->second.Record->Lsn > lsn) {
+                break;
+            }
+
+            records.push_back(std::move(it->second.Record));
+            Records.erase(it);
+            LastErasedLsn = records.back()->Lsn;
+        }
+
+        // ready records chaining from below the watermark can never join
+        for (auto it = Records.begin(); it != Records.end();) {
+            if (it->first < LastErasedLsn && it->second.Ready) {
+                records.push_back(std::move(it->second.Record));
+                Records.erase(it++);
+            } else {
+                ++it;
+            }
+        }
     }
 
     return records;
@@ -91,20 +128,24 @@ TVector<TLogRecordPtr> TLogRecordChain::EraseUpTo(ui64 lsn)
 TLogRecordPtr TLogRecordChain::GetOldest() const
 {
     with_lock (Lock) {
-        return Records.empty() ? nullptr : Records.begin()->second;
+        return GetNextImpl(LastErasedLsn);
     }
 }
 
-TLogRecordPtr TLogRecordChain::GetChainedNext(ui64 lsn) const
+TLogRecordPtr TLogRecordChain::GetNext(ui64 lsn) const
 {
     with_lock (Lock) {
-        auto nextIt = Records.upper_bound(lsn);
-        if (nextIt == Records.end() || nextIt->second->PrevLsn != lsn) {
-            return nullptr;
-        }
-
-        return nextIt->second;
+        return GetNextImpl(lsn);
     }
+}
+
+TLogRecordPtr TLogRecordChain::GetNextImpl(ui64 lsn) const
+{
+    auto it = Records.find(lsn);
+    if (it == Records.end() || !it->second.Ready) {
+        return nullptr;
+    }
+    return it->second.Record;
 }
 
 TVector<TLogRecordPtr> TLogRecordChain::GetReadyRun(
@@ -115,21 +156,20 @@ TVector<TLogRecordPtr> TLogRecordChain::GetReadyRun(
 
     with_lock (Lock) {
         auto recordCount = maxRecordCount > 0
-                             ? Min<size_t>(maxRecordCount, Records.size())
-                             : Records.size();
+                               ? Min<size_t>(maxRecordCount, Records.size())
+                               : Records.size();
 
         records.reserve(recordCount);
 
         ui64 tailLsn = afterLsn;
-        auto it = Records.upper_bound(tailLsn);
-        for (; it != Records.end() && records.size() < recordCount; ++it) {
-            const auto& record = it->second;
-            if (record->PrevLsn != tailLsn || !record->Ready.load()) {
+        while (records.size() < recordCount) {
+            auto it = Records.find(tailLsn);
+            if (it == Records.end() || !it->second.Ready) {
                 break;
             }
 
-            records.push_back(record);
-            tailLsn = record->Lsn;
+            records.push_back(it->second.Record);
+            tailLsn = it->second.Record->Lsn;
         }
     }
 

--- a/cloud/storage/core/libs/journalled_device/log_chain.h
+++ b/cloud/storage/core/libs/journalled_device/log_chain.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "public.h"
+
+#include "log_record.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/generic/map.h>
+#include <util/generic/vector.h>
+#include <util/system/spinlock.h>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TLogRecordChain
+{
+private:
+    mutable TAdaptiveLock Lock;
+    ui64 LastErasedLsn = 0;
+    TMap<ui64, TLogRecordPtr> Records;
+
+public:
+    void InitLastErasedLsn(ui64 lsn);
+
+    // On success returns the record whose promise the caller should wait on.
+    // That is the given record when it has been inserted.
+    TResultOrError<TLogRecordPtr> Insert(TLogRecordPtr record);
+
+    // Removes one record and returns it, nullptr if there is no such lsn.
+    // Does not move LastErasedLsn.
+    TLogRecordPtr Extract(ui64 lsn);
+
+    // Removes everything at or below |lsn| and moves LastErasedLsn up to it.
+    // Returns the removed records ordered by lsn.
+    TVector<TLogRecordPtr> EraseUpTo(ui64 lsn);
+
+    TLogRecordPtr GetOldest() const;
+
+    // Returns the record chained from |lsn| - the one whose PrevLsn is |lsn| -
+    // and nullptr across a gap, even when later records are held.
+    TLogRecordPtr GetChainedNext(ui64 lsn) const;
+
+    // Returns the longest unbroken run of ready records starting right after
+    // |lsn|, stopping at the first gap or unready record. A zero
+    // |maxRecordCount| means no limit.
+    TVector<TLogRecordPtr> GetReadyRun(ui64 afterLsn, ui64 maxRecordCount)
+        const;
+};
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/log_chain.h
+++ b/cloud/storage/core/libs/journalled_device/log_chain.h
@@ -6,7 +6,7 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 
-#include <util/generic/map.h>
+#include <util/generic/hash.h>
 #include <util/generic/vector.h>
 #include <util/system/spinlock.h>
 
@@ -14,39 +14,52 @@ namespace NCloud::NJournalled {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// In-flight records keyed by PrevLsn. They may arrive out of order, so there
+// can be gaps; the ready records that follow each other unbroken from
+// LastErasedLsn form the chained run, which ends at LastChainedLsn.
 class TLogRecordChain
 {
 private:
+    struct TEntry
+    {
+        bool Ready = false;
+        TLogRecordPtr Record;
+    };
+
     mutable TAdaptiveLock Lock;
     ui64 LastErasedLsn = 0;
-    TMap<ui64, TLogRecordPtr> Records;
+    ui64 LastChainedLsn = 0;
+    THashMap<ui64 /*prevLsn*/, TEntry> Records;
+
+    TLogRecordPtr GetNextImpl(ui64 lsn) const;
 
 public:
+    // Call before any Insert; |lsn| is the PrevLsn of the oldest record.
     void InitLastErasedLsn(ui64 lsn);
 
-    // On success returns the record whose promise the caller should wait on.
-    // That is the given record when it has been inserted.
+    // Rejects a record that overlaps a held one or ends at or below the
+    // watermark. Returns the record to wait on: the held one for a duplicate.
     TResultOrError<TLogRecordPtr> Insert(TLogRecordPtr record);
 
-    // Removes one record and returns it, nullptr if there is no such lsn.
-    // Does not move LastErasedLsn.
-    TLogRecordPtr Extract(ui64 lsn);
+    [[nodiscard]] bool MarkAsReady(ui64 prevLsn);
+    [[nodiscard]] bool Remove(ui64 prevLsn);
 
-    // Removes everything at or below |lsn| and moves LastErasedLsn up to it.
-    // Returns the removed records ordered by lsn.
-    TVector<TLogRecordPtr> EraseUpTo(ui64 lsn);
+    // Removes and returns the run up to |lsn|, plus the ready records left
+    // starting below the new watermark; failing their promises is up to the
+    // caller. Fails without changing anything when |lsn| > LastChainedLsn.
+    TResultOrError<TVector<TLogRecordPtr>> EraseUpTo(ui64 lsn);
 
+    // The head of the chained run, nullptr when the run is empty.
     TLogRecordPtr GetOldest() const;
 
-    // Returns the record chained from |lsn| - the one whose PrevLsn is |lsn| -
-    // and nullptr across a gap, even when later records are held.
-    TLogRecordPtr GetChainedNext(ui64 lsn) const;
+    // The ready record following |lsn|, nullptr when missing or not ready.
+    TLogRecordPtr GetNext(ui64 lsn) const;
 
-    // Returns the longest unbroken run of ready records starting right after
-    // |lsn|, stopping at the first gap or unready record. A zero
-    // |maxRecordCount| means no limit.
-    TVector<TLogRecordPtr> GetReadyRun(ui64 afterLsn, ui64 maxRecordCount)
-        const;
+    // Ready records following |afterLsn| up to the first gap or record not
+    // ready yet. A zero |maxRecordCount| means no limit.
+    TVector<TLogRecordPtr> GetReadyRun(
+        ui64 afterLsn,
+        ui64 maxRecordCount) const;
 };
 
 }   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/log_chain_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_chain_ut.cpp
@@ -1,0 +1,506 @@
+#include "log_chain.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+TLogRecordPtr MakeRecord(ui64 prevLsn, ui64 lsn, bool ready = true)
+{
+    auto record = std::make_shared<TLogRecord>();
+    record->PrevLsn = prevLsn;
+    record->Lsn = lsn;
+    record->Ready = ready;
+    return record;
+}
+
+TVector<ui64> GetLsns(const TVector<TLogRecordPtr>& records)
+{
+    TVector<ui64> lsns;
+    for (const auto& record: records) {
+        lsns.push_back(record->Lsn);
+    }
+    return lsns;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLogRecordChainTest)
+{
+    Y_UNIT_TEST(ShouldRejectRecordWithPrevLsnNotBelowLsn)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            chain.Insert(MakeRecord(25, 20)).GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            chain.Insert(MakeRecord(20, 20)).GetError().GetCode());
+
+        UNIT_ASSERT(!chain.GetOldest());
+    }
+
+    Y_UNIT_TEST(ShouldInsertChainedRecords)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(20, 30)).GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+    }
+
+    Y_UNIT_TEST(ShouldAcceptRecordsInsertedOutOfOrder)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(20, 30)).GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+    }
+
+    Y_UNIT_TEST(ShouldReturnTheHeldRecordForAnExactDuplicate)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(20, 30)).GetError().GetCode());
+
+        // a duplicate is not an error: the chain hands back the record it
+        // already holds, so the caller can wait on that one's promise
+        auto first = chain.Insert(MakeRecord(10, 20));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, first.GetError().GetCode());
+        UNIT_ASSERT(first.GetResult());
+        UNIT_ASSERT_VALUES_EQUAL(20, first.GetResult()->Lsn);
+
+        auto second = chain.Insert(MakeRecord(20, 30));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, second.GetError().GetCode());
+        UNIT_ASSERT(second.GetResult());
+        UNIT_ASSERT_VALUES_EQUAL(30, second.GetResult()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldRejectConflictingRecordWithSameLsn)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+
+        // same lsn, different prev lsn
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(5, 20)).GetError().GetCode());
+
+        // the original record is still the one held by the chain
+        UNIT_ASSERT_VALUES_EQUAL(10, chain.GetOldest()->PrevLsn);
+    }
+
+    Y_UNIT_TEST(ShouldRejectOverlapWithPreviousRecord)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+
+        // (15, 25] intersects (10, 20]
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(15, 25)).GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+    }
+
+    Y_UNIT_TEST(ShouldRejectOverlapWithNextRecord)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+
+        // (0, 15] intersects (10, 20] - the new record sorts before every
+        // existing one, so only a check against the next record catches it
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(0, 15)).GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+    }
+
+    Y_UNIT_TEST(ShouldAcceptAbuttingRecords)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+
+        // (0, 10] abuts (10, 20] without intersecting it
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(0, 10)).GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{10, 20}),
+            GetLsns(chain.GetReadyRun(0, 10)));
+    }
+
+    Y_UNIT_TEST(ShouldReturnNullptrFromGetOldestAndGetChainedNextWhenEmpty)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT(!chain.GetOldest());
+        UNIT_ASSERT(!chain.GetChainedNext(0));
+        UNIT_ASSERT(!chain.GetChainedNext(100));
+    }
+
+    Y_UNIT_TEST(ShouldReturnTheLowestRecordAsOldest)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(20, 30));
+        chain.Insert(MakeRecord(10, 20));
+
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldExtractRecordByLsn)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+
+        // the removed record is handed back to the caller
+        auto extracted = chain.Extract(20);
+        UNIT_ASSERT(extracted);
+        UNIT_ASSERT_VALUES_EQUAL(20, extracted->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetOldest()->Lsn);
+
+        // removing an unknown lsn is a no-op
+        UNIT_ASSERT(!chain.Extract(20));
+        UNIT_ASSERT(!chain.Extract(999));
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetOldest()->Lsn);
+
+        UNIT_ASSERT(chain.Extract(30));
+        UNIT_ASSERT(!chain.GetOldest());
+    }
+
+    Y_UNIT_TEST(ShouldGetRecordChainedFromLsn)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+
+        // GetNext follows the chain: it returns the record whose prev lsn is
+        // exactly the given lsn
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetChainedNext(10)->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetChainedNext(20)->Lsn);
+
+        // nothing chains from an lsn that is not a record boundary
+        UNIT_ASSERT(!chain.GetChainedNext(0));
+        UNIT_ASSERT(!chain.GetChainedNext(15));
+        UNIT_ASSERT(!chain.GetChainedNext(25));
+
+        // nothing chains from the last record
+        UNIT_ASSERT(!chain.GetChainedNext(30));
+        UNIT_ASSERT(!chain.GetChainedNext(100));
+    }
+
+    Y_UNIT_TEST(ShouldNotGetTheChainedNextAcrossAGap)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(30, 40));
+
+        // (20, 30] is missing, so the chain stops at 20 even though a record
+        // with a greater lsn exists
+        UNIT_ASSERT(!chain.GetChainedNext(20));
+        UNIT_ASSERT_VALUES_EQUAL(40, chain.GetChainedNext(30)->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldReturnAnEmptyRunWhenEmpty)
+    {
+        TLogRecordChain chain;
+
+        UNIT_ASSERT(chain.GetReadyRun(0, 10).empty());
+    }
+
+    Y_UNIT_TEST(ShouldReturnTheReadyRunAfterLsn)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+        chain.Insert(MakeRecord(30, 40));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30, 40}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+
+        // the tail continues from afterLsn, ascending
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{30, 40}),
+            GetLsns(chain.GetReadyRun(20, 10)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{40}),
+            GetLsns(chain.GetReadyRun(30, 10)));
+
+        UNIT_ASSERT(chain.GetReadyRun(40, 10).empty());
+        UNIT_ASSERT(chain.GetReadyRun(100, 10).empty());
+    }
+
+    Y_UNIT_TEST(ShouldLimitTheRunByMaxRecordCount)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+        chain.Insert(MakeRecord(30, 40));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20}),
+            GetLsns(chain.GetReadyRun(10, 1)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30}),
+            GetLsns(chain.GetReadyRun(10, 2)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{30}),
+            GetLsns(chain.GetReadyRun(20, 1)));
+
+        // asking for more than the chain holds is not an error
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30, 40}),
+            GetLsns(chain.GetReadyRun(10, Max<ui64>())));
+    }
+
+    Y_UNIT_TEST(ShouldReturnAnEmptyRunWhenAfterLsnIsNotARecordBoundary)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+
+        // the tail is anchored at afterLsn: nothing chains from 0, 15 or 25,
+        // so no run can be returned without leaving a hole behind it
+        UNIT_ASSERT(chain.GetReadyRun(0, 10).empty());
+        UNIT_ASSERT(chain.GetReadyRun(15, 10).empty());
+        UNIT_ASSERT(chain.GetReadyRun(25, 10).empty());
+    }
+
+    Y_UNIT_TEST(ShouldStopTheRunAtAGap)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(30, 40));
+
+        // (20, 30] is missing, so the tail ends at 20 rather than spanning it
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{40}),
+            GetLsns(chain.GetReadyRun(30, 10)));
+    }
+
+    Y_UNIT_TEST(ShouldTreatZeroMaxRecordCountAsNoLimit)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+        chain.Insert(MakeRecord(30, 40));
+
+        // TReadJournalTailRequest documents 0 as "no limit"
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30, 40}),
+            GetLsns(chain.GetReadyRun(10, 0)));
+
+        UNIT_ASSERT(chain.GetReadyRun(40, 0).empty());
+    }
+
+    Y_UNIT_TEST(ShouldStopTheRunAtTheFirstDirtyRecord)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30, false));   // dirty
+        chain.Insert(MakeRecord(30, 40));
+
+        // the tail stops at the dirty record instead of skipping it and
+        // returning a hole
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+
+        // once it becomes durable the rest of the tail is visible
+        chain.GetChainedNext(20)->Ready = true;
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30, 40}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+    }
+
+    Y_UNIT_TEST(ShouldReturnAnEmptyRunWhenTheFirstRecordIsDirty)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20, false));
+        chain.Insert(MakeRecord(20, 30));
+
+        UNIT_ASSERT(chain.GetReadyRun(10, 10).empty());
+
+        // a dirty record is still reachable through GetOldest and
+        // GetChainedNext - only the ready run filters on readiness
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetChainedNext(10)->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldNotMarkAnExtractedRecordAsErased)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        UNIT_ASSERT(chain.Extract(20));
+
+        // Extract leaves LastErasedLsn alone, so the very same record is
+        // accepted again rather than reported as already done
+        auto record = MakeRecord(10, 20);
+        auto result = chain.Insert(record);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(record.get(), result.GetResult().get());
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldEraseRecordsUpToLsn)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+        chain.Insert(MakeRecord(30, 40));
+
+        // everything at or below lsn 30 is removed and handed back in order
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30}),
+            GetLsns(chain.EraseUpTo(30)));
+        UNIT_ASSERT_VALUES_EQUAL(40, chain.GetOldest()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldEraseNothingBelowTheOldestLsn)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+
+        UNIT_ASSERT(chain.EraseUpTo(19).empty());
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20}),
+            GetLsns(chain.EraseUpTo(20)));
+        UNIT_ASSERT(!chain.GetOldest());
+    }
+
+    Y_UNIT_TEST(ShouldReportAlreadyForARecordAtOrBelowLastErasedLsn)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+        chain.Insert(MakeRecord(30, 40));
+        chain.EraseUpTo(30);
+
+        auto record = MakeRecord(10, 20);
+        auto result = chain.Insert(record);
+
+        // the caller gets a stub carrying the answer, not an error
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetError().GetCode());
+
+        auto stub = result.GetResult();
+        UNIT_ASSERT(stub);
+        UNIT_ASSERT(stub.get() != record.get());
+        UNIT_ASSERT_VALUES_EQUAL(20, stub->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(10, stub->PrevLsn);
+        UNIT_ASSERT(stub->Ready.load());
+
+        auto future = stub->Promise.GetFuture();
+        UNIT_ASSERT(future.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, future.GetValue().GetCode());
+
+        // nothing was inserted - the chain still starts where it did
+        UNIT_ASSERT_VALUES_EQUAL(40, chain.GetOldest()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldTreatLsnsBelowInitLastErasedLsnAsErased)
+    {
+        TLogRecordChain chain;
+        chain.InitLastErasedLsn(30);
+
+        auto stub = chain.Insert(MakeRecord(20, 30)).GetResult();
+        UNIT_ASSERT(stub);
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_ALREADY,
+            stub->Promise.GetFuture().GetValue().GetCode());
+        UNIT_ASSERT(!chain.GetOldest());
+
+        // the first record above the watermark is inserted as usual
+        auto record = MakeRecord(30, 40);
+        UNIT_ASSERT_VALUES_EQUAL(
+            record.get(),
+            chain.Insert(record).GetResult().get());
+        UNIT_ASSERT_VALUES_EQUAL(40, chain.GetOldest()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldNotRewindLastErasedLsnOnEraseUpTo)
+    {
+        TLogRecordChain chain;
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+        chain.EraseUpTo(30);
+        chain.EraseUpTo(10);
+
+        // the watermark stays at 30, so lsn 20 is still reported as done
+        auto stub = chain.Insert(MakeRecord(10, 20)).GetResult();
+        UNIT_ASSERT(stub);
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_ALREADY,
+            stub->Promise.GetFuture().GetValue().GetCode());
+        UNIT_ASSERT(!chain.GetOldest());
+    }
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/log_chain_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_chain_ut.cpp
@@ -2,19 +2,44 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
-namespace NCloud::NJournalled {
+#include <util/generic/algorithm.h>
 
-////////////////////////////////////////////////////////////////////////////////
+namespace NCloud::NJournalled {
 
 namespace {
 
-TLogRecordPtr MakeRecord(ui64 prevLsn, ui64 lsn, bool ready = true)
+////////////////////////////////////////////////////////////////////////////////
+
+TLogRecordPtr MakeRecord(ui64 prevLsn, ui64 lsn)
 {
     auto record = std::make_shared<TLogRecord>();
     record->PrevLsn = prevLsn;
     record->Lsn = lsn;
-    record->Ready = ready;
     return record;
+}
+
+// inserts a record and marks it as ready, the way a finished write lands in
+// the chain
+TLogRecordPtr InsertReady(TLogRecordChain& chain, ui64 prevLsn, ui64 lsn)
+{
+    auto record = MakeRecord(prevLsn, lsn);
+    auto result = chain.Insert(record);
+    UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetError().GetCode());
+    UNIT_ASSERT_VALUES_EQUAL(record.get(), result.GetResult().get());
+    UNIT_ASSERT(chain.MarkAsReady(prevLsn));
+    return record;
+}
+
+// erases up to |lsn| the way cleanup does, once the watermark is known to
+// sit inside the chained run
+TVector<TLogRecordPtr> EraseUpTo(TLogRecordChain& chain, ui64 lsn)
+{
+    auto result = chain.EraseUpTo(lsn);
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        S_OK,
+        result.GetError().GetCode(),
+        result.GetError().GetMessage());
+    return result.ExtractResult();
 }
 
 TVector<ui64> GetLsns(const TVector<TLogRecordPtr>& records)
@@ -23,6 +48,13 @@ TVector<ui64> GetLsns(const TVector<TLogRecordPtr>& records)
     for (const auto& record: records) {
         lsns.push_back(record->Lsn);
     }
+    return lsns;
+}
+
+TVector<ui64> GetSortedLsns(const TVector<TLogRecordPtr>& records)
+{
+    auto lsns = GetLsns(records);
+    Sort(lsns);
     return lsns;
 }
 
@@ -35,6 +67,7 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldRejectRecordWithPrevLsnNotBelowLsn)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
         UNIT_ASSERT_VALUES_EQUAL(
             E_ARGUMENT,
@@ -49,13 +82,10 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldInsertChainedRecords)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(20, 30)).GetError().GetCode());
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
 
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{20, 30}),
@@ -65,29 +95,74 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldAcceptRecordsInsertedOutOfOrder)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(20, 30)).GetError().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+        InsertReady(chain, 20, 30);
+        InsertReady(chain, 10, 20);
 
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{20, 30}),
             GetLsns(chain.GetReadyRun(10, 10)));
     }
 
+    Y_UNIT_TEST(ShouldMarkRecordAsReadyByPrevLsn)
+    {
+        TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
+
+        // nothing to mark yet
+        UNIT_ASSERT(!chain.MarkAsReady(10));
+
+        chain.Insert(MakeRecord(10, 20));
+
+        // a record that is not ready is held but invisible to the walk
+        UNIT_ASSERT(!chain.GetNext(10));
+        UNIT_ASSERT(!chain.GetOldest());
+
+        UNIT_ASSERT(chain.MarkAsReady(10));
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetNext(10)->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+
+        // marking twice is harmless
+        UNIT_ASSERT(chain.MarkAsReady(10));
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldExtendTheRunOnlyOverReadyRecords)
+    {
+        TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
+
+        chain.Insert(MakeRecord(10, 20));
+        chain.Insert(MakeRecord(20, 30));
+
+        // the second record is durable before the first one, so the run
+        // cannot move past the first yet
+        UNIT_ASSERT(chain.MarkAsReady(20));
+        UNIT_ASSERT(!chain.GetOldest());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            chain.Insert(MakeRecord(15, 25)).GetError().GetCode());
+
+        // marking the first one carries the run over both
+        UNIT_ASSERT(chain.MarkAsReady(10));
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(25, 35)).GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30}),
+            GetSortedLsns(EraseUpTo(chain, 30)));
+    }
+
     Y_UNIT_TEST(ShouldReturnTheHeldRecordForAnExactDuplicate)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(20, 30)).GetError().GetCode());
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
 
         // a duplicate is not an error: the chain hands back the record it
         // already holds, so the caller can wait on that one's promise
@@ -105,10 +180,9 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldRejectConflictingRecordWithSameLsn)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+        InsertReady(chain, 10, 20);
 
         // same lsn, different prev lsn
         UNIT_ASSERT_VALUES_EQUAL(
@@ -119,140 +193,214 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
         UNIT_ASSERT_VALUES_EQUAL(10, chain.GetOldest()->PrevLsn);
     }
 
-    Y_UNIT_TEST(ShouldRejectOverlapWithPreviousRecord)
+    Y_UNIT_TEST(ShouldRejectForkFromTheSameLsn)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
+
+        InsertReady(chain, 10, 20);
+
+        // two records cannot both continue from lsn 10
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(10, 25)).GetError().GetCode());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+            (TVector<ui64>{20}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetNext(10)->Lsn);
+    }
 
-        // (15, 25] intersects (10, 20]
+    Y_UNIT_TEST(ShouldRejectRecordStartingInsideTheChainedRun)
+    {
+        TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
+
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
+
+        // every boundary of the run is held, so a record starting anywhere
+        // else below its end starts inside another record
         UNIT_ASSERT_VALUES_EQUAL(
             E_INVALID_STATE,
             chain.Insert(MakeRecord(15, 25)).GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(25, 35)).GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(5, 15)).GetError().GetCode());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            (TVector<ui64>{20}),
+            (TVector<ui64>{20, 30}),
             GetLsns(chain.GetReadyRun(10, 10)));
     }
 
-    Y_UNIT_TEST(ShouldRejectOverlapWithNextRecord)
+    Y_UNIT_TEST(ShouldNotDetectOverlapPastAGap)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 30, 40);
+
+        // (35, 45] intersects (30, 40], but past the gap the chain only
+        // looks up records by their boundaries, so this is the caller's
+        // responsibility
         UNIT_ASSERT_VALUES_EQUAL(
             S_OK,
-            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
-
-        // (0, 15] intersects (10, 20] - the new record sorts before every
-        // existing one, so only a check against the next record catches it
-        UNIT_ASSERT_VALUES_EQUAL(
-            E_INVALID_STATE,
-            chain.Insert(MakeRecord(0, 15)).GetError().GetCode());
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            (TVector<ui64>{20}),
-            GetLsns(chain.GetReadyRun(10, 10)));
+            chain.Insert(MakeRecord(35, 45)).GetError().GetCode());
     }
 
     Y_UNIT_TEST(ShouldAcceptAbuttingRecords)
     {
         TLogRecordChain chain;
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+        InsertReady(chain, 10, 20);
 
         // (0, 10] abuts (10, 20] without intersecting it
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            chain.Insert(MakeRecord(0, 10)).GetError().GetCode());
+        InsertReady(chain, 0, 10);
 
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{10, 20}),
             GetLsns(chain.GetReadyRun(0, 10)));
     }
 
-    Y_UNIT_TEST(ShouldReturnNullptrFromGetOldestAndGetChainedNextWhenEmpty)
+    Y_UNIT_TEST(ShouldReturnNullptrFromGetOldestAndGetNextWhenEmpty)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
         UNIT_ASSERT(!chain.GetOldest());
-        UNIT_ASSERT(!chain.GetChainedNext(0));
-        UNIT_ASSERT(!chain.GetChainedNext(100));
+        UNIT_ASSERT(!chain.GetNext(0));
+        UNIT_ASSERT(!chain.GetNext(100));
     }
 
     Y_UNIT_TEST(ShouldReturnTheLowestRecordAsOldest)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(20, 30));
-        chain.Insert(MakeRecord(10, 20));
+        InsertReady(chain, 20, 30);
+        InsertReady(chain, 10, 20);
 
         UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
     }
 
-    Y_UNIT_TEST(ShouldExtractRecordByLsn)
+    Y_UNIT_TEST(ShouldRemoveRecordByPrevLsn)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
         chain.Insert(MakeRecord(10, 20));
         chain.Insert(MakeRecord(20, 30));
 
-        // the removed record is handed back to the caller
-        auto extracted = chain.Extract(20);
-        UNIT_ASSERT(extracted);
-        UNIT_ASSERT_VALUES_EQUAL(20, extracted->Lsn);
-        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetOldest()->Lsn);
+        UNIT_ASSERT(chain.Remove(10));
 
-        // removing an unknown lsn is a no-op
-        UNIT_ASSERT(!chain.Extract(20));
-        UNIT_ASSERT(!chain.Extract(999));
-        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetOldest()->Lsn);
+        // removing an unknown prev lsn is reported, not ignored
+        UNIT_ASSERT(!chain.Remove(10));
+        UNIT_ASSERT(!chain.Remove(999));
 
-        UNIT_ASSERT(chain.Extract(30));
+        // the record after it is still held
+        UNIT_ASSERT(chain.MarkAsReady(20));
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetNext(20)->Lsn);
+        UNIT_ASSERT(!chain.MarkAsReady(10));
+
+        // a ready record is part of the chain and cannot be taken out
+        UNIT_ASSERT(!chain.Remove(20));
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetNext(20)->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldRestoreTheRunWhenARemovedRecordIsReinserted)
+    {
+        TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
+
+        InsertReady(chain, 10, 20);
+        chain.Insert(MakeRecord(20, 30));   // its write is about to fail
+        InsertReady(chain, 30, 40);
+
+        // the failed write is taken out, the run still ends before it
+        UNIT_ASSERT(chain.Remove(20));
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+
+        // the retry starts at the end of the run and rejoins the rest
+        InsertReady(chain, 20, 30);
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30, 40}),
+            GetLsns(chain.GetReadyRun(10, 10)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30, 40}),
+            GetSortedLsns(EraseUpTo(chain, 40)));
+    }
+
+    Y_UNIT_TEST(ShouldExtendTheRunThroughWaitingRecords)
+    {
+        TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
+
+        InsertReady(chain, 30, 40);
+        InsertReady(chain, 20, 30);
+
+        // nothing chains from the watermark yet
         UNIT_ASSERT(!chain.GetOldest());
+
+        // filling the gap joins everything behind it, so the run now covers
+        // (10, 40] and guards against records starting inside it
+        InsertReady(chain, 10, 20);
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(35, 45)).GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30, 40}),
+            GetSortedLsns(EraseUpTo(chain, 40)));
     }
 
     Y_UNIT_TEST(ShouldGetRecordChainedFromLsn)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30));
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
 
         // GetNext follows the chain: it returns the record whose prev lsn is
         // exactly the given lsn
-        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetChainedNext(10)->Lsn);
-        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetChainedNext(20)->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetNext(10)->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetNext(20)->Lsn);
 
         // nothing chains from an lsn that is not a record boundary
-        UNIT_ASSERT(!chain.GetChainedNext(0));
-        UNIT_ASSERT(!chain.GetChainedNext(15));
-        UNIT_ASSERT(!chain.GetChainedNext(25));
+        UNIT_ASSERT(!chain.GetNext(0));
+        UNIT_ASSERT(!chain.GetNext(15));
+        UNIT_ASSERT(!chain.GetNext(25));
 
         // nothing chains from the last record
-        UNIT_ASSERT(!chain.GetChainedNext(30));
-        UNIT_ASSERT(!chain.GetChainedNext(100));
+        UNIT_ASSERT(!chain.GetNext(30));
+        UNIT_ASSERT(!chain.GetNext(100));
     }
 
-    Y_UNIT_TEST(ShouldNotGetTheChainedNextAcrossAGap)
+    Y_UNIT_TEST(ShouldNotGetTheNextAcrossAGap)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(30, 40));
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 30, 40);
 
         // (20, 30] is missing, so the chain stops at 20 even though a record
         // with a greater lsn exists
-        UNIT_ASSERT(!chain.GetChainedNext(20));
-        UNIT_ASSERT_VALUES_EQUAL(40, chain.GetChainedNext(30)->Lsn);
+        UNIT_ASSERT(!chain.GetNext(20));
+        UNIT_ASSERT_VALUES_EQUAL(40, chain.GetNext(30)->Lsn);
     }
 
     Y_UNIT_TEST(ShouldReturnAnEmptyRunWhenEmpty)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
         UNIT_ASSERT(chain.GetReadyRun(0, 10).empty());
     }
@@ -260,10 +408,11 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldReturnTheReadyRunAfterLsn)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30));
-        chain.Insert(MakeRecord(30, 40));
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
+        InsertReady(chain, 30, 40);
 
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{20, 30, 40}),
@@ -284,10 +433,11 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldLimitTheRunByMaxRecordCount)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30));
-        chain.Insert(MakeRecord(30, 40));
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
+        InsertReady(chain, 30, 40);
 
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{20}),
@@ -308,9 +458,10 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldReturnAnEmptyRunWhenAfterLsnIsNotARecordBoundary)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30));
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
 
         // the tail is anchored at afterLsn: nothing chains from 0, 15 or 25,
         // so no run can be returned without leaving a hole behind it
@@ -322,9 +473,10 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldStopTheRunAtAGap)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(30, 40));
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 30, 40);
 
         // (20, 30] is missing, so the tail ends at 20 rather than spanning it
         UNIT_ASSERT_VALUES_EQUAL(
@@ -339,10 +491,11 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
     Y_UNIT_TEST(ShouldTreatZeroMaxRecordCountAsNoLimit)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30));
-        chain.Insert(MakeRecord(30, 40));
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
+        InsertReady(chain, 30, 40);
 
         // TReadJournalTailRequest documents 0 as "no limit"
         UNIT_ASSERT_VALUES_EQUAL(
@@ -352,115 +505,154 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
         UNIT_ASSERT(chain.GetReadyRun(40, 0).empty());
     }
 
-    Y_UNIT_TEST(ShouldStopTheRunAtTheFirstDirtyRecord)
+    Y_UNIT_TEST(ShouldStopTheRunAtTheFirstRecordThatIsNotReady)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30, false));   // dirty
-        chain.Insert(MakeRecord(30, 40));
+        InsertReady(chain, 10, 20);
+        chain.Insert(MakeRecord(20, 30));   // still being written
+        InsertReady(chain, 30, 40);
 
-        // the tail stops at the dirty record instead of skipping it and
-        // returning a hole
+        // the tail stops at the record that is not ready instead of skipping
+        // it and returning a hole
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{20}),
             GetLsns(chain.GetReadyRun(10, 10)));
 
         // once it becomes durable the rest of the tail is visible
-        chain.GetChainedNext(20)->Ready = true;
+        UNIT_ASSERT(chain.MarkAsReady(20));
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{20, 30, 40}),
             GetLsns(chain.GetReadyRun(10, 10)));
     }
 
-    Y_UNIT_TEST(ShouldReturnAnEmptyRunWhenTheFirstRecordIsDirty)
+    Y_UNIT_TEST(ShouldReturnAnEmptyRunWhenTheFirstRecordIsNotReady)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20, false));
-        chain.Insert(MakeRecord(20, 30));
+        chain.Insert(MakeRecord(10, 20));
+        InsertReady(chain, 20, 30);
 
         UNIT_ASSERT(chain.GetReadyRun(10, 10).empty());
 
-        // a dirty record is still reachable through GetOldest and
-        // GetChainedNext - only the ready run filters on readiness
+        // a record that is not ready is invisible to GetOldest and GetNext as
+        // well, but the ready ones behind it can still be reached
+        UNIT_ASSERT(!chain.GetOldest());
+        UNIT_ASSERT(!chain.GetNext(10));
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetNext(20)->Lsn);
+
+        UNIT_ASSERT(chain.MarkAsReady(10));
         UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
-        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetChainedNext(10)->Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 30}),
+            GetLsns(chain.GetReadyRun(10, 10)));
     }
 
-    Y_UNIT_TEST(ShouldNotMarkAnExtractedRecordAsErased)
+    Y_UNIT_TEST(ShouldNotMarkARemovedRecordAsErased)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
         chain.Insert(MakeRecord(10, 20));
-        UNIT_ASSERT(chain.Extract(20));
+        UNIT_ASSERT(chain.Remove(10));
 
-        // Extract leaves LastErasedLsn alone, so the very same record is
+        // Remove leaves LastErasedLsn alone, so the very same record is
         // accepted again rather than reported as already done
         auto record = MakeRecord(10, 20);
         auto result = chain.Insert(record);
         UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetError().GetCode());
         UNIT_ASSERT_VALUES_EQUAL(record.get(), result.GetResult().get());
+
+        UNIT_ASSERT(chain.MarkAsReady(10));
         UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
     }
 
     Y_UNIT_TEST(ShouldEraseRecordsUpToLsn)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30));
-        chain.Insert(MakeRecord(30, 40));
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
+        InsertReady(chain, 30, 40);
 
-        // everything at or below lsn 30 is removed and handed back in order
+        // everything at or below lsn 30 is removed and handed back
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{20, 30}),
-            GetLsns(chain.EraseUpTo(30)));
+            GetSortedLsns(EraseUpTo(chain, 30)));
         UNIT_ASSERT_VALUES_EQUAL(40, chain.GetOldest()->Lsn);
     }
 
     Y_UNIT_TEST(ShouldEraseNothingBelowTheOldestLsn)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
+        InsertReady(chain, 10, 20);
 
-        UNIT_ASSERT(chain.EraseUpTo(19).empty());
+        UNIT_ASSERT(EraseUpTo(chain, 19).empty());
         UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
 
         UNIT_ASSERT_VALUES_EQUAL(
             (TVector<ui64>{20}),
-            GetLsns(chain.EraseUpTo(20)));
+            GetLsns(EraseUpTo(chain, 20)));
         UNIT_ASSERT(!chain.GetOldest());
     }
 
-    Y_UNIT_TEST(ShouldReportAlreadyForARecordAtOrBelowLastErasedLsn)
+    Y_UNIT_TEST(ShouldDropReadyRecordsStrandedBelowTheWatermark)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30));
-        chain.Insert(MakeRecord(30, 40));
-        chain.EraseUpTo(30);
+        // both start inside (10, 20], which is not held yet, so the overlap
+        // goes unnoticed
+        auto ready = InsertReady(chain, 15, 25);
+        chain.Insert(MakeRecord(18, 28));   // still being written
 
-        auto record = MakeRecord(10, 20);
-        auto result = chain.Insert(record);
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
 
-        // the caller gets a stub carrying the answer, not an error
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, result.GetError().GetCode());
+        // the head is erased, and so is the ready record that now starts
+        // below the watermark: it can never join the chain
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{20, 25}),
+            GetSortedLsns(EraseUpTo(chain, 20)));
 
-        auto stub = result.GetResult();
-        UNIT_ASSERT(stub);
-        UNIT_ASSERT(stub.get() != record.get());
-        UNIT_ASSERT_VALUES_EQUAL(20, stub->Lsn);
-        UNIT_ASSERT_VALUES_EQUAL(10, stub->PrevLsn);
-        UNIT_ASSERT(stub->Ready.load());
+        // the chain does not touch promises, the caller fails them
+        UNIT_ASSERT(!ready->Promise.Initialized());
 
-        auto future = stub->Promise.GetFuture();
-        UNIT_ASSERT(future.HasValue());
-        UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, future.GetValue().GetCode());
+        // the one that is not ready is left alone until its write finishes
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetOldest()->Lsn);
+        UNIT_ASSERT(chain.MarkAsReady(18));
+        UNIT_ASSERT_VALUES_EQUAL(
+            (TVector<ui64>{28}),
+            GetLsns(EraseUpTo(chain, 20)));
+        UNIT_ASSERT(!chain.MarkAsReady(18));
+        UNIT_ASSERT_VALUES_EQUAL(30, chain.GetOldest()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldRejectARecordAtOrBelowLastErasedLsn)
+    {
+        TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
+
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
+        InsertReady(chain, 30, 40);
+        EraseUpTo(chain, 30);
+
+        // an erased record is gone for good, the chain will not take it back
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(20, 30)).GetError().GetCode());
 
         // nothing was inserted - the chain still starts where it did
+        UNIT_ASSERT(!chain.MarkAsReady(10));
         UNIT_ASSERT_VALUES_EQUAL(40, chain.GetOldest()->Lsn);
     }
 
@@ -469,36 +661,54 @@ Y_UNIT_TEST_SUITE(TLogRecordChainTest)
         TLogRecordChain chain;
         chain.InitLastErasedLsn(30);
 
-        auto stub = chain.Insert(MakeRecord(20, 30)).GetResult();
-        UNIT_ASSERT(stub);
         UNIT_ASSERT_VALUES_EQUAL(
-            S_ALREADY,
-            stub->Promise.GetFuture().GetValue().GetCode());
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(20, 30)).GetError().GetCode());
         UNIT_ASSERT(!chain.GetOldest());
 
         // the first record above the watermark is inserted as usual
-        auto record = MakeRecord(30, 40);
+        InsertReady(chain, 30, 40);
+        UNIT_ASSERT_VALUES_EQUAL(40, chain.GetOldest()->Lsn);
+    }
+
+    Y_UNIT_TEST(ShouldRejectEraseUpToPastTheChainedRun)
+    {
+        TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
+
+        InsertReady(chain, 10, 20);
+        chain.Insert(MakeRecord(20, 30));   // still being written
+        InsertReady(chain, 30, 40);
+
+        // the run ends at 20, so nothing past it can be erased yet and the
+        // chain stays as it was
+        auto result = chain.EraseUpTo(30);
+        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, result.GetError().GetCode());
+        UNIT_ASSERT(result.GetResult().empty());
+        UNIT_ASSERT_VALUES_EQUAL(20, chain.GetOldest()->Lsn);
+
+        // once the gap is filled the same watermark goes through
+        UNIT_ASSERT(chain.MarkAsReady(20));
         UNIT_ASSERT_VALUES_EQUAL(
-            record.get(),
-            chain.Insert(record).GetResult().get());
+            (TVector<ui64>{20, 30}),
+            GetSortedLsns(EraseUpTo(chain, 30)));
         UNIT_ASSERT_VALUES_EQUAL(40, chain.GetOldest()->Lsn);
     }
 
     Y_UNIT_TEST(ShouldNotRewindLastErasedLsnOnEraseUpTo)
     {
         TLogRecordChain chain;
+        chain.InitLastErasedLsn(10);
 
-        chain.Insert(MakeRecord(10, 20));
-        chain.Insert(MakeRecord(20, 30));
-        chain.EraseUpTo(30);
-        chain.EraseUpTo(10);
+        InsertReady(chain, 10, 20);
+        InsertReady(chain, 20, 30);
+        EraseUpTo(chain, 30);
+        EraseUpTo(chain, 10);
 
-        // the watermark stays at 30, so lsn 20 is still reported as done
-        auto stub = chain.Insert(MakeRecord(10, 20)).GetResult();
-        UNIT_ASSERT(stub);
+        // the watermark stays at 30, so lsn 20 is still reported as erased
         UNIT_ASSERT_VALUES_EQUAL(
-            S_ALREADY,
-            stub->Promise.GetFuture().GetValue().GetCode());
+            E_INVALID_STATE,
+            chain.Insert(MakeRecord(10, 20)).GetError().GetCode());
         UNIT_ASSERT(!chain.GetOldest());
     }
 }

--- a/cloud/storage/core/libs/journalled_device/log_index.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_index.cpp
@@ -23,18 +23,13 @@ bool TLogPageIndex::TryApplyNext(const TLogRecord& record)
         }
 
         for (const auto& [pageNo, location]: record.PageMappings) {
-            if (location.PageCount == 0) {
-                continue;
-            }
-
-            const auto hint =
-                ClearRange(pageNo, pageNo + location.PageCount);
+            const auto hint = ClearRange(pageNo, pageNo + location.PageCount);
 
             const size_t sizeBefore = Entries.size();
             Entries.emplace_hint(
                 hint,
                 pageNo,
-                std::make_pair(record.Lsn, location));
+                TEntry{.Lsn = record.Lsn, .Location = location});
 
             STORAGE_VERIFY(Entries.size() == sizeBefore + 1, "PageNo", pageNo);
         }
@@ -48,7 +43,7 @@ void TLogPageIndex::EraseUpTo(ui64 lsn)
 {
     with_lock (Lock) {
         for (auto it = Entries.begin(); it != Entries.end();) {
-            if (it->second.first <= lsn) {
+            if (it->second.Lsn <= lsn) {
                 it = Entries.erase(it);
             } else {
                 ++it;
@@ -102,12 +97,13 @@ auto TLogPageIndex::Lookup(
                 const ui64 clipFrom = Max(entryFrom, from);
                 const ui64 clipTo = Min(entryTo, to);
 
-                result.Mappings.push_back(TPageMapping{
-                    .PageNo = clipFrom,
-                    .Location = TPageRange{
-                        .FirstPageNo =
-                            location.FirstPageNo + (clipFrom - entryFrom),
-                        .PageCount = clipTo - clipFrom}});
+                result.Mappings.push_back(
+                    TPageMapping{
+                        .PageNo = clipFrom,
+                        .Location = TPageRange{
+                            .FirstPageNo =
+                                location.FirstPageNo + (clipFrom - entryFrom),
+                            .PageCount = clipTo - clipFrom}});
             }
         }
     }
@@ -124,14 +120,9 @@ TLogPageIndex::TEntries::iterator TLogPageIndex::ClearRange(ui64 from, ui64 to)
 
     while (it != Entries.end() && it->first < to) {
         const ui64 entryFrom = it->first;
-        const ui64 lsn = it->second.first;
-        const TPageRange location = it->second.second;
+        const ui64 lsn = it->second.Lsn;
+        const TPageRange location = it->second.Location;
         const ui64 entryTo = entryFrom + location.PageCount;
-
-        if (!location.PageCount) {
-            it = Entries.erase(it);
-            continue;
-        }
 
         if (entryTo <= from) {
             ++it;
@@ -144,23 +135,22 @@ TLogPageIndex::TEntries::iterator TLogPageIndex::ClearRange(ui64 from, ui64 to)
             Entries.emplace_hint(
                 it,
                 entryFrom,
-                std::make_pair(
-                    lsn,
-                    TPageRange{
+                TEntry{
+                    .Lsn = lsn,
+                    .Location = TPageRange{
                         .FirstPageNo = location.FirstPageNo,
-                        .PageCount = from - entryFrom}));
+                        .PageCount = from - entryFrom}});
         }
 
         if (entryTo > to) {
             it = Entries.emplace_hint(
                 it,
                 to,
-                std::make_pair(
-                    lsn,
-                    TPageRange{
-                        .FirstPageNo =
-                            location.FirstPageNo + (to - entryFrom),
-                        .PageCount = entryTo - to}));
+                TEntry{
+                    .Lsn = lsn,
+                    .Location = TPageRange{
+                        .FirstPageNo = location.FirstPageNo + (to - entryFrom),
+                        .PageCount = entryTo - to}});
         }
     }
 

--- a/cloud/storage/core/libs/journalled_device/log_index.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_index.cpp
@@ -1,0 +1,170 @@
+#include "log_index.h"
+
+#include <cloud/storage/core/libs/common/verify.h>
+
+#include <util/generic/utility.h>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TLogPageIndex::InitLastIndexedLsn(ui64 lastIndexedLsn)
+{
+    with_lock (Lock) {
+        LastIndexedLsn = lastIndexedLsn;
+    }
+}
+
+bool TLogPageIndex::TryApplyNext(const TLogRecord& record)
+{
+    with_lock (Lock) {
+        if (record.PrevLsn != LastIndexedLsn) {
+            return false;
+        }
+
+        for (const auto& [pageNo, location]: record.PageMappings) {
+            if (location.PageCount == 0) {
+                continue;
+            }
+
+            const auto hint =
+                ClearRange(pageNo, pageNo + location.PageCount);
+
+            const size_t sizeBefore = Entries.size();
+            Entries.emplace_hint(
+                hint,
+                pageNo,
+                std::make_pair(record.Lsn, location));
+
+            STORAGE_VERIFY(Entries.size() == sizeBefore + 1, "PageNo", pageNo);
+        }
+
+        LastIndexedLsn = record.Lsn;
+    }
+    return true;
+}
+
+void TLogPageIndex::EraseUpTo(ui64 lsn)
+{
+    with_lock (Lock) {
+        for (auto it = Entries.begin(); it != Entries.end();) {
+            if (it->second.first <= lsn) {
+                it = Entries.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+}
+
+ui64 TLogPageIndex::GetLastIndexedLsn() const
+{
+    with_lock (Lock) {
+        return LastIndexedLsn;
+    }
+}
+
+auto TLogPageIndex::Lookup(
+    const TVector<TPageRange>& ranges,
+    ui64 afterLsn) const -> TLookupResult
+{
+    TLookupResult result;
+
+    with_lock (Lock) {
+        result.LastIndexedLsn = LastIndexedLsn;
+
+        if (afterLsn >= LastIndexedLsn) {
+            return result;
+        }
+
+        for (const auto& range: ranges) {
+            const ui64 from = range.FirstPageNo;
+            const ui64 to = from + range.PageCount;
+
+            auto it = Entries.lower_bound(from);
+            if (it != Entries.begin()) {
+                --it;
+            }
+
+            for (; it != Entries.end() && it->first < to; ++it) {
+                const auto& [lsn, location] = it->second;
+                const ui64 entryFrom = it->first;
+                const ui64 entryTo = entryFrom + location.PageCount;
+
+                if (entryTo <= from) {
+                    continue;
+                }
+
+                if (lsn <= afterLsn) {
+                    continue;
+                }
+
+                const ui64 clipFrom = Max(entryFrom, from);
+                const ui64 clipTo = Min(entryTo, to);
+
+                result.Mappings.push_back(TPageMapping{
+                    .PageNo = clipFrom,
+                    .Location = TPageRange{
+                        .FirstPageNo =
+                            location.FirstPageNo + (clipFrom - entryFrom),
+                        .PageCount = clipTo - clipFrom}});
+            }
+        }
+    }
+
+    return result;
+}
+
+TLogPageIndex::TEntries::iterator TLogPageIndex::ClearRange(ui64 from, ui64 to)
+{
+    auto it = Entries.lower_bound(from);
+    if (it != Entries.begin()) {
+        --it;
+    }
+
+    while (it != Entries.end() && it->first < to) {
+        const ui64 entryFrom = it->first;
+        const ui64 lsn = it->second.first;
+        const TPageRange location = it->second.second;
+        const ui64 entryTo = entryFrom + location.PageCount;
+
+        if (!location.PageCount) {
+            it = Entries.erase(it);
+            continue;
+        }
+
+        if (entryTo <= from) {
+            ++it;
+            continue;
+        }
+
+        it = Entries.erase(it);
+
+        if (entryFrom < from) {
+            Entries.emplace_hint(
+                it,
+                entryFrom,
+                std::make_pair(
+                    lsn,
+                    TPageRange{
+                        .FirstPageNo = location.FirstPageNo,
+                        .PageCount = from - entryFrom}));
+        }
+
+        if (entryTo > to) {
+            it = Entries.emplace_hint(
+                it,
+                to,
+                std::make_pair(
+                    lsn,
+                    TPageRange{
+                        .FirstPageNo =
+                            location.FirstPageNo + (to - entryFrom),
+                        .PageCount = entryTo - to}));
+        }
+    }
+
+    return it;
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/log_index.h
+++ b/cloud/storage/core/libs/journalled_device/log_index.h
@@ -17,8 +17,13 @@ namespace NCloud::NJournalled {
 class TLogPageIndex
 {
 private:
-    using TEntries =
-        TMap<ui64 /*pageNo*/, std::pair<ui64 /*lsn*/, TPageRange>>;
+    struct TEntry
+    {
+        ui64 Lsn = 0;
+        TPageRange Location;
+    };
+
+    using TEntries = TMap<ui64 /*pageNo*/, TEntry>;
 
     mutable TAdaptiveLock Lock;
     ui64 LastIndexedLsn = 0;

--- a/cloud/storage/core/libs/journalled_device/log_index.h
+++ b/cloud/storage/core/libs/journalled_device/log_index.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "public.h"
+
+#include "log_record.h"
+
+#include <util/generic/map.h>
+#include <util/generic/vector.h>
+#include <util/system/spinlock.h>
+
+#include <utility>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TLogPageIndex
+{
+private:
+    using TEntries =
+        TMap<ui64 /*pageNo*/, std::pair<ui64 /*lsn*/, TPageRange>>;
+
+    mutable TAdaptiveLock Lock;
+    ui64 LastIndexedLsn = 0;
+    TEntries Entries;
+
+public:
+    struct TLookupResult
+    {
+        ui64 LastIndexedLsn = 0;
+        TVector<TPageMapping> Mappings;
+    };
+
+    void InitLastIndexedLsn(ui64 lastIndexedLsn);
+
+    // Applies the record continuing the chain from LastIndexedLsn,
+    // overwriting the pages it maps and moving LastIndexedLsn up to the
+    // record's lsn. Returns false and changes nothing when the record does
+    // not chain from it.
+    [[nodiscard]] bool TryApplyNext(const TLogRecord& record);
+
+    // Removes the mappings written at or below |lsn|. Does not move
+    // LastIndexedLsn.
+    void EraseUpTo(ui64 lsn);
+
+    ui64 GetLastIndexedLsn() const;
+
+    // Returns the mappings for |ranges| written after |afterLsn|, clipped to
+    // the requested ranges, and the LastIndexedLsn they were read at.
+    TLookupResult Lookup(
+        const TVector<TPageRange>& ranges,
+        ui64 afterLsn) const;
+
+private:
+    TEntries::iterator ClearRange(ui64 from, ui64 to);
+};
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/log_index_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_index_ut.cpp
@@ -6,15 +6,12 @@
 
 namespace NCloud::NJournalled {
 
-////////////////////////////////////////////////////////////////////////////////
-
 namespace {
 
-// TLogRecord holds an atomic, so it is neither copyable nor movable
-TLogRecordPtr MakePageRecord(
-    ui64 prevLsn,
-    ui64 lsn,
-    TVector<TPageMapping> pageMappings)
+////////////////////////////////////////////////////////////////////////////////
+
+TLogRecordPtr
+MakePageRecord(ui64 prevLsn, ui64 lsn, TVector<TPageMapping> pageMappings)
 {
     auto record = std::make_shared<TLogRecord>();
     record->PrevLsn = prevLsn;
@@ -309,36 +306,6 @@ Y_UNIT_TEST_SUITE(TLogPageIndexTest)
         UNIT_ASSERT(map.Lookup({Range(1, 1)}, 100).Mappings.empty());
     }
 
-    Y_UNIT_TEST(ShouldNotLetADegenerateEntryBlockALaterMapping)
-    {
-        TLogPageIndex map;
-        map.InitLastIndexedLsn(10);
-
-        // a group covering no pages at all
-        auto empty = MakePageRecord(10, 20, {{5, Range(100, 0)}});
-        UNIT_ASSERT(map.TryApplyNext(*empty));
-
-        // a later record maps that same first page for real
-        auto real = MakePageRecord(20, 30, {{5, Range(200, 3)}});
-        UNIT_ASSERT(map.TryApplyNext(*real));
-
-        // the real mapping must win rather than be dropped on a taken key
-        UNIT_ASSERT_VALUES_EQUAL("5->200x3", DescribeAll(map));
-    }
-
-    Y_UNIT_TEST(ShouldIgnoreADegenerateEntryWhenReading)
-    {
-        TLogPageIndex map;
-        map.InitLastIndexedLsn(10);
-
-        auto record =
-            MakePageRecord(10, 20, {{1, Range(100, 2)}, {7, Range(200, 0)}});
-        UNIT_ASSERT(map.TryApplyNext(*record));
-
-        // the zero length group contributes nothing to what can be served
-        UNIT_ASSERT_VALUES_EQUAL("1->100x2", DescribeAll(map));
-    }
-
     Y_UNIT_TEST(ShouldRemoveEverythingUpToTheGivenLsn)
     {
         TLogPageIndex map;
@@ -415,10 +382,7 @@ namespace {
 // brute-force model: one entry per device page, no ranges at all
 using TModel = TMap<ui64, std::pair<ui64 /*lsn*/, ui64 /*storePage*/>>;
 
-void ModelApply(
-    TModel& model,
-    ui64 lsn,
-    const TVector<TPageMapping>& mappings)
+void ModelApply(TModel& model, ui64 lsn, const TVector<TPageMapping>& mappings)
 {
     for (const auto& [pageNo, location]: mappings) {
         for (ui64 i = 0; i < location.PageCount; ++i) {
@@ -448,8 +412,7 @@ ModelGet(const TModel& model, ui64 from, ui64 to, ui64 afterLsn)
 }
 
 // expand the range-based answer back to one entry per page
-TVector<std::pair<ui64, ui64>> Expand(
-    const TVector<TPageMapping>& mappings)
+TVector<std::pair<ui64, ui64>> Expand(const TVector<TPageMapping>& mappings)
 {
     TVector<std::pair<ui64, ui64>> out;
     for (const auto& [pageNo, location]: mappings) {
@@ -511,11 +474,12 @@ Y_UNIT_TEST_SUITE(TLogPageIndexModelTest)
                 for (ui64 g = 0; g < groupCnt; ++g) {
                     const ui64 len = 1 + rng.Next(8);
                     const ui64 start = rng.Next(PageSpace - len);
-                    mappings.push_back(TPageMapping{
-                        .PageNo = start,
-                        .Location = TPageRange{
-                            .FirstPageNo = storeNext,
-                            .PageCount = len}});
+                    mappings.push_back(
+                        TPageMapping{
+                            .PageNo = start,
+                            .Location = TPageRange{
+                                .FirstPageNo = storeNext,
+                                .PageCount = len}});
                     storeNext += len;
                 }
 
@@ -539,13 +503,12 @@ Y_UNIT_TEST_SUITE(TLogPageIndexModelTest)
                     const ui64 from = rng.Next(PageSpace + 8);
                     const ui64 afterLsn = rng.Next(lsn + 20);
 
-                    const auto got = Expand(
-                        map.Lookup(
-                               {TPageRange{
-                                   .FirstPageNo = from,
-                                   .PageCount = len}},
-                               afterLsn)
-                            .Mappings);
+                    const auto got = Expand(map.Lookup(
+                                                   {TPageRange{
+                                                       .FirstPageNo = from,
+                                                       .PageCount = len}},
+                                                   afterLsn)
+                                                .Mappings);
                     const auto want =
                         ModelGet(model, from, from + len, afterLsn);
 

--- a/cloud/storage/core/libs/journalled_device/log_index_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_index_ut.cpp
@@ -1,0 +1,570 @@
+#include "log_index.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/map.h>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+// TLogRecord holds an atomic, so it is neither copyable nor movable
+TLogRecordPtr MakePageRecord(
+    ui64 prevLsn,
+    ui64 lsn,
+    TVector<TPageMapping> pageMappings)
+{
+    auto record = std::make_shared<TLogRecord>();
+    record->PrevLsn = prevLsn;
+    record->Lsn = lsn;
+    record->PageMappings = std::move(pageMappings);
+    return record;
+}
+
+// a run of pages - in the page store when it is the location a mapping points
+// at, in the device address space when it is what a reader asks for
+TPageRange Range(ui64 firstPageNo, ui64 pageCount)
+{
+    return {.FirstPageNo = firstPageNo, .PageCount = pageCount};
+}
+
+// "<device page> -> <page store page> x<count>", in the order returned
+TString Describe(const TVector<TPageMapping>& mappings)
+{
+    TStringBuilder sb;
+    for (const auto& [pageNo, location]: mappings) {
+        if (sb) {
+            sb << ", ";
+        }
+        sb << pageNo << "->" << location.FirstPageNo << "x"
+           << location.PageCount;
+    }
+    return sb;
+}
+
+// everything the log holds, for asserting on the whole index at once
+TString DescribeAll(const TLogPageIndex& map)
+{
+    return Describe(map.Lookup({Range(0, 1000)}, 0).Mappings);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLogPageIndexTest)
+{
+    Y_UNIT_TEST(ShouldStartEmpty)
+    {
+        TLogPageIndex map;
+
+        UNIT_ASSERT_VALUES_EQUAL(0, map.GetLastIndexedLsn());
+        UNIT_ASSERT(map.Lookup({Range(0, 4)}, 0).Mappings.empty());
+    }
+
+    Y_UNIT_TEST(ShouldInitLastIndexedLsn)
+    {
+        TLogPageIndex map;
+
+        map.InitLastIndexedLsn(10);
+        UNIT_ASSERT_VALUES_EQUAL(10, map.GetLastIndexedLsn());
+    }
+
+    Y_UNIT_TEST(ShouldRejectRecordThatDoesNotChainFromLastIndexedLsn)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto stale = MakePageRecord(0, 20, {{1, Range(100, 1)}});
+        auto ahead = MakePageRecord(15, 20, {{1, Range(100, 1)}});
+
+        UNIT_ASSERT(!map.TryApplyNext(*stale));
+        UNIT_ASSERT(!map.TryApplyNext(*ahead));
+
+        // rejected records leave the map untouched
+        UNIT_ASSERT_VALUES_EQUAL(10, map.GetLastIndexedLsn());
+        UNIT_ASSERT_VALUES_EQUAL("", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldAdvanceLastIndexedLsnOnTryApplyNext)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto first = MakePageRecord(10, 20, {{1, Range(100, 1)}});
+        auto second = MakePageRecord(20, 30, {{5, Range(200, 1)}});
+        auto stale = MakePageRecord(20, 40, {{9, Range(300, 1)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*first));
+        UNIT_ASSERT_VALUES_EQUAL(20, map.GetLastIndexedLsn());
+
+        UNIT_ASSERT(map.TryApplyNext(*second));
+        UNIT_ASSERT_VALUES_EQUAL(30, map.GetLastIndexedLsn());
+
+        // the chain continues from the lsn just applied
+        UNIT_ASSERT(!map.TryApplyNext(*stale));
+        UNIT_ASSERT_VALUES_EQUAL(30, map.GetLastIndexedLsn());
+    }
+
+    Y_UNIT_TEST(ShouldKeepDisjointRanges)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto record =
+            MakePageRecord(10, 20, {{1, Range(100, 2)}, {5, Range(200, 3)}});
+        UNIT_ASSERT(map.TryApplyNext(*record));
+
+        UNIT_ASSERT_VALUES_EQUAL("1->100x2, 5->200x3", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldSkipPagesThatAreNotInTheLog)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto record = MakePageRecord(10, 20, {{2, Range(100, 2)}});
+        UNIT_ASSERT(map.TryApplyNext(*record));
+
+        // pages 0, 1, 4 and 5 live only on the device, so they are left out
+        UNIT_ASSERT_VALUES_EQUAL(
+            "2->100x2",
+            Describe(map.Lookup({Range(0, 6)}, 0).Mappings));
+    }
+
+    Y_UNIT_TEST(ShouldOverrideAnOlderRangeEntirely)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto older = MakePageRecord(10, 20, {{1, Range(100, 4)}});
+        auto newer = MakePageRecord(20, 30, {{1, Range(200, 4)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*older));
+        UNIT_ASSERT(map.TryApplyNext(*newer));
+
+        UNIT_ASSERT_VALUES_EQUAL("1->200x4", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldOverrideAnOlderRangeThatItContains)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto older = MakePageRecord(10, 20, {{3, Range(100, 2)}});
+        auto newer = MakePageRecord(20, 30, {{1, Range(200, 8)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*older));
+        UNIT_ASSERT(map.TryApplyNext(*newer));
+
+        UNIT_ASSERT_VALUES_EQUAL("1->200x8", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldTrimTheTailOfAnOlderRange)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        // device [1, 5) -> store [100, 104)
+        auto older = MakePageRecord(10, 20, {{1, Range(100, 4)}});
+        // device [3, 7) -> store [200, 204)
+        auto newer = MakePageRecord(20, 30, {{3, Range(200, 4)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*older));
+        UNIT_ASSERT(map.TryApplyNext(*newer));
+
+        // the old range keeps only [1, 3), still at store 100
+        UNIT_ASSERT_VALUES_EQUAL("1->100x2, 3->200x4", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldTrimTheHeadOfAnOlderRangeAndMoveItsOffset)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        // device [3, 7) -> store [100, 104)
+        auto older = MakePageRecord(10, 20, {{3, Range(100, 4)}});
+        // device [1, 5) -> store [200, 204)
+        auto newer = MakePageRecord(20, 30, {{1, Range(200, 4)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*older));
+        UNIT_ASSERT(map.TryApplyNext(*newer));
+
+        // the old range keeps [5, 7); device page 5 was the third page of the
+        // old group, so it now points at store page 102
+        UNIT_ASSERT_VALUES_EQUAL("1->200x4, 5->102x2", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldSplitAnOlderRangeInTwo)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        // device [1, 9) -> store [100, 108)
+        auto older = MakePageRecord(10, 20, {{1, Range(100, 8)}});
+        // device [4, 6) -> store [200, 202)
+        auto newer = MakePageRecord(20, 30, {{4, Range(200, 2)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*older));
+        UNIT_ASSERT(map.TryApplyNext(*newer));
+
+        // [1, 4) keeps store 100, [6, 9) picks up store 105
+        UNIT_ASSERT_VALUES_EQUAL(
+            "1->100x3, 4->200x2, 6->105x3",
+            DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldLeaveAbuttingRangesAlone)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto older = MakePageRecord(10, 20, {{1, Range(100, 4)}});
+        auto newer = MakePageRecord(20, 30, {{5, Range(200, 4)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*older));
+        UNIT_ASSERT(map.TryApplyNext(*newer));
+
+        // [1, 5) and [5, 9) touch but do not intersect
+        UNIT_ASSERT_VALUES_EQUAL("1->100x4, 5->200x4", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldTrimSeveralOlderRangesAtOnce)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto first = MakePageRecord(
+            10,
+            20,
+            {{1, Range(100, 3)}, {6, Range(200, 2)}, {10, Range(300, 3)}});
+        // device [2, 11) swallows the middle range and clips the outer two
+        auto second = MakePageRecord(20, 30, {{2, Range(400, 9)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*first));
+        UNIT_ASSERT(map.TryApplyNext(*second));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "1->100x1, 2->400x9, 11->301x2",
+            DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldClipTheResultToTheRequestedRange)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        // device [1, 9) -> store [100, 108)
+        auto record = MakePageRecord(10, 20, {{1, Range(100, 8)}});
+        UNIT_ASSERT(map.TryApplyNext(*record));
+
+        // asking for [3, 5) yields only that slice of the stored group
+        UNIT_ASSERT_VALUES_EQUAL(
+            "3->102x2",
+            Describe(map.Lookup({Range(3, 2)}, 0).Mappings));
+
+        // a request reaching past both ends is clipped to what the log holds
+        UNIT_ASSERT_VALUES_EQUAL(
+            "1->100x8",
+            Describe(map.Lookup({Range(0, 20)}, 0).Mappings));
+
+        // several requested groups are served in request order
+        UNIT_ASSERT_VALUES_EQUAL(
+            "6->105x1, 2->101x1",
+            Describe(map.Lookup({Range(6, 1), Range(2, 1)}, 0).Mappings));
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreRangesAtOrBelowAfterLsn)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto older = MakePageRecord(10, 20, {{1, Range(100, 2)}});
+        auto newer = MakePageRecord(20, 30, {{5, Range(200, 2)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*older));
+        UNIT_ASSERT(map.TryApplyNext(*newer));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "1->100x2, 5->200x2",
+            Describe(map.Lookup({Range(0, 10)}, 0).Mappings));
+
+        // the older range may already have been reclaimed
+        UNIT_ASSERT_VALUES_EQUAL(
+            "5->200x2",
+            Describe(map.Lookup({Range(0, 10)}, 20).Mappings));
+    }
+
+    Y_UNIT_TEST(ShouldReturnNothingWhenAfterLsnIsAtOrBeyondLastIndexedLsn)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto record = MakePageRecord(10, 20, {{1, Range(100, 1)}});
+        UNIT_ASSERT(map.TryApplyNext(*record));
+
+        UNIT_ASSERT(map.Lookup({Range(1, 1)}, 20).Mappings.empty());
+        UNIT_ASSERT(map.Lookup({Range(1, 1)}, 100).Mappings.empty());
+    }
+
+    Y_UNIT_TEST(ShouldNotLetADegenerateEntryBlockALaterMapping)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        // a group covering no pages at all
+        auto empty = MakePageRecord(10, 20, {{5, Range(100, 0)}});
+        UNIT_ASSERT(map.TryApplyNext(*empty));
+
+        // a later record maps that same first page for real
+        auto real = MakePageRecord(20, 30, {{5, Range(200, 3)}});
+        UNIT_ASSERT(map.TryApplyNext(*real));
+
+        // the real mapping must win rather than be dropped on a taken key
+        UNIT_ASSERT_VALUES_EQUAL("5->200x3", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreADegenerateEntryWhenReading)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto record =
+            MakePageRecord(10, 20, {{1, Range(100, 2)}, {7, Range(200, 0)}});
+        UNIT_ASSERT(map.TryApplyNext(*record));
+
+        // the zero length group contributes nothing to what can be served
+        UNIT_ASSERT_VALUES_EQUAL("1->100x2", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldRemoveEverythingUpToTheGivenLsn)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto first = MakePageRecord(10, 20, {{1, Range(100, 2)}});
+        auto second = MakePageRecord(20, 30, {{5, Range(200, 2)}});
+        auto third = MakePageRecord(30, 40, {{9, Range(300, 2)}});
+
+        UNIT_ASSERT(map.TryApplyNext(*first));
+        UNIT_ASSERT(map.TryApplyNext(*second));
+        UNIT_ASSERT(map.TryApplyNext(*third));
+
+        map.EraseUpTo(30);
+
+        // everything at or below lsn 30 is gone, lsn 40 stays
+        UNIT_ASSERT_VALUES_EQUAL("9->300x2", DescribeAll(map));
+
+        // removing does not rewind the applied position
+        UNIT_ASSERT_VALUES_EQUAL(40, map.GetLastIndexedLsn());
+    }
+
+    Y_UNIT_TEST(ShouldRemoveEverythingWhenTrimmingPastLastIndexedLsn)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto record = MakePageRecord(10, 20, {{1, Range(100, 2)}});
+        UNIT_ASSERT(map.TryApplyNext(*record));
+
+        // trimming beyond the applied position drops everything applied so far
+        map.EraseUpTo(30);
+        UNIT_ASSERT_VALUES_EQUAL("", DescribeAll(map));
+
+        // and it does not rewind the applied position
+        UNIT_ASSERT_VALUES_EQUAL(20, map.GetLastIndexedLsn());
+    }
+
+    Y_UNIT_TEST(ShouldRemoveNothingBelowTheOldestLsn)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto record = MakePageRecord(10, 20, {{1, Range(100, 2)}});
+        UNIT_ASSERT(map.TryApplyNext(*record));
+
+        map.EraseUpTo(19);
+        UNIT_ASSERT_VALUES_EQUAL("1->100x2", DescribeAll(map));
+
+        map.EraseUpTo(20);
+        UNIT_ASSERT_VALUES_EQUAL("", DescribeAll(map));
+    }
+
+    Y_UNIT_TEST(ShouldBeReadableThroughAConstReference)
+    {
+        TLogPageIndex map;
+        map.InitLastIndexedLsn(10);
+
+        auto record = MakePageRecord(10, 20, {{1, Range(100, 2)}});
+        UNIT_ASSERT(map.TryApplyNext(*record));
+
+        const auto& constMap = map;
+        UNIT_ASSERT_VALUES_EQUAL(20, constMap.GetLastIndexedLsn());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "1->100x2",
+            Describe(constMap.Lookup({Range(1, 2)}, 0).Mappings));
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+// brute-force model: one entry per device page, no ranges at all
+using TModel = TMap<ui64, std::pair<ui64 /*lsn*/, ui64 /*storePage*/>>;
+
+void ModelApply(
+    TModel& model,
+    ui64 lsn,
+    const TVector<TPageMapping>& mappings)
+{
+    for (const auto& [pageNo, location]: mappings) {
+        for (ui64 i = 0; i < location.PageCount; ++i) {
+            model[pageNo + i] = {lsn, location.FirstPageNo + i};
+        }
+    }
+}
+
+void ModelEraseUpTo(TModel& model, ui64 lsn)
+{
+    for (auto it = model.begin(); it != model.end();) {
+        it = it->second.first <= lsn ? model.erase(it) : std::next(it);
+    }
+}
+
+TVector<std::pair<ui64, ui64>>
+ModelGet(const TModel& model, ui64 from, ui64 to, ui64 afterLsn)
+{
+    TVector<std::pair<ui64, ui64>> out;
+    for (ui64 p = from; p < to; ++p) {
+        auto it = model.find(p);
+        if (it != model.end() && it->second.first > afterLsn) {
+            out.emplace_back(p, it->second.second);
+        }
+    }
+    return out;
+}
+
+// expand the range-based answer back to one entry per page
+TVector<std::pair<ui64, ui64>> Expand(
+    const TVector<TPageMapping>& mappings)
+{
+    TVector<std::pair<ui64, ui64>> out;
+    for (const auto& [pageNo, location]: mappings) {
+        for (ui64 i = 0; i < location.PageCount; ++i) {
+            out.emplace_back(pageNo + i, location.FirstPageNo + i);
+        }
+    }
+    return out;
+}
+
+TString Show(const TVector<std::pair<ui64, ui64>>& v)
+{
+    TStringBuilder sb;
+    for (const auto& [a, b]: v) {
+        if (sb) {
+            sb << " ";
+        }
+        sb << a << "->" << b;
+    }
+    return sb;
+}
+
+struct TRng
+{
+    ui64 S = 88172645463325252ull;
+
+    ui64 Next(ui64 n)
+    {
+        S ^= S << 13;
+        S ^= S >> 7;
+        S ^= S << 17;
+        return S % n;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TLogPageIndexModelTest)
+{
+    Y_UNIT_TEST(DifferentialAgainstPerPageModel)
+    {
+        constexpr ui64 PageSpace = 48;
+        ui64 mismatches = 0;
+
+        for (ui64 seed = 1; seed <= 500 && mismatches < 5; ++seed) {
+            TRng rng{seed * 6364136223846793005ull + 1442695040888963407ull};
+
+            TLogPageIndex map;
+            TModel model;
+            ui64 lsn = 0;
+            ui64 storeNext = 1000;
+
+            for (ui64 step = 0; step < 40 && mismatches < 5; ++step) {
+                // apply one record made of 1..3 page groups
+                TVector<TPageMapping> mappings;
+                const ui64 groupCnt = 1 + rng.Next(3);
+                for (ui64 g = 0; g < groupCnt; ++g) {
+                    const ui64 len = 1 + rng.Next(8);
+                    const ui64 start = rng.Next(PageSpace - len);
+                    mappings.push_back(TPageMapping{
+                        .PageNo = start,
+                        .Location = TPageRange{
+                            .FirstPageNo = storeNext,
+                            .PageCount = len}});
+                    storeNext += len;
+                }
+
+                auto record = std::make_shared<TLogRecord>();
+                record->PrevLsn = lsn;
+                record->Lsn = lsn + 10;
+                record->PageMappings = mappings;
+                UNIT_ASSERT(map.TryApplyNext(*record));
+                lsn += 10;
+                ModelApply(model, lsn, mappings);
+
+                if (rng.Next(6) == 0) {
+                    const ui64 upTo = rng.Next(lsn + 20);
+                    map.EraseUpTo(upTo);
+                    ModelEraseUpTo(model, upTo);
+                }
+
+                // query random windows with random afterLsn
+                for (ui64 q = 0; q < 6; ++q) {
+                    const ui64 len = 1 + rng.Next(PageSpace);
+                    const ui64 from = rng.Next(PageSpace + 8);
+                    const ui64 afterLsn = rng.Next(lsn + 20);
+
+                    const auto got = Expand(
+                        map.Lookup(
+                               {TPageRange{
+                                   .FirstPageNo = from,
+                                   .PageCount = len}},
+                               afterLsn)
+                            .Mappings);
+                    const auto want =
+                        ModelGet(model, from, from + len, afterLsn);
+
+                    if (Show(got) != Show(want)) {
+                        ++mismatches;
+                        Cerr << "\nMISMATCH seed=" << seed << " step=" << step
+                             << " query=[" << from << "," << (from + len)
+                             << ") afterLsn=" << afterLsn
+                             << " lastIndexedLsn=" << map.GetLastIndexedLsn()
+                             << "\n"
+                             << "  got : " << Show(got) << "\n"
+                             << "  want: " << Show(want) << "\n";
+                    }
+                }
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(0, mismatches);
+    }
+}
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/log_record.cpp
+++ b/cloud/storage/core/libs/journalled_device/log_record.cpp
@@ -1,0 +1,1 @@
+#include "log_record.h"

--- a/cloud/storage/core/libs/journalled_device/log_record.h
+++ b/cloud/storage/core/libs/journalled_device/log_record.h
@@ -9,8 +9,6 @@
 
 #include <util/generic/vector.h>
 
-#include <atomic>
-
 namespace NCloud::NJournalled {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -42,7 +40,6 @@ struct TLogRecord
     TVector<TPageMapping> PageMappings;
 
     NThreading::TPromise<NCloud::NProto::TError> Promise;
-    std::atomic<bool> Ready = false;
 };
 
 }   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/log_record.h
+++ b/cloud/storage/core/libs/journalled_device/log_record.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <library/cpp/threading/future/future.h>
+
+#include <util/generic/vector.h>
+
+#include <atomic>
+
+namespace NCloud::NJournalled {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 CurrentFormatVersion = 1;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TPageRange
+{
+    ui64 FirstPageNo = 0;
+    ui64 PageCount = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TPageMapping
+{
+    ui64 PageNo = 0;
+    TPageRange Location;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TLogRecord
+{
+    ui64 Lsn = 0;
+    ui64 PrevLsn = 0;
+    TVector<TPageMapping> PageMappings;
+
+    NThreading::TPromise<NCloud::NProto::TError> Promise;
+    std::atomic<bool> Ready = false;
+};
+
+}   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/public.h
+++ b/cloud/storage/core/libs/journalled_device/public.h
@@ -12,6 +12,9 @@ using IDevicePtr = std::shared_ptr<IDevice>;
 struct IDevicePageStore;
 using IDevicePageStorePtr = std::shared_ptr<IDevicePageStore>;
 
+struct TLogRecord;
+using TLogRecordPtr = std::shared_ptr<TLogRecord>;
+
 struct IJournal;
 using IJournalPtr = std::shared_ptr<IJournal>;
 

--- a/cloud/storage/core/libs/journalled_device/ut/ya.make
+++ b/cloud/storage/core/libs/journalled_device/ut/ya.make
@@ -8,6 +8,8 @@ SRCS(
     journalled_device_ut.cpp
     journalled_device_v2_ut.cpp
     key_buffer_store_ut.cpp
+    log_chain_ut.cpp
+    log_index_ut.cpp
     lsn_barrier_ut.cpp
 )
 

--- a/cloud/storage/core/libs/journalled_device/ya.make
+++ b/cloud/storage/core/libs/journalled_device/ya.make
@@ -7,6 +7,9 @@ SRCS(
     journalled_device.cpp
     journalled_device_v2.cpp
     key_buffer_store.cpp
+    log_chain.cpp
+    log_index.cpp
+    log_record.cpp
     lsn_barrier.cpp
 )
 


### PR DESCRIPTION
### Notes
TLogRecord describes the page mappings a single journal record writes. TLogRecordChain keeps the in-flight records ordered by lsn. TLogPageIndex maps the device pages that are journalled but not yet flushed onto the page store locations holding their newest contents.

### Issue
https://github.com/ydb-platform/nbs/issues/6956
