### PR TITLE
[NBS]: Fix vhost server shutdown race

### DIFF
--- a/cloud/blockstore/vhost-server/server.cpp
+++ b/cloud/blockstore/vhost-server/server.cpp
@@ -178,18 +178,10 @@ void TServer::Start(const TOptions& options)
 
 void TServer::Stop()
 {
-    // Make consecutive repeated Stop() calls safe
-    if (!Handler) {
-        return;
-    }
-
-    auto* handler = Handler;
-    Handler = nullptr;
-
     STORAGE_INFO("Stopping the server");
 
     auto promise = NewPromise();
-    vhd_unregister_blockdev(handler, [] (void* opaque) {
+    vhd_unregister_blockdev(Handler, [] (void* opaque) {
         static_cast<TPromise<void>*>(opaque)->SetValue();
     }, &promise);
 

--- a/cloud/blockstore/vhost-server/server.cpp
+++ b/cloud/blockstore/vhost-server/server.cpp
@@ -178,10 +178,18 @@ void TServer::Start(const TOptions& options)
 
 void TServer::Stop()
 {
+    // Make consecutive repeated Stop() calls safe
+    if (!Handler) {
+        return;
+    }
+
+    auto* handler = Handler;
+    Handler = nullptr;
+
     STORAGE_INFO("Stopping the server");
 
     auto promise = NewPromise();
-    vhd_unregister_blockdev(Handler, [] (void* opaque) {
+    vhd_unregister_blockdev(handler, [] (void* opaque) {
         static_cast<TPromise<void>*>(opaque)->SetValue();
     }, &promise);
 

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -1513,10 +1513,15 @@ TEST_P(TSlowEncryptorServerTest, ShouldWaitForAllThreadPoolTasksBeforeStop)
     Sleep(TDuration::MilliSeconds(200));
 
     Server->Stop();
+    Server.reset();
 
     EXPECT_EQ(
         TDuration::MilliSeconds(requestCount * 100),
         GetTotalSleepTime());
+
+    ASSERT_TRUE(
+        NThreading::WaitAll(futures).Wait(TDuration::Seconds(5)))
+        << "client did not observe all completed requests";
 
     for (size_t i = 0; i < futures.size(); ++i) {
         ASSERT_TRUE(futures[i].HasValue())
@@ -1529,7 +1534,6 @@ TEST_P(TSlowEncryptorServerTest, ShouldWaitForAllThreadPoolTasksBeforeStop)
     }
 
     Client.DeInit();
-    Server.reset();
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### Notes
Fix synchronisation in `TSlowEncryptorServerTest.ShouldWaitForAllThreadPoolTasksBeforeStop`.

The test previously assumed that all client futures were ready immediately after `Server->Stop()`. However, `Stop()` waits for the server-side worker tasks, while the client queue thread publishes completed requests to the futures asynchronously.

The test now:
- destroys the explicitly stopped server before any subsequent assertations, so `TearDown(`) cannot call` Stop()` for the same server again if an assertation fails;
- waits for all client futures with a bounded timeout before checking their values.

This is a test-only change. The production `TServer::Stop()` implementation is not modified.

### Original failure

The race was observed under MemorySanitizer. Affected parametrizations:
- `ENCRYPTION_AES_XTS_bc1_bs512_aligned_tc4`
- `ENCRYPTION_AES_XTS_bc4_bs512_aligned_tc4`

<details>
<summary>MSan report excerpt</summary>

```text
Test crashed (return code: 100)
ERROR: MemorySanitizer: SEGV on unknown address 0x000000000020
The signal is caused by a READ memory access.
Hint: address points to the zero page.

#0 bh_enqueue
   cloud/contrib/vhost/event.c:118
#1 vhd_bh_schedule_oneshot
#2 vhd_submit_work_and_wait
#3 vdev_submit_work_and_wait
#4 vhd_vdev_stop_server
#5 NCloud::NBlockStore::NVHostServer::TServer::Stop()
   cloud/blockstore/vhost-server/server.cpp:184
#6 NCloud::NBlockStore::NVHostServer::TServerTest::TearDown()
   cloud/blockstore/vhost-server/server_ut.cpp:292

SUMMARY: MemorySanitizer: SEGV in bh_enqueue
```