### PR TITLE
Filestore: remove unneeded deletion unconfirmed data by session

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
@@ -184,7 +184,7 @@ enum class EShardPipeToDisconnect
     Data,
 };
 
-void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
+void DoTestShardUnconfirmedDataOnServicePipeDisconnect(
     EShardPipeToDisconnect pipeToDisconnect)
 {
     TShardedFileSystemConfig fsConfig;
@@ -414,13 +414,12 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
         false /* updateConfig */);
 
     // At this point the write actor is blocked on blob storage, so the
-    // unconfirmed entry must stay visible until either the data pipe or the
-    // control pipe is disconnected.
+    // unconfirmed entry must stay visible until the data pipe that issued
+    // GenerateBlobIds is disconnected.
     UNIT_ASSERT_VALUES_EQUAL(
         1,
         GetStorageStats(shardTablet).GetUnconfirmedDataCount());
 
-    // Select either the shard control pipe or the active data pipe.
     struct TPipeToDisconnect
     {
         TActorId Server;
@@ -437,36 +436,43 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
         dataPipeClientIt->second,
         serviceNodeIdx};
 
-    const TPipeToDisconnect pipeToDisconnectInfo =
-        pipeToDisconnect == EShardPipeToDisconnect::Control
-            ? controlPipeToDisconnect
-            : dataPipeToDisconnect;
+    // Close the pipe and wait until the shard observes the tablet pipe server
+    // disconnect. The disconnect dispatch can already execute and commit the
+    // cleanup tx, so querying stats after it is the synchronization point for
+    // the assertions below.
+    auto disconnectPipe = [&](const TPipeToDisconnect& pipe)
+    {
+        runtime.ClosePipe(pipe.Client, TActorId(), pipe.NodeIdx);
 
-    runtime.ClosePipe(
-        pipeToDisconnectInfo.Client,
-        TActorId(),
-        pipeToDisconnectInfo.NodeIdx);
+        TDispatchOptions disconnectOptions;
+        disconnectOptions.FinalEvents = {TDispatchOptions::TFinalEventCondition(
+            [server = pipe.Server](IEventHandle& event)
+            {
+                if (event.GetTypeRewrite() !=
+                    TEvTabletPipe::EvServerDisconnected) {
+                    return false;
+                }
 
-    // Wait until the shard observes the selected tablet pipe server
-    // disconnect.
-    TDispatchOptions disconnectOptions;
-    disconnectOptions.FinalEvents = {TDispatchOptions::TFinalEventCondition(
-        [server = pipeToDisconnectInfo.Server](IEventHandle& event)
-        {
-            if (event.GetTypeRewrite() != TEvTabletPipe::EvServerDisconnected) {
-                return false;
-            }
+                const auto* msg =
+                    event.Get<TEvTabletPipe::TEvServerDisconnected>();
+                return msg->ServerId == server;
+            })};
+        UNIT_ASSERT_C(
+            runtime.DispatchEvents(disconnectOptions, TDuration::Seconds(5)),
+            TStringBuilder() << "Timed out waiting for shard pipe disconnect "
+                             << pipe.Server);
+    };
 
-            const auto* msg = event.Get<TEvTabletPipe::TEvServerDisconnected>();
-            return msg->ServerId == server;
-        })};
-    UNIT_ASSERT_C(
-        runtime.DispatchEvents(disconnectOptions, TDuration::Seconds(5)),
-        TStringBuilder() << "Timed out waiting for shard pipe disconnect "
-                         << pipeToDisconnectInfo.Server);
+    if (pipeToDisconnect == EShardPipeToDisconnect::Control) {
+        // The control pipe only carried CreateSession. Unconfirmed data is
+        // owned by the pipe that issued GenerateBlobIds, so it must survive.
+        disconnectPipe(controlPipeToDisconnect);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            GetStorageStats(shardTablet).GetUnconfirmedDataCount());
+    }
 
-    // The disconnect dispatch can already execute and commit the cleanup tx.
-    // Querying stats after it is the synchronization point for the assertion.
+    disconnectPipe(dataPipeToDisconnect);
     UNIT_ASSERT_VALUES_EQUAL(
         0,
         GetStorageStats(shardTablet).GetUnconfirmedDataCount());
@@ -1496,13 +1502,13 @@ Y_UNIT_TEST_SUITE(TWriteDataUnconfirmedTest)
 
     Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceDataPipeDisconnect)
     {
-        DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
+        DoTestShardUnconfirmedDataOnServicePipeDisconnect(
             EShardPipeToDisconnect::Data);
     }
 
-    Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceControlPipeDisconnect)
+    Y_UNIT_TEST(ShouldKeepShardUnconfirmedDataOnServiceControlPipeDisconnect)
     {
-        DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
+        DoTestShardUnconfirmedDataOnServicePipeDisconnect(
             EShardPipeToDisconnect::Control);
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1075,40 +1075,19 @@ void TIndexTabletActor::HandleSessionDisconnectedInWork(
 {
     const auto& msg = *ev->Get();
 
-    // TODO (#4962): once owner-to-session relation is tracked properly, use
-    // the session id directly and simplify this split session/pipe cleanup.
-    const auto& sessionIds = FindSessionIdsByPipeServer(msg.ServerId);
-
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET,
-        "%s Server disconnected, sender: %s, client: %s, server: %s, "
-        "matchedSessions: %zu",
+        "%s Server disconnected, sender: %s, client: %s, server: %s",
         LogTag.c_str(),
         ev->Sender.ToString().c_str(),
         msg.ClientId.ToString().c_str(),
-        msg.ServerId.ToString().c_str(),
-        sessionIds.size());
-
-    // The disconnected pipe may be the control pipe, while unconfirmed writes
-    // for the same logical session can be tracked with a separate data pipe
-    // server id. Delete by session too.
-    for (const auto& sessionId: sessionIds) {
-        LOG_INFO(
-            ctx,
-            TFileStoreComponents::TABLET,
-            "%s Deleting unconfirmed data for session: sessionId=%s",
-            LogTag.c_str(),
-            sessionId.Quote().c_str());
-
-        DeleteUnconfirmedDataForSession(sessionId, ctx);
-    }
+        msg.ServerId.ToString().c_str());
 
     // msg.ServerId is the tablet-pipe server actor that received requests
     // from this client connection. Unconfirmed data keeps this actor id from
     // GenerateBlobIds, so clean it up when the pipe disconnects.
     DeleteUnconfirmedDataForPipeServer(msg.ServerId, ctx);
-    RemoveSessionByPipeServer(msg.ServerId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -306,7 +306,6 @@ void TIndexTabletActor::HandleCreateSession(
     ExecuteTx<TCreateSession>(
         ctx,
         std::move(requestInfo),
-        ev->Recipient,
         std::move(msg->Record));
 }
 
@@ -517,9 +516,6 @@ void TIndexTabletActor::CompleteTx_CreateSession(
         NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
         return;
     }
-
-    UnregisterSessionByPipeServer(args.SessionId);
-    RegisterSessionByPipeServer(args.PipeServerId, args.SessionId);
 
     auto response = std::make_unique<TResponse>(args.Error);
     response->Record.SetSessionId(std::move(args.SessionId));

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -217,7 +217,6 @@ void TIndexTabletActor::CompleteTx_DestroySession(
         return;
     }
 
-    UnregisterSessionByPipeServer(args.SessionId);
     DeleteUnconfirmedDataForSession(args.SessionId, ctx);
 
     const auto& shardIds = GetFileSystem().GetShardFileSystemIds();

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -848,13 +848,6 @@ public:
         ui64 sessionSeqNo,
         bool readOnly,
         const NActors::TActorId& owner);
-    void RegisterSessionByPipeServer(
-        const NActors::TActorId& pipeServer,
-        const TString& sessionId);
-    void UnregisterSessionByPipeServer(const TString& sessionId);
-    const TVector<TString>& FindSessionIdsByPipeServer(
-        const NActors::TActorId& pipeServer) const;
-    void RemoveSessionByPipeServer(const NActors::TActorId& pipeServer);
     void OrphanSession(const NActors::TActorId& owner, TInstant inactivityDeadline);
     void ResetSession(IIndexTabletDatabase& db, TSession* session, const TMaybe<TString>& state);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -31,12 +31,6 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-using TSessionIds = TVector<TString>;
-using TSessionIdsByPipeServerMap =
-    THashMap<NActors::TActorId, TSessionIds>;
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct TIndexTabletState::TImpl
 {
     TSessionList Sessions;
@@ -44,7 +38,6 @@ struct TIndexTabletState::TImpl
     TSessionMap SessionById;
     TSessionOwnerMap SessionByOwner;
     TSessionClientMap SessionByClient;
-    TSessionIdsByPipeServerMap SessionIdsByPipeServer;
     TSessionHistoryList SessionHistoryList;
 
     TNodeRefsByHandle NodeRefsByHandle;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -251,63 +251,6 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     return oldOwner;
 }
 
-void TIndexTabletState::RegisterSessionByPipeServer(
-    const TActorId& pipeServer,
-    const TString& sessionId)
-{
-    if (!pipeServer || sessionId.empty()) {
-        return;
-    }
-
-    auto& sessionIds = Impl->SessionIdsByPipeServer[pipeServer];
-    for (const auto& existingSessionId: sessionIds) {
-        if (existingSessionId == sessionId) {
-            return;
-        }
-    }
-
-    sessionIds.push_back(sessionId);
-}
-
-void TIndexTabletState::UnregisterSessionByPipeServer(const TString& sessionId)
-{
-    for (auto it = Impl->SessionIdsByPipeServer.begin();
-         it != Impl->SessionIdsByPipeServer.end();)
-    {
-        auto& sessionIds = it->second;
-        for (auto jt = sessionIds.begin(); jt != sessionIds.end();) {
-            if (*jt == sessionId) {
-                jt = sessionIds.erase(jt);
-            } else {
-                ++jt;
-            }
-        }
-
-        if (sessionIds.empty()) {
-            auto erased = it++;
-            Impl->SessionIdsByPipeServer.erase(erased);
-        } else {
-            ++it;
-        }
-    }
-}
-
-const TVector<TString>& TIndexTabletState::FindSessionIdsByPipeServer(
-    const TActorId& pipeServer) const
-{
-    auto it = Impl->SessionIdsByPipeServer.find(pipeServer);
-    if (it != Impl->SessionIdsByPipeServer.end()) {
-        return it->second;
-    }
-
-    return Default<TVector<TString>>();
-}
-
-void TIndexTabletState::RemoveSessionByPipeServer(const TActorId& pipeServer)
-{
-    Impl->SessionIdsByPipeServer.erase(pipeServer);
-}
-
 TSession* TIndexTabletState::FindSession(const TString& sessionId) const
 {
     auto it = Impl->SessionById.find(sessionId);

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -515,7 +515,6 @@ struct TTxIndexTablet
     struct TCreateSession: TTxIndexTabletBase, TErrorAware
     {
         /* const */ TRequestInfoPtr RequestInfo;
-        const NActors::TActorId PipeServerId;
         /* const */ NProtoPrivate::TCreateSessionRequest Request;
 
         TString SessionId;
@@ -524,10 +523,8 @@ struct TTxIndexTablet
 
         TCreateSession(
                 TRequestInfoPtr requestInfo,
-                const NActors::TActorId& pipeServerId,
                 NProtoPrivate::TCreateSessionRequest request)
             : RequestInfo(std::move(requestInfo))
-            , PipeServerId(pipeServerId)
             , Request(std::move(request))
         {}
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -2276,6 +2276,63 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         AssertStorageStats(client2, 0, 0);
     }
 
+    Y_UNIT_TEST(ShouldRejectStaleConfirmAddDataAfterSessionRecovery)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient oldClient(runtime, nodeIdx, tabletId);
+        oldClient.InitSession("client", "session");
+
+        auto id =
+            CreateNode(oldClient, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 oldHandle = CreateHandle(oldClient, id);
+
+        // Old incarnation gets as far as PutBlob but never confirms.
+        const ui64 staleCommitId = GenerateBlobIdsAndPutBlob(
+            env,
+            oldClient,
+            id,
+            oldHandle,
+            0,
+            block,
+            'a');
+        WaitForTabletCommit(env);
+        AssertStorageStats(oldClient, 1, 0);
+
+        // New incarnation on another pipe recovers the session, and its
+        // write to the same range must not be superseded by the stale one.
+        TIndexTabletClient newClient(runtime, nodeIdx, tabletId);
+        newClient.InitSession("client", "session");
+        AssertStorageStats(newClient, 0, 0);
+
+        ui64 newHandle = CreateHandle(newClient, id);
+        newClient.WriteData(newHandle, 0, block, 'b');
+
+        oldClient.SendConfirmAddDataRequest(staleCommitId);
+        auto confirmResponse =
+            oldClient.AssertConfirmAddDataResponse(E_REJECTED);
+        UNIT_ASSERT_C(
+            confirmResponse->GetErrorReason().find(
+                "unconfirmed data not found") != TString::npos,
+            confirmResponse->GetErrorReason());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(block, 'b'),
+            ReadData(newClient, newHandle, block, 0));
+        AssertStorageStats(newClient, 0, 0);
+    }
+
     Y_UNIT_TEST(ShouldDeleteUnconfirmedDataOnDestroySession)
     {
         constexpr ui32 block = 4_KB;
@@ -2387,6 +2444,115 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
 
         TIndexTabletClient observer(runtime, nodeIdx, tabletId);
         AssertStorageStats(observer, 0, 0);
+    }
+
+    Y_UNIT_TEST(ShouldKeepUnconfirmedDataOnSessionPipeDisconnection)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient sessionClient(runtime, nodeIdx, tabletId);
+        sessionClient.InitSession("client", "session");
+
+        auto id = CreateNode(
+            sessionClient,
+            TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(sessionClient, id);
+
+        TIndexTabletClient writeClient(
+            runtime,
+            nodeIdx,
+            tabletId,
+            {},
+            false /* updateConfig */);
+        writeClient.SetHeaders("client", "session", 0 /* sessionSeqNo */);
+
+        auto gbi = writeClient.GenerateBlobIds(id, handle, 0, block);
+        Y_UNUSED(gbi);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        AssertStorageStats(writeClient, 1, 0);
+
+        // The pipe that created the session goes away, the pipe that issued
+        // GenerateBlobIds is still alive: its unconfirmed data must survive.
+        sessionClient.DisconnectPipe();
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        AssertStorageStats(writeClient, 1, 0);
+
+        writeClient.DisconnectPipe();
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        TIndexTabletClient observer(runtime, nodeIdx, tabletId);
+        AssertStorageStats(observer, 0, 0);
+    }
+
+    Y_UNIT_TEST(ShouldDeleteUnconfirmedDataOnlyForDisconnectedPipe)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient sessionClient(runtime, nodeIdx, tabletId);
+        sessionClient.InitSession("client", "session");
+
+        auto id = CreateNode(
+            sessionClient,
+            TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(sessionClient, id);
+
+        TIndexTabletClient writeClient1(
+            runtime,
+            nodeIdx,
+            tabletId,
+            {},
+            false /* updateConfig */);
+        writeClient1.SetHeaders("client", "session", 0 /* sessionSeqNo */);
+
+        TIndexTabletClient writeClient2(
+            runtime,
+            nodeIdx,
+            tabletId,
+            {},
+            false /* updateConfig */);
+        writeClient2.SetHeaders("client", "session", 0 /* sessionSeqNo */);
+
+        auto gbi1 = writeClient1.GenerateBlobIds(id, handle, 0, block);
+        Y_UNUSED(gbi1);
+        auto gbi2 = writeClient2.GenerateBlobIds(id, handle, block, block);
+        Y_UNUSED(gbi2);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        AssertStorageStats(sessionClient, 2, 0);
+
+        writeClient1.DisconnectPipe();
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        AssertStorageStats(sessionClient, 1, 0);
+
+        writeClient2.DisconnectPipe();
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        AssertStorageStats(sessionClient, 0, 0);
     }
 
     Y_UNIT_TEST(ShouldReleaseCollectBarrierOnGenerateBlobIdsChannelError)

--- a/doc/filestore/design/unconfirmed_three_stage_write.md
+++ b/doc/filestore/design/unconfirmed_three_stage_write.md
@@ -337,43 +337,49 @@ IDs).
 For such cases we return errors to client even if client somehow managed to
 receive response.
 
-### Cleanup by both session id and pipe server id
+### Cleanup by pipe server id and by session id
 
-A pipe disconnect arrives as `TEvServerDisconnected` and is handled by
-`HandleSessionDisconnectedInWork`. Cleanup is driven by **two** keys, because a
-single key is not sufficient:
+Unconfirmed data is cleaned up by two different keys, each on its own trigger.
 
-- **By session id.** From the disconnected pipe server we resolve the matching
-  session ids (`FindSessionIdsByPipeServer`) and call
-  `DeleteUnconfirmedDataForSession` for each.
-- **By pipe server id.** We additionally call
-  `DeleteUnconfirmedDataForPipeServer(msg.ServerId)`.
+**By pipe server id on pipe disconnect.** A pipe disconnect arrives as
+`TEvServerDisconnected` and is handled by `HandleSessionDisconnectedInWork`,
+which calls `DeleteUnconfirmedDataForPipeServer(msg.ServerId)`.
+`HandleGenerateBlobIds` stores the pipe server id (`ev->Recipient`) in each
+`TTrackedUnconfirmedData` entry alongside `SessionId`, so on disconnect every
+entry owned by that pipe is dropped. This is the key that actually identifies
+the writer: `GenerateBlobIds` is sent over the shared tablet-proxy pipe (or, for
+sharded `WriteData`, over a direct write pipe created by the service write
+actor) not over the pipe that created the session. Only the pipe that
+issued `GenerateBlobIds` is relevant here; a disconnect of the session's
+control pipe does not touch unconfirmed data.
 
-Deletion by **session id** is not limited to the disconnect path.
-`DeleteUnconfirmedDataForSession` is also called when:
+**By session id — on session recovery or destruction.**
+`DeleteUnconfirmedDataForSession` is called when:
 
 - a session is **recreated/restored** — `CompleteTx_CreateSession` with
   `SessionInterrupted` set (a client `CreateSession` that recovers an existing
   session, by seqNo or via `RestoreClientSession`);
 - a session is **destroyed** — `CompleteTx_DestroySession`.
 
-So a session recreation still drops that session's unconfirmed data. Deletion by
-**pipe server id** is the part that is specific to the disconnect path.
-
-The pipe-server-id path matters for the **sharded WriteData** case. There,
-`GenerateBlobIds` can reach the shard through a *direct write pipe* created by
-the service write actor — **not** through the pipe that created the shard
-session. When such a direct write pipe disconnects, the shard cannot resolve it
-back to a session, so deleting by session id alone would leave the unconfirmed
-record behind. To cover this, `HandleGenerateBlobIds` stores the pipe server id
-(`ev->Recipient`) in each `TTrackedUnconfirmedData` entry (alongside
-`SessionId`), and on disconnect we also delete every entry owned by that pipe.
+The control pipe case is covered by the first bullet: when the pipe that
+created the session drops, the service-side session actor reconnects and
+re-sends `CreateSession`, which takes the recovery branch and deletes the
+session's unconfirmed data before the response is sent. That is what guarantees
+a reincarnated client's writes cannot be superseded by stale unconfirmed
+records from the previous incarnation `AddBlob` allocates a fresh commit id
+at execution time, so a late `ConfirmAddData` for a stale entry would otherwise
+win over a newer write. Instead it is rejected with `unconfirmed data not
+found`.
 
 Both paths funnel through the same `DeleteUnconfirmedData` helper (it just takes
 a different `shouldDelete` predicate), so they share the ordering guarantee
 described below: once commit ids are placed into the `DeletionQueue`, the
 `DeleteUnconfirmedData` tx must run before any later `AddBlob` execute, which is
 why it is kept page-fault-free.
+
+If neither trigger fires (the writer's pipe stays alive but the client never
+confirms or cancels), the record is dropped by the
+`GenerateBlobIdsReleaseCollectBarrierTimeout` timer.
 
 Some scenarios with such interruptions can be observed below. `CancelAddData`,
 generally speaking, has the same situation but in comparison with
@@ -395,7 +401,6 @@ sequenceDiagram
     V->>T: ConfirmAddData commitId (arrived early)
 
     alt Pipe / server disconnect (TEvServerDisconnected)
-        T->>T: DeleteUnconfirmedDataForSession (each matched session)
         T->>T: DeleteUnconfirmedDataForPipeServer (msg.ServerId)
     else Session recreation (CreateSession, SessionInterrupted)
         T->>T: DeleteUnconfirmedDataForSession (this session)
@@ -414,7 +419,7 @@ sequenceDiagram
     V->>T: ConfirmAddData commitId (arrived late)
     T-->>V: ConfirmAddDataResponse error unconfirmed data not found
 
-    Note over T: Session-id and pipe-id cleanup share DeleteUnconfirmedData
+    Note over T: Pipe-id and session-id cleanup share DeleteUnconfirmedData
 ```
 
 ```mermaid
@@ -435,7 +440,6 @@ sequenceDiagram
     T->>T: commitId is in progress, store PendingConfirmation
 
     alt Pipe / server disconnect (TEvServerDisconnected)
-        T->>T: DeleteUnconfirmedDataForSession (each matched session)
         T->>T: DeleteUnconfirmedDataForPipeServer (msg.ServerId)
     else Session recreation (CreateSession, SessionInterrupted)
         T->>T: DeleteUnconfirmedDataForSession (this session)
@@ -470,7 +474,6 @@ sequenceDiagram
     X->>T: Complete AddDataUnconfirmed move to UnconfirmedData
 
     alt Pipe / server disconnect (TEvServerDisconnected)
-        T->>T: DeleteUnconfirmedDataForSession (each matched session)
         T->>T: DeleteUnconfirmedDataForPipeServer (msg.ServerId)
     else Session recreation (CreateSession, SessionInterrupted)
         T->>T: DeleteUnconfirmedDataForSession (this session)


### PR DESCRIPTION
### Notes
remove unneeded deletion unconfirmed data by session, deletion only by pipeId is enough
updated docs
added ai-assisted UTs

### Issue
#2293
