### PR TITLE
support for down policy in drain request

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_actor_actions_drain_node.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_drain_node.cpp
@@ -79,9 +79,9 @@ void TDrainNodeActionActor::Bootstrap(const TActorContext& ctx)
     LOG_INFO_S(
         ctx,
         TBlockStoreComponents::SERVICE,
-        "Draining node started, DownPolicy="
-            << NCloud::NProto::EDrainDownPolicy_Name(
-                   drainRequest.GetDownPolicy()));
+        "Draining node started, DownPolicy=" <<
+        NCloud::NProto::EDrainDownPolicy_Name(
+            drainRequest.GetDownPolicy()));
 
     DrainNode(ctx, drainRequest);
     Become(&TThis::StateWork);

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_drain_node.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_drain_node.cpp
@@ -76,6 +76,13 @@ void TDrainNodeActionActor::Bootstrap(const TActorContext& ctx)
         return;
     }
 
+    LOG_INFO_S(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "Draining node started, DownPolicy="
+            << NCloud::NProto::EDrainDownPolicy_Name(
+                   drainRequest.GetDownPolicy()));
+
     DrainNode(ctx, drainRequest);
     Become(&TThis::StateWork);
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_drain_node.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_drain_node.cpp
@@ -44,7 +44,9 @@ public:
     void Bootstrap(const TActorContext& ctx);
 
 private:
-    void DrainNode(const TActorContext& ctx, bool keepDown);
+    void DrainNode(
+        const TActorContext& ctx,
+        const NPrivateProto::TDrainNodeRequest& drainRequest);
 
     void HandleSuccess(const TActorContext& ctx);
     void HandleError(const TActorContext& ctx, const NProto::TError& error);
@@ -74,14 +76,16 @@ void TDrainNodeActionActor::Bootstrap(const TActorContext& ctx)
         return;
     }
 
-    DrainNode(ctx, drainRequest.GetKeepDown());
+    DrainNode(ctx, drainRequest);
     Become(&TThis::StateWork);
 }
 
-void TDrainNodeActionActor::DrainNode(const TActorContext& ctx, bool keepDown)
+void TDrainNodeActionActor::DrainNode(
+    const TActorContext& ctx,
+    const NPrivateProto::TDrainNodeRequest& drainRequest)
 {
-    auto request =
-        std::make_unique<TEvHiveProxy::TEvDrainNodeRequest>(keepDown);
+    auto request = std::make_unique<TEvHiveProxy::TEvDrainNodeRequest>(
+        drainRequest.GetDownPolicy());
 
     NCloud::Send(
         ctx,

--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -682,14 +682,15 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
         ui64 observedNodeIdx = 0;
-        bool observedKeepDown = false;
+        NKikimrHive::EDrainDownPolicy observedDownPolicy =
+            NKikimrHive::DRAIN_POLICY_NO_DOWN;
 
         env.GetRuntime().SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
                 switch (event->GetTypeRewrite()) {
                     case TEvHive::EvDrainNode: {
                         auto* msg = event->Get<TEvHive::TEvDrainNode>();
                         observedNodeIdx = msg->Record.GetNodeID();
-                        observedKeepDown = msg->Record.GetKeepDown();
+                        observedDownPolicy = msg->Record.GetDownPolicy();
                     }
                 }
                 return TTestActorRuntime::DefaultObserverFunc(event);
@@ -708,9 +709,12 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
             observedNodeIdx
         );
 
-        UNIT_ASSERT(!observedKeepDown);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NKikimrHive::DRAIN_POLICY_NO_DOWN),
+            static_cast<int>(observedDownPolicy));
 
-        request.SetKeepDown(true);
+        request.SetDownPolicy(
+            NCloud::NProto::DRAIN_POLICY_KEEP_DOWN);
 
         buf.clear();
         google::protobuf::util::MessageToJsonString(request, &buf);
@@ -722,7 +726,9 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
             observedNodeIdx
         );
 
-        UNIT_ASSERT(observedKeepDown);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NKikimrHive::DRAIN_POLICY_KEEP_DOWN),
+            static_cast<int>(observedDownPolicy));
     }
 
     Y_UNIT_TEST(ShouldForwardUpdateUsedBlocksToVolume)
@@ -2464,6 +2470,38 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
 
         UNIT_ASSERT_VALUES_EQUAL(true, exactDiskIdMatch);
         UNIT_ASSERT_VALUES_EQUAL(false, hasDiskIdInVolumeConfig);
+    }
+
+    Y_UNIT_TEST(ShouldForwardDrainDownPolicy)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        NKikimrHive::EDrainDownPolicy observedDownPolicy =
+            NKikimrHive::DRAIN_POLICY_NO_DOWN;
+        env.GetRuntime().SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+            if (event->GetTypeRewrite() == TEvHive::EvDrainNode) {
+                observedDownPolicy = event->Get<TEvHive::TEvDrainNode>()
+                    ->Record.GetDownPolicy();
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        NPrivateProto::TDrainNodeRequest request;
+        request.SetDownPolicy(
+            NCloud::NProto::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART);
+
+        TString input;
+        google::protobuf::util::MessageToJsonString(request, &input);
+        service.ExecuteAction("drainnode", input);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(
+                NKikimrHive::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART),
+            static_cast<int>(observedDownPolicy));
     }
 }
 

--- a/cloud/blockstore/private/api/protos/volume.proto
+++ b/cloud/blockstore/private/api/protos/volume.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package NCloud.NBlockStore.NPrivateProto;
 
 import "cloud/blockstore/private/api/protos/blob.proto";
+import "cloud/storage/core/protos/drain.proto";
 
 option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/private/api/protos";
 
@@ -172,8 +173,11 @@ message TRebindVolumesResponse
 
 message TDrainNodeRequest
 {
-    // KeepDown hive flag. If set, the node will stay disabled after draining.
-    bool KeepDown = 1;
+    // Deprecated in favor of DownPolicy.
+    bool KeepDown = 1 [deprecated = true];
+
+    // Controls whether and for how long the node stays down after draining.
+    NCloud.NProto.EDrainDownPolicy DownPolicy = 2;
 };
 
 message TDrainNodeResponse

--- a/cloud/filestore/libs/storage/service/service_actor_actions_drain_tablets.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_drain_tablets.cpp
@@ -35,11 +35,12 @@ struct TDrainTabletsActionActor final
             return;
         }
 
-        LOG_INFO(
+        LOG_INFO_S(
             ctx,
             TFileStoreComponents::SERVICE,
-            "Draining tablets started, DownPolicy=%d",
-            request.GetDownPolicy());
+            "Draining tablets started, DownPolicy="
+                << NCloud::NProto::EDrainDownPolicy_Name(
+                       request.GetDownPolicy()));
 
         DrainTablets(ctx, request);
         Become(&TThis::StateWork);

--- a/cloud/filestore/libs/storage/service/service_actor_actions_drain_tablets.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_drain_tablets.cpp
@@ -38,9 +38,9 @@ struct TDrainTabletsActionActor final
         LOG_INFO_S(
             ctx,
             TFileStoreComponents::SERVICE,
-            "Draining tablets started, DownPolicy="
-                << NCloud::NProto::EDrainDownPolicy_Name(
-                       request.GetDownPolicy()));
+            "Draining tablets started, DownPolicy=" <<
+            NCloud::NProto::EDrainDownPolicy_Name(
+                request.GetDownPolicy()));
 
         DrainTablets(ctx, request);
         Become(&TThis::StateWork);

--- a/cloud/filestore/libs/storage/service/service_actor_actions_drain_tablets.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_drain_tablets.cpp
@@ -38,10 +38,10 @@ struct TDrainTabletsActionActor final
         LOG_INFO(
             ctx,
             TFileStoreComponents::SERVICE,
-            "Draining tablets started, KeepDown=%d",
-            request.GetKeepDown());
+            "Draining tablets started, DownPolicy=%d",
+            request.GetDownPolicy());
 
-        DrainTablets(ctx, request.GetKeepDown());
+        DrainTablets(ctx, request);
         Become(&TThis::StateWork);
     }
 
@@ -59,10 +59,12 @@ struct TDrainTabletsActionActor final
         }
     }
 
-    void DrainTablets(const TActorContext& ctx, bool keepDown) const
+    void DrainTablets(
+        const TActorContext& ctx,
+        const NProtoPrivate::TDrainNodeRequest& drainRequest) const
     {
-        auto request =
-            std::make_unique<TEvHiveProxy::TEvDrainNodeRequest>(keepDown);
+        auto request = std::make_unique<TEvHiveProxy::TEvDrainNodeRequest>(
+            drainRequest.GetDownPolicy());
         NCloud::Send(
             ctx,
             MakeHiveProxyServiceId(),

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -162,14 +162,15 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
         ui64 observedNodeId = 0;
-        bool observedKeepDown = false;
+        NKikimrHive::EDrainDownPolicy observedDownPolicy =
+            NKikimrHive::DRAIN_POLICY_NO_DOWN;
         env.GetRuntime().SetObserverFunc([&](TAutoPtr<IEventHandle>& event)
             {
                 switch (event->GetTypeRewrite()) {
                     case TEvHive::EvDrainNode: {
                         auto* msg = event->Get<TEvHive::TEvDrainNode>();
                         observedNodeId = msg->Record.GetNodeID();
-                        observedKeepDown = msg->Record.GetKeepDown();
+                        observedDownPolicy = msg->Record.GetDownPolicy();
                     }
                 }
                 return TTestActorRuntime::DefaultObserverFunc(event);
@@ -185,19 +186,24 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
 
             UNIT_ASSERT_VALUES_EQUAL(service.GetSender().NodeId(), observedNodeId);
-            UNIT_ASSERT(!observedKeepDown);
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(NKikimrHive::DRAIN_POLICY_NO_DOWN),
+                static_cast<int>(observedDownPolicy));
         }
 
         {
             NProtoPrivate::TDrainNodeRequest request;
-            request.SetKeepDown(true);
+            request.SetDownPolicy(
+                NCloud::NProto::DRAIN_POLICY_KEEP_DOWN);
             TString requestJson;
             google::protobuf::util::MessageToJsonString(request, &requestJson);
 
-            auto response = service.ExecuteAction(DrainTabletsActionName, requestJson);
+            auto response =
+                service.ExecuteAction(DrainTabletsActionName, requestJson);
             UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
-            UNIT_ASSERT_VALUES_EQUAL(service.GetSender().NodeId(), observedNodeId);
-            UNIT_ASSERT(observedKeepDown);
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(NKikimrHive::DRAIN_POLICY_KEEP_DOWN),
+                static_cast<int>(observedDownPolicy));
         }
     }
 
@@ -1579,6 +1585,38 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
                 false,
                 response.GetParentlessFilesOnly());
         }
+    }
+
+    Y_UNIT_TEST(ShouldForwardDrainDownPolicy)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        NKikimrHive::EDrainDownPolicy observedDownPolicy =
+            NKikimrHive::DRAIN_POLICY_NO_DOWN;
+        env.GetRuntime().SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+            if (event->GetTypeRewrite() == TEvHive::EvDrainNode) {
+                observedDownPolicy = event->Get<TEvHive::TEvDrainNode>()
+                    ->Record.GetDownPolicy();
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        NProtoPrivate::TDrainNodeRequest request;
+        request.SetDownPolicy(
+            NCloud::NProto::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART);
+
+        TString input;
+        google::protobuf::util::MessageToJsonString(request, &input);
+        auto response = service.ExecuteAction("draintablets", input);
+
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(
+                NKikimrHive::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART),
+            static_cast<int>(observedDownPolicy));
     }
 }
 

--- a/cloud/filestore/private/api/protos/actions.proto
+++ b/cloud/filestore/private/api/protos/actions.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "cloud/filestore/public/api/protos/ping.proto";
+import "cloud/storage/core/protos/drain.proto";
 
 package NCloud.NFileStore.NProtoPrivate;
 
@@ -11,7 +12,11 @@ option go_package = "github.com/ydb-platform/nbs/cloud/filestore/private/api/pro
 
 message TDrainNodeRequest
 {
-    bool KeepDown = 1;
+    // Deprecated in favor of DownPolicy.
+    bool KeepDown = 1 [deprecated = true];
+
+    // Controls whether and for how long the node stays down after draining.
+    NCloud.NProto.EDrainDownPolicy DownPolicy = 2;
 }
 
 message TDrainNodeResponse

--- a/cloud/storage/core/libs/api/hive_proxy.h
+++ b/cloud/storage/core/libs/api/hive_proxy.h
@@ -5,6 +5,7 @@
 #include <cloud/storage/core/libs/hive_proxy/tablet_boot_info.h>
 #include <cloud/storage/core/libs/kikimr/components.h>
 #include <cloud/storage/core/libs/kikimr/events.h>
+#include <cloud/storage/core/protos/drain.pb.h>
 
 #include <contrib/ydb/core/base/hive.h>
 
@@ -235,10 +236,10 @@ struct TEvHiveProxy
 
     struct TDrainNodeRequest
     {
-        const bool KeepDown;
+        const NProto::EDrainDownPolicy DownPolicy;
 
-        explicit TDrainNodeRequest(bool keepDown)
-            : KeepDown(keepDown)
+        explicit TDrainNodeRequest(NProto::EDrainDownPolicy downPolicy)
+            : DownPolicy(downPolicy)
         {}
     };
 

--- a/cloud/storage/core/libs/api/ya.make
+++ b/cloud/storage/core/libs/api/ya.make
@@ -9,6 +9,7 @@ SRCS(
 
 PEERDIR(
     cloud/storage/core/libs/kikimr
+    cloud/storage/core/protos
 
     contrib/ydb/core/base
 

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
@@ -12,12 +12,40 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+NKikimrHive::EDrainDownPolicy ConvertDownPolicy(
+    NProto::EDrainDownPolicy downPolicy)
+{
+    using TDownPolicy = NProto::EDrainDownPolicy;
+
+    constexpr auto MinSentinel = static_cast<TDownPolicy>(
+        std::numeric_limits<i32>::min());
+    constexpr auto MaxSentinel = static_cast<TDownPolicy>(
+        std::numeric_limits<i32>::max());
+
+    switch (downPolicy) {
+        case NProto::DRAIN_POLICY_NO_DOWN:
+            return NKikimrHive::DRAIN_POLICY_NO_DOWN;
+        case NProto::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART:
+            return NKikimrHive::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART;
+        case NProto::DRAIN_POLICY_KEEP_DOWN:
+            return NKikimrHive::DRAIN_POLICY_KEEP_DOWN;
+        case MinSentinel:
+        case MaxSentinel:
+            Y_ABORT_UNLESS(
+                false,
+                "Unknown drain down policy: %d",
+                static_cast<int>(downPolicy));
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TDrainNodeRequestActor final
     : public TActorBootstrapped<TDrainNodeRequestActor>
 {
 private:
     const TActorId Owner;
-    const bool KeepDown;
+    const NProto::EDrainDownPolicy DownPolicy;
     const int LogComponent;
     const THiveProxyActor::TRequestInfo Request;
     TActorId ClientId;
@@ -25,12 +53,12 @@ private:
 public:
     TDrainNodeRequestActor(
             const TActorId& owner,
-            const bool keepDown,
+            NProto::EDrainDownPolicy downPolicy,
             const int logComponent,
             THiveProxyActor::TRequestInfo request,
             TActorId clientId)
         : Owner(owner)
-        , KeepDown(keepDown)
+        , DownPolicy(downPolicy)
         , LogComponent(logComponent)
         , Request(request)
         , ClientId(clientId)
@@ -58,7 +86,7 @@ void TDrainNodeRequestActor::Bootstrap(const TActorContext& ctx)
 {
 
     auto ev = std::make_unique<TEvHive::TEvDrainNode>(Owner.NodeId());
-    ev->Record.SetKeepDown(KeepDown);
+    ev->Record.SetDownPolicy(ConvertDownPolicy(DownPolicy));
     NKikimr::NTabletPipe::SendData(
         ctx,
         ClientId,
@@ -132,7 +160,7 @@ void THiveProxyActor::HandleDrainNode(
     HiveState.Actors.insert(NCloud::Register<TDrainNodeRequestActor>(
         ctx,
         SelfId(),
-        ev->Get()->KeepDown,
+        ev->Get()->DownPolicy,
         LogComponent,
         TRequestInfo(ev->Sender, ev->Cookie),
         clientId

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
@@ -15,13 +15,6 @@ namespace {
 NKikimrHive::EDrainDownPolicy ConvertDownPolicy(
     NProto::EDrainDownPolicy downPolicy)
 {
-    using TDownPolicy = NProto::EDrainDownPolicy;
-
-    constexpr auto MinSentinel = static_cast<TDownPolicy>(
-        std::numeric_limits<i32>::min());
-    constexpr auto MaxSentinel = static_cast<TDownPolicy>(
-        std::numeric_limits<i32>::max());
-
     switch (downPolicy) {
         case NProto::DRAIN_POLICY_NO_DOWN:
             return NKikimrHive::DRAIN_POLICY_NO_DOWN;
@@ -29,8 +22,8 @@ NKikimrHive::EDrainDownPolicy ConvertDownPolicy(
             return NKikimrHive::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART;
         case NProto::DRAIN_POLICY_KEEP_DOWN:
             return NKikimrHive::DRAIN_POLICY_KEEP_DOWN;
-        case MinSentinel:
-        case MaxSentinel:
+        case NProto::EDrainDownPolicy_INT_MIN_SENTINEL_DO_NOT_USE_:
+        case NProto::EDrainDownPolicy_INT_MAX_SENTINEL_DO_NOT_USE_:
             Y_ABORT_UNLESS(
                 false,
                 "Unknown drain down policy: %d",

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
@@ -52,6 +52,8 @@ struct THiveMockState
     THashMap<ui64, ui32> KnownGenerations;
     THashSet<ui32> DrainableNodeIds;
     THashSet<ui32> DownNodeIds;
+    NKikimrHive::EDrainDownPolicy DrainDownPolicy =
+        NKikimrHive::DRAIN_POLICY_NO_DOWN;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -383,8 +385,11 @@ private:
 
         NKikimrProto::EReplyStatus replyStatus = NKikimrProto::OK;
         ui64 nodeId = msg->Record.GetNodeID();
+        State->DrainDownPolicy = msg->Record.GetDownPolicy();
         if (State->DrainableNodeIds.contains(nodeId)) {
-            if (msg->Record.GetKeepDown()) {
+            if (msg->Record.GetDownPolicy() !=
+                NKikimrHive::DRAIN_POLICY_NO_DOWN)
+            {
                 State->DownNodeIds.insert(nodeId);
             }
         } else {
@@ -707,13 +712,13 @@ struct TTestEnv
 
     TEvHiveProxy::TDrainNodeResponse SendDrainNodeRequest(
         const TActorId& sender,
-        bool keepDown,
+        NProto::EDrainDownPolicy downPolicy,
         ui32 errorCode)
     {
         Runtime.Send(new IEventHandle(
             MakeHiveProxyServiceId(),
             sender,
-            new TEvHiveProxy::TEvDrainNodeRequest(keepDown)
+            new TEvHiveProxy::TEvDrainNodeRequest(downPolicy)
         ));
         using TResponse = TEvHiveProxy::TEvDrainNodeResponse;
         auto ev = Runtime.GrabEdgeEvent<TResponse>(sender);
@@ -1171,14 +1176,23 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
 
         auto sender = runtime.AllocateEdgeActor();
 
-        env.SendDrainNodeRequest(sender, false, E_FAIL);
+        env.SendDrainNodeRequest(
+            sender,
+            NProto::DRAIN_POLICY_NO_DOWN,
+            E_FAIL);
 
         env.HiveState->DrainableNodeIds.insert(sender.NodeId());
-        env.SendDrainNodeRequest(sender, false, S_OK);
+        env.SendDrainNodeRequest(
+            sender,
+            NProto::DRAIN_POLICY_NO_DOWN,
+            S_OK);
 
         UNIT_ASSERT(!env.HiveState->DownNodeIds.contains(sender.NodeId()));
 
-        env.SendDrainNodeRequest(sender, true, S_OK);
+        env.SendDrainNodeRequest(
+            sender,
+            NProto::DRAIN_POLICY_KEEP_DOWN,
+            S_OK);
         UNIT_ASSERT(env.HiveState->DownNodeIds.contains(sender.NodeId()));
     }
 
@@ -2419,6 +2433,35 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
         auto result2 = env.SendBootExternalRequest(sender, FakeTablet2, S_OK);
         UNIT_ASSERT(result2.StorageInfo);
         UNIT_ASSERT_VALUES_EQUAL(2u, result2.SuggestedGeneration);
+    }
+
+    Y_UNIT_TEST(ShouldForwardDrainDownPolicy)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        auto sender = runtime.AllocateEdgeActor();
+        env.HiveState->DrainableNodeIds.insert(sender.NodeId());
+
+        const auto assertPolicy = [&] (
+            NProto::EDrainDownPolicy policy,
+            NKikimrHive::EDrainDownPolicy expectedPolicy)
+        {
+            env.SendDrainNodeRequest(sender, policy, S_OK);
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(expectedPolicy),
+                static_cast<int>(env.HiveState->DrainDownPolicy));
+        };
+
+        assertPolicy(
+            NProto::DRAIN_POLICY_NO_DOWN,
+            NKikimrHive::DRAIN_POLICY_NO_DOWN);
+        assertPolicy(
+            NProto::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART,
+            NKikimrHive::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART);
+        assertPolicy(
+            NProto::DRAIN_POLICY_KEEP_DOWN,
+            NKikimrHive::DRAIN_POLICY_KEEP_DOWN);
     }
 }
 

--- a/cloud/storage/core/protos/drain.proto
+++ b/cloud/storage/core/protos/drain.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package NCloud.NProto;
+
+option go_package = "github.com/ydb-platform/nbs/cloud/storage/core/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum EDrainDownPolicy
+{
+    DRAIN_POLICY_NO_DOWN = 0;
+    DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART = 1;
+    DRAIN_POLICY_KEEP_DOWN = 2;
+}

--- a/cloud/storage/core/protos/ya.make
+++ b/cloud/storage/core/protos/ya.make
@@ -13,6 +13,7 @@ SRCS(
     config_dispatcher_settings.proto
     device.proto
     diagnostics.proto
+    drain.proto
     endpoints.proto
     error.proto
     media.proto


### PR DESCRIPTION
### Notes
- Added a local EDrainDownPolicy protobuf enum matching the Hive drain policies.
- Added DownPolicy to the private BlockStore and FileStore drain requests.
- Marked the legacy KeepDown field as deprecated and removed its use from the application code.
- Propagated DownPolicy through the service actors and Hive proxy.
- Added explicit conversion from the NBS enum to NKikimrHive::EDrainDownPolicy, avoiding a dependency on the YDB protobuf in the private APIs.
- Added compile-time checks to detect changes to the local policy enum.
- An omitted DownPolicy defaults to DRAIN_POLICY_NO_DOWN.

### Motivation
The existing KeepDown flag is a deprecated compatibility field in the YDB Hive API. As a boolean, it can represent only two policies:
- false → DRAIN_POLICY_NO_DOWN
- true → DRAIN_POLICY_KEEP_DOWN
KeepDown cannot represent DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART, where the drained node remains down until the node itself restarts and registers with Hive again.

### Issue
Put links to the related issues here
