### PR TITLE
issue-6996: only fastshard tablets should return fastshard endpoint info in backend info

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -74,6 +74,7 @@ inline void BuildBackendInfo(
     const TStorageConfig& config,
     const TSystemCounters& systemCounters,
     TString fileSystemId,
+    bool isFastShard,
     ui32 tabletActorCpuUsageRate,
     NProto::TBackendInfo* backendInfo)
 {
@@ -81,7 +82,7 @@ inline void BuildBackendInfo(
         IsTabletOverloaded(config, systemCounters, tabletActorCpuUsageRate));
 
     const ui32 fastShardPort = config.GetFastShardServerPort();
-    if (fastShardPort) {
+    if (isFastShard && fastShardPort) {
         backendInfo->SetFastShardHost(FQDNHostName());
         backendInfo->SetFastShardPort(fastShardPort);
     }
@@ -94,6 +95,7 @@ void BuildBackendInfo(
     const TStorageConfig& config,
     const TSystemCounters& systemCounters,
     TString fileSystemId,
+    bool isFastShard,
     ui32 tabletActorCpuUsageRate,
     T& response)
 {
@@ -104,6 +106,7 @@ void BuildBackendInfo(
             config,
             systemCounters,
             std::move(fileSystemId),
+            isFastShard,
             tabletActorCpuUsageRate,
             backendInfo);
     }
@@ -128,6 +131,7 @@ void CompleteResponse(
     const ITraceSerializerPtr& traceSerializer,
     TSystemCounters& systemCounters,
     const TString& fileSystemId,
+    bool isFastShard,
     TTabletMetrics& metrics,
     typename TMethod::TResponse::ProtoRecordType& response,
     const TCallContextPtr& callContext,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adapter.cpp
@@ -69,6 +69,7 @@ void OnResponse(
         traceSerializer,
         systemCounters,
         fileSystemId,
+        true /* isFastShard */,
         metrics,
         response->Record,
         callContext,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -279,6 +279,7 @@ void TIndexTabletActor::CompleteTx_AddData(
         *Config,
         *SystemCounters,
         GetFileSystemId(),
+        false /* isFastShard */,
         Metrics->CPUUsageRate,
         &backendInfo);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -1202,6 +1202,7 @@ void TIndexTabletActor::CompleteTx_ReadData(
         *Config,
         *SystemCounters,
         GetFileSystemId(),
+        false /* isFastShard */,
         Metrics->CPUUsageRate,
         &backendInfo);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -98,6 +98,7 @@ void CompleteResponse(
     const ITraceSerializerPtr& traceSerializer,
     TSystemCounters& systemCounters,
     const TString& fileSystemId,
+    bool isFastShard,
     TTabletMetrics& metrics,
     typename TMethod::TResponse::ProtoRecordType& response,
     const TCallContextPtr& callContext,
@@ -123,6 +124,7 @@ void CompleteResponse(
         config,
         systemCounters,
         fileSystemId,
+        isFastShard,
         metrics.CPUUsageRate,
         response);
     if constexpr (HasResponseHeaders<decltype(response)>()) {
@@ -146,6 +148,7 @@ void TIndexTabletActor::CompleteResponse(
         TraceSerializer,
         *SystemCounters,
         GetFileSystemId(),
+        FastShard != nullptr,
         *Metrics,
         response,
         callContext,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -533,6 +533,7 @@ void TIndexTabletActor::CompleteTx_WriteData(
         *Config,
         *SystemCounters,
         GetFileSystemId(),
+        false /* isFastShard */,
         Metrics->CPUUsageRate,
         &backendInfo);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
@@ -174,8 +174,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
                 response->GetErrorReason());
             nodeId2 = response->Record.GetNode().GetId();
 
-            auto hResponse =
-                tablet.SendAndRecvCreateHandle(nodeId2, 0 /* flags */);
+            auto hResponse = tablet.SendAndRecvCreateHandle(
+                nodeId2,
+                TCreateHandleArgs::RDWR);
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 hResponse->GetStatus(),
@@ -191,7 +192,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
             auto hResponse = tablet.SendAndRecvCreateHandle(
                 RootNodeId,
                 uuid3,
-                0 /* flags */);
+                TCreateHandleArgs::RDWR);
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_FS_NOENT,
                 hResponse->GetStatus(),
@@ -412,6 +413,119 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
         });
 
         tablet.DestroySession();
+    }
+
+    TABLET_TEST_4K_ONLY(ShouldReturnFastShardEndpointOnlyForFastShards)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetTwoStageReadEnabled(true);
+        storageConfig.SetThreeStageWriteEnabled(true);
+        const ui32 fastShardPort = 11111;
+        storageConfig.SetFastShardServerPort(fastShardPort);
+        TTestEnv env(testEnvConfig, storageConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+
+        {
+            auto response = tablet.InitSession("client", "session");
+            UNIT_ASSERT(!response->Record.GetAdapterModeEnabled());
+        }
+
+        const TString shardId1 = "shard1";
+        const TString uuid1 = CreateGuidAsString();
+        ui64 nodeId1 = 0;
+        ui64 handle1 = 0;
+
+        {
+            auto response = tablet.SendAndRecvCreateNode(
+                TCreateNodeArgs::File(RootNodeId, uuid1));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+            nodeId1 = response->Record.GetNode().GetId();
+
+            auto hResponse = tablet.SendAndRecvCreateHandle(
+                nodeId1,
+                TCreateHandleArgs::RDWR);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                hResponse->GetStatus(),
+                hResponse->GetErrorReason());
+            handle1 = hResponse->Record.GetHandle();
+        }
+
+        {
+            auto response = tablet.SendAndRecvReadData(
+                handle1,
+                0 /* offset */,
+                4_KB /* len */);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+            const auto& bi = response->Record.GetHeaders().GetBackendInfo();
+            UNIT_ASSERT_VALUES_EQUAL(0, bi.GetFastShardPort());
+            UNIT_ASSERT_VALUES_EQUAL("", bi.GetFastShardHost());
+        }
+
+        tablet.ConfigureAsShard(
+            1 /* shardNo */,
+            "main_fs",
+            "main_fs_s1",
+            true /* directoryCreationInShardsEnabled */,
+            TVector<TString>() /* shardIds */,
+            NProtoPrivate::TFastShardConfig(),
+            true /* isFastShard */);
+
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+        {
+            auto response = tablet.InitSession("client", "session");
+            UNIT_ASSERT(response->Record.GetAdapterModeEnabled());
+        }
+
+        tablet.DestroySession();
+
+        {
+            auto response = tablet.SendAndRecvCreateNode(
+                TCreateNodeArgs::File(RootNodeId, uuid1));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+            nodeId1 = response->Record.GetNode().GetId();
+
+            auto hResponse = tablet.SendAndRecvCreateHandle(
+                nodeId1,
+                TCreateHandleArgs::RDWR);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                hResponse->GetStatus(),
+                hResponse->GetErrorReason());
+            handle1 = hResponse->Record.GetHandle();
+        }
+
+        {
+            auto response = tablet.SendAndRecvReadData(
+                handle1,
+                0 /* offset */,
+                4_KB /* len */);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+            const auto& bi = response->Record.GetHeaders().GetBackendInfo();
+            UNIT_ASSERT_VALUES_EQUAL(fastShardPort, bi.GetFastShardPort());
+            UNIT_ASSERT_VALUES_UNEQUAL("", bi.GetFastShardHost());
+        }
     }
 }
 


### PR DESCRIPTION
### Notes
Otherwise filestore-vhosts with tcp-side-channel enabled try to connect to fastshard endpoint for all tablets, not only fastshards.

### Issue
https://github.com/ydb-platform/nbs/issues/6996
