### PR TITLE
[NBS][vhost] Fix deadlock during endpoint shutdown

### DIFF
--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -41,6 +41,28 @@ TVector<TExecutor*> NormalizeExecutors(
     return normalized;
 }
 
+void RequestEndpointStop(
+    const TEndpointPtr& endpoint,
+    bool deleteSocket,
+    TPromise<NProto::TError> stopPromise)
+{
+    const auto error = SafeExecute<NProto::TError>(
+        [&]
+        {
+            endpoint->Stop(deleteSocket).Subscribe(
+                [stopPromise](const auto& future) mutable
+                {
+                    stopPromise.SetValue(
+                        SafeExecute<NProto::TError>(
+                            [&] { return future.GetValue(); }));
+                });
+            return NProto::TError();
+        });
+    if (HasError(error)) {
+        stopPromise.SetValue(error);
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TServer final
@@ -100,6 +122,19 @@ private:
     // Picks |count| distinct executors with the lowest number of assigned
     // vhost queues. Must be called under Lock.
     TVector<TExecutor*> PickExecutors(ui32 count);
+
+    struct TStopRequest
+    {
+        // Has to be completed by RequestEndpointStop().
+        TPromise<NProto::TError> Promise;
+        // Resolved once HandleStoppedEndpoint() has dropped the endpoint.
+        TFuture<NProto::TError> Future;
+    };
+
+    // Must be called under Lock.
+    TStopRequest RegisterStoppingEndpoint(
+        const TString& socketPath,
+        TEndpointPtr endpoint);
 
     void StopAllEndpoints();
 
@@ -220,6 +255,10 @@ TFuture<NProto::TError> TServer::StartEndpoint(
             return MakeFuture(MakeError(E_FAIL, "Vhost server is stopped"));
         }
 
+        if (StoppingEndpoints.contains(socketPath)) {
+            return MakeFuture(MakeError(E_REJECTED, "endpoint is stopping"));
+        }
+
         auto it = Endpoints.find(socketPath);
         if (it != Endpoints.end()) {
             NProto::TError error;
@@ -286,6 +325,33 @@ TFuture<NProto::TError> TServer::StartEndpoint(
     return MakeFuture<NProto::TError>();
 }
 
+TServer::TStopRequest TServer::RegisterStoppingEndpoint(
+    const TString& socketPath,
+    TEndpointPtr endpoint)
+{
+    auto promise = NewPromise<NProto::TError>();
+
+    // Keeps the server alive until the stop completes. Empty when called from
+    // ~TServer() via Stop().
+    auto self = weak_from_this().lock();
+
+    auto stopFuture = promise.GetFuture().Apply(
+        [this, self = std::move(self), socketPath](const auto& future)
+        {
+            Y_UNUSED(self);
+            const auto& error = future.GetValue();
+            HandleStoppedEndpoint(socketPath, error);
+            return error;
+        });
+
+    auto [it, inserted] = StoppingEndpoints.emplace(
+        socketPath,
+        TStoppingEndpoint{std::move(endpoint), stopFuture});
+    Y_ABORT_UNLESS(inserted);
+
+    return {std::move(promise), std::move(stopFuture)};
+}
+
 TFuture<NProto::TError> TServer::StopEndpoint(const TString& socketPath)
 {
     if (ShouldStop.test()) {
@@ -296,9 +362,15 @@ TFuture<NProto::TError> TServer::StopEndpoint(const TString& socketPath)
     }
 
     TEndpointPtr endpoint;
-    TFuture<NProto::TError> stopFuture;
+    TStopRequest stopRequest;
 
     with_lock (Lock) {
+        if (auto stoppingIt = StoppingEndpoints.find(socketPath);
+            stoppingIt != StoppingEndpoints.end())
+        {
+            return stoppingIt->second.Future;
+        }
+
         auto it = Endpoints.find(socketPath);
         if (it == Endpoints.end()) {
             NProto::TError error;
@@ -312,20 +384,11 @@ TFuture<NProto::TError> TServer::StopEndpoint(const TString& socketPath)
         endpoint = std::move(it->second);
         Endpoints.erase(it);
 
-        stopFuture = endpoint->Stop(true);
-        StoppingEndpoints.emplace(
-            socketPath,
-            TStoppingEndpoint{std::move(endpoint), stopFuture});
+        stopRequest = RegisterStoppingEndpoint(socketPath, endpoint);
     }
 
-    auto ptr = shared_from_this();
-    return stopFuture.Apply(
-        [ptr = std::move(ptr), socketPath](const auto& future)
-        {
-            const auto& error = future.GetValue();
-            ptr->HandleStoppedEndpoint(socketPath, error);
-            return error;
-        });
+    RequestEndpointStop(endpoint, true, std::move(stopRequest.Promise));
+    return stopRequest.Future;
 }
 
 NProto::TError TServer::UpdateEndpoint(
@@ -363,48 +426,46 @@ NProto::TError TServer::UpdateEndpoint(
 
 void TServer::StopAllEndpoints()
 {
-    TVector<TString> sockets;
     TVector<TFuture<NProto::TError>> futures;
+    TVector<std::pair<TEndpointPtr, TPromise<NProto::TError>>> endpointsToStop;
 
     with_lock (Lock) {
-        for (const auto& [socketPath, stoppingEndpoint]: StoppingEndpoints) {
-            sockets.push_back(socketPath);
-            futures.push_back(stoppingEndpoint.Future);
+        for (const auto& entry: StoppingEndpoints) {
+            futures.push_back(entry.second.Future);
         }
 
-        for (auto& it: Endpoints) {
-            const auto& socketPath = it.first;
-            auto endpoint = std::move(it.second);
-            auto future = endpoint->Stop(false);
+        for (auto& [socketPath, endpoint]: Endpoints) {
+            auto stopRequest = RegisterStoppingEndpoint(socketPath, endpoint);
 
-            StoppingEndpoints.emplace(
-                socketPath,
-                TStoppingEndpoint{endpoint, future});
+            futures.push_back(std::move(stopRequest.Future));
 
-            sockets.push_back(socketPath);
-            futures.push_back(std::move(future));
+            endpointsToStop.emplace_back(
+                std::move(endpoint),
+                std::move(stopRequest.Promise));
         }
 
         Endpoints.clear();
     }
 
-    WaitAll(futures).Wait();
-
-    for (size_t i = 0; i < sockets.size(); ++i) {
-        const auto& socketPath = sockets[i];
-        const auto& future = futures[i];
-        HandleStoppedEndpoint(socketPath, future.GetValue());
+    for (auto& [endpoint, stopPromise]: endpointsToStop) {
+        RequestEndpointStop(endpoint, false, std::move(stopPromise));
     }
+
+    WaitAll(futures).Wait();
 }
 
 void TServer::HandleStoppedEndpoint(
     const TString& socketPath,
     const NProto::TError& error)
 {
+    // remove endpoint outside of the lock to don't make extra work inside the
+    // lock
+    TStoppingEndpoint stoppedEndpoint;
     bool erased = false;
     with_lock (Lock) {
         auto it = StoppingEndpoints.find(socketPath);
         if (it != StoppingEndpoints.end()) {
+            stoppedEndpoint = std::move(it->second);
             StoppingEndpoints.erase(it);
             erased = true;
         }

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -26,6 +26,7 @@
 #include <util/thread/lfqueue.h>
 
 #include <atomic>
+#include <exception>
 
 namespace NCloud::NBlockStore::NVhost {
 
@@ -322,6 +323,79 @@ ui32 StartEndpointAndCountExecutors(
         executorsCount += !queue->GetDevices().empty();
     }
     return executorsCount;
+}
+
+void TestEndpointStopException(bool failSynchronously)
+{
+    const TString socketPath = CreateGuidAsString() + ".sock";
+    TTempFile socketFile(socketPath);
+
+    auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+    auto asyncStopPromise = NewPromise<NProto::TError>();
+    if (failSynchronously) {
+        queueFactory->DeviceStopHandler = [](const TString&)
+        {
+            throw TFutureException();
+        };
+    } else {
+        queueFactory->DeviceStopFutureHandler =
+            [asyncStopPromise](const TString&)
+        {
+            return asyncStopPromise.GetFuture();
+        };
+    }
+
+    auto server = CreateServer(
+        CreateLoggingService("console"),
+        CreateServerStatsStub(),
+        queueFactory,
+        CreateDefaultDeviceHandlerFactory(),
+        TServerConfig(),
+        TVhostCallbacks());
+    server->Start();
+    Y_DEFER
+    {
+        server->Stop();
+    };
+
+    const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+    while (!queueFactory->Queues.at(0)->IsRun() && TInstant::Now() < deadline) {
+        Sleep(TDuration::MilliSeconds(10));
+    }
+    UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+    TStorageOptions options;
+    options.DiskId = "testDiskId";
+    options.BlockSize = 4096;
+    options.BlocksCount = 256;
+    options.VhostQueuesCount = 1;
+
+    auto startEndpoint = [&]
+    {
+        return server
+            ->StartEndpoint(
+                socketPath,
+                std::make_shared<TTestStorage>(),
+                options)
+            .GetValue(TDuration::Seconds(5));
+    };
+
+    UNIT_ASSERT_VALUES_EQUAL(S_OK, startEndpoint().GetCode());
+
+    auto stopFuture = server->StopEndpoint(socketPath);
+    if (!failSynchronously) {
+        UNIT_ASSERT(!stopFuture.HasValue());
+        asyncStopPromise.SetException(
+            std::make_exception_ptr(TFutureException()));
+    }
+
+    const auto stopError = stopFuture.GetValue(TDuration::Seconds(5));
+    UNIT_ASSERT_VALUES_EQUAL(E_FAIL, stopError.GetCode());
+
+    // A completed error must remove the endpoint from StoppingEndpoints.
+    queueFactory->DeviceStopHandler = {};
+    queueFactory->DeviceStopFutureHandler = {};
+    UNIT_ASSERT_VALUES_EQUAL(S_OK, startEndpoint().GetCode());
 }
 
 }   // namespace
@@ -1848,6 +1922,501 @@ Y_UNIT_TEST_SUITE(TServerTest)
         UNIT_ASSERT_VALUES_EQUAL(
             1,
             StartEndpointAndCountExecutors(1, 4, 4));
+    }
+
+    Y_UNIT_TEST(ShouldCompletePreviousEndpointWhileStoppingAnother)
+    {
+        const TString firstSocket = CreateGuidAsString() + ".sock";
+        const TString secondSocket = CreateGuidAsString() + ".sock";
+        TTempFile firstSocketFile(firstSocket);
+        TTempFile secondSocketFile(secondSocket);
+        TManualEvent secondStopEntered;
+        TManualEvent firstStopCompleted;
+        bool completionWasBlocked = false;
+        auto storagePromise = NewPromise<NProto::TReadBlocksLocalResponse>();
+
+        auto storage = std::make_shared<TTestStorage>();
+        storage->ReadBlocksLocalHandler =
+            [&](TCallContextPtr,
+                std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
+        {
+            return request->GetStartIndex() == 0
+                       ? storagePromise.GetFuture()
+                       : MakeFuture(NProto::TReadBlocksLocalResponse());
+        };
+        auto stats = std::make_shared<TTestServerStats>();
+        stats->RequestCompletedHandler = [&](TLog&,
+                                             TMetricRequest&,
+                                             TCallContext&,
+                                             const NProto::TError& error)
+        {
+            if (error.GetCode() != E_CANCELLED) {
+                return;
+            }
+            // Cancellation runs inside endpoint->Stop(). Model its wait
+            // for another device's unregister callback on a separate thread.
+            secondStopEntered.Signal();
+            completionWasBlocked =
+                !firstStopCompleted.WaitT(TDuration::Seconds(5));
+        };
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            stats,
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            TServerConfig(),
+            TVhostCallbacks());
+        server->Start();
+        Y_DEFER
+        {
+            server->Stop();
+        };
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (!queueFactory->Queues.at(0)->IsRun() &&
+               TInstant::Now() < deadline)
+        {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+        TStorageOptions options;
+        options.BlockSize = 4096;
+        options.BlocksCount = 256;
+        options.VhostQueuesCount = 1;
+        for (const auto& socket: {firstSocket, secondSocket}) {
+            options.DiskId = socket;
+            const auto error = server->StartEndpoint(socket, storage, options)
+                                   .GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(error), error);
+        }
+
+        auto devices = queueFactory->Queues.at(0)->GetDevices();
+        TVector<TString> blocks;
+        auto sglist = ResizeBlocks(blocks, 1, TString(4096, 'x'));
+        Y_DEFER
+        {
+            storagePromise.SetValue(NProto::TReadBlocksLocalResponse());
+        };
+        auto read = devices.at(1)->SendTestRequest(
+            EBlockStoreRequest::ReadBlocks,
+            0,
+            4096,
+            sglist);
+        // A following request on the same executor ensures that the pending
+        // read has finished entering the storage layer before cancellation.
+        auto barrier = devices.at(1)->SendTestRequest(
+            EBlockStoreRequest::ReadBlocks,
+            4096,
+            4096,
+            sglist);
+        UNIT_ASSERT(
+            barrier.GetValue(TDuration::Seconds(5)) == TVhostRequest::SUCCESS);
+
+        devices.at(0)->DisableAutostop(true);
+        auto firstStop = server->StopEndpoint(firstSocket);
+        auto controlThread = SystemThreadFactory()->Run(
+            [&]
+            {
+                secondStopEntered.Wait();
+                // Completing the promise synchronously runs
+                // HandleStoppedEndpoint.
+                devices.at(0)->DisableAutostop(false);
+                firstStopCompleted.Signal();
+            });
+
+        TFuture<NProto::TError> secondStop;
+        {
+            Y_DEFER
+            {
+                secondStopEntered.Signal();
+                controlThread->Join();
+            };
+            secondStop = server->StopEndpoint(secondSocket);
+        }
+
+        UNIT_ASSERT_C(!completionWasBlocked, "Stop held the server mutex");
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            firstStop.GetValue(TDuration::Seconds(5)).GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            secondStop.GetValue(TDuration::Seconds(5)).GetCode());
+        UNIT_ASSERT(
+            read.GetValue(TDuration::Seconds(5)) == TVhostRequest::CANCELLED);
+    }
+
+    Y_UNIT_TEST(ShouldCompletePreviousEndpointWhileStoppingServer)
+    {
+        const TString firstSocket = CreateGuidAsString() + ".sock";
+        const TString secondSocket = CreateGuidAsString() + ".sock";
+        TTempFile firstSocketFile(firstSocket);
+        TTempFile secondSocketFile(secondSocket);
+        TManualEvent serverStopEntered;
+        TManualEvent firstStopCompleted;
+        bool completionWasBlocked = false;
+        auto storagePromise = NewPromise<NProto::TReadBlocksLocalResponse>();
+
+        auto storage = std::make_shared<TTestStorage>();
+        storage->ReadBlocksLocalHandler =
+            [&](TCallContextPtr,
+                std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
+        {
+            return request->GetStartIndex() == 0
+                       ? storagePromise.GetFuture()
+                       : MakeFuture(NProto::TReadBlocksLocalResponse());
+        };
+        auto stats = std::make_shared<TTestServerStats>();
+        stats->RequestCompletedHandler = [&](TLog&,
+                                             TMetricRequest&,
+                                             TCallContext&,
+                                             const NProto::TError& error)
+        {
+            if (error.GetCode() != E_CANCELLED) {
+                return;
+            }
+            // Cancellation runs inside StopAllEndpoints(). Model its wait
+            // for another device's unregister callback on a separate thread.
+            serverStopEntered.Signal();
+            completionWasBlocked =
+                !firstStopCompleted.WaitT(TDuration::Seconds(5));
+        };
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            stats,
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            TServerConfig(),
+            TVhostCallbacks());
+        server->Start();
+        Y_DEFER
+        {
+            server->Stop();
+        };
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (!queueFactory->Queues.at(0)->IsRun() &&
+               TInstant::Now() < deadline)
+        {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+        TStorageOptions options;
+        options.BlockSize = 4096;
+        options.BlocksCount = 256;
+        options.VhostQueuesCount = 1;
+        for (const auto& socket: {firstSocket, secondSocket}) {
+            options.DiskId = socket;
+            const auto error = server->StartEndpoint(socket, storage, options)
+                                   .GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(error), error);
+        }
+
+        auto devices = queueFactory->Queues.at(0)->GetDevices();
+        TVector<TString> blocks;
+        auto sglist = ResizeBlocks(blocks, 1, TString(4096, 'x'));
+        Y_DEFER
+        {
+            storagePromise.SetValue(NProto::TReadBlocksLocalResponse());
+        };
+        auto read = devices.at(1)->SendTestRequest(
+            EBlockStoreRequest::ReadBlocks,
+            0,
+            4096,
+            sglist);
+        // A following request on the same executor ensures that the pending
+        // read has finished entering the storage layer before cancellation.
+        auto barrier = devices.at(1)->SendTestRequest(
+            EBlockStoreRequest::ReadBlocks,
+            4096,
+            4096,
+            sglist);
+        UNIT_ASSERT(
+            barrier.GetValue(TDuration::Seconds(5)) == TVhostRequest::SUCCESS);
+
+        devices.at(0)->DisableAutostop(true);
+        auto firstStop = server->StopEndpoint(firstSocket);
+        auto controlThread = SystemThreadFactory()->Run(
+            [&]
+            {
+                serverStopEntered.Wait();
+                // Completing the promise synchronously runs
+                // HandleStoppedEndpoint.
+                devices.at(0)->DisableAutostop(false);
+                firstStopCompleted.Signal();
+            });
+
+        {
+            Y_DEFER
+            {
+                serverStopEntered.Signal();
+                controlThread->Join();
+            };
+            server->Stop();
+        }
+
+        UNIT_ASSERT_C(!completionWasBlocked, "Stop held the server mutex");
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            firstStop.GetValue(TDuration::Seconds(5)).GetCode());
+        UNIT_ASSERT(
+            read.GetValue(TDuration::Seconds(5)) == TVhostRequest::CANCELLED);
+    }
+
+    Y_UNIT_TEST(ShouldRejectRestartUntilEndpointStopCompletes)
+    {
+        const TString socketPath = CreateGuidAsString() + ".sock";
+        TTempFile socketFile(socketPath);
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            CreateServerStatsStub(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            TServerConfig(),
+            TVhostCallbacks());
+        server->Start();
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (!queueFactory->Queues.at(0)->IsRun() &&
+               TInstant::Now() < deadline)
+        {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+        TStorageOptions options;
+        options.DiskId = "testDiskId";
+        options.BlockSize = 4096;
+        options.BlocksCount = 256;
+        options.VhostQueuesCount = 1;
+
+        auto startEndpoint = [&]
+        {
+            return server
+                ->StartEndpoint(
+                    socketPath,
+                    std::make_shared<TTestStorage>(),
+                    options)
+                .GetValue(TDuration::Seconds(5));
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, startEndpoint().GetCode());
+
+        auto device = queueFactory->Queues.at(0)->GetDevices().at(0);
+        device->DisableAutostop(true);
+        bool stopBlocked = true;
+        Y_DEFER
+        {
+            if (stopBlocked) {
+                device->DisableAutostop(false);
+            }
+            server->Stop();
+        };
+
+        auto stop = server->StopEndpoint(socketPath);
+        UNIT_ASSERT(!stop.HasValue());
+
+        const auto restartDuringStop = startEndpoint();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, restartDuringStop.GetCode());
+
+        device->DisableAutostop(false);
+        stopBlocked = false;
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            stop.GetValue(TDuration::Seconds(5)).GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, startEndpoint().GetCode());
+        UNIT_ASSERT(TFsPath(socketPath).Exists());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            server->StopEndpoint(socketPath)
+                .GetValue(TDuration::Seconds(5))
+                .GetCode());
+        UNIT_ASSERT(!TFsPath(socketPath).Exists());
+    }
+
+    Y_UNIT_TEST(ShouldWaitForRepeatedStopEndpoint)
+    {
+        const TString socketPath = CreateGuidAsString() + ".sock";
+        TTempFile socketFile(socketPath);
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            CreateServerStatsStub(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            TServerConfig(),
+            TVhostCallbacks());
+        server->Start();
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (!queueFactory->Queues.at(0)->IsRun() &&
+               TInstant::Now() < deadline)
+        {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+        TStorageOptions options;
+        options.DiskId = "testDiskId";
+        options.BlockSize = 4096;
+        options.BlocksCount = 256;
+        options.VhostQueuesCount = 1;
+
+        const auto startError = server
+                                    ->StartEndpoint(
+                                        socketPath,
+                                        std::make_shared<TTestStorage>(),
+                                        options)
+                                    .GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, startError.GetCode());
+
+        auto device = queueFactory->Queues.at(0)->GetDevices().at(0);
+        device->DisableAutostop(true);
+        bool stopBlocked = true;
+        Y_DEFER
+        {
+            if (stopBlocked) {
+                device->DisableAutostop(false);
+            }
+            server->Stop();
+        };
+
+        auto firstStop = server->StopEndpoint(socketPath);
+        auto repeatedStop = server->StopEndpoint(socketPath);
+
+        UNIT_ASSERT_EQUAL(firstStop.StateId(), repeatedStop.StateId());
+        UNIT_ASSERT(!firstStop.HasValue());
+        UNIT_ASSERT(!repeatedStop.HasValue());
+
+        device->DisableAutostop(false);
+        stopBlocked = false;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            firstStop.GetValue(TDuration::Seconds(5)).GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            repeatedStop.GetValue(TDuration::Seconds(5)).GetCode());
+    }
+
+    Y_UNIT_TEST(ShouldWaitForSynchronousEndpointStopBeforeShuttingDownExecutors)
+    {
+        const TString socketPath = CreateGuidAsString() + ".sock";
+        TTempFile socketFile(socketPath);
+        TManualEvent endpointStopEntered;
+        TManualEvent resumeEndpointStop;
+        TManualEvent serverStopCompleted;
+
+        auto queueFactory = std::make_shared<TTestVhostQueueFactory>();
+        queueFactory->DeviceStopHandler = [&](const TString&)
+        {
+            endpointStopEntered.Signal();
+            resumeEndpointStop.Wait();
+        };
+
+        auto server = CreateServer(
+            CreateLoggingService("console"),
+            CreateServerStatsStub(),
+            queueFactory,
+            CreateDefaultDeviceHandlerFactory(),
+            TServerConfig(),
+            TVhostCallbacks());
+        server->Start();
+        Y_DEFER
+        {
+            resumeEndpointStop.Signal();
+            server->Stop();
+        };
+
+        const auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (!queueFactory->Queues.at(0)->IsRun() &&
+               TInstant::Now() < deadline)
+        {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(queueFactory->Queues.at(0)->IsRun());
+
+        TStorageOptions options;
+        options.DiskId = "testDiskId";
+        options.BlockSize = 4096;
+        options.BlocksCount = 256;
+        options.VhostQueuesCount = 1;
+
+        const auto startError = server
+                                    ->StartEndpoint(
+                                        socketPath,
+                                        std::make_shared<TTestStorage>(),
+                                        options)
+                                    .GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, startError.GetCode());
+
+        TFuture<NProto::TError> endpointStop;
+        auto endpointThread = SystemThreadFactory()->Run(
+            [&] { endpointStop = server->StopEndpoint(socketPath); });
+        const bool endpointStopStarted =
+            endpointStopEntered.WaitT(TDuration::Seconds(5));
+
+        auto serverThread = SystemThreadFactory()->Run(
+            [&]
+            {
+                server->Stop();
+                serverStopCompleted.Signal();
+            });
+
+        const TString stopProbePath = CreateGuidAsString() + ".sock";
+        NProto::TError stopProbeError;
+        const auto stopDeadline = TInstant::Now() + TDuration::Seconds(5);
+        do {
+            stopProbeError = server->StopEndpoint(stopProbePath)
+                                 .GetValue(TDuration::Seconds(5));
+            if (stopProbeError.GetCode() == E_FAIL) {
+                break;
+            }
+            Sleep(TDuration::MilliSeconds(10));
+        } while (TInstant::Now() < stopDeadline);
+
+        bool serverStoppedEarly = false;
+        bool queueRunningDuringStop = false;
+        {
+            Y_DEFER
+            {
+                resumeEndpointStop.Signal();
+                endpointThread->Join();
+                serverThread->Join();
+            };
+
+            serverStoppedEarly =
+                serverStopCompleted.WaitT(TDuration::MilliSeconds(100));
+            queueRunningDuringStop = queueFactory->Queues.at(0)->IsRun();
+        }
+
+        UNIT_ASSERT(endpointStopStarted);
+        UNIT_ASSERT_VALUES_EQUAL(E_FAIL, stopProbeError.GetCode());
+        UNIT_ASSERT(!serverStoppedEarly);
+        UNIT_ASSERT(queueRunningDuringStop);
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            endpointStop.GetValue(TDuration::Seconds(5)).GetCode());
+        UNIT_ASSERT(serverStopCompleted.WaitT(TDuration::Seconds(5)));
+    }
+
+    Y_UNIT_TEST(ShouldConvertSynchronousEndpointStopExceptionToError)
+    {
+        TestEndpointStopException(true);
+    }
+
+    Y_UNIT_TEST(ShouldConvertAsynchronousEndpointStopExceptionToError)
+    {
+        TestEndpointStopException(false);
     }
 }
 

--- a/cloud/blockstore/libs/vhost/vhost_test.cpp
+++ b/cloud/blockstore/libs/vhost/vhost_test.cpp
@@ -64,6 +64,9 @@ private:
     void* const Cookie;
     const ui32 OptimalIoSize;
     const std::function<void()> RequestCompletionHandler;
+    const std::function<void(const TString&)> DeviceStopHandler;
+    const std::function<TFuture<NProto::TError>(const TString&)>
+        DeviceStopFutureHandler;
 
     TLockFreeQueue<TVhostRequest*> Requests;
 
@@ -79,11 +82,16 @@ public:
         TString socketPath,
         void* cookie,
         ui32 optimalIoSize,
-        std::function<void()> requestCompletionHandler)
+        std::function<void()> requestCompletionHandler,
+        std::function<void(const TString&)> deviceStopHandler,
+        std::function<TFuture<NProto::TError>(const TString&)>
+            deviceStopFutureHandler)
         : SocketPath(std::move(socketPath))
         , Cookie(cookie)
         , OptimalIoSize(optimalIoSize)
         , RequestCompletionHandler(std::move(requestCompletionHandler))
+        , DeviceStopHandler(std::move(deviceStopHandler))
+        , DeviceStopFutureHandler(std::move(deviceStopFutureHandler))
     {
         Autostop = NewPromise<void>();
         Autostop.SetValue();
@@ -98,6 +106,12 @@ public:
     TFuture<NProto::TError> Stop() override
     {
         Y_UNUSED(Stopped.test_and_set());
+        if (DeviceStopHandler) {
+            DeviceStopHandler(SocketPath);
+        }
+        if (DeviceStopFutureHandler) {
+            return DeviceStopFutureHandler(SocketPath);
+        }
         return Autostop.GetFuture().Apply([this] (const auto&) {
             with_lock (Lock) {
                 return WaitAll(Futures).Apply([] (const auto&) {
@@ -311,7 +325,9 @@ IVhostDevicePtr TTestVhostQueueFactory::CreateDevice(
         std::move(socketPath),
         cookie,
         optimalIoSize,
-        RequestCompletionHandler);
+        RequestCompletionHandler,
+        DeviceStopHandler,
+        DeviceStopFutureHandler);
 
     for (const auto& queue: queues) {
         static_cast<TTestVhostQueue*>(queue.get())->AddDevice(vhostDevice);

--- a/cloud/blockstore/libs/vhost/vhost_test.h
+++ b/cloud/blockstore/libs/vhost/vhost_test.h
@@ -51,6 +51,11 @@ struct TTestVhostQueueFactory final
     TManualEvent FailedEvent;
     TVector<std::shared_ptr<ITestVhostQueue>> Queues;
     std::function<void()> RequestCompletionHandler;
+    // Models the synchronous part of libvhost device unregistration.
+    std::function<void(const TString&)> DeviceStopHandler;
+    // Overrides the asynchronous result of device unregistration.
+    std::function<NThreading::TFuture<NProto::TError>(const TString&)>
+        DeviceStopFutureHandler;
 
     IVhostQueuePtr CreateQueue() override;
 


### PR DESCRIPTION
## Summary

Fix a deadlock during vhost endpoint shutdown that prevents `StopEndpoint` from completing and causes subsequent requests to time out. The fix covers both individual `StopEndpoint` calls and server shutdown through `StopAllEndpoints`.

## Root cause

`StopEndpoint` calls `TEndpoint::Stop()` while holding the server mutex. Inside libvhost, this call synchronously waits for the control thread.
If the control thread is completing another endpoint's shutdown, its callback attempts to acquire the same mutex through `HandleStoppedEndpoint`. This creates a circular wait that blocks further endpoint operations.
`StopAllEndpoints` also calls `TEndpoint::Stop()` while holding the mutex.