### PR TITLE
issue-6956: add a device-backed key buffer store

### DIFF
--- a/cloud/storage/core/libs/journalled_device/key_buffer_store.cpp
+++ b/cloud/storage/core/libs/journalled_device/key_buffer_store.cpp
@@ -1,8 +1,24 @@
 #include "key_buffer_store.h"
 
-#include <util/generic/map.h>
+#include "device.h"
+#include "device_page_store.h"
+
+#include <cloud/storage/core/libs/common/future_helper.h>
+
+#include <library/cpp/digest/crc32c/crc32c.h>
+
+#include <util/generic/algorithm.h>
+#include <util/generic/utility.h>
+#include <util/generic/ylimits.h>
+#include <util/stream/buffer.h>
+#include <util/stream/mem.h>
 #include <util/string/builder.h>
 #include <util/system/spinlock.h>
+#include <util/system/yassert.h>
+#include <util/ysaveload.h>
+
+#include <optional>
+#include <utility>
 
 namespace NCloud::NJournalled {
 
@@ -12,38 +28,46 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using TRestoreResult = TResultOrError<TMap<ui64, TBuffer>>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TInMemoryKeyBufferStore final: public IKeyBufferStore
 {
 private:
-    mutable TAdaptiveLock Lock;
+    TAdaptiveLock Lock;
     TMap<ui64, TBuffer> Buffers;
+    std::optional<ui64> ErasedUpToKey;
 
 public:
+    TFuture<TRestoreResult> Restore() override
+    {
+        with_lock (Lock) {
+            return MakeFuture<TRestoreResult>(Buffers);
+        }
+    }
+
     TFuture<NCloud::NProto::TError> Write(ui64 key, TBuffer buffer) override
     {
         with_lock (Lock) {
+            if (ErasedUpToKey && key <= *ErasedUpToKey) {
+                return MakeFuture(MakeError(
+                    E_ARGUMENT,
+                    TStringBuilder() << "key " << key << " is erased"));
+            }
+
             Buffers[key] = std::move(buffer);
         }
         return MakeFuture(MakeError(S_OK));
     }
 
-    TFuture<TResultOrError<TBuffer>> Read(ui64 key) const override
-    {
-        with_lock (Lock) {
-            auto it = Buffers.find(key);
-            if (it == Buffers.end()) {
-                return MakeFuture<TResultOrError<TBuffer>>(MakeError(
-                    E_NOT_FOUND,
-                    TStringBuilder() << "no buffer for key " << key));
-            }
-
-            return MakeFuture<TResultOrError<TBuffer>>(it->second);
-        }
-    }
-
     TFuture<NCloud::NProto::TError> EraseUpTo(ui64 lastKey) override
     {
         with_lock (Lock) {
+            if (!ErasedUpToKey || *ErasedUpToKey < lastKey) {
+                ErasedUpToKey = lastKey;
+            }
+
             auto end = Buffers.upper_bound(lastKey);
             if (end == Buffers.begin()) {
                 return MakeFuture(MakeError(S_FALSE));
@@ -53,18 +77,647 @@ public:
             return MakeFuture(MakeError(S_OK));
         }
     }
+};
 
-    TSet<ui64> GetKeys() const override
+////////////////////////////////////////////////////////////////////////////////
+// The on-device format of TDeviceKeyBufferStore.
+
+constexpr ui64 SuperblockMagic = 0x4B4253'53555042ULL;   // KBS'SUPB
+constexpr ui64 EntryMagic = 0x4B4253'454E5452ULL;        // KBS'ENTR
+constexpr ui32 StoreFormatVersion = 1;
+
+constexpr ui64 SuperblockSlotCount = 2;
+
+// Magic, Seq, Key, PayloadSize, Version, PageIndex, PageCount, Crc. The
+// checksum covers the fields before it and the chunk that follows.
+constexpr ui32 EntryHeaderSize = 4 * sizeof(ui64) + 4 * sizeof(ui32);
+
+// Magic, Seq, ErasedUpToKey, Version, HasErasedUpToKey, Crc. The checksum
+// covers the fields before it.
+constexpr ui32 SuperblockSize = 3 * sizeof(ui64) + 3 * sizeof(ui32);
+
+constexpr ui64 MaxPagesPerReadRequest = 1024;
+
+struct TEntryHeader
+{
+    ui64 Seq = 0;
+    ui64 Key = 0;
+    ui64 PayloadSize = 0;
+    ui32 PageIndex = 0;
+    ui32 PageCount = 0;
+};
+
+struct TSuperblock
+{
+    ui64 Seq = 0;
+    std::optional<ui64> ErasedUpToKey;
+};
+
+ui64 EntryPageCountFor(ui64 payloadSize, ui64 chunkCapacity)
+{
+    return Max<ui64>(1, (payloadSize + chunkCapacity - 1) / chunkCapacity);
+}
+
+ui64 ChunkSizeOf(const TEntryHeader& header, ui64 chunkCapacity)
+{
+    if (header.PageIndex + 1 < header.PageCount) {
+        return chunkCapacity;
+    }
+    return header.PayloadSize - chunkCapacity * header.PageIndex;
+}
+
+TBuffer
+MakeEntryPage(const TEntryHeader& header, TStringBuf chunk, ui32 pageSize)
+{
+    TBuffer page(pageSize);
+    TBufferOutput out(page);
+
+    Save(&out, EntryMagic);
+    Save(&out, header.Seq);
+    Save(&out, header.Key);
+    Save(&out, header.PayloadSize);
+    Save(&out, StoreFormatVersion);
+    Save(&out, header.PageIndex);
+    Save(&out, header.PageCount);
+
+    ui32 crc = Crc32c(page.Data(), page.Size());
+    crc = Crc32cExtend(crc, chunk.data(), chunk.size());
+    Save(&out, crc);
+
+    out.Write(chunk.data(), chunk.size());
+    page.Fill('\0', pageSize - page.Size());
+
+    return page;
+}
+
+// Returns the header and the chunk of a valid entry page, nothing for a page
+// that holds anything else.
+std::optional<std::pair<TEntryHeader, TStringBuf>> ParseEntryPage(
+    TStringBuf page,
+    ui32 pageSize)
+{
+    if (page.size() != pageSize) {
+        return std::nullopt;
+    }
+
+    TMemoryInput in(page.data(), page.size());
+
+    ui64 magic = 0;
+    ui32 version = 0;
+    ui32 crc = 0;
+    TEntryHeader header;
+
+    Load(&in, magic);
+    Load(&in, header.Seq);
+    Load(&in, header.Key);
+    Load(&in, header.PayloadSize);
+    Load(&in, version);
+    Load(&in, header.PageIndex);
+    Load(&in, header.PageCount);
+    Load(&in, crc);
+
+    if (magic != EntryMagic || version != StoreFormatVersion) {
+        return std::nullopt;
+    }
+
+    const ui64 chunkCapacity = pageSize - EntryHeaderSize;
+    if (header.PageIndex >= header.PageCount ||
+        header.PageCount !=
+            EntryPageCountFor(header.PayloadSize, chunkCapacity))
     {
-        TSet<ui64> keys;
-        with_lock (Lock) {
-            for (const auto& [key, buffer]: Buffers) {
-                keys.insert(key);
+        return std::nullopt;
+    }
+
+    const ui64 chunkSize = ChunkSizeOf(header, chunkCapacity);
+    TStringBuf chunk = page.SubStr(EntryHeaderSize, chunkSize);
+
+    ui32 expectedCrc = Crc32c(page.data(), EntryHeaderSize - sizeof(ui32));
+    expectedCrc = Crc32cExtend(expectedCrc, chunk.data(), chunk.size());
+
+    if (crc != expectedCrc) {
+        return std::nullopt;
+    }
+
+    return std::make_pair(header, chunk);
+}
+
+TBuffer MakeSuperblockPage(const TSuperblock& superblock, ui32 pageSize)
+{
+    TBuffer page(pageSize);
+    TBufferOutput out(page);
+
+    Save(&out, SuperblockMagic);
+    Save(&out, superblock.Seq);
+    Save(&out, superblock.ErasedUpToKey.value_or(0));
+    Save(&out, StoreFormatVersion);
+    Save(&out, static_cast<ui32>(superblock.ErasedUpToKey.has_value()));
+
+    ui32 crc = Crc32c(page.Data(), page.Size());
+    Save(&out, crc);
+
+    page.Fill('\0', pageSize - page.Size());
+
+    return page;
+}
+
+std::optional<TSuperblock> ParseSuperblockPage(TStringBuf page, ui32 pageSize)
+{
+    if (page.size() != pageSize) {
+        return std::nullopt;
+    }
+
+    TMemoryInput in(page.data(), page.size());
+
+    ui64 magic = 0;
+    ui64 erasedUpToKey = 0;
+    ui32 version = 0;
+    ui32 hasErasedUpToKey = 0;
+    ui32 crc = 0;
+    TSuperblock superblock;
+
+    Load(&in, magic);
+    Load(&in, superblock.Seq);
+    Load(&in, erasedUpToKey);
+    Load(&in, version);
+    Load(&in, hasErasedUpToKey);
+    Load(&in, crc);
+
+    if (magic != SuperblockMagic || version != StoreFormatVersion ||
+        crc != Crc32c(page.data(), SuperblockSize - sizeof(ui32)))
+    {
+        return std::nullopt;
+    }
+
+    if (hasErasedUpToKey) {
+        superblock.ErasedUpToKey = erasedUpToKey;
+    }
+
+    return superblock;
+}
+
+// Merges the consecutive page numbers into ranges.
+TVector<TPageRange> ToPageRanges(const TVector<ui64>& pageNos)
+{
+    TVector<TPageRange> ranges;
+
+    for (ui64 pageNo: pageNos) {
+        if (!ranges.empty() &&
+            ranges.back().FirstPageNo + ranges.back().PageCount == pageNo)
+        {
+            ++ranges.back().PageCount;
+            continue;
+        }
+
+        ranges.push_back({.FirstPageNo = pageNo, .PageCount = 1});
+    }
+
+    return ranges;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TDeviceKeyBufferStore final
+    : public IKeyBufferStore
+    , public std::enable_shared_from_this<TDeviceKeyBufferStore>
+{
+private:
+    struct TEntry
+    {
+        ui64 Seq = 0;
+        TVector<TPageRange> Locations;
+    };
+
+    const IDevicePtr Device;
+    const ui64 PageCount;
+    const ui32 PageSize;
+    const ui64 ChunkCapacity;
+    const IDevicePageStorePtr Pages;
+
+    TAdaptiveLock Lock;
+
+    bool RestoreStarted = false;
+    bool Restored = false;
+    ui64 NextSeq = 1;
+    TMap<ui64, TEntry> Entries;
+
+    // The erased bound the device holds.
+    std::optional<ui64> ErasedUpToKey;
+    // The bound of the last erase requested - the keys at or below it are
+    // refused right away, whether the erase has been persisted or not.
+    std::optional<ui64> RequestedErasedUpToKey;
+
+    bool EraseInFlight = false;
+    ui64 NextSuperblockSlot = 0;
+
+public:
+    TDeviceKeyBufferStore(IDevicePtr device, ui64 pageCount, ui32 pageSize);
+
+    TFuture<TRestoreResult> Restore() override;
+
+    TFuture<NCloud::NProto::TError> Write(ui64 key, TBuffer buffer) override;
+
+    // The erases do not overlap - the bound is persisted with a superblock
+    // write, and a second erase is refused until it is done.
+    TFuture<NCloud::NProto::TError> EraseUpTo(ui64 lastKey) override;
+
+private:
+    TRestoreResult RestoreFromPages(const TVector<TString>& pages);
+
+    NCloud::NProto::TError OnEntryWritten(
+        ui64 key,
+        ui64 seq,
+        const TVector<TPageRange>& locations,
+        const TFuture<NCloud::NProto::TError>& future);
+
+    NCloud::NProto::TError OnSuperblockWritten(
+        ui64 lastKey,
+        const TFuture<NCloud::NProto::TError>& future);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDeviceKeyBufferStore::TDeviceKeyBufferStore(
+    IDevicePtr device,
+    ui64 pageCount,
+    ui32 pageSize)
+    : Device(std::move(device))
+    , PageCount(pageCount)
+    , PageSize(pageSize)
+    , ChunkCapacity(pageSize - EntryHeaderSize)
+    , Pages(CreateDevicePageStore(Device, PageCount, PageSize))
+{
+    // the superblock slots are never given to an entry
+    auto error = Pages->AllocateAt(
+        {{.FirstPageNo = 0, .PageCount = SuperblockSlotCount}});
+    Y_ABORT_UNLESS(!HasError(error), "%s", FormatError(error).c_str());
+}
+
+TFuture<TRestoreResult> TDeviceKeyBufferStore::Restore()
+{
+    with_lock (Lock) {
+        if (RestoreStarted) {
+            return MakeFuture<TRestoreResult>(MakeError(
+                E_INVALID_STATE,
+                "the store is being restored already"));
+        }
+        RestoreStarted = true;
+    }
+
+    // the scan goes straight to the device - the page store knows
+    // nothing about the pages before the restore
+    TVector<TFuture<NCloud::NProto::TReadPagesResponse>> futures;
+
+    for (ui64 offset = 0; offset < PageCount; offset += MaxPagesPerReadRequest)
+    {
+        NCloud::NProto::TReadPagesRequest request;
+        auto& ref = *request.AddPageGroupRefs();
+        ref.SetFirstPageNo(offset);
+        ref.SetPageCount(Min(MaxPagesPerReadRequest, PageCount - offset));
+        ref.SetPageSize(PageSize);
+
+        futures.push_back(Device->ReadPages(std::move(request)));
+    }
+
+    return WaitAll(futures).Apply(
+        [self = shared_from_this(),
+         futures = std::move(futures)](const TFuture<void>&)
+        {
+            TVector<TString> pages;
+            pages.reserve(self->PageCount);
+
+            for (auto& future: futures) {
+                auto response = UnsafeExtractValue(future);
+                if (HasError(response)) {
+                    return TRestoreResult(response.GetError());
+                }
+
+                for (auto& group: *response.MutablePageGroups()) {
+                    for (auto& content: *group.MutableContent()) {
+                        pages.push_back(std::move(content));
+                    }
+                }
+            }
+
+            if (pages.size() != self->PageCount) {
+                return TRestoreResult(MakeError(
+                    E_INVALID_STATE,
+                    TStringBuilder()
+                        << "the device returned " << pages.size()
+                        << " pages, expected " << self->PageCount));
+            }
+
+            return self->RestoreFromPages(pages);
+        });
+}
+
+TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::Write(
+    ui64 key,
+    TBuffer buffer)
+{
+    ui64 seq = 0;
+
+    with_lock (Lock) {
+        if (!Restored) {
+            return MakeFuture(
+                MakeError(E_INVALID_STATE, "the store is not restored"));
+        }
+
+        if (RequestedErasedUpToKey && key <= *RequestedErasedUpToKey) {
+            return MakeFuture(MakeError(
+                E_ARGUMENT,
+                TStringBuilder() << "key " << key << " is erased"));
+        }
+
+        seq = NextSeq++;
+    }
+
+    const ui64 pageCount = EntryPageCountFor(buffer.Size(), ChunkCapacity);
+    if (pageCount > Max<ui32>()) {
+        return MakeFuture(MakeError(
+            E_ARGUMENT,
+            TStringBuilder() << "a buffer of " << buffer.Size()
+                             << " bytes is too large for the store"));
+    }
+
+    auto locations = Pages->Allocate(pageCount);
+    if (locations.empty()) {
+        return MakeFuture(MakeError(
+            E_REJECTED,
+            TStringBuilder() << "not enough free pages to store "
+                             << buffer.Size() << " bytes under key " << key));
+    }
+
+    TVector<TBuffer> pages;
+    pages.reserve(pageCount);
+
+    TStringBuf payload(buffer.Data(), buffer.Size());
+    for (ui64 i = 0; i < pageCount; ++i) {
+        TEntryHeader header = {
+            .Seq = seq,
+            .Key = key,
+            .PayloadSize = buffer.Size(),
+            .PageIndex = static_cast<ui32>(i),
+            .PageCount = static_cast<ui32>(pageCount),
+        };
+
+        pages.push_back(MakeEntryPage(
+            header,
+            payload.SubStr(i * ChunkCapacity, ChunkCapacity),
+            PageSize));
+    }
+
+    return Pages->Write(locations, pages)
+        .Apply([self = shared_from_this(), key, seq, locations](
+                   const TFuture<NCloud::NProto::TError>& future)
+               { return self->OnEntryWritten(key, seq, locations, future); });
+}
+
+TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::EraseUpTo(ui64 lastKey)
+{
+    TSuperblock superblock;
+    ui64 slot = 0;
+
+    with_lock (Lock) {
+        if (!Restored) {
+            return MakeFuture(
+                MakeError(E_INVALID_STATE, "the store is not restored"));
+        }
+
+        if (ErasedUpToKey && lastKey <= *ErasedUpToKey) {
+            return MakeFuture(MakeError(S_FALSE));
+        }
+
+        if (EraseInFlight) {
+            return MakeFuture(MakeError(
+                E_REJECTED,
+                TStringBuilder()
+                    << "an erase up to key " << *RequestedErasedUpToKey
+                    << " is in progress"));
+        }
+
+        EraseInFlight = true;
+        RequestedErasedUpToKey = lastKey;
+
+        superblock = {.Seq = NextSeq++, .ErasedUpToKey = lastKey};
+        slot = NextSuperblockSlot;
+        NextSuperblockSlot = (NextSuperblockSlot + 1) % SuperblockSlotCount;
+    }
+
+    TVector<TBuffer> pages;
+    pages.push_back(MakeSuperblockPage(superblock, PageSize));
+
+    return Pages->Write({{.FirstPageNo = slot, .PageCount = 1}}, pages)
+        .Apply([self = shared_from_this(),
+                lastKey](const TFuture<NCloud::NProto::TError>& future)
+               { return self->OnSuperblockWritten(lastKey, future); });
+}
+
+TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
+    const TVector<TString>& pages)
+{
+    struct TCandidate
+    {
+        ui32 PageCount = 0;
+        ui64 PayloadSize = 0;
+        bool Broken = false;
+        TVector<std::optional<TStringBuf>> Chunks;
+        TVector<ui64> PageNos;
+    };
+
+    ui64 maxSeq = 0;
+
+    std::optional<TSuperblock> superblock;
+    ui64 superblockSlot = 0;
+
+    for (ui64 slot = 0; slot < SuperblockSlotCount; ++slot) {
+        auto parsed = ParseSuperblockPage(pages[slot], PageSize);
+        if (!parsed) {
+            continue;
+        }
+
+        maxSeq = Max(maxSeq, parsed->Seq);
+        if (!superblock || superblock->Seq < parsed->Seq) {
+            superblock = *parsed;
+            superblockSlot = slot;
+        }
+    }
+
+    // the pages of a single (key, seq) entry
+    TMap<std::pair<ui64, ui64>, TCandidate> candidates;
+
+    for (ui64 i = SuperblockSlotCount; i < pages.size(); ++i) {
+        auto parsed = ParseEntryPage(pages[i], PageSize);
+        if (!parsed) {
+            continue;
+        }
+
+        const auto& [header, chunk] = *parsed;
+        maxSeq = Max(maxSeq, header.Seq);
+
+        auto& candidate = candidates[{header.Key, header.Seq}];
+        if (candidate.Chunks.empty()) {
+            candidate.PageCount = header.PageCount;
+            candidate.PayloadSize = header.PayloadSize;
+            candidate.Chunks.resize(header.PageCount);
+            candidate.PageNos.resize(header.PageCount);
+        }
+
+        if (candidate.PageCount != header.PageCount ||
+            candidate.PayloadSize != header.PayloadSize ||
+            candidate.Chunks[header.PageIndex])
+        {
+            candidate.Broken = true;
+            continue;
+        }
+
+        candidate.Chunks[header.PageIndex] = chunk;
+        candidate.PageNos[header.PageIndex] = i;
+    }
+
+    // the candidates go in the (key, seq) order, so the last intact one
+    // of a key is the newest
+    struct TWinner
+    {
+        ui64 Seq = 0;
+        const TCandidate* Candidate = nullptr;
+    };
+
+    TMap<ui64, TWinner> winners;
+
+    for (const auto& [keyAndSeq, candidate]: candidates) {
+        const auto& [key, seq] = keyAndSeq;
+
+        if (superblock && superblock->ErasedUpToKey &&
+            key <= *superblock->ErasedUpToKey)
+        {
+            continue;
+        }
+
+        if (candidate.Broken) {
+            continue;
+        }
+
+        const bool complete = AllOf(
+            candidate.Chunks,
+            [](const auto& chunk) { return chunk.has_value(); });
+
+        if (complete) {
+            winners[key] = {.Seq = seq, .Candidate = &candidate};
+        }
+    }
+
+    TMap<ui64, TBuffer> buffers;
+    TMap<ui64, TEntry> entries;
+
+    for (const auto& [key, winner]: winners) {
+        TBuffer buffer(winner.Candidate->PayloadSize);
+        for (const auto& chunk: winner.Candidate->Chunks) {
+            buffer.Append(chunk->data(), chunk->size());
+        }
+
+        auto locations = ToPageRanges(winner.Candidate->PageNos);
+        auto error = Pages->AllocateAt(locations);
+        if (HasError(error)) {
+            return error;
+        }
+
+        entries[key] = {
+            .Seq = winner.Seq,
+            .Locations = std::move(locations),
+        };
+        buffers[key] = std::move(buffer);
+    }
+
+    with_lock (Lock) {
+        Restored = true;
+        NextSeq = maxSeq + 1;
+        Entries = std::move(entries);
+
+        if (superblock) {
+            ErasedUpToKey = superblock->ErasedUpToKey;
+            NextSuperblockSlot = (superblockSlot + 1) % SuperblockSlotCount;
+        }
+        RequestedErasedUpToKey = ErasedUpToKey;
+    }
+
+    return std::move(buffers);
+}
+
+NCloud::NProto::TError TDeviceKeyBufferStore::OnEntryWritten(
+    ui64 key,
+    ui64 seq,
+    const TVector<TPageRange>& locations,
+    const TFuture<NCloud::NProto::TError>& future)
+{
+    auto error = future.GetValue();
+    if (HasError(error)) {
+        Y_UNUSED(Pages->Free(locations));
+        return error;
+    }
+
+    TVector<TPageRange> stalePages;
+
+    with_lock (Lock) {
+        if (RequestedErasedUpToKey && key <= *RequestedErasedUpToKey) {
+            // erased while being written - a restore would drop it
+            stalePages = locations;
+            error = MakeError(
+                E_REJECTED,
+                TStringBuilder()
+                    << "key " << key << " was erased while being written");
+        } else {
+            auto& entry = Entries[key];
+            if (entry.Seq < seq) {
+                stalePages = std::exchange(entry.Locations, locations);
+                entry.Seq = seq;
+            } else {
+                // a newer write of the key has landed already
+                stalePages = locations;
             }
         }
-        return keys;
     }
-};
+
+    if (!stalePages.empty()) {
+        Y_UNUSED(Pages->Free(stalePages));
+    }
+
+    return error;
+}
+
+NCloud::NProto::TError TDeviceKeyBufferStore::OnSuperblockWritten(
+    ui64 lastKey,
+    const TFuture<NCloud::NProto::TError>& future)
+{
+    auto error = future.GetValue();
+    TVector<TPageRange> pagesToFree;
+    bool erasedAny = false;
+
+    with_lock (Lock) {
+        EraseInFlight = false;
+
+        if (HasError(error)) {
+            return error;
+        }
+
+        ErasedUpToKey = lastKey;
+
+        auto end = Entries.upper_bound(lastKey);
+        for (auto it = Entries.begin(); it != end; ++it) {
+            for (const auto& location: it->second.Locations) {
+                pagesToFree.push_back(location);
+            }
+        }
+
+        erasedAny = end != Entries.begin();
+        Entries.erase(Entries.begin(), end);
+    }
+
+    if (!pagesToFree.empty()) {
+        Y_UNUSED(Pages->Free(pagesToFree));
+    }
+
+    return MakeError(erasedAny ? S_OK : S_FALSE);
+}
 
 }   // namespace
 
@@ -73,6 +726,24 @@ public:
 IKeyBufferStorePtr CreateInMemoryKeyBufferStore()
 {
     return std::make_shared<TInMemoryKeyBufferStore>();
+}
+
+IKeyBufferStorePtr
+CreateDeviceKeyBufferStore(IDevicePtr device, ui64 pageCount, ui32 pageSize)
+{
+    Y_ABORT_UNLESS(
+        pageCount > SuperblockSlotCount,
+        "the store needs more than %" PRIu64 " pages",
+        SuperblockSlotCount);
+    Y_ABORT_UNLESS(
+        pageSize > EntryHeaderSize && pageSize >= SuperblockSize,
+        "the page size %" PRIu32 " is too small for the store",
+        pageSize);
+
+    return std::make_shared<TDeviceKeyBufferStore>(
+        std::move(device),
+        pageCount,
+        pageSize);
 }
 
 }   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/key_buffer_store.cpp
+++ b/cloud/storage/core/libs/journalled_device/key_buffer_store.cpp
@@ -8,6 +8,8 @@
 #include <library/cpp/digest/crc32c/crc32c.h>
 
 #include <util/generic/algorithm.h>
+#include <util/generic/hash.h>
+#include <util/generic/map.h>
 #include <util/generic/utility.h>
 #include <util/generic/ylimits.h>
 #include <util/stream/buffer.h>
@@ -28,29 +30,32 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-using TRestoreResult = TResultOrError<TMap<ui64, TBuffer>>;
-
-////////////////////////////////////////////////////////////////////////////////
-
 class TInMemoryKeyBufferStore final: public IKeyBufferStore
 {
 private:
     TAdaptiveLock Lock;
     TMap<ui64, TBuffer> Buffers;
-    std::optional<ui64> ErasedUpToKey;
+    ui64 ErasedBelowKey = 0;
 
 public:
     TFuture<TRestoreResult> Restore() override
     {
+        TVector<std::pair<ui64, TBuffer>> buffers;
+
         with_lock (Lock) {
-            return MakeFuture<TRestoreResult>(Buffers);
+            buffers.reserve(Buffers.size());
+            for (const auto& [key, buffer]: Buffers) {
+                buffers.emplace_back(key, buffer);
+            }
         }
+
+        return MakeFuture<TRestoreResult>(std::move(buffers));
     }
 
     TFuture<NCloud::NProto::TError> Write(ui64 key, TBuffer buffer) override
     {
         with_lock (Lock) {
-            if (ErasedUpToKey && key <= *ErasedUpToKey) {
+            if (key < ErasedBelowKey) {
                 return MakeFuture(MakeError(
                     E_ARGUMENT,
                     TStringBuilder() << "key " << key << " is erased"));
@@ -61,14 +66,12 @@ public:
         return MakeFuture(MakeError(S_OK));
     }
 
-    TFuture<NCloud::NProto::TError> EraseUpTo(ui64 lastKey) override
+    TFuture<NCloud::NProto::TError> EraseBelow(ui64 key) override
     {
         with_lock (Lock) {
-            if (!ErasedUpToKey || *ErasedUpToKey < lastKey) {
-                ErasedUpToKey = lastKey;
-            }
+            ErasedBelowKey = Max(ErasedBelowKey, key);
 
-            auto end = Buffers.upper_bound(lastKey);
+            auto end = Buffers.lower_bound(key);
             if (end == Buffers.begin()) {
                 return MakeFuture(MakeError(S_FALSE));
             }
@@ -92,9 +95,9 @@ constexpr ui64 SuperblockSlotCount = 2;
 // checksum covers the fields before it and the chunk that follows.
 constexpr ui32 EntryHeaderSize = 4 * sizeof(ui64) + 4 * sizeof(ui32);
 
-// Magic, Seq, ErasedUpToKey, Version, HasErasedUpToKey, Crc. The checksum
-// covers the fields before it.
-constexpr ui32 SuperblockSize = 3 * sizeof(ui64) + 3 * sizeof(ui32);
+// Magic, Seq, ErasedBelowKey, Version, Crc. The checksum covers the fields
+// before it.
+constexpr ui32 SuperblockSize = 3 * sizeof(ui64) + 2 * sizeof(ui32);
 
 constexpr ui64 MaxPagesPerReadRequest = 1024;
 
@@ -110,7 +113,7 @@ struct TEntryHeader
 struct TSuperblock
 {
     ui64 Seq = 0;
-    std::optional<ui64> ErasedUpToKey;
+    ui64 ErasedBelowKey = 0;
 };
 
 ui64 EntryPageCountFor(ui64 payloadSize, ui64 chunkCapacity)
@@ -208,9 +211,8 @@ TBuffer MakeSuperblockPage(const TSuperblock& superblock, ui32 pageSize)
 
     Save(&out, SuperblockMagic);
     Save(&out, superblock.Seq);
-    Save(&out, superblock.ErasedUpToKey.value_or(0));
+    Save(&out, superblock.ErasedBelowKey);
     Save(&out, StoreFormatVersion);
-    Save(&out, static_cast<ui32>(superblock.ErasedUpToKey.has_value()));
 
     ui32 crc = Crc32c(page.Data(), page.Size());
     Save(&out, crc);
@@ -229,27 +231,20 @@ std::optional<TSuperblock> ParseSuperblockPage(TStringBuf page, ui32 pageSize)
     TMemoryInput in(page.data(), page.size());
 
     ui64 magic = 0;
-    ui64 erasedUpToKey = 0;
     ui32 version = 0;
-    ui32 hasErasedUpToKey = 0;
     ui32 crc = 0;
     TSuperblock superblock;
 
     Load(&in, magic);
     Load(&in, superblock.Seq);
-    Load(&in, erasedUpToKey);
+    Load(&in, superblock.ErasedBelowKey);
     Load(&in, version);
-    Load(&in, hasErasedUpToKey);
     Load(&in, crc);
 
     if (magic != SuperblockMagic || version != StoreFormatVersion ||
         crc != Crc32c(page.data(), SuperblockSize - sizeof(ui32)))
     {
         return std::nullopt;
-    }
-
-    if (hasErasedUpToKey) {
-        superblock.ErasedUpToKey = erasedUpToKey;
     }
 
     return superblock;
@@ -301,10 +296,10 @@ private:
     TMap<ui64, TEntry> Entries;
 
     // The erased bound the device holds.
-    std::optional<ui64> ErasedUpToKey;
-    // The bound of the last erase requested - the keys at or below it are
-    // refused right away, whether the erase has been persisted or not.
-    std::optional<ui64> RequestedErasedUpToKey;
+    ui64 ErasedBelowKey = 0;
+    // The bound of the last erase requested - the keys below it are refused
+    // right away, whether the erase has been persisted or not.
+    ui64 RequestedErasedBelowKey = 0;
 
     bool EraseInFlight = false;
     ui64 NextSuperblockSlot = 0;
@@ -316,9 +311,7 @@ public:
 
     TFuture<NCloud::NProto::TError> Write(ui64 key, TBuffer buffer) override;
 
-    // The erases do not overlap - the bound is persisted with a superblock
-    // write, and a second erase is refused until it is done.
-    TFuture<NCloud::NProto::TError> EraseUpTo(ui64 lastKey) override;
+    TFuture<NCloud::NProto::TError> EraseBelow(ui64 key) override;
 
 private:
     TRestoreResult RestoreFromPages(const TVector<TString>& pages);
@@ -330,7 +323,7 @@ private:
         const TFuture<NCloud::NProto::TError>& future);
 
     NCloud::NProto::TError OnSuperblockWritten(
-        ui64 lastKey,
+        ui64 key,
         const TFuture<NCloud::NProto::TError>& future);
 };
 
@@ -352,7 +345,7 @@ TDeviceKeyBufferStore::TDeviceKeyBufferStore(
     Y_ABORT_UNLESS(!HasError(error), "%s", FormatError(error).c_str());
 }
 
-TFuture<TRestoreResult> TDeviceKeyBufferStore::Restore()
+TFuture<IKeyBufferStore::TRestoreResult> TDeviceKeyBufferStore::Restore()
 {
     with_lock (Lock) {
         if (RestoreStarted) {
@@ -422,7 +415,7 @@ TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::Write(
                 MakeError(E_INVALID_STATE, "the store is not restored"));
         }
 
-        if (RequestedErasedUpToKey && key <= *RequestedErasedUpToKey) {
+        if (key < RequestedErasedBelowKey) {
             return MakeFuture(MakeError(
                 E_ARGUMENT,
                 TStringBuilder() << "key " << key << " is erased"));
@@ -472,7 +465,7 @@ TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::Write(
                { return self->OnEntryWritten(key, seq, locations, future); });
 }
 
-TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::EraseUpTo(ui64 lastKey)
+TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::EraseBelow(ui64 key)
 {
     TSuperblock superblock;
     ui64 slot = 0;
@@ -483,7 +476,7 @@ TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::EraseUpTo(ui64 lastKey)
                 MakeError(E_INVALID_STATE, "the store is not restored"));
         }
 
-        if (ErasedUpToKey && lastKey <= *ErasedUpToKey) {
+        if (key <= ErasedBelowKey) {
             return MakeFuture(MakeError(S_FALSE));
         }
 
@@ -491,14 +484,14 @@ TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::EraseUpTo(ui64 lastKey)
             return MakeFuture(MakeError(
                 E_REJECTED,
                 TStringBuilder()
-                    << "an erase up to key " << *RequestedErasedUpToKey
+                    << "an erase below key " << RequestedErasedBelowKey
                     << " is in progress"));
         }
 
         EraseInFlight = true;
-        RequestedErasedUpToKey = lastKey;
+        RequestedErasedBelowKey = key;
 
-        superblock = {.Seq = NextSeq++, .ErasedUpToKey = lastKey};
+        superblock = {.Seq = NextSeq++, .ErasedBelowKey = key};
         slot = NextSuperblockSlot;
         NextSuperblockSlot = (NextSuperblockSlot + 1) % SuperblockSlotCount;
     }
@@ -508,11 +501,11 @@ TFuture<NCloud::NProto::TError> TDeviceKeyBufferStore::EraseUpTo(ui64 lastKey)
 
     return Pages->Write({{.FirstPageNo = slot, .PageCount = 1}}, pages)
         .Apply([self = shared_from_this(),
-                lastKey](const TFuture<NCloud::NProto::TError>& future)
-               { return self->OnSuperblockWritten(lastKey, future); });
+                key](const TFuture<NCloud::NProto::TError>& future)
+               { return self->OnSuperblockWritten(key, future); });
 }
 
-TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
+IKeyBufferStore::TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
     const TVector<TString>& pages)
 {
     struct TCandidate
@@ -543,7 +536,7 @@ TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
     }
 
     // the pages of a single (key, seq) entry
-    TMap<std::pair<ui64, ui64>, TCandidate> candidates;
+    THashMap<std::pair<ui64, ui64>, TCandidate> candidates;
 
     for (ui64 i = SuperblockSlotCount; i < pages.size(); ++i) {
         auto parsed = ParseEntryPage(pages[i], PageSize);
@@ -554,7 +547,7 @@ TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
         const auto& [header, chunk] = *parsed;
         maxSeq = Max(maxSeq, header.Seq);
 
-        auto& candidate = candidates[{header.Key, header.Seq}];
+        auto& candidate = candidates[std::pair(header.Key, header.Seq)];
         if (candidate.Chunks.empty()) {
             candidate.PageCount = header.PageCount;
             candidate.PayloadSize = header.PayloadSize;
@@ -574,22 +567,19 @@ TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
         candidate.PageNos[header.PageIndex] = i;
     }
 
-    // the candidates go in the (key, seq) order, so the last intact one
-    // of a key is the newest
+    // the newest intact candidate of a key wins
     struct TWinner
     {
         ui64 Seq = 0;
         const TCandidate* Candidate = nullptr;
     };
 
-    TMap<ui64, TWinner> winners;
+    THashMap<ui64, TWinner> winners;
 
     for (const auto& [keyAndSeq, candidate]: candidates) {
         const auto& [key, seq] = keyAndSeq;
 
-        if (superblock && superblock->ErasedUpToKey &&
-            key <= *superblock->ErasedUpToKey)
-        {
+        if (superblock && key < superblock->ErasedBelowKey) {
             continue;
         }
 
@@ -601,12 +591,18 @@ TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
             candidate.Chunks,
             [](const auto& chunk) { return chunk.has_value(); });
 
-        if (complete) {
-            winners[key] = {.Seq = seq, .Candidate = &candidate};
+        if (!complete) {
+            continue;
+        }
+
+        auto& winner = winners[key];
+        if (!winner.Candidate || winner.Seq < seq) {
+            winner = {.Seq = seq, .Candidate = &candidate};
         }
     }
 
-    TMap<ui64, TBuffer> buffers;
+    TVector<std::pair<ui64, TBuffer>> buffers;
+    buffers.reserve(winners.size());
     TMap<ui64, TEntry> entries;
 
     for (const auto& [key, winner]: winners) {
@@ -625,7 +621,7 @@ TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
             .Seq = winner.Seq,
             .Locations = std::move(locations),
         };
-        buffers[key] = std::move(buffer);
+        buffers.emplace_back(key, std::move(buffer));
     }
 
     with_lock (Lock) {
@@ -634,10 +630,10 @@ TRestoreResult TDeviceKeyBufferStore::RestoreFromPages(
         Entries = std::move(entries);
 
         if (superblock) {
-            ErasedUpToKey = superblock->ErasedUpToKey;
+            ErasedBelowKey = superblock->ErasedBelowKey;
             NextSuperblockSlot = (superblockSlot + 1) % SuperblockSlotCount;
         }
-        RequestedErasedUpToKey = ErasedUpToKey;
+        RequestedErasedBelowKey = ErasedBelowKey;
     }
 
     return std::move(buffers);
@@ -658,7 +654,7 @@ NCloud::NProto::TError TDeviceKeyBufferStore::OnEntryWritten(
     TVector<TPageRange> stalePages;
 
     with_lock (Lock) {
-        if (RequestedErasedUpToKey && key <= *RequestedErasedUpToKey) {
+        if (key < RequestedErasedBelowKey) {
             // erased while being written - a restore would drop it
             stalePages = locations;
             error = MakeError(
@@ -685,7 +681,7 @@ NCloud::NProto::TError TDeviceKeyBufferStore::OnEntryWritten(
 }
 
 NCloud::NProto::TError TDeviceKeyBufferStore::OnSuperblockWritten(
-    ui64 lastKey,
+    ui64 key,
     const TFuture<NCloud::NProto::TError>& future)
 {
     auto error = future.GetValue();
@@ -699,9 +695,9 @@ NCloud::NProto::TError TDeviceKeyBufferStore::OnSuperblockWritten(
             return error;
         }
 
-        ErasedUpToKey = lastKey;
+        ErasedBelowKey = key;
 
-        auto end = Entries.upper_bound(lastKey);
+        auto end = Entries.lower_bound(key);
         for (auto it = Entries.begin(); it != end; ++it) {
             for (const auto& location: it->second.Locations) {
                 pagesToFree.push_back(location);

--- a/cloud/storage/core/libs/journalled_device/key_buffer_store.h
+++ b/cloud/storage/core/libs/journalled_device/key_buffer_store.h
@@ -7,7 +7,7 @@
 #include <library/cpp/threading/future/future.h>
 
 #include <util/generic/buffer.h>
-#include <util/generic/set.h>
+#include <util/generic/map.h>
 
 #include <memory>
 
@@ -19,20 +19,23 @@ struct IKeyBufferStore
 {
     virtual ~IKeyBufferStore() = default;
 
+    [[nodiscard]] virtual auto Restore()
+        -> NThreading::TFuture<TResultOrError<TMap<ui64, TBuffer>>> = 0;
+
     [[nodiscard]] virtual auto Write(ui64 key, TBuffer buffer)
         -> NThreading::TFuture<NCloud::NProto::TError> = 0;
 
-    [[nodiscard]] virtual auto Read(ui64 key) const
-        -> NThreading::TFuture<TResultOrError<TBuffer>> = 0;
-
     [[nodiscard]] virtual auto EraseUpTo(ui64 lastKey)
         -> NThreading::TFuture<NCloud::NProto::TError> = 0;
-
-    [[nodiscard]] virtual TSet<ui64> GetKeys() const = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 IKeyBufferStorePtr CreateInMemoryKeyBufferStore();
+
+IKeyBufferStorePtr CreateDeviceKeyBufferStore(
+    IDevicePtr device,
+    ui64 pageCount,
+    ui32 pageSize);
 
 }   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/key_buffer_store.h
+++ b/cloud/storage/core/libs/journalled_device/key_buffer_store.h
@@ -7,7 +7,7 @@
 #include <library/cpp/threading/future/future.h>
 
 #include <util/generic/buffer.h>
-#include <util/generic/map.h>
+#include <util/generic/vector.h>
 
 #include <memory>
 
@@ -17,15 +17,16 @@ namespace NCloud::NJournalled {
 
 struct IKeyBufferStore
 {
+    using TRestoreResult = TResultOrError<TVector<std::pair<ui64, TBuffer>>>;
+
     virtual ~IKeyBufferStore() = default;
 
-    [[nodiscard]] virtual auto Restore()
-        -> NThreading::TFuture<TResultOrError<TMap<ui64, TBuffer>>> = 0;
+    [[nodiscard]] virtual NThreading::TFuture<TRestoreResult> Restore() = 0;
 
     [[nodiscard]] virtual auto Write(ui64 key, TBuffer buffer)
         -> NThreading::TFuture<NCloud::NProto::TError> = 0;
 
-    [[nodiscard]] virtual auto EraseUpTo(ui64 lastKey)
+    [[nodiscard]] virtual auto EraseBelow(ui64 key)
         -> NThreading::TFuture<NCloud::NProto::TError> = 0;
 };
 

--- a/cloud/storage/core/libs/journalled_device/key_buffer_store_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/key_buffer_store_ut.cpp
@@ -4,6 +4,7 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/algorithm.h>
 #include <util/generic/buffer.h>
 
 namespace NCloud::NJournalled {
@@ -27,7 +28,18 @@ TString AsString(const TBuffer& buffer)
     return TString(buffer.Data(), buffer.Size());
 }
 
-TMap<ui64, TBuffer> Restore(const IKeyBufferStorePtr& store)
+using TKeyBuffers = TVector<std::pair<ui64, TBuffer>>;
+
+TString Get(const TKeyBuffers& buffers, ui64 key)
+{
+    auto it = FindIf(buffers, [key](const auto& entry) {
+        return entry.first == key;
+    });
+    UNIT_ASSERT_C(it != buffers.end(), "key " << key << " is missing");
+    return AsString(it->second);
+}
+
+TKeyBuffers Restore(const IKeyBufferStorePtr& store)
 {
     auto response = store->Restore().GetValueSync();
     UNIT_ASSERT_VALUES_EQUAL_C(
@@ -38,8 +50,10 @@ TMap<ui64, TBuffer> Restore(const IKeyBufferStorePtr& store)
 }
 
 // "<key>=<buffer>|..." in the key order
-TString Describe(const TMap<ui64, TBuffer>& buffers)
+TString Describe(TKeyBuffers buffers)
 {
+    SortBy(buffers, [](const auto& entry) { return entry.first; });
+
     TStringBuilder sb;
     for (const auto& [key, buffer]: buffers) {
         if (sb) {
@@ -56,9 +70,9 @@ void Write(const IKeyBufferStorePtr& store, ui64 key, TStringBuf data)
     UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), FormatError(error));
 }
 
-ui32 EraseUpTo(const IKeyBufferStorePtr& store, ui64 lastKey)
+ui32 EraseBelow(const IKeyBufferStorePtr& store, ui64 key)
 {
-    const auto error = store->EraseUpTo(lastKey).GetValueSync();
+    const auto error = store->EraseBelow(key).GetValueSync();
     UNIT_ASSERT_C(!HasError(error), FormatError(error));
     return error.GetCode();
 }
@@ -83,7 +97,7 @@ IKeyBufferStorePtr OpenTestStore(
 }
 
 // what a fresh store instance restores from the device
-TMap<ui64, TBuffer> Reopen(
+TKeyBuffers Reopen(
     const IDevicePtr& device,
     ui64 pageCount = TestPageCount)
 {
@@ -235,14 +249,14 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
 
         Write(store, 1, "one");
 
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 1));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 2));
         UNIT_ASSERT(Restore(store).empty());
 
         // removing what is not there reports that nothing was done
-        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 1));
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseBelow(store, 2));
     }
 
-    Y_UNIT_TEST(ShouldEraseEveryKeyUpToTheGivenOne)
+    Y_UNIT_TEST(ShouldEraseEveryKeyBelowTheGivenOne)
     {
         auto store = CreateInMemoryKeyBufferStore();
 
@@ -250,11 +264,12 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
             Write(store, key, "x");
         }
 
-        // the bound itself is included, and it need not be a stored key
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 4));
+        // the bound itself is kept
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 5));
         UNIT_ASSERT_VALUES_EQUAL("5=x|7=x", Describe(Restore(store)));
 
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 5));
+        // and it need not be a stored key
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 6));
         UNIT_ASSERT_VALUES_EQUAL("7=x", Describe(Restore(store)));
     }
 
@@ -264,12 +279,12 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
 
         Write(store, 5, "x");
 
-        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 4));
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseBelow(store, 5));
         UNIT_ASSERT_VALUES_EQUAL("5=x", Describe(Restore(store)));
 
         // and on an empty store
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 5));
-        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, Max<ui64>()));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 6));
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseBelow(store, Max<ui64>()));
     }
 
     Y_UNIT_TEST(ShouldEraseKeyZeroLikeAnyOther)
@@ -280,7 +295,12 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
         Write(store, 10, "record");
 
         // the store gives key 0 no special meaning
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 10));
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseBelow(store, 0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "0=metadata|10=record",
+            Describe(Restore(store)));
+
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 11));
         UNIT_ASSERT(Restore(store).empty());
     }
 
@@ -289,7 +309,7 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
         auto store = CreateInMemoryKeyBufferStore();
 
         Write(store, 5, "x");
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 5));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 6));
 
         UNIT_ASSERT_VALUES_EQUAL(
             E_ARGUMENT,
@@ -350,7 +370,7 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
             store->Write(1, MakeBuffer("x")).GetValueSync().GetCode());
         UNIT_ASSERT_VALUES_EQUAL(
             E_INVALID_STATE,
-            store->EraseUpTo(1).GetValueSync().GetCode());
+            store->EraseBelow(2).GetValueSync().GetCode());
     }
 
     Y_UNIT_TEST(ShouldKeepTheBuffersAcrossRestores)
@@ -383,8 +403,8 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
 
         auto buffers = Reopen(device);
         UNIT_ASSERT_VALUES_EQUAL(2, buffers.size());
-        UNIT_ASSERT_VALUES_EQUAL(data, AsString(buffers[1]));
-        UNIT_ASSERT_VALUES_EQUAL("0123456789abcdef", AsString(buffers[2]));
+        UNIT_ASSERT_VALUES_EQUAL(data, Get(buffers, 1));
+        UNIT_ASSERT_VALUES_EQUAL("0123456789abcdef", Get(buffers, 2));
     }
 
     Y_UNIT_TEST(ShouldNotTouchThePagesBeyondTheDevice)
@@ -394,7 +414,7 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
         auto store = OpenTestStore(device);
         Write(store, 1, "0123456789abcdefghijklmnopqrstuvwxyzABCD");
         Write(store, 2, "x");
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 1));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 2));
 
         UNIT_ASSERT(IsZeroDevicePage(device, TestPageCount));
     }
@@ -435,7 +455,7 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
             E_REJECTED,
             store->Write(7, MakeBuffer("x")).GetValueSync().GetCode());
 
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 3));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 4));
 
         Write(store, 7, "0123456789abcdefghijklmnopqrstuvwxyzABCD");
 
@@ -457,7 +477,7 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
             Write(store, 1, "one");
             Write(store, 2, "two");
             Write(store, 3, "three");
-            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 2));
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 3));
         }
 
         // the erased pages were not reused, the bound drops them anyway
@@ -465,14 +485,14 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
             auto store = CreateTestStore(device);
             UNIT_ASSERT_VALUES_EQUAL("3=three", Describe(Restore(store)));
 
-            UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 2));
+            UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseBelow(store, 3));
             UNIT_ASSERT_VALUES_EQUAL(
                 E_ARGUMENT,
                 store->Write(2, MakeBuffer("x")).GetValueSync().GetCode());
 
             // a bound without live keys is persisted all the same
-            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 3));
-            UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 10));
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 4));
+            UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseBelow(store, 11));
         }
 
         {
@@ -565,8 +585,8 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
             Write(store, 1, "one");
             Write(store, 2, "two");
             Write(store, 3, "three");
-            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 1));   // slot 0
-            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 2));   // slot 1
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 2));   // slot 0
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseBelow(store, 3));   // slot 1
         }
 
         // the newest superblock is lost, the previous bound applies
@@ -606,8 +626,8 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
 
         auto buffers = Reopen(device, pageCount);
         UNIT_ASSERT_VALUES_EQUAL(2501, buffers.size());
-        UNIT_ASSERT_VALUES_EQUAL("one", AsString(buffers[1]));
-        UNIT_ASSERT_VALUES_EQUAL("last", AsString(buffers[2501]));
+        UNIT_ASSERT_VALUES_EQUAL("one", Get(buffers, 1));
+        UNIT_ASSERT_VALUES_EQUAL("last", Get(buffers, 2501));
     }
 
     Y_UNIT_TEST(ShouldRejectAnOverlappingErase)
@@ -624,19 +644,19 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
         UNIT_ASSERT_VALUES_EQUAL(S_OK, write2.GetValueSync().GetCode());
         UNIT_ASSERT_VALUES_EQUAL(S_OK, write3.GetValueSync().GetCode());
 
-        auto erase = store->EraseUpTo(2);
+        auto erase = store->EraseBelow(3);
         UNIT_ASSERT_VALUES_EQUAL(1, device->PendingCount());
         UNIT_ASSERT(!erase.HasValue());
 
         // a second erase has to wait for the first one to complete
         UNIT_ASSERT_VALUES_EQUAL(
             E_REJECTED,
-            store->EraseUpTo(3).GetValueSync().GetCode());
+            store->EraseBelow(4).GetValueSync().GetCode());
 
         // even a lower bound - it is not persisted until the write is done
         UNIT_ASSERT_VALUES_EQUAL(
             E_REJECTED,
-            store->EraseUpTo(1).GetValueSync().GetCode());
+            store->EraseBelow(2).GetValueSync().GetCode());
 
         // an erased key is refused right away
         UNIT_ASSERT_VALUES_EQUAL(
@@ -647,9 +667,9 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
         UNIT_ASSERT_VALUES_EQUAL(S_OK, erase.GetValueSync().GetCode());
         UNIT_ASSERT_VALUES_EQUAL(0, device->PendingCount());
 
-        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 1));
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseBelow(store, 2));
 
-        auto erase3 = store->EraseUpTo(3);
+        auto erase3 = store->EraseBelow(4);
         device->ReleaseAll();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, erase3.GetValueSync().GetCode());
 
@@ -675,7 +695,7 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
                 .GetCode());
         UNIT_ASSERT_VALUES_EQUAL(
             E_IO,
-            store->EraseUpTo(1).GetValueSync().GetCode());
+            store->EraseBelow(2).GetValueSync().GetCode());
 
         device->Broken = false;
 
@@ -694,7 +714,7 @@ Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
             store->Write(7, MakeBuffer("x")).GetValueSync().GetCode());
 
         // the failed erase changed nothing, it can be retried
-        auto erase = store->EraseUpTo(1);
+        auto erase = store->EraseBelow(2);
         device->ReleaseAll();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, erase.GetValueSync().GetCode());
 

--- a/cloud/storage/core/libs/journalled_device/key_buffer_store_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/key_buffer_store_ut.cpp
@@ -1,5 +1,7 @@
 #include "key_buffer_store.h"
 
+#include "device.h"
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/buffer.h>
@@ -9,6 +11,11 @@ namespace NCloud::NJournalled {
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+// 48 bytes of header and 16 bytes of payload per page
+constexpr ui32 TestPageSize = 64;
+constexpr ui64 TestPageCount = 8;   // 2 superblock slots and 6 entry pages
+constexpr ui64 FirstEntryPageNo = 2;
 
 TBuffer MakeBuffer(TStringBuf data)
 {
@@ -20,17 +27,174 @@ TString AsString(const TBuffer& buffer)
     return TString(buffer.Data(), buffer.Size());
 }
 
-TString JoinKeys(const TSet<ui64>& keys)
+TMap<ui64, TBuffer> Restore(const IKeyBufferStorePtr& store)
+{
+    auto response = store->Restore().GetValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        S_OK,
+        response.GetError().GetCode(),
+        FormatError(response.GetError()));
+    return response.ExtractResult();
+}
+
+// "<key>=<buffer>|..." in the key order
+TString Describe(const TMap<ui64, TBuffer>& buffers)
 {
     TStringBuilder sb;
-    for (ui64 key: keys) {
+    for (const auto& [key, buffer]: buffers) {
         if (sb) {
             sb << "|";
         }
-        sb << key;
+        sb << key << "=" << AsString(buffer);
     }
     return sb;
 }
+
+void Write(const IKeyBufferStorePtr& store, ui64 key, TStringBuf data)
+{
+    const auto error = store->Write(key, MakeBuffer(data)).GetValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), FormatError(error));
+}
+
+ui32 EraseUpTo(const IKeyBufferStorePtr& store, ui64 lastKey)
+{
+    const auto error = store->EraseUpTo(lastKey).GetValueSync();
+    UNIT_ASSERT_C(!HasError(error), FormatError(error));
+    return error.GetCode();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+IKeyBufferStorePtr CreateTestStore(
+    const IDevicePtr& device,
+    ui64 pageCount = TestPageCount)
+{
+    return CreateDeviceKeyBufferStore(device, pageCount, TestPageSize);
+}
+
+// a store instance restored from the device
+IKeyBufferStorePtr OpenTestStore(
+    const IDevicePtr& device,
+    ui64 pageCount = TestPageCount)
+{
+    auto store = CreateTestStore(device, pageCount);
+    Restore(store);
+    return store;
+}
+
+// what a fresh store instance restores from the device
+TMap<ui64, TBuffer> Reopen(
+    const IDevicePtr& device,
+    ui64 pageCount = TestPageCount)
+{
+    return Restore(CreateTestStore(device, pageCount));
+}
+
+TString ReadFromDevice(const IDevicePtr& device, ui64 pageNo)
+{
+    NCloud::NProto::TReadPagesRequest request;
+    auto& ref = *request.AddPageGroupRefs();
+    ref.SetFirstPageNo(pageNo);
+    ref.SetPageCount(1);
+    ref.SetPageSize(TestPageSize);
+
+    auto response = device->ReadPages(std::move(request)).GetValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        S_OK,
+        response.GetError().GetCode(),
+        FormatError(response.GetError()));
+    UNIT_ASSERT_VALUES_EQUAL(1, response.GetPageGroups(0).ContentSize());
+
+    return response.GetPageGroups(0).GetContent(0);
+}
+
+void WriteToDevice(const IDevicePtr& device, ui64 pageNo, TString content)
+{
+    NCloud::NProto::TWriteLogRecordRequest request;
+    auto& group = *request.AddPageGroups();
+    group.SetFirstPageNo(pageNo);
+    *group.AddContent() = std::move(content);
+
+    auto response = device->WritePages(std::move(request)).GetValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        S_OK,
+        response.GetError().GetCode(),
+        FormatError(response.GetError()));
+}
+
+// flips a byte of the page - by default the first payload byte of an entry
+// page, which only the checksum guards
+void CorruptDevicePage(
+    const IDevicePtr& device,
+    ui64 pageNo,
+    size_t offset = 48)
+{
+    auto content = ReadFromDevice(device, pageNo);
+    content[offset] = static_cast<char>(content[offset] ^ 0xFF);
+    WriteToDevice(device, pageNo, std::move(content));
+}
+
+bool IsZeroDevicePage(const IDevicePtr& device, ui64 pageNo)
+{
+    return ReadFromDevice(device, pageNo) == TString(TestPageSize, '\0');
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// A device that holds its write responses until they are released and fails
+// the writes while broken.
+class TStuckDevice final: public IDevice
+{
+private:
+    const IDevicePtr Device = CreateInMemoryDevice();
+
+    TVector<std::function<void()>> Pending;
+
+public:
+    bool Broken = false;
+
+    NThreading::TFuture<NCloud::NProto::TReadPagesResponse> ReadPages(
+        NCloud::NProto::TReadPagesRequest request) override
+    {
+        return Device->ReadPages(std::move(request));
+    }
+
+    NThreading::TFuture<NCloud::NProto::TWriteLogRecordResponse> WritePages(
+        NCloud::NProto::TWriteLogRecordRequest request) override
+    {
+        if (Broken) {
+            return NThreading::MakeFuture<
+                NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(E_IO, "device is broken"));
+        }
+
+        auto promise =
+            NThreading::NewPromise<NCloud::NProto::TWriteLogRecordResponse>();
+
+        Pending.push_back(
+            [device = Device, request = std::move(request), promise]() mutable
+            {
+                promise.SetValue(
+                    device->WritePages(std::move(request)).GetValueSync());
+            });
+
+        return promise.GetFuture();
+    }
+
+    size_t PendingCount() const
+    {
+        return Pending.size();
+    }
+
+    void ReleaseAll()
+    {
+        auto pending = std::move(Pending);
+        Pending.clear();
+        for (auto& release: pending) {
+            release();
+        }
+    }
+};
 
 }   // namespace
 
@@ -42,67 +206,40 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
     {
         auto store = CreateInMemoryKeyBufferStore();
 
-        UNIT_ASSERT(store->GetKeys().empty());
-        UNIT_ASSERT_VALUES_EQUAL(
-            E_NOT_FOUND,
-            store->Read(1).GetValue().GetError().GetCode());
+        UNIT_ASSERT(Restore(store).empty());
     }
 
     Y_UNIT_TEST(ShouldInsertAndGet)
     {
         auto store = CreateInMemoryKeyBufferStore();
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->Write(1, MakeBuffer("one")).GetValue().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->Write(2, MakeBuffer("two")).GetValue().GetCode());
+        Write(store, 1, "one");
+        Write(store, 2, "two");
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            "one",
-            AsString(store->Read(1).GetValue().GetResult()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            "two",
-            AsString(store->Read(2).GetValue().GetResult()));
+        UNIT_ASSERT_VALUES_EQUAL("1=one|2=two", Describe(Restore(store)));
     }
 
     Y_UNIT_TEST(ShouldOverwriteAnExistingKey)
     {
         auto store = CreateInMemoryKeyBufferStore();
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->Write(1, MakeBuffer("first")).GetValue().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->Write(1, MakeBuffer("second")).GetValue().GetCode());
+        Write(store, 1, "first");
+        Write(store, 1, "second");
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            "second",
-            AsString(store->Read(1).GetValue().GetResult()));
-        UNIT_ASSERT_VALUES_EQUAL(1, store->GetKeys().size());
+        UNIT_ASSERT_VALUES_EQUAL("1=second", Describe(Restore(store)));
     }
 
     Y_UNIT_TEST(ShouldEraseASingleKey)
     {
         auto store = CreateInMemoryKeyBufferStore();
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->Write(1, MakeBuffer("one")).GetValue().GetCode());
+        Write(store, 1, "one");
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->EraseUpTo(1).GetValue().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL(
-            E_NOT_FOUND,
-            store->Read(1).GetValue().GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 1));
+        UNIT_ASSERT(Restore(store).empty());
 
         // removing what is not there reports that nothing was done
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_FALSE,
-            store->EraseUpTo(1).GetValue().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 1));
     }
 
     Y_UNIT_TEST(ShouldEraseEveryKeyUpToTheGivenOne)
@@ -110,61 +247,59 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
         auto store = CreateInMemoryKeyBufferStore();
 
         for (ui64 key: {1, 3, 5, 7}) {
-            UNIT_ASSERT_VALUES_EQUAL(
-                S_OK,
-                store->Write(key, MakeBuffer("x")).GetValue().GetCode());
+            Write(store, key, "x");
         }
 
         // the bound itself is included, and it need not be a stored key
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->EraseUpTo(4).GetValue().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL("5|7", JoinKeys(store->GetKeys()));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 4));
+        UNIT_ASSERT_VALUES_EQUAL("5=x|7=x", Describe(Restore(store)));
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->EraseUpTo(5).GetValue().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL("7", JoinKeys(store->GetKeys()));
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 5));
+        UNIT_ASSERT_VALUES_EQUAL("7=x", Describe(Restore(store)));
     }
 
     Y_UNIT_TEST(ShouldEraseNothingBelowTheLowestKey)
     {
         auto store = CreateInMemoryKeyBufferStore();
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->Write(5, MakeBuffer("x")).GetValue().GetCode());
+        Write(store, 5, "x");
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_FALSE,
-            store->EraseUpTo(4).GetValue().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL("5", JoinKeys(store->GetKeys()));
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 4));
+        UNIT_ASSERT_VALUES_EQUAL("5=x", Describe(Restore(store)));
 
         // and on an empty store
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->EraseUpTo(5).GetValue().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_FALSE,
-            store->EraseUpTo(Max<ui64>()).GetValue().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 5));
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, Max<ui64>()));
     }
 
     Y_UNIT_TEST(ShouldEraseKeyZeroLikeAnyOther)
     {
         auto store = CreateInMemoryKeyBufferStore();
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->Write(0, MakeBuffer("metadata")).GetValue().GetCode());
-        UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->Write(10, MakeBuffer("record")).GetValue().GetCode());
+        Write(store, 0, "metadata");
+        Write(store, 10, "record");
 
         // the store gives key 0 no special meaning
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 10));
+        UNIT_ASSERT(Restore(store).empty());
+    }
+
+    Y_UNIT_TEST(ShouldRefuseToWriteAnErasedKey)
+    {
+        auto store = CreateInMemoryKeyBufferStore();
+
+        Write(store, 5, "x");
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 5));
+
         UNIT_ASSERT_VALUES_EQUAL(
-            S_OK,
-            store->EraseUpTo(10).GetValue().GetCode());
-        UNIT_ASSERT(store->GetKeys().empty());
+            E_ARGUMENT,
+            store->Write(5, MakeBuffer("x")).GetValueSync().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            store->Write(3, MakeBuffer("x")).GetValueSync().GetCode());
+
+        Write(store, 6, "y");
+        UNIT_ASSERT_VALUES_EQUAL("6=y", Describe(Restore(store)));
     }
 
     Y_UNIT_TEST(ShouldReadKeysInAscendingOrder)
@@ -172,12 +307,10 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
         auto store = CreateInMemoryKeyBufferStore();
 
         for (ui64 key: {5, 1, 3}) {
-            UNIT_ASSERT_VALUES_EQUAL(
-                S_OK,
-                store->Write(key, MakeBuffer("x")).GetValue().GetCode());
+            Write(store, key, "x");
         }
 
-        UNIT_ASSERT_VALUES_EQUAL("1|3|5", JoinKeys(store->GetKeys()));
+        UNIT_ASSERT_VALUES_EQUAL("1=x|3=x|5=x", Describe(Restore(store)));
     }
 
     Y_UNIT_TEST(ShouldKeepAnIndependentCopyOfTheBuffer)
@@ -187,13 +320,387 @@ Y_UNIT_TEST_SUITE(TInMemoryKeyBufferStoreTest)
         TBuffer buffer = MakeBuffer("original");
         UNIT_ASSERT_VALUES_EQUAL(
             S_OK,
-            store->Write(1, buffer).GetValue().GetCode());
+            store->Write(1, buffer).GetValueSync().GetCode());
 
         buffer.Clear();
 
+        UNIT_ASSERT_VALUES_EQUAL("1=original", Describe(Restore(store)));
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TDeviceKeyBufferStoreTest)
+{
+    Y_UNIT_TEST(ShouldStartEmptyOnAFreshDevice)
+    {
+        auto device = CreateInMemoryDevice();
+        auto store = CreateTestStore(device);
+
+        UNIT_ASSERT(Restore(store).empty());
+        UNIT_ASSERT(Reopen(device).empty());
+    }
+
+    Y_UNIT_TEST(ShouldRequireRestoreBeforeUse)
+    {
+        auto store = CreateTestStore(CreateInMemoryDevice());
+
         UNIT_ASSERT_VALUES_EQUAL(
-            "original",
-            AsString(store->Read(1).GetValue().GetResult()));
+            E_INVALID_STATE,
+            store->Write(1, MakeBuffer("x")).GetValueSync().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_INVALID_STATE,
+            store->EraseUpTo(1).GetValueSync().GetCode());
+    }
+
+    Y_UNIT_TEST(ShouldKeepTheBuffersAcrossRestores)
+    {
+        auto device = CreateInMemoryDevice();
+
+        {
+            auto store = OpenTestStore(device);
+            Write(store, 1, "one");
+            Write(store, 2, "two");
+            Write(store, 3, "");
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL("1=one|2=two|3=", Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldSplitABufferAcrossPages)
+    {
+        auto device = CreateInMemoryDevice();
+
+        // 40 bytes take 3 pages of 16 bytes payload, the last one partially
+        const TString data = "0123456789abcdefghijklmnopqrstuvwxyzABCD";
+        UNIT_ASSERT_VALUES_EQUAL(40, data.size());
+
+        {
+            auto store = OpenTestStore(device);
+            Write(store, 1, data);
+            Write(store, 2, "0123456789abcdef");   // exactly one page
+        }
+
+        auto buffers = Reopen(device);
+        UNIT_ASSERT_VALUES_EQUAL(2, buffers.size());
+        UNIT_ASSERT_VALUES_EQUAL(data, AsString(buffers[1]));
+        UNIT_ASSERT_VALUES_EQUAL("0123456789abcdef", AsString(buffers[2]));
+    }
+
+    Y_UNIT_TEST(ShouldNotTouchThePagesBeyondTheDevice)
+    {
+        auto device = CreateInMemoryDevice();
+
+        auto store = OpenTestStore(device);
+        Write(store, 1, "0123456789abcdefghijklmnopqrstuvwxyzABCD");
+        Write(store, 2, "x");
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 1));
+
+        UNIT_ASSERT(IsZeroDevicePage(device, TestPageCount));
+    }
+
+    Y_UNIT_TEST(ShouldRejectABufferThatDoesNotFit)
+    {
+        auto device = CreateInMemoryDevice();
+        auto store = OpenTestStore(device);
+
+        // 6 entry pages of 16 bytes payload each
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            store->Write(1, TBuffer(TString(97, 'x').data(), 97))
+                .GetValueSync()
+                .GetCode());
+
+        Write(store, 1, TString(96, 'x'));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            store->Write(2, MakeBuffer("x")).GetValueSync().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "1=" + TString(96, 'x'),
+            Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldReuseThePagesOfErasedBuffers)
+    {
+        auto device = CreateInMemoryDevice();
+        auto store = OpenTestStore(device);
+
+        for (ui64 key = 1; key <= 6; ++key) {
+            Write(store, key, "x");
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            store->Write(7, MakeBuffer("x")).GetValueSync().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 3));
+
+        Write(store, 7, "0123456789abcdefghijklmnopqrstuvwxyzABCD");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            store->Write(8, MakeBuffer("x")).GetValueSync().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "4=x|5=x|6=x|7=0123456789abcdefghijklmnopqrstuvwxyzABCD",
+            Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldPersistTheErasedBound)
+    {
+        auto device = CreateInMemoryDevice();
+
+        {
+            auto store = OpenTestStore(device);
+            Write(store, 1, "one");
+            Write(store, 2, "two");
+            Write(store, 3, "three");
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 2));
+        }
+
+        // the erased pages were not reused, the bound drops them anyway
+        {
+            auto store = CreateTestStore(device);
+            UNIT_ASSERT_VALUES_EQUAL("3=three", Describe(Restore(store)));
+
+            UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 2));
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_ARGUMENT,
+                store->Write(2, MakeBuffer("x")).GetValueSync().GetCode());
+
+            // a bound without live keys is persisted all the same
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 3));
+            UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 10));
+        }
+
+        {
+            auto store = CreateTestStore(device);
+            UNIT_ASSERT(Restore(store).empty());
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_ARGUMENT,
+                store->Write(10, MakeBuffer("x")).GetValueSync().GetCode());
+            Write(store, 11, "x");
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL("11=x", Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldKeepTheNewestCopyOfARewrittenKey)
+    {
+        auto device = CreateInMemoryDevice();
+
+        {
+            auto store = OpenTestStore(device);
+            Write(store, 1, "first");
+            Write(store, 1, "second");
+        }
+
+        // the sequence numbers go on after a restore, so the copy written by
+        // a later instance wins even though it may land on lower pages
+        {
+            auto store = CreateTestStore(device);
+            UNIT_ASSERT_VALUES_EQUAL("1=second", Describe(Restore(store)));
+            Write(store, 1, "third");
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL("1=third", Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldFreeThePagesOfTheOverwrittenCopy)
+    {
+        auto device = CreateInMemoryDevice();
+        auto store = OpenTestStore(device);
+
+        for (int i = 0; i < 20; ++i) {
+            // 3 pages each time, 6 in the store - the old copy must go
+            Write(store, 1, TString(40, static_cast<char>('a' + i)));
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "1=" + TString(40, 't'),
+            Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldDropATornBuffer)
+    {
+        auto device = CreateInMemoryDevice();
+
+        {
+            auto store = OpenTestStore(device);
+            Write(store, 1, "one");
+            Write(store, 2, "0123456789abcdefghijklmnopqrstuvwxyzABCD");
+            Write(store, 3, "three");
+        }
+
+        // key 2 takes the entry pages 1, 2 and 3
+        CorruptDevicePage(device, FirstEntryPageNo + 2);
+
+        UNIT_ASSERT_VALUES_EQUAL("1=one|3=three", Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldKeepTheOldCopyWhenTheRewriteIsTorn)
+    {
+        auto device = CreateInMemoryDevice();
+
+        {
+            auto store = OpenTestStore(device);
+            Write(store, 1, "first");
+            Write(store, 1, "0123456789abcdefghijklmnopqrstuvwxyzABCD");
+        }
+
+        // the old copy sits at the entry page 0, the new one at 1, 2 and 3
+        CorruptDevicePage(device, FirstEntryPageNo + 1);
+
+        UNIT_ASSERT_VALUES_EQUAL("1=first", Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldSurviveATornSuperblock)
+    {
+        auto device = CreateInMemoryDevice();
+
+        {
+            auto store = OpenTestStore(device);
+            Write(store, 1, "one");
+            Write(store, 2, "two");
+            Write(store, 3, "three");
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 1));   // slot 0
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, EraseUpTo(store, 2));   // slot 1
+        }
+
+        // the newest superblock is lost, the previous bound applies
+        CorruptDevicePage(device, 1, 20);
+
+        UNIT_ASSERT_VALUES_EQUAL("2=two|3=three", Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreGarbageOnTheDevice)
+    {
+        auto device = CreateInMemoryDevice();
+
+        for (ui64 pageNo = 0; pageNo < TestPageCount; ++pageNo) {
+            WriteToDevice(device, pageNo, TString(TestPageSize, 'g'));
+        }
+
+        auto store = CreateTestStore(device);
+        UNIT_ASSERT(Restore(store).empty());
+
+        Write(store, 1, "one");
+        UNIT_ASSERT_VALUES_EQUAL("1=one", Describe(Reopen(device)));
+    }
+
+    Y_UNIT_TEST(ShouldRestoreALargeRangeInSeveralReads)
+    {
+        auto device = CreateInMemoryDevice();
+        constexpr ui64 pageCount = 3000;
+
+        {
+            auto store = OpenTestStore(device, pageCount);
+            Write(store, 1, "one");
+            for (ui64 key = 2; key <= 2500; ++key) {
+                Write(store, key, "x");
+            }
+            Write(store, 2501, "last");
+        }
+
+        auto buffers = Reopen(device, pageCount);
+        UNIT_ASSERT_VALUES_EQUAL(2501, buffers.size());
+        UNIT_ASSERT_VALUES_EQUAL("one", AsString(buffers[1]));
+        UNIT_ASSERT_VALUES_EQUAL("last", AsString(buffers[2501]));
+    }
+
+    Y_UNIT_TEST(ShouldRejectAnOverlappingErase)
+    {
+        auto device = std::make_shared<TStuckDevice>();
+        auto store = CreateTestStore(device);
+        Restore(store);
+
+        auto write1 = store->Write(1, MakeBuffer("one"));
+        auto write2 = store->Write(2, MakeBuffer("two"));
+        auto write3 = store->Write(3, MakeBuffer("three"));
+        device->ReleaseAll();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, write1.GetValueSync().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, write2.GetValueSync().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, write3.GetValueSync().GetCode());
+
+        auto erase = store->EraseUpTo(2);
+        UNIT_ASSERT_VALUES_EQUAL(1, device->PendingCount());
+        UNIT_ASSERT(!erase.HasValue());
+
+        // a second erase has to wait for the first one to complete
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            store->EraseUpTo(3).GetValueSync().GetCode());
+
+        // even a lower bound - it is not persisted until the write is done
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            store->EraseUpTo(1).GetValueSync().GetCode());
+
+        // an erased key is refused right away
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            store->Write(2, MakeBuffer("x")).GetValueSync().GetCode());
+
+        device->ReleaseAll();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, erase.GetValueSync().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(0, device->PendingCount());
+
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, EraseUpTo(store, 1));
+
+        auto erase3 = store->EraseUpTo(3);
+        device->ReleaseAll();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, erase3.GetValueSync().GetCode());
+
+        UNIT_ASSERT(Reopen(device).empty());
+    }
+
+    Y_UNIT_TEST(ShouldReportTheDeviceWriteError)
+    {
+        auto device = std::make_shared<TStuckDevice>();
+        auto store = CreateTestStore(device);
+        Restore(store);
+
+        auto write = store->Write(1, MakeBuffer("one"));
+        device->ReleaseAll();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, write.GetValueSync().GetCode());
+
+        device->Broken = true;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_IO,
+            store->Write(2, TBuffer(TString(40, 'x').data(), 40))
+                .GetValueSync()
+                .GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_IO,
+            store->EraseUpTo(1).GetValueSync().GetCode());
+
+        device->Broken = false;
+
+        // the pages of the failed write are free again: 5 of the 6 entry
+        // pages are left after key 1
+        TVector<NThreading::TFuture<NCloud::NProto::TError>> writes;
+        for (ui64 key = 2; key <= 6; ++key) {
+            writes.push_back(store->Write(key, MakeBuffer("x")));
+        }
+        device->ReleaseAll();
+        for (auto& future: writes) {
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, future.GetValueSync().GetCode());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_REJECTED,
+            store->Write(7, MakeBuffer("x")).GetValueSync().GetCode());
+
+        // the failed erase changed nothing, it can be retried
+        auto erase = store->EraseUpTo(1);
+        device->ReleaseAll();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, erase.GetValueSync().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "2=x|3=x|4=x|5=x|6=x",
+            Describe(Reopen(device)));
     }
 }
 

--- a/cloud/storage/core/libs/journalled_device/ya.make
+++ b/cloud/storage/core/libs/journalled_device/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     cloud/storage/core/libs/coroutine
     cloud/storage/core/libs/diagnostics
     cloud/storage/core/protos
+    library/cpp/digest/crc32c
 )
 
 END()


### PR DESCRIPTION
### Notes
The store keeps its buffers in the pages of a device. Two superblock slots at the start of the device carry the erased bound and are written in turns. The rest of the pages hold the buffers, each page carrying a header with the key, the chunk position, a write sequence number and a checksum. Restore scans the device, drops torn or erased entries and keeps the newest intact copy of each key.

### Issue
https://github.com/ydb-platform/nbs/issues/6956