### PR TITLE
issue-5895: fastshard - some clarifications in the doc

### DIFF
--- a/doc/filestore/design/storage/fastshard/README.md
+++ b/doc/filestore/design/storage/fastshard/README.md
@@ -16,10 +16,10 @@ files can be implemented via fastshard.
 This directory documents the prospective design. The version present in the repo
 at `impl/hash_table_index` is currently a prototype and implements a subset of
 it; every gap between the prototype and the design is marked in the per-layer
-documents. This hash_table_index implementation will probably transform into
-the "V1" production implementation. The "V2" implementation will most probably
+documents. This `hash_table_index` implementation will probably transform into
+the V1 production implementation. The V2 implementation will most probably
 differ in the way we work with multiple groups per shard and in the way we index
-file pages (if we ever need to actually implement the "V2" version).
+file pages (if we ever need to actually implement the V2 version).
 
 ## Motivation
 

--- a/doc/filestore/design/storage/fastshard/README.md
+++ b/doc/filestore/design/storage/fastshard/README.md
@@ -13,9 +13,13 @@ Shards that host directories and other inode types keep the existing
 `TIndexTabletActor` implementation on top of BlobStorage. Shards that host
 files can be implemented via fastshard.
 
-This directory documents the prospective design. The prototype
-(`impl/hash_table_index`) implements a subset of it; every gap between the
-prototype and the design is marked in the per-layer documents.
+This directory documents the prospective design. The version present in the repo
+at `impl/hash_table_index` is currently a prototype and implements a subset of
+it; every gap between the prototype and the design is marked in the per-layer
+documents. This hash_table_index implementation will probably transform into
+the "V1" production implementation. The "V2" implementation will most probably
+differ in the way we work with multiple groups per shard and in the way we index
+file pages (if we ever need to actually implement the "V2" version).
 
 ## Motivation
 

--- a/doc/filestore/design/storage/fastshard/shard.md
+++ b/doc/filestore/design/storage/fastshard/shard.md
@@ -43,7 +43,10 @@ groups of 8 consecutive pages.
 
 * Prototype: `TPersistentHashTable` with `<NodeId, PageClusterNo>` keys and
   `StoragePageClusterNo` values.
-* Production: an extent tree / a radix tree hybrid per file.
+* V1: same hash table but page cluster sizes will have variable size - page
+  clusters at further offsets relative to the beginning of the file will be
+  much larger.
+* V2: an extent tree / a radix tree hybrid per file.
 
 #### Page index tree
 
@@ -77,7 +80,10 @@ prototype: one bit per 8-page cluster, stored in page-sized chunks (with
 `PageSize == 4KiB` each chunk stores `2^15 bits`), plus an in-memory stack of
 chunks that have zero bits.
 
-Production mostly keeps this design - but the allocation logic will probably be
+V1 version - one bit per 4-page min-size cluster, larger clusters will be
+tracked as groups of 4-page clusters.
+
+V2 mostly keeps this design - but the allocation logic will probably be
 smarter. Always allocating in multiples of 32KiB (8 pages) may waste too much
 space; a more sophisticated allocator is a possible future change. Large files
 will also need to address storage pages from other groups.
@@ -132,6 +138,11 @@ shard in the following manner:
 
 Steps 0 and 1 can be thought of as the "prepare" stage of a 2PC transaction.
 Steps 2 and 3 can be thought of as the "commit" stage of a 2PC transaction.
+
+V1 might actually end up having only one storage group per shard and omit the
+need to implement this mechanism. We can simply allocate large devices - e.g.
+4TiB per device. This way a single group will be able to store the amount of
+data that we usually expect to store per shard.
 
 ## Diagram
 

--- a/doc/filestore/design/storage/fastshard/shard.md
+++ b/doc/filestore/design/storage/fastshard/shard.md
@@ -83,10 +83,9 @@ chunks that have zero bits.
 V1 version - one bit per 4-page min-size cluster, larger clusters will be
 tracked as groups of 4-page clusters.
 
-V2 mostly keeps this design - but the allocation logic will probably be
-smarter. Always allocating in multiples of 32KiB (8 pages) may waste too much
-space; a more sophisticated allocator is a possible future change. Large files
-will also need to address storage pages from other groups.
+V2 mostly keeps this design; a more sophisticated allocator is a possible
+future change. Large files will also need to address storage pages from other
+groups.
 
 ## Per-group layout
 


### PR DESCRIPTION
### Notes
Noted that we might end up going with a hash-table-based index and one storage group per shard in the V1 production version.

### Issue
https://github.com/ydb-platform/nbs/issues/5895
