### PR TITLE
[NBS] Stop reporting MigrationFailed on non-retriable migration errors

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -124,6 +124,7 @@ using TCritEventParams =
     xxx(DiskAllocationFailure)                                                 \
     xxx(CollectGarbageError)                                                   \
     xxx(MigrationFailed)                                                       \
+    xxx(MigrationNonRetriableError)                                            \
     xxx(BadMigrationConfig)                                                    \
     xxx(InitFreshBlocksError)                                                  \
     xxx(TrimFreshLogError)                                                     \

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -98,8 +98,7 @@ public:
 
 // About error handling. If migration errors occur, they cannot be fixed, on the
 // VolumeActor/PartitionActor side since DiskRegistry manages the allocation of
-// devices. Therefore, in this case, the MigrationFailed critical error is only
-// fired here. When DiskRegistry detects that the device or agent is broken, it
+// devices. When DiskRegistry detects that the device or agent is broken, it
 // selects a new migration target and starts it again by sending a new
 // configuration to VolumeActor, which will lead to the migration actor being
 // recreated with a new device config.

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -446,11 +446,6 @@ void TNonreplicatedPartitionMigrationCommonActor::DoRegisterTrafficSource(
 void TNonreplicatedPartitionMigrationCommonActor::OnMigrationNonRetriableError(
     const NActors::TActorContext& ctx)
 {
-    ReportMigrationFailed(
-        DiskId,
-        CloudId,
-        FolderId,
-        "Non-retriable migration error occurred");
     MigrationOwner->OnMigrationError(ctx);
     MigrationEnabled = false;
 }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -446,6 +446,12 @@ void TNonreplicatedPartitionMigrationCommonActor::DoRegisterTrafficSource(
 void TNonreplicatedPartitionMigrationCommonActor::OnMigrationNonRetriableError(
     const NActors::TActorContext& ctx)
 {
+    ReportMigrationNonRetriableError(
+        DiskId,
+        CloudId,
+        FolderId,
+        "Non-retriable migration error occurred");
+
     MigrationOwner->OnMigrationError(ctx);
     MigrationEnabled = false;
 }

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -1345,8 +1345,11 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         NMonitoring::TDynamicCountersPtr counters = new NMonitoring::TDynamicCounters();
         InitCriticalEventsCounter(counters);
+
         auto migrationFailedCounter =
             counters->GetCounter("AppCriticalEvents/MigrationFailed", true);
+        auto migrationNonRetriableErrorCounter =
+            counters->GetCounter("AppCriticalEvents/MigrationNonRetriableError", true);
 
         TVolumeClient volume(*runtime);
 
@@ -1397,6 +1400,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(1, rangeMigratedCount);
         UNIT_ASSERT_VALUES_EQUAL(0, state->FinishMigrationRequests);
         UNIT_ASSERT_VALUES_EQUAL(0, migrationFailedCounter->Val());
+        UNIT_ASSERT_VALUES_EQUAL(1, migrationNonRetriableErrorCounter->Val());
     }
 
     Y_UNIT_TEST(ShouldRestoreMigrationIndexAfterReboot)

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -1396,7 +1396,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         runtime->DispatchEvents({}, TDuration::Seconds(1));
         UNIT_ASSERT_VALUES_EQUAL(1, rangeMigratedCount);
         UNIT_ASSERT_VALUES_EQUAL(0, state->FinishMigrationRequests);
-        UNIT_ASSERT_VALUES_EQUAL(1, migrationFailedCounter->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, migrationFailedCounter->Val());
     }
 
     Y_UNIT_TEST(ShouldRestoreMigrationIndexAfterReboot)


### PR DESCRIPTION
### Notes
Problem description is in the [related Issue](https://github.com/ydb-platform/nbs/issues/7118)

### Scope
This change stops reporting `MigrationFailed` for all non-retriable migration errors handled by `OnMigrationNonRetriableError`, without distinguishing between source-read, target-write or other error types.
Other `MigrationFailed` reports, such as a non-retriable error returned while finishing a migration, remain unchanged.
