### PR TITLE
Avoid duplicate disk update in Disk Registry `TFinishMigration`

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -6914,7 +6914,9 @@ NProto::TError TDiskRegistryState::FinishDeviceMigration(
 
     *diskStateUpdated = TryUpdateDiskState(db, diskId, disk, timestamp);
 
-    db.UpdateDisk(BuildDiskConfig(diskId, disk));
+    if (!*diskStateUpdated) {
+        db.UpdateDisk(BuildDiskConfig(diskId, disk));
+    }
 
     UpdatePlacementGroup(db, diskId, disk, "FinishDeviceMigration");
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
@@ -1,6 +1,7 @@
 #include "disk_registry_state.h"
 
 #include "disk_registry_database.h"
+#include "disk_registry_schema.h"
 
 #include <cloud/blockstore/libs/diagnostics/critical_events_init.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
@@ -18,6 +19,31 @@ namespace NCloud::NBlockStore::NStorage {
 using namespace NDiskRegistryStateTest;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTableUpdateCounter final
+    : public NKikimr::NTable::ITableObserver
+{
+public:
+    size_t UpdateCount = 0;
+
+    void OnUpdate(
+        NKikimr::NTable::ERowOp,
+        TArrayRef<const NKikimr::TRawTypeValue>,
+        TArrayRef<const NKikimr::NTable::TUpdateOp>,
+        NKikimr::TRowVersion) override
+    {
+        ++UpdateCount;
+    }
+
+    void OnUpdateTx(
+        NKikimr::NTable::ERowOp,
+        TArrayRef<const NKikimr::TRawTypeValue>,
+        TArrayRef<const NKikimr::NTable::TUpdateOp>,
+        ui64) override
+    {}
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -663,6 +689,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
             db.InitSchema();
         });
 
+        auto updateCounter = MakeIntrusive<TTableUpdateCounter>();
+        executor.DB.SetTableObserver(
+            TDiskRegistrySchema::Disks::TableId,
+            updateCounter);
+
         const TVector agents {
             AgentConfig(1, { Device("dev-1", "uuid-1.1", "rack-1") }),
             AgentConfig(2, { Device("dev-1", "uuid-2.1", "rack-1") }),
@@ -708,6 +739,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
         });
 
         executor.WriteTx([&] (TDiskRegistryDatabase db) mutable {
+            updateCounter->UpdateCount = 0;
+
             bool updated = false;
             auto error = state.FinishDeviceMigration(
                 db,
@@ -719,6 +752,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
 
             UNIT_ASSERT_VALUES_EQUAL(S_OK, error.GetCode());
             UNIT_ASSERT(updated);
+            UNIT_ASSERT_VALUES_EQUAL(1, updateCounter->UpdateCount);
         });
 
         UNIT_ASSERT(state.IsMigrationListEmpty());


### PR DESCRIPTION
### Notes

`TFinishMigration` may write the same disk configuration twice when finishing a device migration changes the disk state. `TryUpdateDiskState` persists the updated disk, after which `FinishDeviceMigration` writes it again unconditionally.

Skip the second write when the state update has already persisted the disk. This reduces commit-redo amplification for disks with large configurations.

Added regression coverage that observes the `Disks` table and verifies that the state-changing path performs exactly one update. Without the fix the updated test fails.


### How it is called twice currently

`TryUpdateDiskStateImpl`  -> `UpdateAndReallocateDisk`  -> `UpdateDisk`

https://github.com/ydb-platform/nbs/blob/6e20a5f573cc43c5b859c8854c3be450a59a54cc/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp#L6005-L6041

https://github.com/ydb-platform/nbs/blob/6e20a5f573cc43c5b859c8854c3be450a59a54cc/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp#L5132-L5139