### PR TITLE
issue-6956: flush the journal under the identity of the device

### DIFF
--- a/cloud/storage/core/libs/journalled_device/journalled_device_v2.cpp
+++ b/cloud/storage/core/libs/journalled_device/journalled_device_v2.cpp
@@ -49,7 +49,7 @@ NCloud::NProto::TReadPagesRequest MakeMissingRequest(
         const ui64 endPageNo = ref.GetFirstPageNo() + ref.GetPageCount();
         ui64 pageNo = ref.GetFirstPageNo();
 
-        auto addRef = [&] (ui64 begin, ui64 end)
+        auto addRef = [&](ui64 begin, ui64 end)
         {
             if (begin >= end) {
                 return;
@@ -88,7 +88,7 @@ NCloud::NProto::TReadPagesResponse MergeResponses(
 {
     THashMap<ui64, TString*> pages;
 
-    auto index = [&] (NCloud::NProto::TReadPagesResponse* source)
+    auto index = [&](NCloud::NProto::TReadPagesResponse* source)
     {
         if (!source) {
             return;
@@ -122,8 +122,10 @@ NCloud::NProto::TReadPagesResponse MergeResponses(
             if (it == pages.end()) {
                 return ErrorResponse<NCloud::NProto::TReadPagesResponse>(
                     E_INVALID_STATE,
-                    TStringBuilder() << "page " << pageNo << " is missing"
-                        " in both the journal and the device responses");
+                    TStringBuilder()
+                        << "page " << pageNo
+                        << " is missing"
+                           " in both the journal and the device responses");
             }
 
             *group->AddContent() = std::move(*it->second);
@@ -144,6 +146,8 @@ private:
     const TExecutorPtr Executor;
     const IJournalPtr Journal;
     const IDevicePtr DataStore;
+    const TString DeviceUUID;
+    const TString BackgroundClientId;
 
     TLog Log;
 
@@ -155,20 +159,26 @@ private:
 
 public:
     TJournalledDeviceV2(
-            ILoggingServicePtr logging,
-            TExecutorPtr executor,
-            IJournalPtr journal,
-            IDevicePtr dataStore)
+        ILoggingServicePtr logging,
+        TExecutorPtr executor,
+        IJournalPtr journal,
+        IDevicePtr dataStore,
+        TString deviceUUID,
+        TString backgroundClientId)
         : Logging(std::move(logging))
         , Executor(std::move(executor))
         , Journal(std::move(journal))
         , DataStore(std::move(dataStore))
+        , DeviceUUID(std::move(deviceUUID))
+        , BackgroundClientId(std::move(backgroundClientId))
         , Log(Logging->CreateLog("JOURNALLED_DEVICE"))
     {}
 
-    void Start() override {
+    void Start() override
+    {
         auto future = Executor->Execute(
-            [weakSelf = weak_from_this()] () {
+            [weakSelf = weak_from_this()]()
+            {
                 auto self = weakSelf.lock();
                 if (!self) {
                     return MakeError(E_FAIL, "TJournalledDevice is destroyed");
@@ -181,7 +191,8 @@ public:
         Y_ENSURE(!HasError(error), FormatError(error));
     }
 
-    void Stop() override {
+    void Stop() override
+    {
         ShouldStop.store(true);
 
         if (FlushCycleStopped.Initialized()) {
@@ -192,28 +203,39 @@ public:
     TFuture<NCloud::NProto::TReadPagesResponse> ReadPages(
         NCloud::NProto::TReadPagesRequest request) override
     {
+        if (auto error = ValidateRequest(request); HasError(error)) {
+            return MakeFuture<NCloud::NProto::TReadPagesResponse>(
+                TErrorResponse(std::move(error)));
+        }
+
         return Execute<NCloud::NProto::TReadPagesResponse>(
-            [request = std::move(request)] (auto& self) mutable
-            {
-                return self.DoReadPages(std::move(request));
-            });
+            [request = std::move(request)](auto& self) mutable
+            { return self.DoReadPages(std::move(request)); });
     }
 
     TFuture<NCloud::NProto::TWriteLogRecordResponse> WriteLogRecord(
         NCloud::NProto::TWriteLogRecordRequest request) override
     {
+        if (auto error = ValidateRequest(request); HasError(error)) {
+            return MakeFuture<NCloud::NProto::TWriteLogRecordResponse>(
+                TErrorResponse(std::move(error)));
+        }
+
         return Execute<NCloud::NProto::TWriteLogRecordResponse>(
-            [request = std::move(request)] (auto& self) mutable
-            {
-                return self.DoWriteLogRecord(std::move(request));
-            });
+            [request = std::move(request)](auto& self) mutable
+            { return self.DoWriteLogRecord(std::move(request)); });
     }
 
     TFuture<NCloud::NProto::TReadJournalTailResponse> ReadJournalTail(
         NCloud::NProto::TReadJournalTailRequest request) override
     {
+        if (auto error = ValidateRequest(request); HasError(error)) {
+            return MakeFuture<NCloud::NProto::TReadJournalTailResponse>(
+                TErrorResponse(std::move(error)));
+        }
+
         return Execute<NCloud::NProto::TReadJournalTailResponse>(
-            [request = std::move(request)] (auto& self) mutable
+            [request = std::move(request)](auto& self) mutable
             {
                 return self.Executor->ExtractResponse(
                     self.Journal->ReadTail(std::move(request)));
@@ -224,8 +246,13 @@ public:
         NCloud::NProto::TAdvanceLsnLowWatermarkRequest request)
         -> TFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse> override
     {
+        if (auto error = ValidateRequest(request); HasError(error)) {
+            return MakeFuture<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
+                TErrorResponse(std::move(error)));
+        }
+
         return Execute<NCloud::NProto::TAdvanceLsnLowWatermarkResponse>(
-            [request = std::move(request)] (auto& self) mutable
+            [request = std::move(request)](auto& self) mutable
             {
                 return self.Executor->ExtractResponse(
                     self.Journal->AdvanceLastAckedLsn(std::move(request)));
@@ -233,11 +260,29 @@ public:
     }
 
 private:
+    template <typename TRequest>
+    NCloud::NProto::TError ValidateRequest(const TRequest& request) const
+    {
+        if (request.GetDeviceUUID().empty()) {
+            return MakeError(E_ARGUMENT, "empty device UUID");
+        }
+
+        if (request.GetDeviceUUID() != DeviceUUID) {
+            return MakeError(
+                E_ARGUMENT,
+                TStringBuilder() << "the request is addressed to device "
+                                 << request.GetDeviceUUID().Quote()
+                                 << ", this is " << DeviceUUID.Quote());
+        }
+
+        return {};
+    }
+
     template <typename T, typename F>
     TFuture<T> Execute(F func)
     {
         return Executor->Execute(
-            [weakSelf = weak_from_this(), func = std::move(func)] () mutable -> T
+            [weakSelf = weak_from_this(), func = std::move(func)]() mutable -> T
             {
                 auto self = weakSelf.lock();
                 if (!self) {
@@ -313,16 +358,31 @@ private:
         return response;
     }
 
+    NCloud::NProto::TWriteLogRecordRequest MakeFlushRequest(
+        NCloud::NProto::TJournalRecord& record) const
+    {
+        NCloud::NProto::TWriteLogRecordRequest request;
+        request.MutableHeaders()->SetClientId(BackgroundClientId);
+        request.SetDeviceUUID(DeviceUUID);
+        request.SetLogSequenceNumber(record.GetLogSequenceNumber());
+        request.SetPrevLogSequenceNumber(record.GetPrevLogSequenceNumber());
+        request.MutablePageGroups()->Swap(record.MutablePageGroups());
+
+        return request;
+    }
+
     void ScheduleFlushCycle()
     {
-        Executor->Execute([weakSelf = weak_from_this()] () {
-            auto self = weakSelf.lock();
-            if (!self) {
-                return;
-            }
+        Executor->Execute(
+            [weakSelf = weak_from_this()]()
+            {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    return;
+                }
 
-            self->RunFlushCycle();
-        });
+                self->RunFlushCycle();
+            });
     }
 
     void RunFlushCycle()
@@ -347,16 +407,18 @@ private:
                 break;
             }
 
-            NCloud::NProto::TWriteLogRecordRequest request;
-            request.MutablePageGroups()->Swap(record.MutablePageGroups());
+            if (record.PageGroupsSize()) {
+                auto request = MakeFlushRequest(record);
 
-            auto writeFuture = DataStore->WritePages(std::move(request));
-            auto writeResponse = Executor->WaitFor(writeFuture);
-            if (HasError(writeResponse)) {
-                STORAGE_ERROR(
-                    "unable to flush the record with lsn " << lsn << ": "
-                    << FormatError(writeResponse.GetError()));
-                break;
+                auto writeFuture = DataStore->WritePages(std::move(request));
+                auto writeResponse = Executor->WaitFor(writeFuture);
+                if (HasError(writeResponse)) {
+                    STORAGE_ERROR(
+                        "unable to flush the record with lsn "
+                        << lsn << ": "
+                        << FormatError(writeResponse.GetError()));
+                    break;
+                }
             }
 
             Journal->MarkRecordAsFlushed(lsn);
@@ -372,8 +434,8 @@ private:
         const auto& response = Executor->WaitFor(future);
         if (HasError(response)) {
             STORAGE_ERROR(
-                "unable to cleanup flushed records up to lsn " << lastFlushedLsn
-                << ": " << FormatError(response));
+                "unable to cleanup flushed records up to lsn "
+                << lastFlushedLsn << ": " << FormatError(response));
         }
 
         RunningCont()->SleepT(IdleFlushDelay);
@@ -390,13 +452,17 @@ IJournalledDevicePtr CreateJournalledDeviceV2(
     ILoggingServicePtr logging,
     TExecutorPtr executor,
     IJournalPtr journal,
-    IDevicePtr dataStore)
+    IDevicePtr dataStore,
+    TString deviceUUID,
+    TString backgroundClientId)
 {
     return std::make_shared<TJournalledDeviceV2>(
         std::move(logging),
         std::move(executor),
         std::move(journal),
-        std::move(dataStore));
+        std::move(dataStore),
+        std::move(deviceUUID),
+        std::move(backgroundClientId));
 }
 
 }   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journalled_device_v2.h
+++ b/cloud/storage/core/libs/journalled_device/journalled_device_v2.h
@@ -7,6 +7,8 @@
 #include <cloud/storage/core/libs/coroutine/public.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
 
+#include <util/generic/string.h>
+
 namespace NCloud::NJournalled {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -15,6 +17,8 @@ IJournalledDevicePtr CreateJournalledDeviceV2(
     ILoggingServicePtr logging,
     TExecutorPtr executor,
     IJournalPtr journal,
-    IDevicePtr dataStore);
+    IDevicePtr dataStore,
+    TString deviceUUID,
+    TString backgroundClientId);
 
 }   // namespace NCloud::NJournalled

--- a/cloud/storage/core/libs/journalled_device/journalled_device_v2_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device/journalled_device_v2_ut.cpp
@@ -29,6 +29,7 @@ namespace {
 constexpr ui32 DefaultPageSize = 4096;
 constexpr TStringBuf DefaultDeviceUUID = "uuid";
 constexpr TStringBuf DefaultClientId = "test-client";
+constexpr TStringBuf BackgroundClientId = "background-ops";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -48,11 +49,12 @@ NCloud::NProto::TDevicePageGroup MakeGroup(
 }
 
 NCloud::NProto::TReadPagesRequest MakeReadRequest(
-    const TVector<std::pair<ui64 /*firstPageNo*/, ui64 /*pageCount*/>>& refs)
+    const TVector<std::pair<ui64 /*firstPageNo*/, ui64 /*pageCount*/>>& refs,
+    TStringBuf deviceUUID = DefaultDeviceUUID)
 {
     NCloud::NProto::TReadPagesRequest request;
     request.MutableHeaders()->SetClientId(TString{DefaultClientId});
-    request.SetDeviceUUID(TString{DefaultDeviceUUID});
+    request.SetDeviceUUID(TString{deviceUUID});
 
     for (const auto& [firstPageNo, pageCount]: refs) {
         auto& ref = *request.AddPageGroupRefs();
@@ -60,6 +62,34 @@ NCloud::NProto::TReadPagesRequest MakeReadRequest(
         ref.SetPageCount(pageCount);
         ref.SetPageSize(DefaultPageSize);
     }
+
+    return request;
+}
+
+NCloud::NProto::TWriteLogRecordRequest MakeWriteRequest(TStringBuf deviceUUID)
+{
+    NCloud::NProto::TWriteLogRecordRequest request;
+    request.SetDeviceUUID(TString{deviceUUID});
+    request.SetLogSequenceNumber(1);
+    *request.AddPageGroups() = MakeGroup(10, 1, "W");
+
+    return request;
+}
+
+NCloud::NProto::TReadJournalTailRequest MakeTailRequest(TStringBuf deviceUUID)
+{
+    NCloud::NProto::TReadJournalTailRequest request;
+    request.SetDeviceUUID(TString{deviceUUID});
+
+    return request;
+}
+
+NCloud::NProto::TAdvanceLsnLowWatermarkRequest MakeAdvanceRequest(
+    TStringBuf deviceUUID)
+{
+    NCloud::NProto::TAdvanceLsnLowWatermarkRequest request;
+    request.SetDeviceUUID(TString{deviceUUID});
+    request.SetLsnLowWatermark(1);
 
     return request;
 }
@@ -374,7 +404,13 @@ struct TFixture: public NUnitTest::TBaseFixture
         Journal = std::make_shared<TTestJournal>();
         DataStore = std::make_shared<TTestDevice>();
 
-        Device = CreateJournalledDeviceV2(Logging, Executor, Journal, DataStore);
+        Device = CreateJournalledDeviceV2(
+            Logging,
+            Executor,
+            Journal,
+            DataStore,
+            TString{DefaultDeviceUUID},
+            TString{BackgroundClientId});
     }
 
     void TearDown(NUnitTest::TTestContext& /*context*/) override
@@ -692,6 +728,110 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceV2Test)
             "device is broken");
     }
 
+    Y_UNIT_TEST_F(ShouldRejectARequestForAnotherDevice, TFixture)
+    {
+        constexpr TStringBuf otherUUID = "another-device";
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            ReadPages(MakeReadRequest({{10, 4}}, otherUUID))
+                .GetError()
+                .GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            Device->WriteLogRecord(MakeWriteRequest(otherUUID))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            Device->ReadJournalTail(MakeTailRequest(otherUUID))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            Device->AdvanceLsnLowWatermark(MakeAdvanceRequest(otherUUID))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+
+        // none of them got anywhere near the journal or the device
+
+        UNIT_ASSERT_VALUES_EQUAL(0, Journal->GetReadRequests().size());
+        UNIT_ASSERT_VALUES_EQUAL(0, DataStore->GetReadRequests().size());
+        UNIT_ASSERT_VALUES_EQUAL(0, DataStore->GetWriteRequests().size());
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectARequestWithNoDeviceUUID, TFixture)
+    {
+        auto response = ReadPages(MakeReadRequest({{10, 4}}, ""));
+        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, response.GetError().GetCode());
+        UNIT_ASSERT_STRING_CONTAINS(
+            response.GetError().GetMessage(),
+            "empty device UUID");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            Device->WriteLogRecord(MakeWriteRequest(""))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            Device->ReadJournalTail(MakeTailRequest(""))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_ARGUMENT,
+            Device->AdvanceLsnLowWatermark(MakeAdvanceRequest(""))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(0, Journal->GetReadRequests().size());
+    }
+
+    Y_UNIT_TEST_F(ShouldServeARequestForThisDevice, TFixture)
+    {
+        Journal->ReadHandler = [] (const auto& request) {
+            Y_UNUSED(request);
+            return MakeReadResponse({MakeGroup(10, 1, "J")}, 1);
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            ReadPages(MakeReadRequest({{10, 1}})).GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            Device->WriteLogRecord(MakeWriteRequest(DefaultDeviceUUID))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            Device->ReadJournalTail(MakeTailRequest(DefaultDeviceUUID))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            Device
+                ->AdvanceLsnLowWatermark(MakeAdvanceRequest(DefaultDeviceUUID))
+                .GetValueSync()
+                .GetError()
+                .GetCode());
+    }
+
     Y_UNIT_TEST_F(ShouldFlushJournalRecordsToTheDataStore, TFixture)
     {
         Journal->RestoreResponse = 3;
@@ -710,6 +850,19 @@ Y_UNIT_TEST_SUITE(TJournalledDeviceV2Test)
         UNIT_ASSERT_VALUES_EQUAL("10:[J10,J11]", DescribeGroups(writes[0]));
         UNIT_ASSERT_VALUES_EQUAL("20:[J20]", DescribeGroups(writes[1]));
         UNIT_ASSERT_VALUES_EQUAL("30:[J30,J31,J32]", DescribeGroups(writes[2]));
+
+        // the flush has no client request behind it, so it goes out under the
+        // identity of the device itself - a real device refuses a write
+        // without one
+
+        for (size_t i = 0; i < writes.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(DefaultDeviceUUID, writes[i].GetDeviceUUID());
+            UNIT_ASSERT_VALUES_EQUAL(
+                BackgroundClientId,
+                writes[i].GetHeaders().GetClientId());
+            UNIT_ASSERT_VALUES_EQUAL(i + 1, writes[i].GetLogSequenceNumber());
+            UNIT_ASSERT_VALUES_EQUAL(i, writes[i].GetPrevLogSequenceNumber());
+        }
 
         // every flushed record has been acked in the journal
 


### PR DESCRIPTION
### Notes

The background flush has no client request behind it, so the write it made up carried no device uuid and no client id, which a device refuses - the flush cycle would break on the error, retry the same record every hundred milliseconds and never drain the journal. The device now takes the uuid and the client id to write as, and puts them, along with the lsns of the record, on every flush request.

### Issue
https://github.com/ydb-platform/nbs/issues/6956