### PR TITLE
issue-7136: fixing cross-shard RenameNode with EXCHANGE flag - properly returning OldTargetNodeShard{Id,Name} to the source shard

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -73,6 +73,7 @@ namespace NCloud::NFileStore{
     xxx(AvailabilityCountersUnavailableInterval)                               \
     xxx(AvailabilityCountersMissingIntervals)                                  \
     xxx(PersistentStateSessionDirNotEmpty)                                     \
+    xxx(ListNodesLocalNodeNotFound)                                            \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_CRITICAL_EVENTS_WITHOUT_LOGGING(xxx)                         \
@@ -98,6 +99,7 @@ namespace NCloud::NFileStore{
     xxx(UnexpectedLocalNode)                                                   \
     xxx(NoRenameNodeInDestinationRequest)                                      \
     xxx(BadChildRefUponCommitRenameNodeInSource)                               \
+    xxx(EmptyOldTargetNodeInExchangeRename)                                    \
     xxx(FailedToLockNodeRef)                                                   \
     xxx(InvalidNodeRefUponCompleteUnlinkNode)                                  \
     xxx(UnknownOpLogEntry)                                                     \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -356,7 +356,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
         NProto::LNSM_NAME_ONLY                                                )\
     xxx(UseListNodesInternal,              bool,      false                   )\
                                                                                \
-    xxx(ResponseLogEntryTTL,                TDuration,  TDuration::Hours(1)   )\
+    xxx(ResponseLogEntryTTL,                TDuration,  TDuration::Days(1)    )\
     xxx(TabletRegularTasksSchedulePeriod,   TDuration,  TDuration::Minutes(1) )\
                                                                                \
     xxx(ForceDestroySizeThreshold,          ui64,       0                     )\

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -236,9 +236,18 @@ bool TIndexTabletActor::PrepareTx_ListNodes(
         }
 
         if (ready) {
-            // TODO: AccessCheck
-            TABLET_VERIFY(childNode);
-            args.ChildNodes.emplace_back(std::move(childNode.GetRef()));
+            if (childNode) {
+                args.ChildNodes.emplace_back(std::move(childNode.GetRef()));
+            } else {
+                auto message = ReportListNodesLocalNodeNotFound(
+                    TStringBuilder() << "NodeId: " << args.NodeId
+                        << ", ref.Name: " << ref.Name
+                        << ", ref.ChildNodeId: " << ref.ChildNodeId
+                        << ", ref.ShardId: " << ref.ShardId
+                        << ", ref.ShardNodeName: " << ref.ShardNodeName);
+                args.Error = MakeError(E_INVALID_STATE, std::move(message));
+                break;
+            }
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -575,6 +575,16 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
             && args.Request.GetSourceNodeShardNodeName()
                 == args.NewChildRef->ShardNodeName;
         if (isSameExternalNode) {
+            //
+            // The old target is the source node itself. Report its location
+            // anyway - the exchange path in the source uses these fields to
+            // recreate its ref and must not receive them empty.
+            //
+
+            args.Response.SetOldTargetNodeShardId(args.NewChildRef->ShardId);
+            args.Response.SetOldTargetNodeShardNodeName(
+                args.NewChildRef->ShardNodeName);
+
             args.Error = MakeError(S_ALREADY, "is the same file");
             return true;
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -845,8 +845,20 @@ void TIndexTabletActor::CompleteTx_RenameNodeInDestination(
         0,
         ctx.Now() - args.RequestInfo->StartedTs);
 
+    //
+    // On the exchange path args.Response carries the old target node
+    // location which the source tablet needs to link the old target under
+    // the old name - without it the old target node leaks.
+    //
+
+    // args.Error is used below in FinalizeProfileLogRequestInfo - copy, not
+    // move
+    *args.Response.MutableError() = args.Error;
+
     using TMethod = TEvIndexTablet::TRenameNodeInDestinationMethod;
-    auto response = std::make_unique<TMethod::TResponse>(args.Error);
+    auto response = std::make_unique<TMethod::TResponse>();
+    response->Record = std::move(args.Response);
+
     CompleteResponse<TMethod>(
         response->Record,
         args.RequestInfo->CallContext,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -766,6 +766,20 @@ void TIndexTabletActor::ExecuteTx_CommitRenameNodeInSource(
             NProto::TRenameNodeRequest::F_EXCHANGE);
 
         if (isExchange) {
+            if (!args.Response.GetOldTargetNodeShardId()
+                    || !args.Response.GetOldTargetNodeShardNodeName())
+            {
+                //
+                // Without the old target location the ref created below is
+                // dangling and the old target node leaks.
+                //
+
+                ReportEmptyOldTargetNodeInExchangeRename(TStringBuilder()
+                    << "CommitRenameNodeInSource: "
+                    << args.Request.ShortDebugString()
+                    << ", response: " << args.Response.ShortDebugString());
+            }
+
             // create source ref to target node
             CreateNodeRef(
                 *db,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
@@ -740,7 +740,7 @@ void TIndexTabletActor::CompleteTx_UnsafeGetNodeRef(
         std::make_unique<TEvIndexTablet::TEvUnsafeGetNodeRefResponse>();
 
     if (args.NodeRef) {
-        response->Record.SetChildId(args.NodeRef->NodeId);
+        response->Record.SetChildId(args.NodeRef->ChildNodeId);
         response->Record.SetShardId(args.NodeRef->ShardId);
         response->Record.SetShardNodeName(args.NodeRef->ShardNodeName);
     } else {

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -453,8 +453,8 @@ void TTabletMetrics::Register(
     REGISTER_AGGREGATABLE_SUM(CPUUsageMicros, EMetricType::MT_DERIVATIVE);
     REGISTER_LOCAL(CPUUsageRate, EMetricType::MT_ABSOLUTE);
 
-    REGISTER_LOCAL(OpLogEntryCount, EMetricType::MT_ABSOLUTE);
-    REGISTER_LOCAL(ResponseLogEntryCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(OpLogEntryCount, EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(ResponseLogEntryCount, EMetricType::MT_ABSOLUTE);
 
     REGISTER_AGGREGATABLE_SUM(
         RenameNotSupportedErrorCount,

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -638,6 +638,136 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         }
     }
 
+    TABLET_TEST_4K_ONLY(
+        ShouldReturnOldTargetRefUponSameNodeRenameInDestinationWithExchange)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetDirectoryCreationInShardsEnabled(true);
+        TTestEnv env(testEnvConfig, storageConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.ConfigureShards(true);
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+        tablet.InitSession("client", "session");
+
+        //
+        //  Scenario:
+        //
+        //  name1 -> shard1/uuid1 (the target ref already points at the
+        //  source node - oldpath and newpath are hard links to the same
+        //  node, or the response log entry for a completed exchange aged
+        //  out before a late retry)
+        //
+        //  exchange-move shard1/uuid1 to name1 -> S_ALREADY, and the
+        //  response must still carry the old target location - the source
+        //  uses it to recreate its ref and must not receive it empty.
+        //
+        //  The current hardlink implementation cannot run into this scenario
+        //  but in TODO(#2667) we'll change it - so we need to prepare for that
+        //  case in advance.
+        //
+        //  An aged out response log entry is still a problem in theory. It's
+        //  mitigated by very long default ResponseLogEntryTTL.
+        //
+
+        const TString shardId1 = "shard1";
+        const TString name1 = "name1";
+        const TString uuid1 = CreateGuidAsString();
+
+        CreateExternalRef(tablet, RootNodeId, name1, shardId1, uuid1);
+
+        const ui32 exchange =
+            ProtoFlag(NProto::TRenameNodeRequest::F_EXCHANGE);
+
+        tablet.SendRenameNodeInDestinationRequest(
+            RootNodeId,
+            name1,
+            shardId1,
+            uuid1,
+            exchange);
+        {
+            auto response = tablet.RecvRenameNodeInDestinationResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_ALREADY,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_VALUES_EQUAL(
+                shardId1,
+                response->Record.GetOldTargetNodeShardId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                uuid1,
+                response->Record.GetOldTargetNodeShardNodeName());
+        }
+
+        //
+        // The ref must stay intact.
+        //
+
+        const auto nodeRef = tablet.UnsafeGetNodeRef(RootNodeId, name1)->Record;
+        UNIT_ASSERT_VALUES_EQUAL(shardId1, nodeRef.GetShardId());
+        UNIT_ASSERT_VALUES_EQUAL(uuid1, nodeRef.GetShardNodeName());
+    }
+
+    TABLET_TEST_4K_ONLY(ShouldReportCriticalEventUponListNodesWithBrokenRef)
+    {
+        TTestEnv env(testEnvConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto localNodeNotFoundCounter = counters->GetCounter(
+            "AppCriticalEvents/ListNodesLocalNodeNotFound",
+            true);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        const TString name = "broken";
+        CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, name));
+
+        //
+        // Corrupt the ref: neither a valid local child id nor an external
+        // shard location - ListNodes should report a critical event
+        // instead of crashing the tablet.
+        //
+
+        tablet.UnsafeUpdateNodeRef(
+            RootNodeId,
+            name,
+            0 /* childId */,
+            "" /* shardId */,
+            "" /* shardNodeName */);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, localNodeNotFoundCounter->Val());
+
+        tablet.SendListNodesRequest(RootNodeId);
+        {
+            auto response = tablet.RecvListNodesResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_INVALID_STATE,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(1, localNodeNotFoundCounter->Val());
+    }
+
     TABLET_TEST_4K_ONLY(ShouldReturnErrorUponRenameNodeForFileToDirOp)
     {
         DoTestShouldReturnErrorUponRenameNodeForFileToDirOp(

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -539,6 +539,105 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
             true /* useRenameInDestination */);
     }
 
+    TABLET_TEST_4K_ONLY(
+        ShouldReturnOldTargetRefUponRenameNodeInDestinationWithExchange)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetDirectoryCreationInShardsEnabled(true);
+        TTestEnv env(testEnvConfig, storageConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.ConfigureShards(true);
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+        tablet.InitSession("client", "session");
+
+        //
+        //  Scenario:
+        //
+        //  name2 -> shard2/uuid2 (existing external target)
+        //
+        //  exchange-move shard1/uuid1 to name2 -> ok, the response must
+        //  carry the old target location (shard2/uuid2) - the source shard
+        //  needs it to link the old target under the old name.
+        //
+
+        const TString shardId1 = "shard1";
+        const TString uuid1 = CreateGuidAsString();
+
+        const TString shardId2 = "shard2";
+        const TString name2 = "name2";
+        const TString uuid2 = CreateGuidAsString();
+
+        CreateExternalRef(tablet, RootNodeId, name2, shardId2, uuid2);
+
+        const ui32 exchange =
+            ProtoFlag(NProto::TRenameNodeRequest::F_EXCHANGE);
+        const ui64 clientTabletId = 1;
+        const ui64 requestId = 777;
+
+        tablet.SendRenameNodeInDestinationRequest(
+            RootNodeId,
+            name2,
+            shardId1,
+            uuid1,
+            exchange,
+            clientTabletId,
+            requestId);
+        {
+            auto response = tablet.RecvRenameNodeInDestinationResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_VALUES_EQUAL(
+                shardId2,
+                response->Record.GetOldTargetNodeShardId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                uuid2,
+                response->Record.GetOldTargetNodeShardNodeName());
+        }
+
+        const auto nodeRef = tablet.UnsafeGetNodeRef(RootNodeId, name2)->Record;
+        UNIT_ASSERT_VALUES_EQUAL(shardId1, nodeRef.GetShardId());
+        UNIT_ASSERT_VALUES_EQUAL(uuid1, nodeRef.GetShardNodeName());
+
+        //
+        // A retry with the same request id replays the response from the
+        // response log and must carry the same old target location.
+        //
+
+        tablet.SendRenameNodeInDestinationRequest(
+            RootNodeId,
+            name2,
+            shardId1,
+            uuid1,
+            exchange,
+            clientTabletId,
+            requestId);
+        {
+            auto response = tablet.RecvRenameNodeInDestinationResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+            UNIT_ASSERT_VALUES_EQUAL(
+                shardId2,
+                response->Record.GetOldTargetNodeShardId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                uuid2,
+                response->Record.GetOldTargetNodeShardNodeName());
+        }
+    }
+
     TABLET_TEST_4K_ONLY(ShouldReturnErrorUponRenameNodeForFileToDirOp)
     {
         DoTestShouldReturnErrorUponRenameNodeForFileToDirOp(

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -480,6 +480,23 @@ public:
         return request;
     }
 
+    auto CreateUnsafeUpdateNodeRefRequest(
+        ui64 parentId,
+        const TString& name,
+        ui64 childId,
+        const TString& shardId,
+        const TString& shardNodeName)
+    {
+        using TRequestEvent = TEvIndexTablet::TEvUnsafeUpdateNodeRefRequest;
+        auto request = std::make_unique<TRequestEvent>();
+        request->Record.SetParentId(parentId);
+        request->Record.SetName(name);
+        request->Record.SetChildId(childId);
+        request->Record.SetShardId(shardId);
+        request->Record.SetShardNodeName(shardNodeName);
+        return request;
+    }
+
     auto CreateUnsafeDeleteNodeRefRequest(ui64 parentId, const TString& name)
     {
         using TRequestEvent = TEvIndexTablet::TEvUnsafeDeleteNodeRefRequest;


### PR DESCRIPTION
### Notes
The main problem: `args.Response` was filled but not copied to the actual response - fixed it, added a ut.

Other changes:
* `RenameNodeInDestination` with `EXCHANGE` flag returns `OldTargetNode` ref upon `S_ALREADY`
* `ListNodes` doesn't crash upon missing local node - reports a critical event instead
* `ResponseLogEntryTTL` is now 1 day by default
* `OpLogEntryCount` and `ResponseLogEntryCount` sensors are now aggregatable sums

### Issue
https://github.com/ydb-platform/nbs/issues/7136
https://github.com/ydb-platform/nbs/issues/2667
