### PR TITLE
issue-6958: fastshard - extracted StorageGroupFactory away from the shard implementation library

### DIFF
--- a/cloud/filestore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/common/bootstrap.cpp
@@ -12,7 +12,7 @@
 #include <cloud/filestore/libs/server/probes.h>
 #include <cloud/filestore/libs/server/server.h>
 #include <cloud/filestore/libs/storage/core/config.h>
-#include <cloud/filestore/libs/storage/fastshard/impl/factory/factory.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/factory/shard_factory.h>
 #include <cloud/filestore/libs/storage/init/actorsystem.h>
 #include <cloud/storage/core/libs/aio/service.h>
 #include <cloud/storage/core/libs/common/file_io_service.h>

--- a/cloud/filestore/libs/storage/fastshard/iface/fs.h
+++ b/cloud/filestore/libs/storage/fastshard/iface/fs.h
@@ -98,6 +98,19 @@ struct IFileSystemShard
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct IFileSystemShardFactory
+{
+    virtual ~IFileSystemShardFactory() = default;
+
+    virtual IFileSystemShardPtr CreateShard(
+        const TString& fileSystemId,
+        const NProtoPrivate::TFastShardConfig& config,
+        ui32 shardNo,
+        ui64 generation) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 IFileSystemShardPtr CreateFileSystemShardStub();
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/iface/fs.h
+++ b/cloud/filestore/libs/storage/fastshard/iface/fs.h
@@ -98,19 +98,6 @@ struct IFileSystemShard
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IFileSystemShardFactory
-{
-    virtual ~IFileSystemShardFactory() = default;
-
-    virtual IFileSystemShardPtr CreateShard(
-        const TString& fileSystemId,
-        const NProtoPrivate::TFastShardConfig& config,
-        ui32 shardNo,
-        ui64 generation) = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 IFileSystemShardPtr CreateFileSystemShardStub();
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/iface/public.h
+++ b/cloud/filestore/libs/storage/fastshard/iface/public.h
@@ -11,4 +11,7 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 struct IFileSystemShard;
 using IFileSystemShardPtr = std::shared_ptr<IFileSystemShard>;
 
+struct IFileSystemShardFactory;
+using IFileSystemShardFactoryPtr = std::shared_ptr<IFileSystemShardFactory>;
+
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/null_storage_group.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/null_storage_group.cpp
@@ -1,5 +1,7 @@
 #include "null_storage_group.h"
 
+#include <cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.h>
+
 #include <silk/fibers/fiber.h>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {

--- a/cloud/filestore/libs/storage/fastshard/impl/bench/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/bench/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     cloud/filestore/libs/service
     cloud/filestore/libs/storage/fastshard/iface
     cloud/filestore/libs/storage/fastshard/impl/hash_table_index
+    cloud/filestore/libs/storage/fastshard/sn/factory
     cloud/filestore/libs/storage/fastshard/sn/quorum
     cloud/filestore/private/api/protos
 

--- a/cloud/filestore/libs/storage/fastshard/impl/factory/group_factory.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/factory/group_factory.cpp
@@ -1,0 +1,64 @@
+#include "group_factory.h"
+
+#include <cloud/filestore/libs/storage/fastshard/sn/client/client.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_quorum.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TStorageGroupFactory: IStorageGroupFactory
+{
+    IStorageGroupPtr MakeStorageGroup(
+        const NProtoPrivate::TPersistentFastShardConfig& config,
+        ui64 generation) override
+    {
+        TVector<TStorageDevice> devices;
+        const auto& sg = config.GetStorageGroups(0);
+        for (const auto& d: sg.GetDevices()) {
+            devices.push_back({
+                .Node = CreateStorageNodeClient(d.GetHost(), d.GetPort()),
+                .DeviceUUID = d.GetDeviceId(),
+            });
+        }
+
+        TStorageGroupConfig groupConfig;
+        // TODO(#5894): set client id
+        groupConfig.AcquireGeneration = generation;
+        if (config.GetRetryTotalTimeoutMs()) {
+            groupConfig.RetryPolicy.TotalTimeout =
+                TDuration::MilliSeconds(config.GetRetryTotalTimeoutMs());
+        }
+        if (config.GetRetryBackoffIncrementMs()) {
+            groupConfig.RetryPolicy.BackoffIncrement =
+                TDuration::MilliSeconds(config.GetRetryBackoffIncrementMs());
+        }
+
+        groupConfig.JournalRestoreEnabled = config.GetJournalRestoreEnabled();
+
+        if (sg.GetType() == NProtoPrivate::TStorageGroup::E_SG_QUORUM_MIRROR) {
+            return CreateQuorumMirroredStorageGroup(
+                std::move(groupConfig),
+                std::move(devices),
+                CreateFiberTimer());
+        }
+
+        return CreateNaiveMirroredStorageGroup(
+            std::move(groupConfig),
+            std::move(devices),
+            CreateFiberTimer());
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IStorageGroupFactoryPtr CreateStorageGroupFactory()
+{
+    return std::make_shared<TStorageGroupFactory>();
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/factory/group_factory.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/factory/group_factory.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.h>
+
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+/**
+ * An unrecognised type falls back to E_SG_MIRROR.
+ */
+IStorageGroupFactoryPtr CreateStorageGroupFactory();
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/factory/public.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/factory/public.h
@@ -8,9 +8,6 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IFileSystemShardFactory;
-using IFileSystemShardFactoryPtr = std::shared_ptr<IFileSystemShardFactory>;
-
 struct IStorageGroupFactory;
 using IStorageGroupFactoryPtr = std::shared_ptr<IStorageGroupFactory>;
 

--- a/cloud/filestore/libs/storage/fastshard/impl/factory/public.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/factory/public.h
@@ -8,7 +8,10 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IFileSystemShard;
-using IFileSystemShardPtr = std::shared_ptr<IFileSystemShard>;
+struct IFileSystemShardFactory;
+using IFileSystemShardFactoryPtr = std::shared_ptr<IFileSystemShardFactory>;
+
+struct IStorageGroupFactory;
+using IStorageGroupFactoryPtr = std::shared_ptr<IStorageGroupFactory>;
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/factory/shard_factory.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/factory/shard_factory.cpp
@@ -1,4 +1,6 @@
-#include "factory.h"
+#include "shard_factory.h"
+
+#include "group_factory.h"
 
 #include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/mem/memshard.h>
@@ -38,6 +40,7 @@ public:
             fileSystemId,
             shardNo,
             generation,
+            CreateStorageGroupFactory(),
             config.GetPersistentConfig());
     }
 };

--- a/cloud/filestore/libs/storage/fastshard/impl/factory/shard_factory.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/factory/shard_factory.h
@@ -1,8 +1,25 @@
 #pragma once
 
+#include "public.h"
+
 #include <cloud/filestore/libs/storage/fastshard/iface/public.h>
 
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
+
 namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IFileSystemShardFactory
+{
+    virtual ~IFileSystemShardFactory() = default;
+
+    virtual IFileSystemShardPtr CreateShard(
+        const TString& fileSystemId,
+        const NProtoPrivate::TFastShardConfig& config,
+        ui32 shardNo,
+        ui64 generation) = 0;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/fastshard/impl/factory/shard_factory.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/factory/shard_factory.h
@@ -10,19 +10,6 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IFileSystemShardFactory
-{
-    virtual ~IFileSystemShardFactory() = default;
-
-    virtual IFileSystemShardPtr CreateShard(
-        const TString& fileSystemId,
-        const NProtoPrivate::TFastShardConfig& config,
-        ui32 shardNo,
-        ui64 generation) = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 // A mem shard for a mem config, the persistent one for a persistent config,
 // or a stub answering E_NOT_IMPLEMENTED if the runtime is not enabled here.
 IFileSystemShardFactoryPtr CreateFileSystemShardFactory(bool runtimeEnabled);

--- a/cloud/filestore/libs/storage/fastshard/impl/factory/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/factory/ya.make
@@ -1,13 +1,16 @@
 LIBRARY()
 
 SRCS(
-    factory.cpp
+    group_factory.cpp
+    shard_factory.cpp
 )
 
 PEERDIR(
     cloud/filestore/libs/storage/fastshard/iface
     cloud/filestore/libs/storage/fastshard/impl/mem
     cloud/filestore/libs/storage/fastshard/impl/hash_table_index
+    cloud/filestore/libs/storage/fastshard/sn/client
+    cloud/filestore/libs/storage/fastshard/sn/quorum
 
     cloud/filestore/private/api/protos
 )

--- a/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.cpp
@@ -12,9 +12,8 @@
 #include <cloud/filestore/libs/storage/fastshard/impl/model/persistent_bitmap.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/model/persistent_hash_table.h>
 #include <cloud/filestore/libs/storage/fastshard/sn/client/client.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.h>
 #include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h>
-#include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_helpers.h>
-#include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_quorum.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
@@ -2145,59 +2144,7 @@ public:
     }
 };
 
-////////////////////////////////////////////////////////////////////////////////
-
-struct TStorageGroupFactory: IStorageGroupFactory
-{
-    IStorageGroupPtr MakeStorageGroup(
-        const NProtoPrivate::TPersistentFastShardConfig& config,
-        ui64 generation) override
-    {
-        TVector<TStorageDevice> devices;
-        const auto& sg = config.GetStorageGroups(0);
-        for (const auto& d: sg.GetDevices()) {
-            devices.push_back({
-                .Node = CreateStorageNodeClient(d.GetHost(), d.GetPort()),
-                .DeviceUUID = d.GetDeviceId(),
-            });
-        }
-
-        TStorageGroupConfig groupConfig;
-        // TODO(#5894): set client id
-        groupConfig.AcquireGeneration = generation;
-        if (config.GetRetryTotalTimeoutMs()) {
-            groupConfig.RetryPolicy.TotalTimeout =
-                TDuration::MilliSeconds(config.GetRetryTotalTimeoutMs());
-        }
-        if (config.GetRetryBackoffIncrementMs()) {
-            groupConfig.RetryPolicy.BackoffIncrement =
-                TDuration::MilliSeconds(config.GetRetryBackoffIncrementMs());
-        }
-
-        groupConfig.JournalRestoreEnabled = config.GetJournalRestoreEnabled();
-
-        if (sg.GetType() == NProtoPrivate::TStorageGroup::E_SG_QUORUM_MIRROR) {
-            return CreateQuorumMirroredStorageGroup(
-                std::move(groupConfig),
-                std::move(devices),
-                CreateFiberTimer());
-        }
-
-        return CreateNaiveMirroredStorageGroup(
-            std::move(groupConfig),
-            std::move(devices),
-            CreateFiberTimer());
-    }
-};
-
 }   // namespace
-
-////////////////////////////////////////////////////////////////////////////////
-
-IStorageGroupFactoryPtr CreateStorageGroupFactory()
-{
-    return std::make_shared<TStorageGroupFactory>();
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2234,20 +2181,6 @@ IFileSystemShardPtr CreateHashTableIndexFileSystemShard(
         shardNo,
         generation,
         std::move(storageGroupFactory),
-        config);
-}
-
-IFileSystemShardPtr CreateHashTableIndexFileSystemShard(
-    TString fileSystemId,
-    ui32 shardNo,
-    ui64 generation,
-    const NProtoPrivate::TPersistentFastShardConfig& config)
-{
-    return std::make_shared<THashTableIndexFileSystemShard>(
-        std::move(fileSystemId),
-        shardNo,
-        generation,
-        CreateStorageGroupFactory(),
         config);
 }
 

--- a/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cloud/filestore/libs/storage/fastshard/iface/public.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/factory/public.h>
 #include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h>
 
 namespace NCloud::NFileStore::NProtoPrivate {
@@ -16,34 +17,11 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IStorageGroupFactory
-{
-    virtual ~IStorageGroupFactory() = default;
-    virtual IStorageGroupPtr MakeStorageGroup(
-        const NProtoPrivate::TPersistentFastShardConfig& config,
-        ui64 generation) = 0;
-};
-
-using IStorageGroupFactoryPtr = std::shared_ptr<IStorageGroupFactory>;
-
-/**
- * An unrecognised type falls back to E_SG_MIRROR.
- */
-IStorageGroupFactoryPtr CreateStorageGroupFactory();
-
-////////////////////////////////////////////////////////////////////////////////
-
 IFileSystemShardPtr CreateHashTableIndexFileSystemShard(
     TString fileSystemId,
     ui32 shardNo,
     ui64 generation,
     IStorageGroupFactoryPtr storageGroupFactory,
-    const NProtoPrivate::TPersistentFastShardConfig& config);
-
-IFileSystemShardPtr CreateHashTableIndexFileSystemShard(
-    TString fileSystemId,
-    ui32 shardNo,
-    ui64 generation,
     const NProtoPrivate::TPersistentFastShardConfig& config);
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard_ut.cpp
@@ -1,5 +1,6 @@
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/factory/group_factory.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.h>
 #include <cloud/filestore/libs/storage/fastshard/sn/impl/storage_node.h>
 #include <cloud/filestore/libs/storage/fastshard/sn/server/server.h>
@@ -136,6 +137,7 @@ TEST(HashTableIndexShardTest, CreatesFiles)
         "fs0",
         ShardNo,
         1 /* generation */,
+        CreateStorageGroupFactory(),
         fx.Config);
     {
         auto e = shard->Init().GetValueSync();
@@ -209,6 +211,7 @@ TEST(HashTableIndexShardTest, ValidatesRequests)
         "fs0",
         ShardNo,
         1 /* generation */,
+        CreateStorageGroupFactory(),
         fx.Config);
     {
         auto e = shard->Init().GetValueSync();
@@ -286,6 +289,7 @@ TEST(HashTableIndexShardTest, CreatesHandles)
         "fs0",
         ShardNo,
         1 /* generation */,
+        CreateStorageGroupFactory(),
         fx.Config);
     {
         auto e = shard->Init().GetValueSync();
@@ -495,6 +499,7 @@ TEST(HashTableIndexShardTest, WritesAndReadsFiles)
         "fs0",
         ShardNo,
         1 /* generation */,
+        CreateStorageGroupFactory(),
         fx.Config);
     {
         auto e = shard->Init().GetValueSync();
@@ -621,6 +626,7 @@ TEST(HashTableIndexShardTest, WritesAndReadsLongUnalignedRangesWithHoles)
         "fs0",
         ShardNo,
         1 /* generation */,
+        CreateStorageGroupFactory(),
         fx.Config);
     {
         auto e = shard->Init().GetValueSync();
@@ -855,6 +861,7 @@ TEST(HashTableIndexShardTest, UnalignedAppend)
         "fs0",
         ShardNo,
         1 /* generation */,
+        CreateStorageGroupFactory(),
         fx.Config);
     {
         auto e = shard->Init().GetValueSync();
@@ -963,6 +970,7 @@ TEST(HashTableIndexShardTest, DeallocatesPagesUponUnlink)
         "fs0",
         ShardNo,
         1 /* generation */,
+        CreateStorageGroupFactory(),
         fx.Config);
     {
         auto e = shard->Init().GetValueSync();
@@ -1109,6 +1117,7 @@ TEST(HashTableIndexShardTest, DeallocatesPagesUponTruncate)
         "fs0",
         ShardNo,
         1 /* generation */,
+        CreateStorageGroupFactory(),
         fx.Config);
     {
         auto e = shard->Init().GetValueSync();

--- a/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard_ut_error.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard_ut_error.cpp
@@ -1,6 +1,7 @@
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
 #include <cloud/storage/core/libs/common/error.h>

--- a/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard_ut_layout.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard_ut_layout.cpp
@@ -1,6 +1,7 @@
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/hash_table_index/shard.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
 #include <cloud/storage/core/libs/common/error.h>

--- a/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/ut/ya.make
@@ -7,6 +7,7 @@ SRCS(
 )
 
 PEERDIR(
+    cloud/filestore/libs/storage/fastshard/impl/factory
     cloud/filestore/libs/storage/fastshard/impl/hash_table_index
     cloud/filestore/libs/storage/fastshard/sn/impl
     cloud/filestore/libs/storage/fastshard/sn/server

--- a/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/hash_table_index/ya.make
@@ -30,6 +30,7 @@ PEERDIR(
     cloud/filestore/libs/service
     cloud/filestore/libs/storage/fastshard/iface
     cloud/filestore/libs/storage/fastshard/sn/client
+    cloud/filestore/libs/storage/fastshard/sn/factory
     cloud/filestore/libs/storage/fastshard/sn/quorum
     cloud/filestore/libs/storage/model
 

--- a/cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.cpp
@@ -1,0 +1,1 @@
+#include "group_factory.h"

--- a/cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/factory/group_factory.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h>
+
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IStorageGroupFactory
+{
+    virtual ~IStorageGroupFactory() = default;
+    virtual IStorageGroupPtr MakeStorageGroup(
+        const NProtoPrivate::TPersistentFastShardConfig& config,
+        ui64 generation) = 0;
+};
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/factory/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/factory/ya.make
@@ -1,0 +1,13 @@
+LIBRARY()
+
+SRCS(
+    group_factory.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/sn/quorum
+
+    cloud/filestore/private/api/protos
+)
+
+END()

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -10,7 +10,7 @@
 #include <cloud/filestore/libs/storage/core/public.h>
 #include <cloud/filestore/libs/storage/core/system_counters.h>
 #include <cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h>
-#include <cloud/filestore/libs/storage/fastshard/impl/factory/factory.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/factory/shard_factory.h>
 #include <cloud/filestore/libs/storage/tablet/tablet.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 


### PR DESCRIPTION
### Notes
Just fixing a small tech debt. `StorageGroupFactory` implementation and iface don't have a direct relation to the specific shard implementation (`HashTableIndexShard`).

### Issue
https://github.com/ydb-platform/nbs/issues/6958
